### PR TITLE
Nitpicks and one bug fix for CuratorStateStore

### DIFF
--- a/src/main/java/org/apache/mesos/state/CuratorStateStore.java
+++ b/src/main/java/org/apache/mesos/state/CuratorStateStore.java
@@ -13,39 +13,45 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * A CuratorStateStore stores TaskInfo and TaskStatus data in Zookeeper.
+ * CuratorStateStore is an implementation of {@link StateStore} which persists data in Zookeeper.
  *
  * The ZNode structure in Zookeeper is as follows:
- * rootPath
- *     -> ExecutorID-0
- *         -> TaskName-0
- *             -> TaskInfo
- *             -> TaskStatus
- *         -> TaskName-1
- *             -> TaskInfo
- *             -> TaskStatus
+ * <code>
+ * rootPath/
+ *     -> "FrameworkID"
+ *     -> ExecutorID-0/
+ *         -> TaskName-0/
+ *             -> "TaskInfo"
+ *             -> "TaskStatus"
+ *         -> TaskName-1/
+ *             -> "TaskInfo"
+ *             -> "TaskStatus"
  *         -> ...
- *    -> ExecutorID-1
- *         -> TaskName-0
- *             -> TaskInfo
- *             -> TaskStatus
- *         -> TaskName-1
- *             -> TaskInfo
- *             -> TaskStatus
+ *    -> ExecutorID-1/
+ *         -> TaskName-0/
+ *             -> "TaskInfo"
+ *             -> "TaskStatus"
+ *         -> TaskName-1/
+ *             -> "TaskInfo"
+ *             -> "TaskStatus"
  *         -> ...
  *    -> ...
+ * </code>
  */
