### PR TITLE
Fix mount volume update

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,7 +84,7 @@ ext {
 }
 
 group = "mesosphere"
-version = "0.4.6-SNAPSHOT"
+version = "0.4.7-SNAPSHOT"
 
 task sourceJar(type: Jar) {
   from sourceSets.main.allJava

--- a/src/main/java/org/apache/mesos/offer/MesosResourcePool.java
+++ b/src/main/java/org/apache/mesos/offer/MesosResourcePool.java
@@ -113,8 +113,17 @@ public class MesosResourcePool {
 
   private MesosResource consumeReserved(ResourceRequirement resReq) {
     MesosResource mesRes = reservedPool.get(resReq.getResourceId());
+
     if (mesRes != null) {
-      reservedPool.remove(resReq.getResourceId());
+      if (mesRes.isAtomic()) {
+        if (sufficientValue(resReq.getValue(), mesRes.getValue())) {
+          reservedPool.remove(resReq.getResourceId());
+        } else {
+          return null;
+        }
+      } else {
+        reservedPool.remove(resReq.getResourceId());
+      }
     }
 
     return mesRes;

--- a/src/main/java/org/apache/mesos/offer/OfferEvaluator.java
+++ b/src/main/java/org/apache/mesos/offer/OfferEvaluator.java
@@ -150,8 +150,10 @@ public class OfferEvaluator {
         if (resReq.expectsResource()) {
           logger.info("Expects Resource");
           // Compute any needed resource pool consumption / release operations
-          // as well as any additional needed Mesos Operations
-          if (expectedValueChanged(resReq, mesRes)) {
+          // as well as any additional needed Mesos Operations.  In the case
+          // where a requirement has changed for an Atomic resource, no Operations
+          // can be performed because the resource is Atomic.
+          if (expectedValueChanged(resReq, mesRes) && !mesRes.isAtomic()) {
             Value reserveValue = ValueUtils.subtract(resReq.getValue(), mesRes.getValue());
             Value unreserveValue = ValueUtils.subtract(mesRes.getValue(), resReq.getValue());
 

--- a/src/test/java/org/apache/mesos/offer/OfferEvaluatorTest.java
+++ b/src/test/java/org/apache/mesos/offer/OfferEvaluatorTest.java
@@ -103,6 +103,43 @@ public class OfferEvaluatorTest {
     Assert.assertEquals(persistenceId, launchResource.getDisk().getPersistence().getId());
     Assert.assertEquals(ResourceTestUtils.testMountRoot, launchResource.getDisk().getSource().getMount().getRoot());
     Assert.assertEquals(ResourceTestUtils.testPrincipal, launchResource.getDisk().getPersistence().getPrincipal());
+    Assert.assertEquals(2000, launchResource.getScalar().getValue(), 0.0);
+  }
+
+  @Test
+  public void testUpdateMountVolumeSuccess() throws Exception {
+    Resource updatedResource = ResourceTestUtils.getExpectedMountVolume(1500);
+    Resource offeredResource = ResourceTestUtils.getExpectedMountVolume(2000);
+
+    List<OfferRecommendation> recommendations = evaluator.evaluate(
+            getOfferRequirement(updatedResource), getOffers(offeredResource));
+    Assert.assertEquals(1, recommendations.size());
+
+    Operation launchOperation = recommendations.get(0).getOperation();
+    Resource launchResource =
+            launchOperation
+                    .getLaunch()
+                    .getTaskInfosList()
+                    .get(0)
+                    .getResourcesList()
+                    .get(0);
+
+    Assert.assertEquals(Operation.Type.LAUNCH, launchOperation.getType());
+    Assert.assertEquals(getFirstLabel(updatedResource).getValue(), getFirstLabel(launchResource).getValue());
+    Assert.assertEquals(updatedResource.getDisk().getPersistence().getId(), launchResource.getDisk().getPersistence().getId());
+    Assert.assertEquals(ResourceTestUtils.testMountRoot, launchResource.getDisk().getSource().getMount().getRoot());
+    Assert.assertEquals(ResourceTestUtils.testPrincipal, launchResource.getDisk().getPersistence().getPrincipal());
+    Assert.assertEquals(2000, launchResource.getScalar().getValue(), 0.0);
+  }
+
+  @Test
+  public void testUpdateMountVolumeFailure() throws Exception {
+    Resource updatedResource = ResourceTestUtils.getExpectedMountVolume(2500);
+    Resource offeredResource = ResourceTestUtils.getExpectedMountVolume(2000);
+
+    List<OfferRecommendation> recommendations = evaluator.evaluate(
+            getOfferRequirement(updatedResource), getOffers(offeredResource));
+    Assert.assertEquals(0, recommendations.size());
   }
 
   @Test


### PR DESCRIPTION
Updating a mount volume resource requirement cannot result in additional RESERVE or
UNRESERVE Operations.  However, it must be validated that the new
requirement is still met.