### PR TITLE
Add support for viewing Properties data, add 1MB value requirement

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,7 +88,7 @@ ext {
 }
 
 group = "mesosphere"
-version = "0.4.23-SNAPSHOT"
+version = "0.4.24-SNAPSHOT"
 
 task sourceJar(type: Jar) {
   from sourceSets.main.allJava

--- a/build.gradle
+++ b/build.gradle
@@ -88,7 +88,7 @@ ext {
 }
 
 group = "mesosphere"
-version = "0.4.24-SNAPSHOT"
+version = "0.4.25-SNAPSHOT"
 
 task sourceJar(type: Jar) {
   from sourceSets.main.allJava

--- a/src/main/java/org/apache/mesos/scheduler/plan/DefaultStageManager.java
+++ b/src/main/java/org/apache/mesos/scheduler/plan/DefaultStageManager.java
@@ -124,22 +124,21 @@ public class DefaultStageManager implements StageManager {
 
   @Override
   public void update(final Protos.TaskStatus status) {
-    LOGGER.info("Received status update : status = {}", TextFormat.shortDebugString(status));
-
+    LOGGER.debug("Received status update : status = {}", TextFormat.shortDebugString(status));
     final PhaseStrategy currentPhaseStrategy = getCurrentPhaseStrategy();
     if (currentPhaseStrategy != null) {
       final Phase currentPhase = currentPhaseStrategy.getPhase();
       if (currentPhase != null) {
         final List<? extends Block> blocks = currentPhase.getBlocks();
         for (Block block : blocks) {
-          LOGGER.info("Updating block '{}' with status", block.getName());
+          LOGGER.debug("Updating block '{}' with status", block.getName());
           block.update(status);
         }
       } else {
-        LOGGER.info("currentPhase is null. No blocks to receive status");
+        LOGGER.debug("currentPhase is null. No blocks to receive status");
       }
     } else {
-      LOGGER.info("currentPhaseStrategy is null. No blocks to receive status");
+      LOGGER.debug("currentPhaseStrategy is null. No blocks to receive status");
     }
   }
 

--- a/src/main/java/org/apache/mesos/state/CuratorStateStore.java
+++ b/src/main/java/org/apache/mesos/state/CuratorStateStore.java
@@ -1,6 +1,5 @@
 package org.apache.mesos.state;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.curator.RetryPolicy;
 import org.apache.curator.retry.ExponentialBackoffRetry;
 import org.apache.mesos.Protos;
@@ -10,6 +9,7 @@ import org.apache.mesos.storage.CuratorPersister;
 import org.apache.zookeeper.KeeperException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -287,7 +287,8 @@ public class CuratorStateStore implements StateStore {
 
     @Override
     public void storeProperty(final String key, final byte[] value) throws StateStoreException {
-        validateKey(key);
+        StateStoreUtils.validateKey(key);
+        StateStoreUtils.validateValue(value);
         try {
             final String path = this.propertiesPath + "/" + key;
             logger.debug("Storing property key: {} into path: {}", key, path);
@@ -299,7 +300,7 @@ public class CuratorStateStore implements StateStore {
 
     @Override
     public byte[] fetchProperty(final String key) throws StateStoreException {
-        validateKey(key);
+        StateStoreUtils.validateKey(key);
         try {
             final String path = this.propertiesPath + "/" + key;
             logger.debug("Fetching property key: {} from path: {}", key, path);
@@ -310,9 +311,13 @@ public class CuratorStateStore implements StateStore {
     }
 
     @Override
-    public Collection<String> listPropertyKeys() throws StateStoreException {
+    public Collection<String> fetchPropertyKeys() throws StateStoreException {
         try {
             return curator.getChildren(this.propertiesPath);
+        } catch (KeeperException.NoNodeException e) {
+            // Root path doesn't exist yet. Treat as an empty list of properties. This scenario is
+            // expected to commonly occur when the Framework is being run for the first time.
+            return Collections.emptyList();
         } catch (Exception e) {
             throw new StateStoreException(e);
         }
@@ -320,11 +325,15 @@ public class CuratorStateStore implements StateStore {
 
     @Override
     public void clearProperty(final String key) throws StateStoreException {
-        validateKey(key);
+        StateStoreUtils.validateKey(key);
         try {
             final String path = this.propertiesPath + "/" + key;
             logger.debug("Removing property key: {} from path: {}", key, path);
             curator.clear(path);
+        } catch (KeeperException.NoNodeException e) {
+            // Clearing a non-existent Property should not result in an exception from us.
+            logger.warn("Cleared nonexistent Property, continuing silently: {}", key, e);
+            return;
         } catch (Exception e) {
             throw new StateStoreException(e);
         }
@@ -353,15 +362,6 @@ public class CuratorStateStore implements StateStore {
 
         private String getTasksRootPath() {
             return tasksRootPath;
-        }
-    }
-
-    private void validateKey(String key) {
-        if (StringUtils.isBlank(key)) {
-            throw new StateStoreException("Key cannot be blank or null");
-        }
-        if (key.contains("/")) {
-            throw new StateStoreException("Key cannot contain '/'");
         }
     }
 }

--- a/src/main/java/org/apache/mesos/state/CuratorStateStore.java
+++ b/src/main/java/org/apache/mesos/state/CuratorStateStore.java
@@ -10,7 +10,6 @@ import org.apache.zookeeper.KeeperException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;

--- a/src/main/java/org/apache/mesos/state/StateStore.java
+++ b/src/main/java/org/apache/mesos/state/StateStore.java
@@ -110,14 +110,13 @@ public interface StateStore {
      * {@link #fetchStatuses()}.
      *
      * @return All TaskInfos
-     * @throws StateStoreException if fetching
-     *                             the TaskInfo information otherwise fails
+     * @throws StateStoreException if fetching the TaskInfo information otherwise fails
      */
     Collection<Protos.TaskInfo> fetchTasks() throws StateStoreException;
 
 
     /**
-     * Fetches the TaskInfo for a particular Task, or an error if no matching task is found.
+     * Fetches the TaskInfo for a particular Task, or throws an error if no matching task is found.
      *
      * @param taskName The name of the Task
      * @return The corresponding TaskInfo object
@@ -139,44 +138,56 @@ public interface StateStore {
 
 
     /**
-     * Fetches the TaskStatus for a particular Task, or an error if no matching status is found.
-     * A given task may sometimes have {@link TaskInfo} while lacking {@link TaskStatus}.
+     * Fetches the TaskStatus for a particular Task, or throws an error if no matching status is
+     * found. A given task may sometimes have {@link TaskInfo} while lacking {@link TaskStatus}.
      *
      * @param taskName The name of the Task which should have its status retrieved
      * @return The TaskStatus associated with a particular Task
-     * @throws StateStoreException if no data was found for the requested Task, or if fetching the
+     * @throws StateStoreException if no data was found for the requested name, or if fetching the
      *                             TaskStatus information otherwise fails
      */
     Protos.TaskStatus fetchStatus(String taskName) throws StateStoreException;
 
 
-    // Property storage
+    // Read/Write Properties
+
 
     /**
      * Stores an arbitrary key/value pair.
      *
-     * @param key The key should be a String, and should not contain a forward slash ('/').
-     * @param value The value should be a byte array.
+     * @param key must be a non-blank String without any forward slashes ('/')
+     * @param value The value should be a byte array no larger than 1MB (1024 * 1024 bytes)
+     * @throw StateStoreException if the key or value fail validation, or if storing the data
+     *                            otherwise fails
+     * @see StateStoreUtils#validateKey(String)
+     * @see StateStoreUtils#validateValue(String)
      */
-    void storeProperty(String key, byte[] value);
+    void storeProperty(String key, byte[] value) throws StateStoreException;
 
     /**
-     * Fetches the value byte array, stored against the Property 'key'.
+     * Fetches the value byte array, stored against the Property {@code key}, or throws an error if
+     * no matching {@code key} is found.
      *
-     * @param key The key should be a String, and should not contain a forward slash ('/').
+     * @param key must be a non-blank String without any forward slashes ('/')
+     * @throw StateStoreException if no data was found for the requested key, or if fetching the
+     *                            data otherwise fails
+     * @see StateStoreUtils#validateKey(String)
      */
-    byte[] fetchProperty(String key);
+    byte[] fetchProperty(String key) throws StateStoreException;
 
     /**
-     * Fetches the list of Property keys.
-     */
-    Collection<String> listPropertyKeys();
-
-    /**
-     * Clears a given property from the StateStore.
+     * Fetches the list of Property keys, or an empty list if none are found.
      *
-     * @param key The key that needs to be removed.
-     * @throws StateStoreException
+     * @throws StateStoreException if fetching the list otherwise fails
+     */
+    Collection<String> fetchPropertyKeys() throws StateStoreException;
+
+    /**
+     * Clears a given property from the StateStore, or does nothing if no such property exists.
+     *
+     * @param key must be a non-blank String without any forward slashes ('/')
+     * @throws StateStoreException if key validation fails or clearing the entry fails
      */
     void clearProperty(final String key) throws StateStoreException;
+
 }

--- a/src/main/java/org/apache/mesos/state/StateStoreUtils.java
+++ b/src/main/java/org/apache/mesos/state/StateStoreUtils.java
@@ -1,0 +1,62 @@
+package org.apache.mesos.state;
+
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Utilities for implementations and users of {@link StateStore}.
+ */
+public class StateStoreUtils {
+
+    private StateStoreUtils() {
+        // do not instantiate
+    }
+
+
+    // Utilities for StateStore users:
+
+
+    /**
+     * Returns the requested property, or an empty array if the property is not present.
+     */
+    public static byte[] fetchPropertyOrEmptyArray(StateStore stateStore, String key) {
+        if (stateStore.fetchPropertyKeys().contains(key)) {
+            return stateStore.fetchProperty(key);
+        } else {
+            return new byte[0];
+        }
+    }
+
+
+    // Utilities for StateStore implementations:
+
+
+    /**
+     * Shared implementation for validating property key limits, for use by all StateStore
+     * implementations.
+     *
+     * @see StateStore#storeProperty(String, byte[])
+     * @see StateStore#fetchProperty(String)
+     */
+    public static void validateKey(String key) throws StateStoreException {
+        if (StringUtils.isBlank(key)) {
+            throw new StateStoreException("Key cannot be blank or null");
+        }
+        if (key.contains("/")) {
+            throw new StateStoreException("Key cannot contain '/'");
+        }
+    }
+
+    /**
+     * Shared implementation for validating property value limits, for use by all StateStore
+     * implementations.
+     *
+     * @see StateStore#storeProperty(String, byte[])
+     */
+    public static void validateValue(byte[] value) throws StateStoreException {
+        final int maxLength = 1024 * 1024;
+        if (value.length > maxLength) {
+            throw new StateStoreException(String.format(
+                    "Value length %d exceeds limit of %d bytes.", value.length, maxLength));
+        }
+    }
+}

--- a/src/main/java/org/apache/mesos/state/StateStoreUtils.java
+++ b/src/main/java/org/apache/mesos/state/StateStoreUtils.java
@@ -7,6 +7,8 @@ import org.apache.commons.lang3.StringUtils;
  */
 public class StateStoreUtils {
 
+    private static final int MAX_VALUE_LENGTH_BYTES = 1024 * 1024; // 1MB
+
     private StateStoreUtils() {
         // do not instantiate
     }
@@ -53,10 +55,13 @@ public class StateStoreUtils {
      * @see StateStore#storeProperty(String, byte[])
      */
     public static void validateValue(byte[] value) throws StateStoreException {
-        final int maxLength = 1024 * 1024;
-        if (value.length > maxLength) {
+        if (value == null) {
+            throw new StateStoreException("Property value must not be null.");
+        }
+        if (value.length > MAX_VALUE_LENGTH_BYTES) {
             throw new StateStoreException(String.format(
-                    "Value length %d exceeds limit of %d bytes.", value.length, maxLength));
+                    "Property value length %d exceeds limit of %d bytes.",
+                    value.length, MAX_VALUE_LENGTH_BYTES));
         }
     }
 }

--- a/src/main/java/org/apache/mesos/state/api/PropertyDeserializer.java
+++ b/src/main/java/org/apache/mesos/state/api/PropertyDeserializer.java
@@ -1,5 +1,7 @@
 package org.apache.mesos.state.api;
 
+import org.apache.mesos.state.StateStoreException;
+
 /**
  * Interface which handles deserializing StateStore Property data for viewing by users.
  *
@@ -9,6 +11,8 @@ public interface PropertyDeserializer {
     /**
      * Returns a valid JSON representation for the data in {@code value} for display to an end user.
      * {@code key} is provided to support datatypes which vary on a per-key basis.
+     *
+     * @throws StateStoreException if the provided data failed to be deserialized to JSON
      */
-    public String toJsonString(String key, byte[] value);
+    public String toJsonString(String key, byte[] value) throws StateStoreException;
 }

--- a/src/main/java/org/apache/mesos/state/api/PropertyDeserializer.java
+++ b/src/main/java/org/apache/mesos/state/api/PropertyDeserializer.java
@@ -1,0 +1,14 @@
+package org.apache.mesos.state.api;
+
+/**
+ * Interface which handles deserializing StateStore Property data for viewing by users.
+ *
+ * @see com.googlecode.protobuf.format.JsonFormat for turning protobufs into JSON
+ */
+public interface PropertyDeserializer {
+    /**
+     * Returns a valid JSON representation for the data in {@code value} for display to an end user.
+     * {@code key} is provided to support datatypes which vary on a per-key basis.
+     */
+    public String toJsonString(String key, byte[] value);
+}

--- a/src/main/java/org/apache/mesos/state/api/StateResource.java
+++ b/src/main/java/org/apache/mesos/state/api/StateResource.java
@@ -27,20 +27,21 @@ public class StateResource {
     private final PropertyDeserializer propertyDeserializer;
 
     /**
-     * Creates a new StateResource which cannot deserialize Properties.
+     * Creates a new StateResource which cannot deserialize Properties. Callers will receive a
+     * "204 NO_CONTENT" HTTP response when attempting to view the content of a property.
      *
-     * @param stateStore the source of data to be returned to users
+     * @param stateStore the source of data to be returned to callers
      */
     public StateResource(StateStore stateStore) {
-        this.stateStore = stateStore;
-        this.propertyDeserializer = null;
+        this(stateStore, null /*propertyDeserializer*/);
     }
 
     /**
-     * Creates a new StateResource which can deserialize Properties.
+     * Creates a new StateResource which can deserialize Properties. Callers will be able to view
+     * the content of individual Properties.
      *
-     * @param stateStore the source of data to be returned to users
-     * @param propertyDeserializer a deserializer which can turn any property in the provided
+     * @param stateStore the source of data to be returned to callers
+     * @param propertyDeserializer a deserializer which can turn any Property in the provided
      *                             {@code stateStore} to valid JSON
      */
     public StateResource(StateStore stateStore, PropertyDeserializer propertyDeserializer) {
@@ -144,7 +145,7 @@ public class StateResource {
             if (propertyDeserializer == null) {
                 logger.warn("Cannot deserialize requested Property '{}': " +
                         "No deserializer was provided to StateResource constructor", key);
-                return Response.noContent().build();
+                return Response.noContent().build(); // 204 NO_CONTENT
             } else {
                 logger.info("Attempting to fetch Property for key '{}'", key);
                 byte[] value = stateStore.fetchProperty(key);

--- a/src/test/java/org/apache/mesos/executor/CustomExecutorTest.java
+++ b/src/test/java/org/apache/mesos/executor/CustomExecutorTest.java
@@ -13,8 +13,6 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
 import java.time.Duration;
-import java.util.Arrays;
-import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -262,17 +260,5 @@ public class CustomExecutorTest {
                 .setExecutorId(Protos.ExecutorID.newBuilder().setValue(UUID.randomUUID().toString()))
                 .setCommand(Protos.CommandInfo.newBuilder().setValue("ls"))
                 .build();
-    }
-
-    private List<TimedExecutorTask> getTestRegistrationTasks() {
-        return Arrays.asList(
-                new TestTimedExecutorTask(
-                        Duration.ofSeconds(10),
-                        Duration.ZERO,
-                        Protos.TaskStatus.newBuilder()
-                                .setTaskId(Protos.TaskID.newBuilder().setValue("test-task-id"))
-                                .setState(Protos.TaskState.TASK_FINISHED)
-                                .build(),
-                        mockExecutorDriver));
     }
 }

--- a/src/test/java/org/apache/mesos/state/CuratorStateStoreTest.java
+++ b/src/test/java/org/apache/mesos/state/CuratorStateStoreTest.java
@@ -407,12 +407,7 @@ public class CuratorStateStoreTest {
     }
 
     @Test
-    public void testPropertiesListEmpty() {
-        assertTrue(store.fetchPropertyKeys().isEmpty());
-    }
-
-    @Test
-    public void testPropertiesStoreFetch() {
+    public void testPropertiesStoreFetchListClear() {
         store.storeProperty(GOOD_PROPERTY_KEY, PROPERTY_VALUE.getBytes(StandardCharsets.UTF_8));
 
         final byte[] bytes = store.fetchProperty(GOOD_PROPERTY_KEY);
@@ -421,50 +416,55 @@ public class CuratorStateStoreTest {
         final Collection<String> keys = store.fetchPropertyKeys();
         assertEquals(1, keys.size());
         assertEquals(GOOD_PROPERTY_KEY, keys.iterator().next());
-    }
 
-    @Test(expected = StateStoreException.class)
-    public void testPropertiesWhitespaceStore() {
-        store.storeProperty(
-                WHITESPACE_PROPERTY_KEY, PROPERTY_VALUE.getBytes(StandardCharsets.UTF_8));
-    }
-
-    @Test(expected = StateStoreException.class)
-    public void testPropertiesWhitespaceFetch() {
-        store.fetchProperty(WHITESPACE_PROPERTY_KEY);
-    }
-
-    @Test
-    public void testClearPropertiesGood() {
-        store.storeProperty(GOOD_PROPERTY_KEY, PROPERTY_VALUE.getBytes(StandardCharsets.UTF_8));
-        assertEquals(1, store.fetchPropertyKeys().size());
         store.clearProperty(GOOD_PROPERTY_KEY);
         assertTrue(store.fetchPropertyKeys().isEmpty());
     }
 
     @Test
-    public void testClearPropertiesNonExistent() {
-        store.clearProperty(GOOD_PROPERTY_KEY + "a");
+    public void testPropertiesListEmpty() {
+        assertTrue(store.fetchPropertyKeys().isEmpty());
+    }
+
+    @Test
+    public void testPropertiesClearEmpty() {
+        store.clearProperty(GOOD_PROPERTY_KEY);
     }
 
     @Test(expected = StateStoreException.class)
-    public void testClearPropertiesEmpty() {
+    public void testPropertiesStoreWhitespace() {
+        store.storeProperty(
+                WHITESPACE_PROPERTY_KEY, PROPERTY_VALUE.getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Test(expected = StateStoreException.class)
+    public void testPropertiesFetchWhitespace() {
+        store.fetchProperty(WHITESPACE_PROPERTY_KEY);
+    }
+
+    @Test(expected = StateStoreException.class)
+    public void testPropertiesClearWhitespace() {
         store.clearProperty(WHITESPACE_PROPERTY_KEY);
     }
 
     @Test(expected = StateStoreException.class)
-    public void testClearPropertiesSlash() {
-        store.clearProperty(SLASH_PROPERTY_KEY);
-    }
-
-    @Test(expected = StateStoreException.class)
-    public void testPropertiesSlashStore() {
+    public void testPropertiesStoreSlash() {
         store.storeProperty(SLASH_PROPERTY_KEY, PROPERTY_VALUE.getBytes(StandardCharsets.UTF_8));
     }
 
     @Test(expected = StateStoreException.class)
-    public void testPropertiesSlashFetch() {
+    public void testPropertiesFetchSlash() {
         store.fetchProperty(SLASH_PROPERTY_KEY);
+    }
+
+    @Test(expected = StateStoreException.class)
+    public void testPropertiesClearSlash() {
+        store.clearProperty(SLASH_PROPERTY_KEY);
+    }
+
+    @Test(expected = StateStoreException.class)
+    public void testPropertiesStoreNullValue() {
+        store.storeProperty(GOOD_PROPERTY_KEY, null);
     }
 
     private static Protos.TaskStatus createTaskStatus(Protos.TaskID taskId) {


### PR DESCRIPTION
May be optionally supported by individual frameworks (by either providing or omitting the PropertyDeserializer). Adds a new /properties endpoint to StateResource to match.

Also:
- Refrain from throwing an error when listing or clearing Properties that aren't available (mirroring current task list/clear behavior)
- Set some noisy logs as 'debug'