### PR TITLE
Fixes #49

### DIFF
--- a/src/main/java/org/apache/mesos/offer/ResourceCleanerScheduler.java
+++ b/src/main/java/org/apache/mesos/offer/ResourceCleanerScheduler.java
@@ -24,6 +24,9 @@ public class ResourceCleanerScheduler {
 
   public List<OfferID> resourceOffers(SchedulerDriver driver, List<Offer> offers) {
     final List<OfferRecommendation> recommendations = resourceCleaner.evaluate(offers);
+
+    // Recommendations should be grouped by agent, as Mesos enforces processing of acceptOffers Operations
+    // that belong to a single agent.
     final Map<Protos.SlaveID, List<OfferRecommendation>> recommendationsGroupedByAgents =
             groupRecommendationsByAgent(recommendations);
 
@@ -35,6 +38,11 @@ public class ResourceCleanerScheduler {
     return processedOffers;
   }
 
+  /**
+   * Groups recommendations by agent.
+   *
+   * Visibility is protected to enable testing.
+   */
   protected Map<Protos.SlaveID, List<OfferRecommendation>> groupRecommendationsByAgent(
           List<OfferRecommendation> recommendations) {
     final Map<Protos.SlaveID, List<OfferRecommendation>> recommendationsGroupedByAgents = new HashMap<>();

--- a/src/main/java/org/apache/mesos/offer/ResourceCleanerScheduler.java
+++ b/src/main/java/org/apache/mesos/offer/ResourceCleanerScheduler.java
@@ -1,10 +1,11 @@
 package org.apache.mesos.offer;
 
-import java.util.List;
-
+import org.apache.mesos.Protos;
 import org.apache.mesos.Protos.Offer;
 import org.apache.mesos.Protos.OfferID;
 import org.apache.mesos.SchedulerDriver;
+
+import java.util.*;
 
 /**
  * This scheduler performs UNRESERVE and DESTROY operations on resources which are identified
@@ -17,13 +18,39 @@ public class ResourceCleanerScheduler {
   public ResourceCleanerScheduler(
       ResourceCleaner resourceCleaner,
       OfferAccepter offerAccepter) {
-
     this.resourceCleaner = resourceCleaner;
     this.offerAccepter = offerAccepter;
   }
 
   public List<OfferID> resourceOffers(SchedulerDriver driver, List<Offer> offers) {
-    List<OfferRecommendation> recommendations = resourceCleaner.evaluate(offers);
-    return offerAccepter.accept(driver, recommendations);
+    final List<OfferRecommendation> recommendations = resourceCleaner.evaluate(offers);
+    final Map<Protos.SlaveID, List<OfferRecommendation>> recommendationsGroupedByAgents =
+            groupRecommendationsByAgent(recommendations);
+
+    final List<OfferID> processedOffers = new ArrayList<>(offers.size());
+    for (Map.Entry<Protos.SlaveID, List<OfferRecommendation>> entry : recommendationsGroupedByAgents.entrySet()) {
+      processedOffers.addAll(offerAccepter.accept(driver, recommendationsGroupedByAgents.get(entry.getKey())));
+    }
+
+    return processedOffers;
+  }
+
+  protected Map<Protos.SlaveID, List<OfferRecommendation>> groupRecommendationsByAgent(
+          List<OfferRecommendation> recommendations) {
+    final Map<Protos.SlaveID, List<OfferRecommendation>> recommendationsGroupedByAgents = new HashMap<>();
+
+    for (OfferRecommendation recommendation : recommendations) {
+      final Protos.SlaveID agentId = recommendation.getOffer().getSlaveId();
+
+      if (!recommendationsGroupedByAgents.containsKey(agentId)) {
+        recommendationsGroupedByAgents.put(agentId, new ArrayList<>());
+      }
+
+      final List<OfferRecommendation> agentRecommendations = recommendationsGroupedByAgents.get(agentId);
+      agentRecommendations.add(recommendation);
+      recommendationsGroupedByAgents.put(agentId, agentRecommendations);
+    }
+
+    return recommendationsGroupedByAgents;
   }
 }

--- a/src/test/java/org/apache/mesos/offer/ResourceCleanerSchedulerTest.java
+++ b/src/test/java/org/apache/mesos/offer/ResourceCleanerSchedulerTest.java
@@ -1,0 +1,89 @@
+package org.apache.mesos.offer;
+
+import org.apache.mesos.Protos;
+import org.apache.mesos.SchedulerDriver;
+import org.apache.mesos.protobuf.ResourceBuilder;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.Mockito.*;
+
+public class ResourceCleanerSchedulerTest {
+    @Mock
+    private ResourceCleaner resourceCleaner;
+    @Mock
+    private OfferAccepter offerAccepter;
+    @Mock
+    private SchedulerDriver driver;
+
+    private ResourceCleanerScheduler scheduler;
+    private List<OfferRecommendation> recommendations;
+    private List<Protos.Offer> offers;
+
+    @Before
+    public void beforeEach() {
+        MockitoAnnotations.initMocks(this);
+        scheduler = new ResourceCleanerScheduler(resourceCleaner, offerAccepter);
+        Protos.Offer offerA = Protos.Offer.newBuilder(Protos.Offer.getDefaultInstance())
+                .setHostname("A")
+                .setSlaveId(Protos.SlaveID.newBuilder().setValue("A").build())
+                .setId(Protos.OfferID.newBuilder().setValue("A"))
+                .setFrameworkId(Protos.FrameworkID.newBuilder().setValue("A"))
+                .build();
+        Protos.Offer offerB = Protos.Offer.newBuilder(Protos.Offer.getDefaultInstance())
+                .setHostname("B")
+                .setSlaveId(Protos.SlaveID.newBuilder().setValue("B").build())
+                .setId(Protos.OfferID.newBuilder().setValue("B"))
+                .setFrameworkId(Protos.FrameworkID.newBuilder().setValue("B"))
+                .build();
+
+        offers = Arrays.asList(offerA, offerB);
+
+        final DestroyOfferRecommendation destroyRecommendationA = new DestroyOfferRecommendation(offerA, ResourceBuilder.cpus(1));
+        final DestroyOfferRecommendation destroyRecommendationB = new DestroyOfferRecommendation(offerB, ResourceBuilder.cpus(1));
+        final UnreserveOfferRecommendation unreserveRecommendationA = new UnreserveOfferRecommendation(offerA, ResourceBuilder.cpus(1));
+        final UnreserveOfferRecommendation unreserveRecommendationB = new UnreserveOfferRecommendation(offerB, ResourceBuilder.cpus(1));
+
+        recommendations = Arrays.asList(
+                destroyRecommendationA,
+                destroyRecommendationB,
+                unreserveRecommendationA,
+                unreserveRecommendationB);
+        when(resourceCleaner.evaluate(offers)).thenReturn(recommendations);
+    }
+
+    @Test
+    public void testResourceOffers() {
+        scheduler.resourceOffers(driver, offers);
+        verify(offerAccepter, times(2)).accept(any(), any());
+    }
+
+    @Test
+    public void testGroupRecommendationsByAgent() {
+        final Map<Protos.SlaveID, List<OfferRecommendation>> group
+                = scheduler.groupRecommendationsByAgent(recommendations);
+        Assert.assertTrue(group.size() == 2);
+        Protos.SlaveID prevSlaveID = null;
+        for (Map.Entry<Protos.SlaveID, List<OfferRecommendation>> entry : group.entrySet()) {
+            final List<OfferRecommendation> recommendations = entry.getValue();
+            Assert.assertNotNull(recommendations);
+            Assert.assertTrue(recommendations.size() == 2);
+            final Protos.SlaveID key = entry.getKey();
+            Assert.assertEquals(key, recommendations.get(0).getOffer().getSlaveId());
+            Assert.assertEquals(key, recommendations.get(1).getOffer().getSlaveId());
+
+            if (prevSlaveID != null) {
+                Assert.assertNotEquals(key, prevSlaveID);
+            }
+
+            prevSlaveID = key;
+        }
+    }
+}


### PR DESCRIPTION
This PR ensures that `ResourceCleanerScheduler` invokes one `accept` call for Operation(s) related to each agent.