### PR TITLE
Move task state into a 'Tasks' subdir

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,7 +84,7 @@ ext {
 }
 
 group = "mesosphere"
-version = "0.4.11-SNAPSHOT"
+version = "0.4.12-SNAPSHOT"
 
 task sourceJar(type: Jar) {
   from sourceSets.main.allJava


### PR DESCRIPTION
Having CuratorStateStore scan the root directly causes it to
misinterpret data which was put there by other sources, eg
CuratorConfigStore's [fwkname]/Configurations/[confid]/.

To CuratorStateStore, this path would look like an execName of
"Configurations" and a taskName of "[confid]".

This also allows us to remove CuratorStateStore's check to avoid
listing the FrameworkID file as an executor name.