### PR TITLE
Remove Executor Name from task paths

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,7 +84,7 @@ ext {
 }
 
 group = "mesosphere"
-version = "0.4.12-SNAPSHOT"
+version = "0.4.13-SNAPSHOT"
 
 task sourceJar(type: Jar) {
   from sourceSets.main.allJava

--- a/src/main/java/org/apache/mesos/config/CuratorConfigStore.java
+++ b/src/main/java/org/apache/mesos/config/CuratorConfigStore.java
@@ -60,6 +60,9 @@ public class CuratorConfigStore<T extends Configuration>
      */
     public CuratorConfigStore(String rootPath, String connectionString, RetryPolicy retryPolicy) {
         super(connectionString, retryPolicy);
+        if (!rootPath.startsWith("/")) {
+            throw new IllegalArgumentException("rootPath must start with '/': " + rootPath);
+        }
         this.targetPath = rootPath + "/" + TARGET_PATH_NAME;
         this.configurationsPath = rootPath + "/" + CONFIGURATIONS_PATH_NAME;
     }

--- a/src/main/java/org/apache/mesos/offer/ExecutorRequirement.java
+++ b/src/main/java/org/apache/mesos/offer/ExecutorRequirement.java
@@ -69,7 +69,7 @@ public class ExecutorRequirement {
         if (executorInfo.hasExecutorId()
                 && !StringUtils.isEmpty(executorInfo.getExecutorId().getValue())) {
             // Executor ID may be included if this is replacing an existing task. In that case, we
-            // still perform a sanity check to ensure that the original Task ID was formatted
+            // still perform a sanity check to ensure that the original Executor ID was formatted
             // correctly. We must allow Executor ID to be present but empty because it is a required
             // proto field.
             String executorName;
@@ -83,7 +83,7 @@ public class ExecutorRequirement {
             }
             if (!executorName.equals(executorInfo.getName())) {
                 throw new InvalidRequirementException(String.format(
-                        "When non-empty, ExecInfo.id must align with ExecInfo.name. Use "
+                        "When non-empty, ExecutorInfo.id must align with ExecutorInfo.name. Use "
                         + "ExecutorUtils.toExecutorId(): %s", executorInfo));
             }
         }

--- a/src/main/java/org/apache/mesos/offer/ExecutorRequirement.java
+++ b/src/main/java/org/apache/mesos/offer/ExecutorRequirement.java
@@ -3,6 +3,7 @@ package org.apache.mesos.offer;
 import java.util.Collection;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.mesos.Protos.ExecutorInfo;
 import org.apache.mesos.executor.ExecutorTaskException;
 import org.apache.mesos.executor.ExecutorUtils;
@@ -86,5 +87,10 @@ public class ExecutorRequirement {
                         + "ExecutorUtils.toExecutorId(): %s", executorInfo));
             }
         }
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
     }
 }

--- a/src/main/java/org/apache/mesos/offer/OfferAccepter.java
+++ b/src/main/java/org/apache/mesos/offer/OfferAccepter.java
@@ -26,7 +26,7 @@ public class OfferAccepter {
   private Collection<OperationRecorder> recorders;
 
   public OfferAccepter(OperationRecorder recorder) {
-    this.recorders = Arrays.asList(recorder);
+    this(Arrays.asList(recorder));
   }
 
   public OfferAccepter(List<OperationRecorder> recorders) {

--- a/src/main/java/org/apache/mesos/offer/OfferRequirement.java
+++ b/src/main/java/org/apache/mesos/offer/OfferRequirement.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.mesos.Protos.ExecutorInfo;
 import org.apache.mesos.Protos.SlaveID;
 import org.apache.mesos.Protos.TaskInfo;
@@ -107,5 +108,10 @@ public class OfferRequirement {
       taskRequirements.add(new TaskRequirement(taskInfo));
     }
     return taskRequirements;
+  }
+
+  @Override
+  public String toString() {
+      return ToStringBuilder.reflectionToString(this);
   }
 }

