### PR TITLE
Add fetchExecutorNames to StateStore interface

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,7 +74,7 @@ ext {
 }
 
 group = "mesosphere"
-version = "0.3.0-SNAPSHOT"
+version = "0.3.1-SNAPSHOT"
 
 task sourceJar(type: Jar) {
   from sourceSets.main.allJava

--- a/src/main/java/org/apache/mesos/state/CuratorStateStore.java
+++ b/src/main/java/org/apache/mesos/state/CuratorStateStore.java
@@ -2,6 +2,7 @@ package org.apache.mesos.state;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 
 import org.apache.curator.RetryPolicy;
 import org.apache.mesos.Protos;
@@ -114,6 +115,17 @@ public class CuratorStateStore extends CuratorPersister implements StateStore {
         }
 
         return taskInfos;
+    }
+
+    @Override
+    public Collection<String> fetchExecutorNames() throws StateStoreException {
+        try {
+            return getChildren(rootPath);
+        } catch (KeeperException.NoNodeException e) {
+            return Collections.emptyList();
+        } catch (Exception e) {
+            throw new StateStoreException(e);
+        }
     }
 
     @Override

--- a/src/main/java/org/apache/mesos/state/StateStore.java
+++ b/src/main/java/org/apache/mesos/state/StateStore.java
@@ -16,15 +16,79 @@ import java.util.Collection;
  * recorded so that the state of a Framework's Tasks can be queried.
  */
 public interface StateStore {
+    /**
+     * Stores the FrameworkID for a framework so on Scheduler restart re-registration
+     * may occur.
+     * @param fwkId FrameworkID to be store
+     * @throws StateStoreException Thrown when persistence of the FrameworkID fails
+     */
     void storeFrameworkId(Protos.FrameworkID fwkId) throws StateStoreException;
+
+
+    /**
+     * Fetches the previously stored FrameworkID
+     * @return The previously stored FrameworkID
+     * @throws StateStoreException Thrown when the FrameworkID cannot be fetched.
+     */
     Protos.FrameworkID fetchFrameworkId() throws StateStoreException;
+
+
+    /**
+     * Removes any previously stored FrameworkID or does nothing if no FrameworkID
+     * was previously stored.
+     * @throws StateStoreException Thrown when clearing a FrameworkID fails
+     */
     void clearFrameworkId() throws StateStoreException;
 
+    /**
+     * Stores TasksInfo objects representing tasks in the sub-path of the Executor
+     * which launched or will launch the Task.
+     * @param tasks Tasks to be associated persistently with a particular Executor
+     * @param execName The name of the Executor hosting the tasks.
+     * @throws StateStoreException Thrown when persisting TaskInfo information fails
+     */
     void storeTasks(Collection<Protos.TaskInfo> tasks, String execName) throws StateStoreException;
+
+
+    /**
+     * Fetches the TaskInfo objects associated with a particular Executor
+     * @param execName The name of the Executor associated with some Tasks
+     * @return The TaskInfo objects associated with the indicated Executor
+     * @throws StateStoreException Thrown when fetching the TaskInfo information fails
+     */
     Collection<Protos.TaskInfo> fetchTasks(String execName) throws StateStoreException;
 
+
+    /**
+     * Fetches all the Executor names so far stored.
+     * @return All the Executor names so far stored
+     * @throws StateStoreException Thrown when fetching the Executor names fails
+     */
+    Collection<String> fetchExecutorNames() throws StateStoreException;
+
+    /**
+     * Stores the TaskStatus of a particular Task
+     * @param status The status to be stored
+     * @param taskName The name of the Task associated with the indicated status
+     * @param execName The name of the Executor which the Task is associated with
+     * @throws StateStoreException Thrown when storing the TaskStatus fails
+     */
     void storeStatus(Protos.TaskStatus status, String taskName, String execName) throws StateStoreException;
+
+    /**
+     * Fetches the TaskStatus of a particular Task.
+     * @param taskName The name of the Task which should have its status retrieved
+     * @param execName The name of the Executor associated with the indicated Task
+     * @return The TaskStatus associated with a particular Task
+     * @throws StateStoreException Thrown when fetch a TaskStatus fails
+     */
     Protos.TaskStatus fetchStatus(String taskName, String execName) throws StateStoreException;
 
+    /**
+     * Removes all data associated with a particular Executor including all stored TaskInfos
+     * and TaskStatuses
+     * @param execName The name of the Executor to be cleared
+     * @throws StateStoreException Thrown when clearing the indicated Executor's informations fails
+     */
     void clearExecutor(String execName) throws StateStoreException;
 }

--- a/src/test/java/org/apache/mesos/state/CuratorStateStoreTest.java
+++ b/src/test/java/org/apache/mesos/state/CuratorStateStoreTest.java
@@ -10,6 +10,7 @@ import org.junit.Assert;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Iterator;
 
 /**
  * Tests to validate the operation of the CuratorStateStore.
@@ -98,6 +99,28 @@ public class CuratorStateStoreTest {
     @Test
     public void testClearEmptyExecutor() throws Exception {
         store.clearExecutor(getTestExecutorName());
+    }
+
+    @Test
+    public void testFetchEmptyExecutors() throws Exception {
+        Collection<String> execNames = store.fetchExecutorNames();
+        Assert.assertEquals(0, execNames.size());
+    }
+
+    @Test
+    public void testFetchExecutors() throws Exception {
+        String testExecutorNamePrefix = "test-executor";
+        String testExecutorName0 = testExecutorNamePrefix + "-0";
+        String testExecutorName1 = testExecutorNamePrefix + "-1";
+
+        store.storeTasks(getTestTasks(), testExecutorName0);
+        store.storeTasks(getTestTasks(), testExecutorName1);
+        Collection<String> execNames = store.fetchExecutorNames();
+        Assert.assertEquals(2, execNames.size());
+
+        Iterator<String> iter =  execNames.iterator();
+        Assert.assertEquals(testExecutorName1, iter.next());
+        Assert.assertEquals(testExecutorName0, iter.next());
     }
 
     @Test


### PR DESCRIPTION
This allows the whole state store to be iterated over for retrieval of
all information