### PR TITLE
Fix ExecutorId alignment

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,7 +86,7 @@ ext {
 }
 
 group = "mesosphere"
-version = "0.4.17-SNAPSHOT"
+version = "0.4.18-SNAPSHOT"
 
 task sourceJar(type: Jar) {
   from sourceSets.main.allJava

--- a/src/main/java/org/apache/mesos/offer/OfferEvaluator.java
+++ b/src/main/java/org/apache/mesos/offer/OfferEvaluator.java
@@ -99,6 +99,16 @@ public class OfferEvaluator {
       }
     }
 
+    ExecutorInfo execInfo = null;
+    if (execReq != null) {
+      execInfo = execReq.getExecutorInfo();
+      if (execInfo.getExecutorId().getValue().isEmpty()) {
+        execInfo = ExecutorInfo.newBuilder(execInfo)
+                .setExecutorId(ExecutorUtils.toExecutorId(execInfo.getName()))
+                .build();
+      }
+    }
+
     for (TaskRequirement taskReq : offerRequirement.getTaskRequirements()) {
       FulfilledRequirement fulfilledTaskRequirement =
         FulfilledRequirement.fulfillRequirement(taskReq.getResourceRequirements(), offer, pool);
@@ -110,16 +120,6 @@ public class OfferEvaluator {
       unreserves.addAll(fulfilledTaskRequirement.getUnreserveRecommendations());
       reserves.addAll(fulfilledTaskRequirement.getReserveRecommendations());
       creates.addAll(fulfilledTaskRequirement.getCreateRecommendations());
-
-      ExecutorInfo execInfo = null;
-      if (execReq != null) {
-        execInfo = execReq.getExecutorInfo();
-        if (execInfo.getExecutorId().getValue().isEmpty()) {
-          execInfo = ExecutorInfo.newBuilder(execInfo)
-                  .setExecutorId(ExecutorUtils.toExecutorId(execInfo.getName()))
-                  .build();
-        }
-      }
 
       launches.add(
         new LaunchOfferRecommendation(


### PR DESCRIPTION
Tasks in the same OfferRequirement should all share the same Executor
and therefore ExecutorIDs