--- a/src/main/java/org/apache/mesos/offer/ResourceCleaner.java
+++ b/src/main/java/org/apache/mesos/offer/ResourceCleaner.java
@@ -112,13 +112,11 @@ public class ResourceCleaner {
             throws StateStoreException {
         Collection<Resource> resources = new ArrayList<>();
 
-        for (String execName : stateStore.fetchExecutorNames()) {
-            for (Protos.TaskInfo taskInfo : stateStore.fetchTasks(execName)) {
-                // get all resources from both the task level and the executor level
-                resources.addAll(taskInfo.getResourcesList());
-                if (taskInfo.hasExecutor()) {
-                    resources.addAll(taskInfo.getExecutor().getResourcesList());
-                }
+        for (Protos.TaskInfo taskInfo : stateStore.fetchTasks()) {
+            // get all resources from both the task level and the executor level
+            resources.addAll(taskInfo.getResourcesList());
+            if (taskInfo.hasExecutor()) {
+                resources.addAll(taskInfo.getExecutor().getResourcesList());
             }
         }
 

--- a/src/main/java/org/apache/mesos/state/StateStore.java
+++ b/src/main/java/org/apache/mesos/state/StateStore.java
@@ -103,8 +103,7 @@ public interface StateStore {
      *
      * <ul>
      * <li>TaskStatus.task_id (required by proto)</li>
-     * <li>TaskStatus.executor_id, or TaskStatus.command should be set to indicate a command
-     * executor, in which case the executor name is extracted from TaskInfo.task_id</li>
+     * <li>TaskStatus.executor_id on the initial status update, optional thereafter</li>
      * </ul>
      *
      * @param status The status to be stored, which meets the above requirements

--- a/src/main/java/org/apache/mesos/state/StateStore.java
+++ b/src/main/java/org/apache/mesos/state/StateStore.java
@@ -1,12 +1,14 @@
 package org.apache.mesos.state;
 
 import org.apache.mesos.Protos;
+import org.apache.mesos.offer.TaskUtils;
 
 import java.util.Collection;
 
 /**
  * This interface should be implemented in order to store and fetch TaskInfo
- * and TaskStatus information.
+ * and TaskStatus information on a per Task basis. Each distinct Task is expected to
+ * have a unique Task Name, determined by the framework developer.
  *
  * TaskInfo objects should be persisted when a Task is launched or when reserved
  * resources associated with a potential future Task launch should be recorded.
@@ -16,6 +18,10 @@ import java.util.Collection;
  * recorded so that the state of a Framework's Tasks can be queried.
  */
 public interface StateStore {
+
+
+    // Write Framework ID
+
 
     /**
      * Stores the FrameworkID for a framework so on Scheduler restart re-registration
@@ -28,6 +34,18 @@ public interface StateStore {
 
 
     /**
+     * Removes any previously stored FrameworkID or does nothing if no FrameworkID
+     * was previously stored.
+     *
+     * @throws StateStoreException when clearing a FrameworkID fails
+     */
+    void clearFrameworkId() throws StateStoreException;
+
+
+    // Read Framework ID
+
+
+    /**
      * Fetches the previously stored FrameworkID.
      *
      * @return The previously stored FrameworkID
@@ -37,13 +55,7 @@ public interface StateStore {
     Protos.FrameworkID fetchFrameworkId() throws StateStoreException;
 
 
-    /**
-     * Removes any previously stored FrameworkID or does nothing if no FrameworkID
-     * was previously stored.
-     *
-     * @throws StateStoreException when clearing a FrameworkID fails
-     */
-    void clearFrameworkId() throws StateStoreException;
+    // Write Tasks
 
 
     /**
@@ -63,84 +75,77 @@ public interface StateStore {
 
 
     /**
-     * Fetches all TaskInfos associated with a particular Executor Name. In the case of command
-     * executors, this returns at most one TaskInfo for the provided task name.
+     * Stores the TaskStatus of a particular Task. It must include a valid TaskStatus.task_id value,
+     * as produced by {@link TaskUtils#toTaskId(String)}.
      *
-     * @param execName The name of the Executor associated with some Tasks
-     * @return The TaskInfo objects associated with the indicated Executor
-     * @see #fetchExecutorNames() for a list of all executor names
-     * @throws StateStoreException if no data was found for the requested Executor, or if fetching
-     *                             the TaskInfo information otherwise fails
-     */
-    Collection<Protos.TaskInfo> fetchTasks(String execName) throws StateStoreException;
-
-
-    /**
-     * Fetches the TaskInfo of a particular Task.
-     *
-     * @param taskName The name of the Task
-     * @param execName The name of the Executor associated with the Task. If a command executor is
-     *                 being used, this should be equal to taskName
-     * @return The corresponding TaskInfo object
-     * @throws StateStoreException if no data was found for the requested Task, or if fetching the
-     *                             TaskInfo information otherwise fails
-     */
-    Protos.TaskInfo fetchTask(String taskName, String execName) throws StateStoreException;
-
-
-    /**
-     * Fetches all the Executor names stored so far. In the case of command executors, this returns
-     * the names of the tasks.
-     *
-     * @return All the Executor names stored so far, or an empty list if none are found
-     * @throws StateStoreException when fetching the data fails
-     */
-    Collection<String> fetchExecutorNames() throws StateStoreException;
-
-
-    /**
-     * Stores the TaskStatus of a particular Task. It must include the following information:
-     *
-     * <ul>
-     * <li>TaskStatus.task_id (required by proto)</li>
-     * <li>TaskStatus.executor_id on the initial status update, optional thereafter</li>
-     * </ul>
-     *
-     * @param status The status to be stored, which meets the above requirements
-     * @throws StateStoreException when storing the TaskStatus fails
+     * @param status The status to be stored, which meets the above requirement
+     * @throws StateStoreException if storing the TaskStatus fails
      */
     void storeStatus(Protos.TaskStatus status) throws StateStoreException;
 
 
     /**
-     * Fetches the TaskStatuses of all Tasks associated with a particular Executor.
+     * Removes all data associated with a particular Task including any stored TaskInfo and/or
+     * TaskStatus.
      *
-     * @param execName The name of the Executor associated with some Tasks
+     * @param taskName The name of the task to be cleared
+     * @throws StateStoreException when clearing the indicated Executor's informations fails
+     */
+    void clearTask(String taskName) throws StateStoreException;
+
+
+    // Read Tasks
+
+
+    /**
+     * Fetches all the Task names listed in the underlying storage. Note that these may lack either
+     * TaskInfo or TaskStatus (but not both).
+     *
+     * @return All the Executor names stored so far, or an empty list if none are found
+     * @throws StateStoreException when fetching the data fails
+     */
+    Collection<String> fetchTaskNames() throws StateStoreException;
+
+
+    /**
+     * Fetches and returns all {@link TaskInfo}s from the underlying storage, or an empty list if
+     * none are found.
+     *
+     * @return All TaskInfos
+     * @throws StateStoreException if fetching
+     *                             the TaskInfo information otherwise fails
+     */
+    Collection<Protos.TaskInfo> fetchTasks() throws StateStoreException;
+
+
+    /**
+     * Fetches the TaskInfo for a particular Task, or an error if no matching task is found.
+     *
+     * @param taskName The name of the Task
+     * @return The corresponding TaskInfo object
+     * @throws StateStoreException if no data was found for the requested name, or if fetching the
+     *                             TaskInfo otherwise fails
+     */
+    Protos.TaskInfo fetchTask(String taskName) throws StateStoreException;
+
+
+    /**
+     * Fetches all {@link TaskStatus}es from the underlying storage.
+     *
      * @return The TaskStatus objects associated with all tasks for the indicated Executor
      * @throws StateStoreException if no data was found for the requested Executor, or if fetching
      *                             the TaskStatus information otherwise fails
      */
-    Collection<Protos.TaskStatus> fetchStatuses(String execName) throws StateStoreException;
+    Collection<Protos.TaskStatus> fetchStatuses() throws StateStoreException;
 
 
     /**
-     * Fetches the TaskStatus of a particular Task.
+     * Fetches the TaskStatus for a particular Task, or an error if no matching status is found.
      *
      * @param taskName The name of the Task which should have its status retrieved
-     * @param execName The name of the Executor associated with the indicated Task
      * @return The TaskStatus associated with a particular Task
      * @throws StateStoreException if no data was found for the requested Task, or if fetching the
      *                             TaskStatus information otherwise fails
      */
-    Protos.TaskStatus fetchStatus(String taskName, String execName) throws StateStoreException;
-
-
-    /**
-     * Removes all data associated with a particular Executor including all stored TaskInfos.
-     * and TaskStatuses
-     *
-     * @param execName The name of the Executor to be cleared
-     * @throws StateStoreException when clearing the indicated Executor's informations fails
-     */
-    void clearExecutor(String execName) throws StateStoreException;
+    Protos.TaskStatus fetchStatus(String taskName) throws StateStoreException;
 }

--- a/src/test/java/org/apache/mesos/offer/ResourceCleanerTest.java
+++ b/src/test/java/org/apache/mesos/offer/ResourceCleanerTest.java
@@ -62,19 +62,15 @@ public class ResourceCleanerTest {
         StateStore mockStateStore = mock(StateStore.class);
 
         // cleaners without any expected resources
-        when(mockStateStore.fetchExecutorNames()).thenReturn(new ArrayList<>());
+        when(mockStateStore.fetchTasks()).thenReturn(new ArrayList<>());
         emptyCleaners.add(new ResourceCleaner(Collections.emptyList()));
         emptyCleaners.add(new ResourceCleaner(mockStateStore));
 
         // cleaners with expected resources
         populatedCleaners.add(new ResourceCleaner(Arrays.asList(
                 TASK_INFO_1.getExecutor().getResources(0), TASK_INFO_2.getResources(0))));
-        when(mockStateStore.fetchExecutorNames())
-                .thenReturn(Arrays.asList("a", "b"));
-        when(mockStateStore.fetchTasks("a"))
-                .thenReturn(Arrays.asList(TASK_INFO_1));
-        when(mockStateStore.fetchTasks("b"))
-                .thenReturn(Arrays.asList(TASK_INFO_2));
+        when(mockStateStore.fetchTasks())
+                .thenReturn(Arrays.asList(TASK_INFO_1, TASK_INFO_2));
         populatedCleaners.add(new ResourceCleaner(mockStateStore));
 
         allCleaners.addAll(emptyCleaners);


### PR DESCRIPTION
Consistently getting an executor id is a surprisingly difficult exercise. Switch to a flatter structure where we just require that distinct tasks have unique task names.

This also simplifies things a bit for the developer -- they now only need to think about task names; 'execName' is gone.