### PR TITLE
Require valid names/ids in data passed to OfferEvaluator/StateStore

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,7 +84,7 @@ ext {
 }
 
 group = "mesosphere"
-version = "0.4.10-SNAPSHOT"
+version = "0.4.11-SNAPSHOT"
 
 task sourceJar(type: Jar) {
   from sourceSets.main.allJava

--- a/src/main/java/org/apache/mesos/executor/ExecutorUtils.java
+++ b/src/main/java/org/apache/mesos/executor/ExecutorUtils.java
@@ -10,6 +10,27 @@ import java.util.UUID;
 public class ExecutorUtils {
     private static final String EXECUTOR_NAME_DELIM = "__";
 
+    private ExecutorUtils() {
+        // do not instantiate
+    }
+
+    /**
+     * Converts the unique {@link Protos.ExecutorID} into a Framework defined executor name.
+     *
+     * For example: "instance-0_aoeu5678" => "instance-0"
+     */
+    public static String toExecutorName(Protos.ExecutorID executorId) throws ExecutorTaskException {
+      int underScoreIndex = executorId.getValue().lastIndexOf(EXECUTOR_NAME_DELIM);
+
+      if (underScoreIndex == -1) {
+        throw new ExecutorTaskException(String.format(
+                "ExecutorID '%s' is malformed.  Expected '%s' to extract ExecutorName from ExecutorID.  "
+                + "ExecutorIDs should be generated with TaskUtils.toTaskId().", executorId, EXECUTOR_NAME_DELIM));
+      }
+
+      return executorId.getValue().substring(0, underScoreIndex);
+    }
+
     /**
      * Converts the Framework defined Executor name into a unique {@link Protos.ExecutorID}.
      *

--- a/src/main/java/org/apache/mesos/offer/ExecutorRequirement.java
+++ b/src/main/java/org/apache/mesos/offer/ExecutorRequirement.java
@@ -17,7 +17,11 @@ public class ExecutorRequirement {
 
     public ExecutorRequirement(ExecutorInfo unverifiedExecutorInfo)
             throws InvalidRequirementException {
-        this.executorInfo = validateExecutorInfo(unverifiedExecutorInfo);
+        validateExecutorInfo(unverifiedExecutorInfo);
+        // ExecutorID is always overwritten with a new UUID, even if already present:
+        this.executorInfo = ExecutorInfo.newBuilder(unverifiedExecutorInfo)
+                .setExecutorId(ExecutorUtils.toExecutorId(unverifiedExecutorInfo.getName()))
+                .build();
         this.resourceRequirements =
                 RequirementUtils.getResourceRequirements(this.executorInfo.getResourcesList());
     }
@@ -55,7 +59,7 @@ public class ExecutorRequirement {
      * @return a validated ExecutorInfo
      * @throws InvalidRequirementException if the ExecutorInfo is malformed
      */
-    private static ExecutorInfo validateExecutorInfo(ExecutorInfo executorInfo)
+    private static void validateExecutorInfo(ExecutorInfo executorInfo)
             throws InvalidRequirementException {
         if (!executorInfo.hasName() || StringUtils.isEmpty(executorInfo.getName())) {
             throw new InvalidRequirementException(String.format(
@@ -82,9 +86,5 @@ public class ExecutorRequirement {
                         + "ExecutorUtils.toExecutorId(): %s", executorInfo));
             }
         }
-        // ExecutorID is always overwritten with a new UUID, even if already present:
-        return ExecutorInfo.newBuilder(executorInfo)
-                .setExecutorId(ExecutorUtils.toExecutorId(executorInfo.getName()))
-                .build();
     }
 }

--- a/src/main/java/org/apache/mesos/offer/ExecutorRequirement.java
+++ b/src/main/java/org/apache/mesos/offer/ExecutorRequirement.java
@@ -2,56 +2,89 @@ package org.apache.mesos.offer;
 
 import java.util.Collection;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.mesos.Protos.ExecutorInfo;
-import org.apache.mesos.Protos.Resource;
+import org.apache.mesos.executor.ExecutorTaskException;
 import org.apache.mesos.executor.ExecutorUtils;
 
 /**
- * An ExecutorRequirement encapsulates the needed resources an Executor must have.
+ * An ExecutorRequirement encapsulates the needed resources an Executor must
+ * have.
  */
 public class ExecutorRequirement {
-  private ExecutorInfo executorInfo;
-  private Collection<Resource> resources;
-  private Collection<ResourceRequirement> resourceRequirements;
+    private ExecutorInfo executorInfo;
+    private Collection<ResourceRequirement> resourceRequirements;
 
-  public ExecutorRequirement(ExecutorInfo executorInfo) {
-    this.executorInfo = populateExecutorId(executorInfo);
-    this.resources = getExecutorResources(executorInfo);
-    this.resourceRequirements = RequirementUtils.getResourceRequirements(resources);
-  }
-
-  private ExecutorInfo populateExecutorId(ExecutorInfo executorInfo) {
-    return ExecutorInfo.newBuilder(executorInfo)
-      .setExecutorId(ExecutorUtils.toExecutorId(executorInfo.getName())).build();
-  }
-
-  public ExecutorInfo getExecutorInfo() {
-    return executorInfo;
-  }
-
-  public Collection<ResourceRequirement> getResourceRequirements() {
-    return resourceRequirements;
-  }
-
-  public Collection<String> getResourceIds() {
-    return RequirementUtils.getResourceIds(getResourceRequirements());
-  }
-
-  public Collection<String> getPersistenceIds() {
-    return RequirementUtils.getPersistenceIds(getResourceRequirements());
-  }
-
-  public boolean desiresResources() {
-    for (ResourceRequirement resReq : resourceRequirements) {
-      if (resReq.reservesResource()) {
-        return true;
-      }
+    public ExecutorRequirement(ExecutorInfo unverifiedExecutorInfo)
+            throws InvalidRequirementException {
+        this.executorInfo = validateExecutorInfo(unverifiedExecutorInfo);
+        this.resourceRequirements =
+                RequirementUtils.getResourceRequirements(this.executorInfo.getResourcesList());
     }
 
-    return false;
-  }
+    public ExecutorInfo getExecutorInfo() {
+        return executorInfo;
+    }
 
-  private Collection<Resource> getExecutorResources(ExecutorInfo executorInfo) {
-    return executorInfo.getResourcesList();
-  }
+    public Collection<ResourceRequirement> getResourceRequirements() {
+        return resourceRequirements;
+    }
+
+    public Collection<String> getResourceIds() {
+        return RequirementUtils.getResourceIds(getResourceRequirements());
+    }
+
+    public Collection<String> getPersistenceIds() {
+        return RequirementUtils.getPersistenceIds(getResourceRequirements());
+    }
+
+    public boolean desiresResources() {
+        for (ResourceRequirement resReq : resourceRequirements) {
+            if (resReq.reservesResource()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Checks that the ExecutorInfo is valid at the point of requirement construction, making it
+     * easier for the framework developer to trace problems in their implementation. These checks
+     * reflect requirements enforced elsewhere, eg in {@link StateStore}.
+     *
+     * @return a validated ExecutorInfo
+     * @throws InvalidRequirementException if the ExecutorInfo is malformed
+     */
+    private static ExecutorInfo validateExecutorInfo(ExecutorInfo executorInfo)
+            throws InvalidRequirementException {
+        if (!executorInfo.hasName() || StringUtils.isEmpty(executorInfo.getName())) {
+            throw new InvalidRequirementException(String.format(
+                    "ExecutorInfo must have a name: %s", executorInfo));
+        }
+        if (executorInfo.hasExecutorId()
+                && !StringUtils.isEmpty(executorInfo.getExecutorId().getValue())) {
+            // Executor ID may be included if this is replacing an existing task. In that case, we
+            // still perform a sanity check to ensure that the original Task ID was formatted
+            // correctly. We must allow Executor ID to be present but empty because it is a required
+            // proto field.
+            String executorName;
+            try {
+                executorName = ExecutorUtils.toExecutorName(executorInfo.getExecutorId());
+            } catch (ExecutorTaskException e) {
+                throw new InvalidRequirementException(String.format(
+                        "When non-empty, ExecutorInfo.id must be a valid ID. "
+                        + "Set to an empty string or leave existing valid value. %s %s",
+                        executorInfo, e));
+            }
+            if (!executorName.equals(executorInfo.getName())) {
+                throw new InvalidRequirementException(String.format(
+                        "When non-empty, ExecInfo.id must align with ExecInfo.name. Use "
+                        + "ExecutorUtils.toExecutorId(): %s", executorInfo));
+            }
+        }
+        // ExecutorID is always overwritten with a new UUID, even if already present:
+        return ExecutorInfo.newBuilder(executorInfo)
+                .setExecutorId(ExecutorUtils.toExecutorId(executorInfo.getName()))
+                .build();
+    }
 }

--- a/src/main/java/org/apache/mesos/offer/InvalidRequirementException.java
+++ b/src/main/java/org/apache/mesos/offer/InvalidRequirementException.java
@@ -1,0 +1,14 @@
+package org.apache.mesos.offer;
+
+/**
+ * An exception which describes an error in a provided set of Offer Requirements.
+ */
+public class InvalidRequirementException extends Exception {
+    public InvalidRequirementException(String msg) {
+        super(msg);
+    }
+
+    public InvalidRequirementException(String msg, Throwable cause) {
+        super(msg, cause);
+    }
+}

--- a/src/main/java/org/apache/mesos/offer/OfferRequirement.java
+++ b/src/main/java/org/apache/mesos/offer/OfferRequirement.java
@@ -4,8 +4,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 
-import org.apache.mesos.offer.TaskRequirement.InvalidTaskRequirementException;
-
 import org.apache.mesos.Protos.ExecutorInfo;
 import org.apache.mesos.Protos.SlaveID;
 import org.apache.mesos.Protos.TaskInfo;
@@ -30,10 +28,8 @@ public class OfferRequirement {
     ExecutorInfo execInfo,
     Collection<SlaveID> avoidAgents,
     Collection<SlaveID> colocateAgents)
-    throws InvalidTaskRequirementException {
-
+    throws InvalidRequirementException {
     this.taskRequirements = getTaskRequirementsInternal(taskInfos);
-
     if (execInfo != null) {
       this.executorRequirement = new ExecutorRequirement(execInfo);
     }
@@ -51,12 +47,12 @@ public class OfferRequirement {
     }
   }
 
-  public OfferRequirement(Collection<TaskInfo> taskInfos) throws InvalidTaskRequirementException {
+  public OfferRequirement(Collection<TaskInfo> taskInfos) throws InvalidRequirementException {
     this(taskInfos, null, Collections.emptyList(), Collections.emptyList());
   }
 
   public OfferRequirement(Collection<TaskInfo> taskInfos, ExecutorInfo execInfo)
-    throws InvalidTaskRequirementException {
+      throws InvalidRequirementException {
     this(taskInfos, execInfo, Collections.emptyList(), Collections.emptyList());
   }
 
@@ -104,15 +100,12 @@ public class OfferRequirement {
     return persistenceIds;
   }
 
-  private Collection<TaskRequirement> getTaskRequirementsInternal(Collection<TaskInfo> taskInfos)
-    throws InvalidTaskRequirementException {
-
+  private static Collection<TaskRequirement> getTaskRequirementsInternal(
+      Collection<TaskInfo> taskInfos) throws InvalidRequirementException {
     Collection<TaskRequirement> taskRequirements = new ArrayList<TaskRequirement>();
-
     for (TaskInfo taskInfo : taskInfos) {
       taskRequirements.add(new TaskRequirement(taskInfo));
     }
-
     return taskRequirements;
   }
 }

--- a/src/main/java/org/apache/mesos/offer/TaskRequirement.java
+++ b/src/main/java/org/apache/mesos/offer/TaskRequirement.java
@@ -1,62 +1,81 @@
 package org.apache.mesos.offer;
 
 import java.util.Collection;
-import org.apache.mesos.Protos.Resource;
+
+import org.apache.commons.lang3.StringUtils;
 import org.apache.mesos.Protos.TaskInfo;
 
 /**
  * A TaskRequirement encapsulates the needed resources a Task must have.
  */
 public class TaskRequirement {
-  private TaskInfo taskInfo;
-  private Collection<Resource> resources;
-  private Collection<ResourceRequirement> resourceRequirements;
+    private final TaskInfo taskInfo;
+    private final Collection<ResourceRequirement> resourceRequirements;
 
-  public TaskRequirement(TaskInfo taskInfo) throws InvalidTaskRequirementException {
-    validateTaskInfo(taskInfo);
-    taskInfo = TaskInfo.newBuilder(taskInfo)
-      .setTaskId(TaskUtils.toTaskId(taskInfo.getName())).build();
-
-    this.taskInfo = taskInfo;
-    this.resources = getTaskResources(taskInfo);
-    this.resourceRequirements = RequirementUtils.getResourceRequirements(resources);
-  }
-
-  private void validateTaskInfo(TaskInfo taskInfo) throws InvalidTaskRequirementException {
-    if (taskInfo.hasExecutor()) {
-      throw new InvalidTaskRequirementException(
-          "TaskInfo must not contain ExecutorInfo. "
-        + "Use ExecutorRequirement to encapsulate Executor requirements.");
+    public TaskRequirement(TaskInfo unverifiedTaskInfo) throws InvalidRequirementException {
+        this.taskInfo = validateTaskInfo(unverifiedTaskInfo);
+        this.resourceRequirements =
+                RequirementUtils.getResourceRequirements(this.taskInfo.getResourcesList());
     }
-  }
 
-  public TaskInfo getTaskInfo() {
-    return taskInfo;
-  }
-
-  public Collection<ResourceRequirement> getResourceRequirements() {
-    return resourceRequirements;
-  }
-
-  public Collection<String> getResourceIds() {
-    return RequirementUtils.getResourceIds(getResourceRequirements());
-  }
-
-  public Collection<String> getPersistenceIds() {
-    return RequirementUtils.getPersistenceIds(getResourceRequirements());
-  }
-
-  private Collection<Resource> getTaskResources(TaskInfo taskInfo) {
-    return taskInfo.getResourcesList();
-  }
-
- /**
-  * An InvalidTaskRequirement exception is thrown when an attempt is made to intialize a
-  * TaskRequirement with invalid arguments.
-  */
-  public static class InvalidTaskRequirementException extends Exception {
-    public InvalidTaskRequirementException(String msg) {
-      super(msg);
+    public TaskInfo getTaskInfo() {
+        return taskInfo;
     }
-  }
+
+    public Collection<ResourceRequirement> getResourceRequirements() {
+        return resourceRequirements;
+    }
+
+    public Collection<String> getResourceIds() {
+        return RequirementUtils.getResourceIds(getResourceRequirements());
+    }
+
+    public Collection<String> getPersistenceIds() {
+        return RequirementUtils.getPersistenceIds(getResourceRequirements());
+    }
+
+    /**
+     * Checks that the TaskInfo is valid at the point of requirement construction, making it
+     * easier for the framework developer to trace problems in their implementation. These checks
+     * reflect requirements enforced elsewhere, eg in {@link StateStore}.
+     *
+     * @return a validated TaskInfo
+     * @throws InvalidRequirementException if the TaskInfo is malformed
+     */
+    private static TaskInfo validateTaskInfo(TaskInfo taskInfo)
+            throws InvalidRequirementException {
+        if (!taskInfo.hasName() || StringUtils.isEmpty(taskInfo.getName())) {
+            throw new InvalidRequirementException(String.format(
+                    "TaskInfo must have a name: %s", taskInfo));
+        }
+        if (taskInfo.hasTaskId()
+                && !StringUtils.isEmpty(taskInfo.getTaskId().getValue())) {
+            // Task ID may be included if this is replacing an existing task. In that case, we still
+            // perform a sanity check to ensure that the original Task ID was formatted correctly.
+            // We must allow Task ID to be present but empty because it is a required proto field.
+            String taskName;
+            try {
+                taskName = TaskUtils.toTaskName(taskInfo.getTaskId());
+            } catch (TaskException e) {
+                throw new InvalidRequirementException(String.format(
+                        "When non-empty, TaskInfo.id must be a valid ID. "
+                        + "Set to an empty string or leave existing valid value. %s %s",
+                        taskInfo, e));
+            }
+            if (!taskName.equals(taskInfo.getName())) {
+                throw new InvalidRequirementException(String.format(
+                        "When non-empty, TaskInfo.id must align with TaskInfo.name. Use "
+                        + "TaskUtils.toTaskId(): %s", taskInfo));
+            }
+        }
+        if (taskInfo.hasExecutor()) {
+            throw new InvalidRequirementException(String.format(
+                    "TaskInfo must not contain ExecutorInfo. "
+                    + "Use ExecutorRequirement for any Executor requirements: %s", taskInfo));
+        }
+        // TaskID is always overwritten with a new UUID, even if already present:
+        return TaskInfo.newBuilder(taskInfo)
+                .setTaskId(TaskUtils.toTaskId(taskInfo.getName()))
+                .build();
+    }
 }

--- a/src/main/java/org/apache/mesos/offer/TaskRequirement.java
+++ b/src/main/java/org/apache/mesos/offer/TaskRequirement.java
@@ -13,7 +13,11 @@ public class TaskRequirement {
     private final Collection<ResourceRequirement> resourceRequirements;
 
     public TaskRequirement(TaskInfo unverifiedTaskInfo) throws InvalidRequirementException {
-        this.taskInfo = validateTaskInfo(unverifiedTaskInfo);
+        validateTaskInfo(unverifiedTaskInfo);
+        // TaskID is always overwritten with a new UUID, even if already present:
+        this.taskInfo = TaskInfo.newBuilder(unverifiedTaskInfo)
+                .setTaskId(TaskUtils.toTaskId(unverifiedTaskInfo.getName()))
+                .build();
         this.resourceRequirements =
                 RequirementUtils.getResourceRequirements(this.taskInfo.getResourcesList());
     }
@@ -42,7 +46,7 @@ public class TaskRequirement {
      * @return a validated TaskInfo
      * @throws InvalidRequirementException if the TaskInfo is malformed
      */
-    private static TaskInfo validateTaskInfo(TaskInfo taskInfo)
+    private static void validateTaskInfo(TaskInfo taskInfo)
             throws InvalidRequirementException {
         if (!taskInfo.hasName() || StringUtils.isEmpty(taskInfo.getName())) {
             throw new InvalidRequirementException(String.format(
@@ -73,9 +77,5 @@ public class TaskRequirement {
                     "TaskInfo must not contain ExecutorInfo. "
                     + "Use ExecutorRequirement for any Executor requirements: %s", taskInfo));
         }
-        // TaskID is always overwritten with a new UUID, even if already present:
-        return TaskInfo.newBuilder(taskInfo)
-                .setTaskId(TaskUtils.toTaskId(taskInfo.getName()))
-                .build();
     }
 }

--- a/src/main/java/org/apache/mesos/offer/TaskUtils.java
+++ b/src/main/java/org/apache/mesos/offer/TaskUtils.java
@@ -19,6 +19,10 @@ public class TaskUtils {
   private static final String TARGET_CONFIGURATION_KEY = "target_configuration";
   private static final String TASK_NAME_DELIM = "__";
 
+  private TaskUtils() {
+      // do not instantiate
+  }
+
   /**
    * Converts the unique {@link TaskID} into a Framework defined task name.
    *
@@ -28,10 +32,9 @@ public class TaskUtils {
     int underScoreIndex = taskId.getValue().lastIndexOf(TASK_NAME_DELIM);
 
     if (underScoreIndex == -1) {
-      throw new TaskException(
-              String.format(
-                      "TaskID '%s' is malformed.  Expected '%s' to extract TaskName from TaskID",
-                      taskId, TASK_NAME_DELIM));
+      throw new TaskException(String.format(
+              "TaskID '%s' is malformed.  Expected '%s' to extract TaskName from TaskID.  "
+              + "TaskIDs should be generated with TaskUtils.toTaskId().", taskId, TASK_NAME_DELIM));
     }
 
     return taskId.getValue().substring(0, underScoreIndex);

--- a/src/main/java/org/apache/mesos/protobuf/ExecutorInfoBuilder.java
+++ b/src/main/java/org/apache/mesos/protobuf/ExecutorInfoBuilder.java
@@ -17,14 +17,10 @@ public class ExecutorInfoBuilder {
 
   private Protos.ExecutorInfo.Builder builder = Protos.ExecutorInfo.newBuilder();
 
-  public ExecutorInfoBuilder(String executorId, Protos.CommandInfo cmdInfo) {
-    setExecutorId(executorId);
-    builder.setCommand(cmdInfo);
-  }
-
   public ExecutorInfoBuilder(String executorId, String name, Protos.CommandInfo cmdInfo) {
-    this(executorId, cmdInfo);
+    setExecutorId(executorId);
     setName(name);
+    builder.setCommand(cmdInfo);
   }
 
   public ExecutorInfoBuilder setExecutorId(String executorId) {

--- a/src/main/java/org/apache/mesos/scheduler/plan/api/BlockInfo.java
+++ b/src/main/java/org/apache/mesos/scheduler/plan/api/BlockInfo.java
@@ -4,12 +4,11 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import org.apache.mesos.scheduler.plan.Block;
 import org.apache.mesos.scheduler.plan.StageManager;
 import org.apache.mesos.scheduler.plan.Status;
-
-import java.util.Objects;
 
 /**
  * Immutable JSON serialization object for a Block.
@@ -87,8 +86,7 @@ class BlockInfo {
 
     @Override
     public int hashCode() {
-        return Objects.hash(getId(), getStatus(), getName(), getMessage(),
-                getHasDecisionPoint());
+        return HashCodeBuilder.reflectionHashCode(this);
     }
 
     @Override

--- a/src/main/java/org/apache/mesos/state/StateStore.java
+++ b/src/main/java/org/apache/mesos/state/StateStore.java
@@ -47,44 +47,81 @@ public interface StateStore {
 
 
     /**
-     * Stores TasksInfo objects representing tasks in the sub-path of the Executor
-     * which launched or will launch the Task.
+     * Stores TaskInfo objects representing tasks in the sub-path of the Executor
+     * which launched or will launch the Task. Each TaskInfo must include the following information:
      *
-     * @param tasks Tasks to be associated persistently with a particular Executor
-     * @param execName The name of the Executor hosting the tasks.
+     * <ul>
+     * <li>TaskInfo.name (required by proto)</li>
+     * <li>TaskInfo.executor.name, or TaskInfo.command should be set to indicate a command executor,
+     * in which case TaskInfo.name is used as the executor name</li>
+     * </ul>
+     *
+     * @param tasks Tasks to be stored, which each meet the above requirements
      * @throws StateStoreException when persisting TaskInfo information fails
      */
-    void storeTasks(Collection<Protos.TaskInfo> tasks, String execName) throws StateStoreException;
+    void storeTasks(Collection<Protos.TaskInfo> tasks) throws StateStoreException;
 
 
     /**
-     * Fetches the TaskInfo objects associated with a particular Executor.
+     * Fetches all TaskInfos associated with a particular Executor Name. In the case of command
+     * executors, this returns at most one TaskInfo for the provided task name.
      *
      * @param execName The name of the Executor associated with some Tasks
      * @return The TaskInfo objects associated with the indicated Executor
-     * @throws StateStoreException if no data was found for the requested Executor, or when fetching
+     * @see #fetchExecutorNames() for a list of all executor names
+     * @throws StateStoreException if no data was found for the requested Executor, or if fetching
      *                             the TaskInfo information otherwise fails
      */
     Collection<Protos.TaskInfo> fetchTasks(String execName) throws StateStoreException;
 
 
     /**
-     * Fetches all the Executor names so far stored.
+     * Fetches the TaskInfo of a particular Task.
      *
-     * @return All the Executor names so far stored, or an empty list if none are found
+     * @param taskName The name of the Task
+     * @param execName The name of the Executor associated with the Task. If a command executor is
+     *                 being used, this should be equal to taskName
+     * @return The corresponding TaskInfo object
+     * @throws StateStoreException if no data was found for the requested Task, or if fetching the
+     *                             TaskInfo information otherwise fails
+     */
+    Protos.TaskInfo fetchTask(String taskName, String execName) throws StateStoreException;
+
+
+    /**
+     * Fetches all the Executor names stored so far. In the case of command executors, this returns
+     * the names of the tasks.
+     *
+     * @return All the Executor names stored so far, or an empty list if none are found
      * @throws StateStoreException when fetching the data fails
      */
     Collection<String> fetchExecutorNames() throws StateStoreException;
 
 
     /**
-     * Stores the TaskStatus of a particular Task.
+     * Stores the TaskStatus of a particular Task. It must include the following information:
      *
-     * @param status The status to be stored
-     * @param taskName The name of the Task associated with the indicated status
+     * <ul>
+     * <li>TaskStatus.task_id (required by proto)</li>
+     * <li>TaskStatus.executor_id, or TaskStatus.command should be set to indicate a command
+     * executor, in which case the executor name is extracted from TaskInfo.task_id</li>
+     * </ul>
+     *
+     * @param status The status to be stored, which meets the above requirements
      * @throws StateStoreException when storing the TaskStatus fails
      */
-    void storeStatus(Protos.TaskStatus status, String taskName) throws StateStoreException;
+    void storeStatus(Protos.TaskStatus status) throws StateStoreException;
+
+
+    /**
+     * Fetches the TaskStatuses of all Tasks associated with a particular Executor.
+     *
+     * @param execName The name of the Executor associated with some Tasks
+     * @return The TaskStatus objects associated with all tasks for the indicated Executor
+     * @throws StateStoreException if no data was found for the requested Executor, or if fetching
+     *                             the TaskStatus information otherwise fails
+     */
+    Collection<Protos.TaskStatus> fetchStatuses(String execName) throws StateStoreException;
 
 
     /**
@@ -93,7 +130,7 @@ public interface StateStore {
      * @param taskName The name of the Task which should have its status retrieved
      * @param execName The name of the Executor associated with the indicated Task
      * @return The TaskStatus associated with a particular Task
-     * @throws StateStoreException if no data was found for the requested Task, or when fetching the
+     * @throws StateStoreException if no data was found for the requested Task, or if fetching the
      *                             TaskStatus information otherwise fails
      */
     Protos.TaskStatus fetchStatus(String taskName, String execName) throws StateStoreException;

--- a/src/test/java/org/apache/mesos/executor/ProcessTaskTest.java
+++ b/src/test/java/org/apache/mesos/executor/ProcessTaskTest.java
@@ -2,29 +2,33 @@ package org.apache.mesos.executor;
 
 import org.apache.mesos.ExecutorDriver;
 import org.apache.mesos.Protos;
+import org.apache.mesos.Protos.SlaveID;
+import org.apache.mesos.offer.TaskUtils;
 import org.apache.mesos.protobuf.EnvironmentBuilder;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 public class ProcessTaskTest {
+    private static final String EXECUTOR_NAME = "TEST_EXECUTOR";
+    private static final String TASK_NAME = "TEST_TASK";
+
     @Test
     public void testSimple() throws Exception {
         final ExecutorDriver mockExecutorDriver = Mockito.mock(ExecutorDriver.class);
         final Protos.ExecutorInfo executorInfo = Protos.ExecutorInfo
                 .newBuilder()
-                .setName("TEST_EXECUTOR")
-                .setExecutorId(Protos.ExecutorID.newBuilder().setValue(UUID.randomUUID().toString()))
+                .setName(EXECUTOR_NAME)
+                .setExecutorId(ExecutorUtils.toExecutorId(EXECUTOR_NAME))
                 .setCommand(Protos.CommandInfo.newBuilder().setValue("ls")).build();
         final Protos.TaskInfo taskInfo = Protos.TaskInfo
                 .newBuilder()
-                .setName("TEST")
-                .setTaskId(Protos.TaskID.newBuilder().setValue(UUID.randomUUID().toString()))
-                .setSlaveId(Protos.SlaveID.newBuilder().setValue(UUID.randomUUID().toString()))
+                .setName(TASK_NAME)
+                .setTaskId(TaskUtils.toTaskId(TASK_NAME))
+                .setSlaveId(SlaveID.newBuilder().setValue("ignored"))
                 .setExecutor(executorInfo)
                 .setData(Protos.CommandInfo
                         .newBuilder()
@@ -73,14 +77,14 @@ public class ProcessTaskTest {
 
         final Protos.ExecutorInfo executorInfo = Protos.ExecutorInfo
                 .newBuilder()
-                .setName("TEST_EXECUTOR")
-                .setExecutorId(Protos.ExecutorID.newBuilder().setValue(UUID.randomUUID().toString()))
+                .setName(EXECUTOR_NAME)
+                .setExecutorId(ExecutorUtils.toExecutorId(EXECUTOR_NAME))
                 .setCommand(Protos.CommandInfo.newBuilder().setValue("ls")).build();
         final Protos.TaskInfo taskInfo = Protos.TaskInfo
                 .newBuilder()
-                .setName("TEST")
-                .setTaskId(Protos.TaskID.newBuilder().setValue(UUID.randomUUID().toString()))
-                .setSlaveId(Protos.SlaveID.newBuilder().setValue(UUID.randomUUID().toString()))
+                .setName(TASK_NAME)
+                .setTaskId(TaskUtils.toTaskId(TASK_NAME))
+                .setSlaveId(SlaveID.newBuilder().setValue("ignored"))
                 .setExecutor(executorInfo)
                 .setData(Protos.CommandInfo
                         .newBuilder()

--- a/src/test/java/org/apache/mesos/offer/ExecutorRequirementTest.java
+++ b/src/test/java/org/apache/mesos/offer/ExecutorRequirementTest.java
@@ -1,0 +1,61 @@
+package org.apache.mesos.offer;
+
+import static org.junit.Assert.*;
+
+import org.apache.mesos.Protos.CommandInfo;
+import org.apache.mesos.Protos.ExecutorID;
+import org.apache.mesos.Protos.ExecutorInfo;
+import org.apache.mesos.protobuf.ResourceBuilder;
+import org.junit.Test;
+
+public class ExecutorRequirementTest {
+
+    private static final ExecutorInfo VALID_EXECINFO = ExecutorInfo.newBuilder()
+            .setExecutorId(ExecutorID.newBuilder().setValue(ResourceTestUtils.testExecutorId))
+            .setName(ResourceTestUtils.testExecutorName)
+            .setCommand(CommandInfo.newBuilder().build()) // ignored, required by proto
+            .build();
+
+    @Test
+    public void testExecutorIdChanges() throws Exception {
+        assertNotEquals(ResourceTestUtils.testExecutorId,
+                new ExecutorRequirement(VALID_EXECINFO).getExecutorInfo().getExecutorId().getValue());
+    }
+
+    @Test
+    public void testZeroResourcesValid() throws Exception {
+        assertEquals(0, new ExecutorRequirement(VALID_EXECINFO).getResourceIds().size());
+    }
+
+    @Test
+    public void testTwoResourcesValid() throws Exception {
+        assertEquals(2, new ExecutorRequirement(VALID_EXECINFO.toBuilder()
+                .addResources(ResourceBuilder.cpus(1.0))
+                .addResources(ResourceBuilder.disk(1234.))
+                .build()).getResourceRequirements().size());
+    }
+
+    @Test
+    public void testEmptyExecIdValid() throws Exception {
+        new ExecutorRequirement(VALID_EXECINFO.toBuilder()
+                .setExecutorId(ExecutorID.newBuilder().setValue(""))
+                .build());
+    }
+
+    @Test(expected = InvalidRequirementException.class)
+    public void testBadExecIdFails() throws Exception {
+        new ExecutorRequirement(VALID_EXECINFO.toBuilder()
+                .setExecutorId(ExecutorID.newBuilder().setValue("foo"))
+                .build());
+    }
+
+    @Test(expected = InvalidRequirementException.class)
+    public void testMismatchNameFails() throws Exception {
+        new ExecutorRequirement(VALID_EXECINFO.toBuilder().setName("asdf").build());
+    }
+
+    @Test(expected = InvalidRequirementException.class)
+    public void testEmptyNameFails() throws Exception {
+        new ExecutorRequirement(VALID_EXECINFO.toBuilder().setName("").build());
+    }
+}

--- a/src/test/java/org/apache/mesos/offer/OfferEvaluatorTest.java
+++ b/src/test/java/org/apache/mesos/offer/OfferEvaluatorTest.java
@@ -3,7 +3,6 @@ package org.apache.mesos.offer;
 import java.util.*;
 
 import org.apache.mesos.Protos;
-import org.apache.mesos.offer.TaskRequirement.InvalidTaskRequirementException;
 import org.apache.mesos.protobuf.ExecutorInfoBuilder;
 import org.apache.mesos.protobuf.OfferBuilder;
 import org.apache.mesos.protobuf.ResourceBuilder;
@@ -25,7 +24,7 @@ public class OfferEvaluatorTest {
   private static final OfferEvaluator evaluator = new OfferEvaluator();
 
   @Test
-  public void testReserveTaskExecutorInsufficient() throws InvalidTaskRequirementException {
+  public void testReserveTaskExecutorInsufficient() throws InvalidRequirementException {
     Resource desiredTaskCpu = ResourceUtils.getDesiredScalar(
             ResourceTestUtils.testRole, ResourceTestUtils.testPrincipal, "cpus", 1.0);
     Resource desiredExecutorCpu = desiredTaskCpu;
@@ -44,7 +43,7 @@ public class OfferEvaluatorTest {
   }
 
   @Test
-  public void testReserveCreateLaunchMountVolume() throws InvalidTaskRequirementException {
+  public void testReserveCreateLaunchMountVolume() throws InvalidRequirementException {
     Resource desiredResource = ResourceUtils.getDesiredMountVolume(
         ResourceTestUtils.testRole,
         ResourceTestUtils.testPrincipal,
@@ -143,7 +142,7 @@ public class OfferEvaluatorTest {
   }
 
   @Test
-  public void testFailToCreateVolumeWithWrongResource() throws InvalidTaskRequirementException {
+  public void testFailToCreateVolumeWithWrongResource() throws InvalidRequirementException {
     Resource desiredResource = ResourceUtils.getDesiredRootVolume(
         ResourceTestUtils.testRole,
         ResourceTestUtils.testPrincipal,
@@ -157,7 +156,7 @@ public class OfferEvaluatorTest {
   }
 
   @Test
-  public void testReserveCreateLaunchRootVolume() throws InvalidTaskRequirementException {
+  public void testReserveCreateLaunchRootVolume() throws InvalidRequirementException {
     Resource desiredResource = ResourceUtils.getDesiredRootVolume(
         ResourceTestUtils.testRole,
         ResourceTestUtils.testPrincipal,
@@ -216,7 +215,7 @@ public class OfferEvaluatorTest {
   }
 
   @Test
-  public void testFailCreateRootVolume() throws InvalidTaskRequirementException {
+  public void testFailCreateRootVolume() throws InvalidRequirementException {
     Resource desiredResource = ResourceUtils.getDesiredRootVolume(
         ResourceTestUtils.testRole,
         ResourceTestUtils.testPrincipal,
@@ -230,7 +229,7 @@ public class OfferEvaluatorTest {
   }
 
   @Test
-  public void testExpectedMountVolume() throws InvalidTaskRequirementException {
+  public void testExpectedMountVolume() throws InvalidRequirementException {
     Resource expectedResource = ResourceTestUtils.getExpectedMountVolume(1000);
 
     List<OfferRecommendation> recommendations = evaluator.evaluate(
@@ -258,7 +257,7 @@ public class OfferEvaluatorTest {
   }
 
   @Test
-  public void testExpectedRootVolume() throws InvalidTaskRequirementException {
+  public void testExpectedRootVolume() throws InvalidRequirementException {
     Resource expectedResource = ResourceTestUtils.getExpectedRootVolume(1000);
 
     List<OfferRecommendation> recommendations = evaluator.evaluate(
@@ -285,7 +284,7 @@ public class OfferEvaluatorTest {
   }
 
   @Test
-  public void testReserveLaunchScalar() throws InvalidTaskRequirementException {
+  public void testReserveLaunchScalar() throws InvalidRequirementException {
     Resource desiredResource = ResourceUtils.getDesiredScalar(
         ResourceTestUtils.testRole,
         ResourceTestUtils.testPrincipal,
@@ -328,7 +327,7 @@ public class OfferEvaluatorTest {
   }
 
   @Test
-  public void testCustomExecutorReserveLaunchScalar() throws InvalidTaskRequirementException {
+  public void testCustomExecutorReserveLaunchScalar() throws InvalidRequirementException {
     Resource desiredTaskResource = ResourceUtils.getDesiredScalar(
         ResourceTestUtils.testRole,
         ResourceTestUtils.testPrincipal,
@@ -404,7 +403,7 @@ public class OfferEvaluatorTest {
   }
 
   @Test
-  public void testReuseCustomExecutorReserveLaunchScalar() throws InvalidTaskRequirementException {
+  public void testReuseCustomExecutorReserveLaunchScalar() throws InvalidRequirementException {
     Resource desiredTaskResource = ResourceUtils.getDesiredScalar(
             ResourceTestUtils.testRole,
             ResourceTestUtils.testPrincipal,
@@ -455,7 +454,7 @@ public class OfferEvaluatorTest {
   }
 
   @Test
-  public void testLaunchExpectedScalar() throws InvalidTaskRequirementException {
+  public void testLaunchExpectedScalar() throws InvalidRequirementException {
     Resource desiredResource = ResourceTestUtils.getExpectedScalar(
         "cpus",
         1.0);
@@ -479,7 +478,7 @@ public class OfferEvaluatorTest {
   }
 
   @Test
-  public void testReserveLaunchExpectedScalar() throws InvalidTaskRequirementException {
+  public void testReserveLaunchExpectedScalar() throws InvalidRequirementException {
     Resource desiredResource = ResourceTestUtils.getExpectedScalar("cpus", 2.0);
     Resource offeredResource = ResourceTestUtils.getExpectedScalar("cpus", 1.0);
     Resource unreservedResource = ResourceBuilder.cpus(1.0);
@@ -519,7 +518,7 @@ public class OfferEvaluatorTest {
   }
 
   @Test
-  public void testFailReserveLaunchExpectedScalar() throws InvalidTaskRequirementException {
+  public void testFailReserveLaunchExpectedScalar() throws InvalidRequirementException {
     Resource desiredResource = ResourceTestUtils.getExpectedScalar("cpus", 2.0);
     Resource offeredResource = ResourceTestUtils.getExpectedScalar("cpus", 1.0);
 
@@ -529,7 +528,7 @@ public class OfferEvaluatorTest {
   }
 
   @Test
-  public void testUnreserveLaunchExpectedScalar() throws InvalidTaskRequirementException {
+  public void testUnreserveLaunchExpectedScalar() throws InvalidRequirementException {
     Resource desiredResource = ResourceTestUtils.getExpectedScalar("cpus", 1.0);
     Resource offeredResource = ResourceTestUtils.getExpectedScalar("cpus", 2.0);
 
@@ -631,12 +630,13 @@ public class OfferEvaluatorTest {
   }
 
   private static OfferRequirement getOfferRequirement(Resource resource)
-          throws InvalidTaskRequirementException {
+          throws InvalidRequirementException {
     return getOfferRequirement(resource, Collections.emptyList(), Collections.emptyList());
   }
 
-  private static OfferRequirement getOfferRequirement(Resource resource, List<String> avoidAgents, List<String> collocateAgents)
-    throws InvalidTaskRequirementException {
+  private static OfferRequirement getOfferRequirement(
+          Resource resource, List<String> avoidAgents, List<String> collocateAgents)
+                  throws InvalidRequirementException {
     return new OfferRequirement(
             Arrays.asList(getTaskInfo(resource)),
             null,
@@ -662,7 +662,8 @@ public class OfferEvaluatorTest {
 
   private static ExecutorInfo getExecutorInfo(Resource resource) {
     CommandInfo cmd = CommandInfo.newBuilder().build();
-    ExecutorInfoBuilder builder = new ExecutorInfoBuilder(ResourceTestUtils.testExecutorId, cmd);
+    ExecutorInfoBuilder builder = new ExecutorInfoBuilder(
+        ResourceTestUtils.testExecutorId, ResourceTestUtils.testExecutorName, cmd);
     return builder.addResource(resource).build();
   }
 }

--- a/src/test/java/org/apache/mesos/offer/OfferRequirementTest.java
+++ b/src/test/java/org/apache/mesos/offer/OfferRequirementTest.java
@@ -8,7 +8,6 @@ import org.apache.mesos.Protos.ExecutorInfo;
 import org.apache.mesos.Protos.Resource;
 import org.apache.mesos.Protos.TaskInfo;
 
-import org.apache.mesos.offer.TaskRequirement.InvalidTaskRequirementException;
 import org.apache.mesos.protobuf.ExecutorInfoBuilder;
 import org.apache.mesos.protobuf.ResourceBuilder;
 import org.apache.mesos.protobuf.TaskInfoBuilder;
@@ -19,21 +18,21 @@ import org.junit.Test;
 public class OfferRequirementTest {
 
   @Test
-  public void testConstructor() throws InvalidTaskRequirementException {
+  public void testConstructor() throws InvalidRequirementException {
     Resource resource = ResourceBuilder.cpus(1.0);
     OfferRequirement offerRequirement = getOfferRequirement(resource);
     Assert.assertNotNull(offerRequirement);
   }
 
   @Test
-  public void testNoIds() throws InvalidTaskRequirementException {
+  public void testNoIds() throws InvalidRequirementException {
     Resource resource = ResourceBuilder.cpus(1.0);
     OfferRequirement offerRequirement = getOfferRequirement(resource);
     Assert.assertEquals(0, offerRequirement.getResourceIds().size());
   }
 
   @Test
-  public void testOneResourceId() throws InvalidTaskRequirementException {
+  public void testOneResourceId() throws InvalidRequirementException {
     Resource resource = ResourceBuilder.reservedCpus(1.0, ResourceTestUtils.testRole, ResourceTestUtils.testPrincipal, ResourceTestUtils.testResourceId);
     OfferRequirement offerRequirement = getOfferRequirement(resource);
     Assert.assertEquals(1, offerRequirement.getResourceIds().size());
@@ -41,7 +40,7 @@ public class OfferRequirementTest {
   }
 
   @Test
-  public void testOnePersistenceId() throws InvalidTaskRequirementException {
+  public void testOnePersistenceId() throws InvalidRequirementException {
     Resource resource = ResourceBuilder.volume(1000.0, ResourceTestUtils.testRole, ResourceTestUtils.testPrincipal, ResourceTestUtils.testContainerPath, ResourceTestUtils.testPersistenceId);
     OfferRequirement offerRequirement = getOfferRequirement(resource);
     Assert.assertEquals(1, offerRequirement.getResourceIds().size());
@@ -51,7 +50,7 @@ public class OfferRequirementTest {
   }
 
   @Test
-  public void testOneOfEachId() throws InvalidTaskRequirementException {
+  public void testOneOfEachId() throws InvalidRequirementException {
     Resource cpu = ResourceBuilder.reservedCpus(1.0, ResourceTestUtils.testRole, ResourceTestUtils.testPrincipal, ResourceTestUtils.testResourceId);
     Resource volume = ResourceBuilder.volume(1000.0, ResourceTestUtils.testRole, ResourceTestUtils.testPrincipal, ResourceTestUtils.testContainerPath, ResourceTestUtils.testPersistenceId);
     OfferRequirement offerRequirement = getOfferRequirement(Arrays.asList(cpu, volume));
@@ -63,7 +62,7 @@ public class OfferRequirementTest {
   }
 
   @Test
-  public void testExecutor() throws InvalidTaskRequirementException {
+  public void testExecutor() throws InvalidRequirementException {
     Resource cpu = ResourceBuilder.reservedCpus(1.0, ResourceTestUtils.testRole, ResourceTestUtils.testPrincipal, ResourceTestUtils.testResourceId);
     TaskInfo taskInfo = getTaskInfo(cpu);
     ExecutorInfo execInfo = getExecutorInfo(cpu);
@@ -77,11 +76,11 @@ public class OfferRequirementTest {
     Assert.assertEquals(cpu, executorResource);
   }
 
-  private OfferRequirement getOfferRequirement(Resource resource) throws InvalidTaskRequirementException {
+  private OfferRequirement getOfferRequirement(Resource resource) throws InvalidRequirementException {
     return getOfferRequirement(Arrays.asList(resource));
   }
 
-  private OfferRequirement getOfferRequirement(List<Resource> resources) throws InvalidTaskRequirementException {
+  private OfferRequirement getOfferRequirement(List<Resource> resources) throws InvalidRequirementException {
     return new OfferRequirement(Arrays.asList(getTaskInfo(resources)));
   }
 
@@ -103,7 +102,8 @@ public class OfferRequirementTest {
 
   private ExecutorInfo getExecutorInfo(List<Resource> resources) {
     CommandInfo cmd = CommandInfo.newBuilder().build();
-    ExecutorInfoBuilder builder = new ExecutorInfoBuilder(ResourceTestUtils.testExecutorId, cmd);
+    ExecutorInfoBuilder builder = new ExecutorInfoBuilder(
+        ResourceTestUtils.testExecutorId, ResourceTestUtils.testExecutorName, cmd);
     return builder.addAllResources(resources).build();
   }
 }

--- a/src/test/java/org/apache/mesos/offer/ResourceTestUtils.java
+++ b/src/test/java/org/apache/mesos/offer/ResourceTestUtils.java
@@ -9,7 +9,7 @@ import org.apache.mesos.Protos.Resource.DiskInfo.Source;
 import org.apache.mesos.Protos.Resource.DiskInfo.Source.Mount;
 import org.apache.mesos.Protos.Resource.ReservationInfo;
 import org.apache.mesos.Protos.Value;
-
+import org.apache.mesos.executor.ExecutorUtils;
 import org.apache.mesos.protobuf.ValueBuilder;
 
 public class ResourceTestUtils {
@@ -21,8 +21,10 @@ public class ResourceTestUtils {
   public static final String testOfferId = "test-offer-id";
   public static final String testFrameworkId = "test-framework-id";
   public static final String testTaskName = "test-task-name";
-  public static final String testTaskId = "test-task-id";
-  public static final String testExecutorId = "test-executor-id";
+  public static final String testTaskId = TaskUtils.toTaskId(testTaskName).getValue();
+  public static final String testExecutorName = "test-executor-name";
+  public static final String testExecutorId =
+      ExecutorUtils.toExecutorId(testExecutorName).getValue();
   public static final String testSlaveId = "test-slave-id";
   public static final String testHostname = "test-hostname";
   public static final String testContainerPath = "test-container-path";

--- a/src/test/java/org/apache/mesos/scheduler/plan/DefaultStageSchedulerTest.java
+++ b/src/test/java/org/apache/mesos/scheduler/plan/DefaultStageSchedulerTest.java
@@ -11,17 +11,17 @@ import java.util.List;
 import java.util.Optional;
 
 import org.apache.mesos.SchedulerDriver;
+import org.apache.mesos.offer.InvalidRequirementException;
 import org.apache.mesos.offer.OfferAccepter;
 import org.apache.mesos.offer.OfferEvaluator;
 import org.apache.mesos.offer.OfferRecommendation;
 import org.apache.mesos.offer.OfferRequirement;
-import org.apache.mesos.offer.TaskRequirement.InvalidTaskRequirementException;
+import org.apache.mesos.offer.TaskUtils;
 import org.apache.mesos.Protos.FrameworkID;
 import org.apache.mesos.Protos.Offer;
 import org.apache.mesos.Protos.Offer.Operation;
 import org.apache.mesos.Protos.OfferID;
 import org.apache.mesos.Protos.SlaveID;
-import org.apache.mesos.Protos.TaskID;
 import org.apache.mesos.Protos.TaskInfo;
 import org.junit.Before;
 import org.junit.Test;
@@ -35,7 +35,7 @@ public class DefaultStageSchedulerTest {
 
     private static final List<TaskInfo> TASKINFOS = Arrays.asList(TaskInfo.newBuilder()
             .setName("hi")
-            .setTaskId(TaskID.newBuilder().setValue("taskid").build())
+            .setTaskId(TaskUtils.toTaskId("hi"))
             .setSlaveId(SlaveID.newBuilder().setValue("slaveid").build())
             .build());
     private static final List<Offer> OFFERS = Arrays.asList(Offer.newBuilder()
@@ -87,7 +87,7 @@ public class DefaultStageSchedulerTest {
     }
 
     @Test
-    public void testEvaluateNoRecommendations() throws InvalidTaskRequirementException {
+    public void testEvaluateNoRecommendations() throws InvalidRequirementException {
         OfferRequirement requirement = new OfferRequirement(TASKINFOS);
         TestOfferBlock block =(TestOfferBlock)new TestOfferBlock(requirement)
                 .setStatus(Status.Pending);
@@ -101,7 +101,7 @@ public class DefaultStageSchedulerTest {
     }
 
     @Test
-    public void testEvaluateNoAcceptedOffers() throws InvalidTaskRequirementException {
+    public void testEvaluateNoAcceptedOffers() throws InvalidRequirementException {
         OfferRequirement requirement = new OfferRequirement(TASKINFOS);
         TestOfferBlock block =(TestOfferBlock)new TestOfferBlock(requirement)
                 .setStatus(Status.Pending);
@@ -118,7 +118,7 @@ public class DefaultStageSchedulerTest {
     }
 
     @Test
-    public void testEvaluateAcceptedOffers() throws InvalidTaskRequirementException {
+    public void testEvaluateAcceptedOffers() throws InvalidRequirementException {
         OfferRequirement requirement = new OfferRequirement(TASKINFOS);
         TestOfferBlock block =(TestOfferBlock)new TestOfferBlock(requirement)
                 .setStatus(Status.Pending);


### PR DESCRIPTION
- TaskInfo requirements:
  - must have a name
  - if task id is non-empty, it must align with the name
  - if executor is provided, it must have a name (only at StateStore)
- ExecutorInfo requirements:
  - must have a name
  - if executor id is non-empty, it must align with the name
- TaskStatus requirements (only at StateStore):
  - must have a valid/parseable task id
  - must have a valid/parseable executor id