### PR TITLE
Improve StateStore interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ target/
 .idea/
 out/
 classes/
+*.log
 
 # eclipse
 .classpath

--- a/build.gradle
+++ b/build.gradle
@@ -84,7 +84,7 @@ ext {
 }
 
 group = "mesosphere"
-version = "0.4.7-SNAPSHOT"
+version = "0.4.8-SNAPSHOT"
 
 task sourceJar(type: Jar) {
   from sourceSets.main.allJava

--- a/src/main/java/org/apache/mesos/state/StateStore.java
+++ b/src/main/java/org/apache/mesos/state/StateStore.java
@@ -82,10 +82,9 @@ public interface StateStore {
      *
      * @param status The status to be stored
      * @param taskName The name of the Task associated with the indicated status
-     * @param execName The name of the Executor which the Task is associated with
      * @throws StateStoreException when storing the TaskStatus fails
      */
-    void storeStatus(Protos.TaskStatus status, String taskName, String execName) throws StateStoreException;
+    void storeStatus(Protos.TaskStatus status, String taskName) throws StateStoreException;
 
 
     /**

--- a/src/test/java/org/apache/mesos/state/CuratorStateStoreTest.java
+++ b/src/test/java/org/apache/mesos/state/CuratorStateStoreTest.java
@@ -143,7 +143,7 @@ public class CuratorStateStoreTest {
     @Test
     public void testStoreFetchStatus() throws Exception {
         store.storeTasks(getTestTasks(), getTestExecutorName());
-        store.storeStatus(getTestTaskStatus(), TASK_NAME, getTestExecutorName());
+        store.storeStatus(getTestTaskStatus(), TASK_NAME);
         assertEquals(getTestTaskStatus(), store.fetchStatus(TASK_NAME, getTestExecutorName()));
     }
 
@@ -155,8 +155,8 @@ public class CuratorStateStoreTest {
     @Test
     public void testRepeatedStoreStatus() throws Exception {
         store.storeTasks(getTestTasks(), getTestExecutorName());
-        store.storeStatus(getTestTaskStatus(), TASK_NAME, getTestExecutorName());
-        store.storeStatus(getTestTaskStatus(), TASK_NAME, getTestExecutorName());
+        store.storeStatus(getTestTaskStatus(), TASK_NAME);
+        store.storeStatus(getTestTaskStatus(), TASK_NAME);
     }
 
     @Test(expected=StateStoreException.class)
@@ -167,12 +167,12 @@ public class CuratorStateStoreTest {
                 .setState(getTestTaskState())
                 .build();
 
-        store.storeStatus(badTaskStatus, TASK_NAME, getTestExecutorName());
+        store.storeStatus(badTaskStatus, TASK_NAME);
     }
 
     @Test(expected=StateStoreException.class)
     public void testStoreStatusWithoutTaskInfo() throws Exception {
-        store.storeStatus(getTestTaskStatus(), TASK_NAME, getTestExecutorName());
+        store.storeStatus(getTestTaskStatus(), TASK_NAME);
     }
 
     @Test
@@ -182,7 +182,7 @@ public class CuratorStateStoreTest {
         assertEquals(1, outTasks.size());
         assertEquals(getTestTask(), outTasks.iterator().next());
 
-        store.storeStatus(getTestTaskStatus(), TASK_NAME, getTestExecutorName());
+        store.storeStatus(getTestTaskStatus(), TASK_NAME);
         assertEquals(getTestTaskStatus(), store.fetchStatus(TASK_NAME, getTestExecutorName()));
     }
 


### PR DESCRIPTION
    When a TaskStatus is reported by Mesos the Executor name is not readily
    available.  The requirement of providing the Executor name has been
    removed.