### PR TITLE
Add DCOS Cluster Capabilities

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,10 +90,13 @@ ext {
   restServiceVer = "2.0.1"
   slf4jVer = "1.7.10"
   systemRulesVer = "1.16.0"
+  mockServerVer = "3.10.4"
+  springVer = "4.3.1.RELEASE"
+  httpClientVer = "4.5.2"
 }
 
 group = "mesosphere"
-version = "0.4.27-SNAPSHOT"
+version = "0.4.28-SNAPSHOT"
 
 task sourceJar(type: Jar) {
   from sourceSets.main.allJava
@@ -151,6 +154,10 @@ dependencies {
   testCompile "org.mockito:mockito-all:${mockitoVer}"
   testCompile "org.powermock:powermock-mockito-release-full:${powerMockVer}"
   testCompile "org.apache.curator:curator-test:${curatorVer}"
+  testCompile "org.mock-server:mockserver-netty:${mockServerVer}"
+  testCompile "org.springframework.integration:spring-integration-http:${springVer}"
+  compile "org.apache.httpcomponents:httpclient:${httpClientVer}"
+  compile "org.apache.httpcomponents:fluent-hc:${httpClientVer}"
 }
 
 distributions {

--- a/src/main/java/org/apache/mesos/dcos/Capabilities.java
+++ b/src/main/java/org/apache/mesos/dcos/Capabilities.java
@@ -1,0 +1,19 @@
+package org.apache.mesos.dcos;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+
+/**
+ * This class represents a set of capabilities that may or may not be supported in a given version of DC/OS.
+ */
+public class Capabilities {
+    private DcosCluster dcosCluster;
+
+    public Capabilities(DcosCluster dcosCluster) {
+        this.dcosCluster = dcosCluster;
+    }
+
+    public boolean supportsNamedVips() throws IOException, URISyntaxException {
+        return dcosCluster.getDcosVersion().getVersion().startsWith("1.8");
+    }
+}

--- a/src/main/java/org/apache/mesos/dcos/DcosCluster.java
+++ b/src/main/java/org/apache/mesos/dcos/DcosCluster.java
@@ -13,10 +13,10 @@ import java.util.Optional;
  * Instances of this class represent DC/OS clusters.
  */
 public class DcosCluster {
-    public static final String INTERNAL_DCOS_URL = "http://master.mesos";
+    private static final String INTERNAL_DCOS_URL = "http://master.mesos";
     private static final String DCOS_VERSION_PATH = "/dcos-metadata/dcos-version.json";
 
-    private URI dcosUri;
+    private final URI dcosUri;
     private Optional<DcosVersion> dcosVersion = Optional.empty();
 
     DcosCluster(URI dcosUri) {

--- a/src/main/java/org/apache/mesos/dcos/DcosCluster.java
+++ b/src/main/java/org/apache/mesos/dcos/DcosCluster.java
@@ -1,0 +1,45 @@
+package org.apache.mesos.dcos;
+
+import org.apache.http.client.fluent.Content;
+import org.apache.http.client.fluent.Request;
+import org.json.JSONObject;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Optional;
+
+/**
+ * Instances of this class represent DC/OS clusters.
+ */
+public class DcosCluster {
+    public static final String INTERNAL_DCOS_URL = "http://master.mesos";
+    private static final String DCOS_VERSION_PATH = "/dcos-metadata/dcos-version.json";
+
+    private URI dcosUri;
+    private Optional<DcosVersion> dcosVersion = Optional.empty();
+
+    DcosCluster(URI dcosUri) {
+        this.dcosUri = dcosUri;
+    }
+
+    public DcosCluster() throws URISyntaxException {
+        this(new URI(INTERNAL_DCOS_URL));
+    }
+
+    public URI getDcosUri() {
+        return dcosUri;
+    }
+
+    public DcosVersion getDcosVersion() throws IOException, URISyntaxException {
+        if (!dcosVersion.isPresent()) {
+            URI versionUri = new URI(dcosUri + DCOS_VERSION_PATH);
+            Content content = Request.Get(versionUri)
+                    .execute().returnContent();
+            JSONObject jsonObject = new JSONObject(content.toString());
+            dcosVersion = Optional.of(new DcosVersion(jsonObject));
+        }
+
+        return dcosVersion.get();
+    }
+}

--- a/src/main/java/org/apache/mesos/dcos/DcosVersion.java
+++ b/src/main/java/org/apache/mesos/dcos/DcosVersion.java
@@ -22,13 +22,13 @@ import org.json.JSONObject;
  *     }
  */
 public class DcosVersion {
-    public static final String BOOTSTRAP_ID_KEY = "bootstrap-id";
-    public static final String DCOS_IMAGE_COMMIT = "dcos-image-commit";
-    public static final String VERSION_KEY = "version";
+    private static final String BOOTSTRAP_ID_KEY = "bootstrap-id";
+    private static final String DCOS_IMAGE_COMMIT = "dcos-image-commit";
+    private static final String VERSION_KEY = "version";
 
-    private String bootstrapId;
-    private String dcosImageCommit;
-    private String version;
+    private final String bootstrapId;
+    private final String dcosImageCommit;
+    private final String version;
 
     DcosVersion(String bootstrapId, String dcosImageCommit, String version) {
         this.bootstrapId = bootstrapId;

--- a/src/main/java/org/apache/mesos/dcos/DcosVersion.java
+++ b/src/main/java/org/apache/mesos/dcos/DcosVersion.java
@@ -1,0 +1,56 @@
+package org.apache.mesos.dcos;
+
+import org.json.JSONObject;
+
+/**
+ * This class encapsulates the response from a DC/OS cluster's dcos-metadata/dcos-version.json endpoint.
+ * Example response:
+ *     HTTP/1.1 200 OK
+ *     Accept-Ranges: bytes
+ *     Connection: keep-alive
+ *     Content-Length: 154
+ *     Content-Type: application/json
+ *     Date: Thu, 28 Jul 2016 17:57:48 GMT
+ *     ETag: "5797a2e7-9a"
+ *     Last-Modified: Tue, 26 Jul 2016 17:50:31 GMT
+ *     Server: openresty/1.7.10.2
+
+ *     {
+ *         "bootstrap-id": "27f0ee12ec563574dd9a6fa93faba1a1be38bde5",
+ *         "dcos-image-commit": "3fe4305af8ab9b4c2c3606569f3c0cb5c5437aa3",
+ *         "version": "1.7.3"
+ *     }
+ */
+public class DcosVersion {
+    public static final String BOOTSTRAP_ID_KEY = "bootstrap-id";
+    public static final String DCOS_IMAGE_COMMIT = "dcos-image-commit";
+    public static final String VERSION_KEY = "version";
+
+    private String bootstrapId;
+    private String dcosImageCommit;
+    private String version;
+
+    DcosVersion(String bootstrapId, String dcosImageCommit, String version) {
+        this.bootstrapId = bootstrapId;
+        this.dcosImageCommit = dcosImageCommit;
+        this.version = version;
+    }
+
+    DcosVersion(JSONObject jsonObject) {
+        this((String) jsonObject.get(DcosVersion.BOOTSTRAP_ID_KEY),
+             (String) jsonObject.get(DcosVersion.DCOS_IMAGE_COMMIT),
+             (String) jsonObject.get(DcosVersion.VERSION_KEY));
+    }
+
+    public String getBootstrapId() {
+        return bootstrapId;
+    }
+
+    public String getDcosImageCommit() {
+        return dcosImageCommit;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+}

--- a/src/main/java/org/apache/mesos/offer/OfferEvaluator.java
+++ b/src/main/java/org/apache/mesos/offer/OfferEvaluator.java
@@ -70,10 +70,10 @@ public class OfferEvaluator {
 
     MesosResourcePool pool = new MesosResourcePool(offer);
 
-    List<OfferRecommendation> unreserves = new ArrayList<OfferRecommendation>();
-    List<OfferRecommendation> reserves = new ArrayList<OfferRecommendation>();
-    List<OfferRecommendation> creates = new ArrayList<OfferRecommendation>();
-    List<OfferRecommendation> launches = new ArrayList<OfferRecommendation>();
+    List<OfferRecommendation> unreserves = new ArrayList<>();
+    List<OfferRecommendation> reserves = new ArrayList<>();
+    List<OfferRecommendation> creates = new ArrayList<>();
+    List<OfferRecommendation> launches = new ArrayList<>();
 
     ExecutorRequirement execReq = offerRequirement.getExecutorRequirement();
     FulfilledRequirement fulfilledExecutorRequirement = null;

--- a/src/test/java/org/apache/mesos/dcos/CapabilitiesTest.java
+++ b/src/test/java/org/apache/mesos/dcos/CapabilitiesTest.java
@@ -1,0 +1,39 @@
+package org.apache.mesos.dcos;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+
+/**
+ * This class tests the Capabilities class.
+ */
+public class CapabilitiesTest {
+    private MockDcosCluster mockDcosCluster;
+    private DcosCluster dcosCluster;
+
+    @After
+    public void afterEach() {
+        if (mockDcosCluster != null) {
+            mockDcosCluster.stop();
+        }
+    }
+
+    @Test
+    public void testHasNamedVipsFails() throws URISyntaxException, IOException {
+        mockDcosCluster =  MockDcosCluster.create("1.7.0");
+        dcosCluster = mockDcosCluster.getDcosCluster();
+        Capabilities capabilities = new Capabilities(dcosCluster);
+        Assert.assertFalse(capabilities.supportsNamedVips());
+    }
+
+    @Test
+    public void testHasNamedVipsSucceeds() throws URISyntaxException, IOException {
+        mockDcosCluster =  MockDcosCluster.create("1.8.0");
+        dcosCluster = mockDcosCluster.getDcosCluster();
+        Capabilities capabilities = new Capabilities(dcosCluster);
+        Assert.assertTrue(capabilities.supportsNamedVips());
+    }
+}

--- a/src/test/java/org/apache/mesos/dcos/DcosClusterTest.java
+++ b/src/test/java/org/apache/mesos/dcos/DcosClusterTest.java
@@ -1,0 +1,43 @@
+package org.apache.mesos.dcos;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.testng.Assert;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+
+/**
+ * This class tests the DcosCluster class.
+ */
+public class DcosClusterTest {
+    private MockDcosCluster mockDcosCluster;
+    private DcosCluster dcosCluster;
+    private static final String TEST_VERSION = "test-version";
+
+    @Before
+    public void beforeEach() throws URISyntaxException {
+        mockDcosCluster = MockDcosCluster.create(TEST_VERSION);
+        dcosCluster = mockDcosCluster.getDcosCluster();
+    }
+
+    @After
+    public void afterEach() {
+        mockDcosCluster.stop();
+    }
+
+    @Test
+    public void testGetVersion() throws IOException, URISyntaxException {
+        DcosVersion dcosVersion = dcosCluster.getDcosVersion();
+        Assert.assertNotNull(dcosVersion);
+        Assert.assertEquals(MockDcosCluster.TEST_BOOTSTRAP_ID, dcosVersion.getBootstrapId());
+        Assert.assertEquals(MockDcosCluster.TEST_DCOS_IMAGE_COMMIT, dcosVersion.getDcosImageCommit());
+        Assert.assertEquals(TEST_VERSION, dcosVersion.getVersion());
+    }
+
+    @Test
+    public void testGetUri() throws IOException, URISyntaxException {
+        Assert.assertEquals(mockDcosCluster.getUri(), dcosCluster.getDcosUri());
+    }
+}

--- a/src/test/java/org/apache/mesos/dcos/DcosVersionTest.java
+++ b/src/test/java/org/apache/mesos/dcos/DcosVersionTest.java
@@ -1,0 +1,25 @@
+package org.apache.mesos.dcos;
+
+import org.junit.Test;
+import org.testng.Assert;
+
+/**
+ * This class tests the DcosVersion class.
+ */
+public class DcosVersionTest {
+    private String testBootstrapId = "test-bootstrap-id";
+    private String testDcosImageCommit = "test-dcos-image-commit";
+    private String testVersion = "test-version";
+
+    @Test
+    public void testConstruction() {
+        DcosVersion dcosVersion = new DcosVersion(
+                testBootstrapId,
+                testDcosImageCommit,
+                testVersion);
+
+        Assert.assertEquals(testBootstrapId, dcosVersion.getBootstrapId());
+        Assert.assertEquals(testDcosImageCommit, dcosVersion.getDcosImageCommit());
+        Assert.assertEquals(testVersion, dcosVersion.getVersion());
+    }
+}

--- a/src/test/java/org/apache/mesos/dcos/MockDcosCluster.java
+++ b/src/test/java/org/apache/mesos/dcos/MockDcosCluster.java
@@ -1,0 +1,86 @@
+package org.apache.mesos.dcos;
+
+import io.netty.handler.codec.http.HttpHeaders;
+import org.mockserver.integration.ClientAndProxy;
+import org.mockserver.integration.ClientAndServer;
+import org.mockserver.model.Header;
+import org.springframework.http.MediaType;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import static org.mockserver.integration.ClientAndProxy.startClientAndProxy;
+import static org.mockserver.integration.ClientAndServer.startClientAndServer;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
+
+/**
+ * This class encapsulates a DC/OS Cluster which is mocked by a HTTP Server and Proxy.
+ */
+
+public class MockDcosCluster {
+    public static final String TEST_BOOTSTRAP_ID = "test-bootstrap-id";
+    public static final String TEST_DCOS_IMAGE_COMMIT = "test-dcos-image-commit";
+
+    private static final int mockServerPort = 1080;
+    private static final int mockProxyPort = 1090;
+    private ClientAndServer mockServer;
+    private ClientAndProxy mockProxy;
+    private URI testDcosUri;
+    private DcosCluster dcosCluster;
+    private String testVersion;
+
+    public static MockDcosCluster create(String testVersion) throws URISyntaxException {
+        return new MockDcosCluster(testVersion);
+    }
+
+    private MockDcosCluster(String testVersion) throws URISyntaxException {
+        this.testVersion = testVersion;
+        testDcosUri = new URI("http://127.0.0.1:" + getServerPort());
+        mockServer = startClientAndServer(getServerPort());
+        mockProxy = startClientAndProxy(getProxyPort());
+        dcosCluster = new DcosCluster(testDcosUri);
+        initializePaths();
+    }
+
+    public URI getUri() {
+        return testDcosUri;
+    }
+
+    public int getServerPort() {
+        return mockServerPort;
+    }
+
+    public int getProxyPort() {
+        return mockProxyPort;
+    }
+
+    public DcosCluster getDcosCluster() {
+        return dcosCluster;
+    }
+
+    public void stop() {
+        mockProxy.stop();
+        mockServer.stop();
+    }
+
+    private void initializePaths() {
+        mockServer
+                .when(
+                        request()
+                                .withPath("/dcos-metadata/dcos-version.json")
+                )
+                .respond(
+                        response()
+                                .withHeaders(
+                                        new Header(HttpHeaders.Names.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                                )
+                                .withBody("" +
+                                        "    {" + System.getProperty("line.separator") +
+                                        "        \"bootstrap-id\": \"" + TEST_BOOTSTRAP_ID + "\"," + System.getProperty("line.separator") +
+                                        "        \"dcos-image-commit\": \"" + TEST_DCOS_IMAGE_COMMIT + "\"," + System.getProperty("line.separator") +
+                                        "        \"version\": \"" + testVersion + "\"," + System.getProperty("line.separator") +
+                                        "    }")
+                );
+    }
+}


### PR DESCRIPTION
In order to make decisions regarding whether or not to attempt to use a particular feature it is necessary to know whether a particular version of DC/OS supports the feature.  The code here exposes the first example of determining whether a capability (named VIPs) is supported.