-public class CuratorStateStore extends CuratorPersister implements StateStore {
+public class CuratorStateStore implements StateStore {
+
+    private static final Logger logger = LoggerFactory.getLogger(CuratorStateStore.class);
+
     private static final String TASK_INFO_PATH_NAME = "TaskInfo";
     private static final String TASK_STATUS_PATH_NAME = "TaskStatus";
     private static final String FWK_ID_PATH_NAME = "FrameworkID";
 
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private final CuratorPersister curator;
     private final String rootPath;
     private final String fwkIdPath;
 
     public CuratorStateStore(String rootPath, String connectionString, RetryPolicy retryPolicy) {
-        super(connectionString, retryPolicy);
+        this.curator = new CuratorPersister(connectionString, retryPolicy);
         this.rootPath = rootPath;
         this.fwkIdPath = rootPath + "/" + FWK_ID_PATH_NAME;
     }
@@ -53,24 +59,27 @@ public class CuratorStateStore extends CuratorPersister implements StateStore {
     @Override
     public void storeFrameworkId(Protos.FrameworkID fwkId) throws StateStoreException {
         try {
-            logger.info(String.format("Storing FrameworkID in '%s'", fwkIdPath));
-            store(fwkIdPath, fwkId.toByteArray());
+            logger.info("Storing FrameworkID in '{}'", fwkIdPath);
+            curator.store(fwkIdPath, fwkId.toByteArray());
         } catch (Exception e) {
-            throw new StateStoreException(e);
+            throw new StateStoreException(String.format(
+                    "Failed to store FrameworkID in '%s'", fwkIdPath), e);
         }
     }
 
     @Override
     public Protos.FrameworkID fetchFrameworkId() throws StateStoreException {
         try {
-            logger.info(String.format("Fetching FrameworkID from '%s'", fwkIdPath));
-            byte[] bytes = fetch(fwkIdPath);
+            logger.info("Fetching FrameworkID from '{}'", fwkIdPath);
+            byte[] bytes = curator.fetch(fwkIdPath);
             if (bytes.length > 0) {
                 return Protos.FrameworkID.parseFrom(bytes);
             } else {
-               throw new StateStoreException("Failed to retrieve FrameworkID");
+                throw new StateStoreException(String.format(
+                        "Failed to retrieve FrameworkID in '%s'", fwkIdPath));
             }
         } catch (Exception e) {
+            // Also throws if the FrameworkID isn't found
             throw new StateStoreException(e);
         }
     }
@@ -78,12 +87,11 @@ public class CuratorStateStore extends CuratorPersister implements StateStore {
     @Override
     public void clearFrameworkId() throws StateStoreException {
         try {
-            logger.info(String.format("Clearing FrameworkID at '%s'", fwkIdPath));
-            clear(fwkIdPath);
+            logger.info("Clearing FrameworkID at '{}'", fwkIdPath);
+            curator.clear(fwkIdPath);
         } catch (KeeperException.NoNodeException e) {
-            // Clearing a non-existent FrameworkID should not
-            // result in an exception.
-            logger.warn("Clearing unset FrameworkID");
+            // Clearing a non-existent FrameworkID should not result in an exception from us.
+            logger.warn("Cleared unset FrameworkID, continuing silently", e);
             return;
         } catch (Exception e) {
             throw new StateStoreException(e);
@@ -91,19 +99,21 @@ public class CuratorStateStore extends CuratorPersister implements StateStore {
     }
 
     @Override
-    public void storeTasks(Collection<Protos.TaskInfo> tasks, String execName) throws StateStoreException {
+    public void storeTasks(Collection<Protos.TaskInfo> tasks, String execName)
+            throws StateStoreException {
         for (Protos.TaskInfo taskInfo : tasks) {
             storeTask(taskInfo, execName);
         }
     }
 
     private void storeTask(Protos.TaskInfo taskInfo, String execName) {
+        String path = getTaskInfoPath(taskInfo, execName);
+        logger.info("Storing Taskinfo for {}/{} in '{}'", execName, taskInfo.getName(), path);
         try {
-            String path = getTaskInfoPath(taskInfo, execName);
-            logger.info(String.format("Storing Taskinfo for %s/%s in '%s'", execName, taskInfo.getName(), path));
-            store(path, taskInfo.toByteArray());
+            curator.store(path, taskInfo.toByteArray());
         } catch (Exception e) {
-            throw new StateStoreException(e);
+            throw new StateStoreException(String.format(
+                    "Failed to store TaskInfo in '%s'", path), e);
         }
     }
 
@@ -112,10 +122,11 @@ public class CuratorStateStore extends CuratorPersister implements StateStore {
         Collection<Protos.TaskInfo> taskInfos = new ArrayList<>();
 
         try {
-            for (String taskName : getChildren(getExecutorPath(execName))) {
+            for (String taskName : curator.getChildren(getExecutorPath(execName))) {
                 taskInfos.add(fetchTask(taskName, execName));
             }
         } catch (Exception e) {
+            // Requested executor not found, or other storage failure
             throw new StateStoreException(e);
         }
 
@@ -124,17 +135,26 @@ public class CuratorStateStore extends CuratorPersister implements StateStore {
 
     private Protos.TaskInfo fetchTask(String taskName, String execName) throws Exception {
         String path = getTaskInfoPath(taskName, execName);
-        logger.info(String.format("Fetching TaskInfo %s/%s from '%s'", execName, taskName, path));
-        byte[] bytes = fetch(path);
+        logger.info("Fetching TaskInfo {}/{} from '{}'", execName, taskName, path);
+        byte[] bytes = curator.fetch(path);
         return Protos.TaskInfo.parseFrom(bytes);
     }
 
     @Override
     public Collection<String> fetchExecutorNames() throws StateStoreException {
         try {
-            logger.info(String.format("Fetching Executors from '%s'", rootPath));
-            return getChildren(rootPath);
+            logger.info("Fetching Executors from '{}'", rootPath);
+            // Be careful to exclude the Framework ID node, which is also a child of the root:
+            Collection<String> executorNames = new ArrayList<>();
+            for (String childNode : curator.getChildren(rootPath)) {
+                if (!childNode.equals(FWK_ID_PATH_NAME)) {
+                    executorNames.add(childNode);
+                }
+            }
+            return executorNames;
         } catch (KeeperException.NoNodeException e) {
+            // Root path doesn't exist yet. Treat as an empty list of executors. This scenario is
+            // expected to commonly occur when the Framework is being run for the first time.
             return Collections.emptyList();
         } catch (Exception e) {
             throw new StateStoreException(e);
@@ -145,12 +165,11 @@ public class CuratorStateStore extends CuratorPersister implements StateStore {
     public void clearExecutor(String execName) throws StateStoreException {
         try {
             String path = getExecutorPath(execName);
-            logger.info(String.format("Clearing Executor at '%s'", path));
-            clear(path);
+            logger.info("Clearing Executor at '{}'", path);
+            curator.clear(path);
         } catch (KeeperException.NoNodeException e) {
-            // Clearing a non-existent ExecutorID should not
-            // result in an exception.
-            logger.warn("Clearing unset Executor: " + execName);
+            // Clearing a non-existent ExecutorID should not result in an exception from us.
+            logger.warn("Cleared unset Executor, continuing silently: {}", execName, e);
             return;
         } catch (Exception e) {
             throw new StateStoreException(e);
@@ -167,41 +186,39 @@ public class CuratorStateStore extends CuratorPersister implements StateStore {
         try {
             taskInfo = fetchTask(taskName, execName);
         } catch (Exception ex) {
-            throw new StateStoreException(
-                String.format("Failed to retrieve TaskInfo with execName/taskName: '%s/%s' for TaskStatus: '%s'",
-                        execName, taskName, status)
-                    , ex);
+            throw new StateStoreException(String.format(
+                    "Failed to retrieve TaskInfo with execName/taskName: '%s/%s' for TaskStatus: '%s'",
+                    execName, taskName, status), ex);
         }
 
         try {
             if (!taskInfo.getTaskId().equals(status.getTaskId())) {
-                throw new StateStoreException(
-                    String.format(
+                throw new StateStoreException(String.format(
                         "TaskInfo's TaskID '%s' does not match the TaskStatus's TaskID '%s'",
                         taskInfo.getTaskId(), status.getTaskId()));
             }
 
             String path = getTaskStatusPath(taskName, execName);
-            logger.info(String.format("Storing status for '%s/%s' in '%s'", execName, taskName, path));
-            store(path, status.toByteArray());
+            logger.info("Storing status for '{}/{}' in '{}'", execName, taskName, path);
+            curator.store(path, status.toByteArray());
         } catch (Exception e) {
             throw new StateStoreException(e);
         }
     }
 
     @Override
-    public Protos.TaskStatus fetchStatus(String taskName, String execName) throws StateStoreException {
+    public Protos.TaskStatus fetchStatus(String taskName, String execName)
+            throws StateStoreException {
         try {
             String path = getTaskStatusPath(taskName, execName);
-            logger.info(String.format("Fetching status for %s/%s in '%s'", execName, taskName, path));
-            byte[] bytes = fetch(path);
+            logger.info("Fetching status for {}/{} in '{}'", execName, taskName, path);
+            byte[] bytes = curator.fetch(path);
             if (bytes.length > 0) {
                 return Protos.TaskStatus.parseFrom(bytes);
             } else {
-                throw new StateStoreException(
-                        String.format(
-                                "Failed to retrieve TaskStatus for TaskName: %s and ExecutorID: %s",
-                                taskName, execName));
+                throw new StateStoreException(String.format(
+                        "Failed to retrieve TaskStatus for TaskName: %s and ExecutorID: %s",
+                        taskName, execName));
 
             }
         } catch (Exception e) {

--- a/src/main/java/org/apache/mesos/state/CuratorStateStore.java
+++ b/src/main/java/org/apache/mesos/state/CuratorStateStore.java
@@ -59,7 +59,7 @@ public class CuratorStateStore implements StateStore {
     @Override
     public void storeFrameworkId(Protos.FrameworkID fwkId) throws StateStoreException {
         try {
-            logger.info("Storing FrameworkID in '{}'", fwkIdPath);
+            logger.debug("Storing FrameworkID in '{}'", fwkIdPath);
             curator.store(fwkIdPath, fwkId.toByteArray());
         } catch (Exception e) {
             throw new StateStoreException(String.format(
@@ -70,7 +70,7 @@ public class CuratorStateStore implements StateStore {
     @Override
     public Protos.FrameworkID fetchFrameworkId() throws StateStoreException {
         try {
-            logger.info("Fetching FrameworkID from '{}'", fwkIdPath);
+            logger.debug("Fetching FrameworkID from '{}'", fwkIdPath);
             byte[] bytes = curator.fetch(fwkIdPath);
             if (bytes.length > 0) {
                 return Protos.FrameworkID.parseFrom(bytes);
@@ -87,7 +87,7 @@ public class CuratorStateStore implements StateStore {
     @Override
     public void clearFrameworkId() throws StateStoreException {
         try {
-            logger.info("Clearing FrameworkID at '{}'", fwkIdPath);
+            logger.debug("Clearing FrameworkID at '{}'", fwkIdPath);
             curator.clear(fwkIdPath);
         } catch (KeeperException.NoNodeException e) {
             // Clearing a non-existent FrameworkID should not result in an exception from us.
@@ -108,7 +108,7 @@ public class CuratorStateStore implements StateStore {
 
     private void storeTask(Protos.TaskInfo taskInfo, String execName) {
         String path = getTaskInfoPath(taskInfo, execName);
-        logger.info("Storing Taskinfo for {}/{} in '{}'", execName, taskInfo.getName(), path);
+        logger.debug("Storing Taskinfo for {}/{} in '{}'", execName, taskInfo.getName(), path);
         try {
             curator.store(path, taskInfo.toByteArray());
         } catch (Exception e) {
@@ -135,7 +135,7 @@ public class CuratorStateStore implements StateStore {
 
     private Protos.TaskInfo fetchTask(String taskName, String execName) throws Exception {
         String path = getTaskInfoPath(taskName, execName);
-        logger.info("Fetching TaskInfo {}/{} from '{}'", execName, taskName, path);
+        logger.debug("Fetching TaskInfo {}/{} from '{}'", execName, taskName, path);
         byte[] bytes = curator.fetch(path);
         return Protos.TaskInfo.parseFrom(bytes);
     }
@@ -143,7 +143,7 @@ public class CuratorStateStore implements StateStore {
     @Override
     public Collection<String> fetchExecutorNames() throws StateStoreException {
         try {
-            logger.info("Fetching Executors from '{}'", rootPath);
+            logger.debug("Fetching Executors from '{}'", rootPath);
             // Be careful to exclude the Framework ID node, which is also a child of the root:
             Collection<String> executorNames = new ArrayList<>();
             for (String childNode : curator.getChildren(rootPath)) {
@@ -165,7 +165,7 @@ public class CuratorStateStore implements StateStore {
     public void clearExecutor(String execName) throws StateStoreException {
         try {
             String path = getExecutorPath(execName);
-            logger.info("Clearing Executor at '{}'", path);
+            logger.debug("Clearing Executor at '{}'", path);
             curator.clear(path);
         } catch (KeeperException.NoNodeException e) {
             // Clearing a non-existent ExecutorID should not result in an exception from us.
@@ -199,7 +199,7 @@ public class CuratorStateStore implements StateStore {
             }
 
             String path = getTaskStatusPath(taskName, execName);
-            logger.info("Storing status for '{}/{}' in '{}'", execName, taskName, path);
+            logger.debug("Storing status for '{}/{}' in '{}'", execName, taskName, path);
             curator.store(path, status.toByteArray());
         } catch (Exception e) {
             throw new StateStoreException(e);
@@ -211,7 +211,7 @@ public class CuratorStateStore implements StateStore {
             throws StateStoreException {
         try {
             String path = getTaskStatusPath(taskName, execName);
-            logger.info("Fetching status for {}/{} in '{}'", execName, taskName, path);
+            logger.debug("Fetching status for {}/{} in '{}'", execName, taskName, path);
             byte[] bytes = curator.fetch(path);
             if (bytes.length > 0) {
                 return Protos.TaskStatus.parseFrom(bytes);


### PR DESCRIPTION
- Bug: Don't return the Framework ID as an executor name (test added)
- Nit: Have the underlying curator interface be a member rather than
  a superclass
- Nit: Cleanup to logging, use slf4j's built-in formatting
- Nit: Various tweaks/additions to comments