### PR TITLE
Implement a Go-based CLI module SDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 target/
+dcos-tests/
 
 # idea
 *.i??

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+# This script does a full build/upload of dcos-commons artifacts.
+# This script is invoked by Jenkins CI, but may also be run locally on a dev system.
+
+# Prevent jenkins from immediately killing the script when a step fails, allowing us to notify github:
+set +e
+
+REPO_ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd $REPO_ROOT_DIR
+
+# In theory, we could use Jenkins' "Multi SCM" script, but good luck with getting auto-build to work with that
+# Instead, clone the secondary 'dcos-tests' repo manually.
+if [ ! -d dcos-tests ]; then
+    git clone --depth 1 git@github.com:mesosphere/dcos-tests.git
+fi
+echo Running with dcos-tests rev: $(git --git-dir=dcos-tests/.git rev-parse HEAD)
+
+# GitHub notifier config
+_notify_github() {
+    # IF THIS FAILS FOR YOU, your dcos-tests is out of date!
+    # do this: rm -rf dcos-commons/dcos-tests/ then run build.sh again
+    $REPO_ROOT_DIR/dcos-tests/build/update-github-status.py $1 $2 $3
+}
+
+# Build steps for dcos-commons
+
+_notify_github pending build "Build running"
+
+# Java:
+
+./gradlew clean jar
+if [ $? -ne 0 ]; then
+  _notify_github failure build "Gradle build failed"
+  exit 1
+fi
+
+./gradlew check
+if [ $? -ne 0 ]; then
+  _notify_github failure build "Unit tests failed"
+  exit 1
+fi
+
+# Go (optional, build if tools are present):
+
+if [ -n "$(which go)" -a -n "$GOPATH" ]; then
+  echo "Building Go CLI example (GOPATH: $GOPATH, go: $(which go) => $(go version))"
+  # build must be performed within GOPATH, so set things up for that:
+  REPO_NAME=dcos-commons # CI dir does not match repo name
+  GOPATH_MESOSPHERE=$GOPATH/src/github.com/mesosphere
+  rm -rf $GOPATH_MESOSPHERE/$REPO_NAME
+  mkdir -p $GOPATH_MESOSPHERE
+  cd $GOPATH_MESOSPHERE
+  ln -s $REPO_ROOT_DIR $REPO_NAME
+  echo "Created symlink $(pwd)/$REPO_NAME -> $REPO_ROOT_DIR"
+  cd $REPO_NAME/cli/_example && go get && ./build-all.sh
+  if [ $? -ne 0 ]; then
+    _notify_github failure build "Go CLI build failed"
+    exit 1
+  fi
+else
+  echo "NOTICE: Skipping Go CLI build: 'go' executable not found or 'GOPATH' envvar is unset"
+fi
+
+_notify_github success build "Build succeeded"

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,86 @@
+# CLI Module
+
+**WARNING: This library has not yet settled on a stable API and may break at any time. For now we recommend using vendoring to avoid surprise breakages.**
+
+Common tools and libraries for implementing DC/OS CLI Modules for services.
+
+We recommend sticking to a 'thin client' model where possible, where the CLI is effectively a thin convenience wrapper around an HTTP API provided by your scheduler. This allows end-users to directly query those HTTP APIs (and develop tooling against them) without needing to (re)implement a lot of additional logic.
+
+The following functionality is provided to cover the needs of most 'thin clients' in line with the above model:
+- Standardized argument handling (via the [Kingpin](https://github.com/alecthomas/kingpin) library)
+- DC/OS authentication support (reusing authentication provided to the CLI)
+- Making HTTP GET/PUT/POST/DELETE calls to services
+- Pretty-printing JSON responses
+
+While the main DC/OS CLI is written in Python (and then compiled into a standalone binary), the CLI Modules developed using these tools are instead written directly in Go 1.5+. This is chosen to greatly simplify cross-compilation compared to Python. See the [example build-all.sh](_example/build-all.sh) for an example which cross compiles Linux/Mac/Win binaries in a single script.
+
+## Build
+
+Prerequisites:
+- git
+- [Go 1.5+](https://golang.org/dl/)
+
+First, get the code and set up the environment (edit `/YOUR/CODEPATH` and `/YOUR/GOPATH` as needed):
+
+```bash
+export CODEPATH=/YOUR/CODEPATH # eg ~/code
+export GOPATH=/YOUR/GOPATH # eg ~/go
+export GO15VENDOREXPERIMENT=1 # only required if using Go 1.5. for Go 1.6+ this step can be skipped
+
+mkdir -p $CODEPATH
+cd $CODEPATH
+
+git clone git@github.com:mesosphere/dcos-commons
+mkdir -p $GOPATH/src/github.com/mesosphere
+ln -s $CODEPATH/dcos-commons $GOPATH/src/github.com/mesosphere/dcos-commons
+```
+
+Assuming the above structure (with `~/code` for where you put your code and `~/go` for your `GOPATH`), the directory structure should look something like the following:
+
+```
+~/
+  code/
+    dcos-commons/
+  go/
+    src/
+      github.com/
+        mesosphere/
+          dcos-commons # symlink to ~/code/dcos-commons
+```
+
+Now you may build the example CLI module for each targeted platform:
+
+```bash
+cd $GOPATH/src/github.com/mesosphere/dcos-commons/cli/_example
+go get
+./build-all.sh # creates example.exe, example-darwin, example-linux
+./example-linux -h
+```
+
+## Develop
+
+See the [example CLI module](example/) for an example of how your CLI module could be built. The provided example adds a set of custom commands on top of the standard set.
+
+Like the example CLI module, your own code may simply access the CLI libraries provided here by importing `github.com/mesosphere/dcos-commons/cli`. Your CLI module implementation may pick and choose which standard commands should be included, while also implementing its own custom commands.
+
+### Direct execution
+
+You may manually test calls to your executable the same way that the DC/OS CLI would call it. See `Run` below.
+
+### Packaging
+
+1. Upload the executables to a persistent store.
+2. Generate SHA256 checksums for the executables, by running `sha256sum <file>` on Linux or OSX.
+3. Update your package's `resources.json` to point to the URLs from step 1, and to reference the checksums generated in step 2.
+
+## Run
+
+When installed, the module is executed as a regular binary by the DC/OS CLI, with a predefined set of arguments mapping to what the module is called and to what the user entered. The CLI will call it as follows:
+
+```bash
+$ <exename> <modulename> [args]
+```
+
+So for example, if someone called `dcos kafka broker list`, the `dcos-kafka` CLI module would be run as `dcos-kafka kafka broker list` by the DC/OS CLI.
+
+The inclusion of `modulename` (`kafka` in this example) as an argument allows reuse of a single CLI module binary across multiple installed modules. For example, the `kafka` and `confluent` packages are using the same underlying code for their CLI module, where the module just detects which branding to display via the `modulename`.

--- a/cli/_example/.gitignore
+++ b/cli/_example/.gitignore
@@ -1,0 +1,3 @@
+_example
+example-*
+example.exe

--- a/cli/_example/build-all.sh
+++ b/cli/_example/build-all.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+REPO_ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd $REPO_ROOT_DIR
+
+# The name of the binary produced by Go:
+if [ -z "$ORIG_EXE_NAME" ]; then
+    ORIG_EXE_NAME="_example"
+fi
+if [ -z "$EXE_NAME" ]; then
+    EXE_NAME="example"
+fi
+
+# Override the sha256 command using e.g.:
+# SHA_EXE="shasum -256" ./build.sh
+# Or, disable the command using:
+# SHA_EXE="" ./build.sh
+if [ -z "$SHA_EXE" ]; then
+    SHA_EXE=sha256sum
+fi
+
+print_file_and_shasum() {
+    # Only show 'file <filename>' if that utility is available: often missing in CI builds.
+    if [ -n "$(which file)" ]; then
+        file "$1"
+    fi
+    ls -l "$1"
+    if [ -n "$SHA_EXE" ]; then
+        $SHA_EXE "$1"
+    fi
+    echo ""
+}
+
+# may be omitted in 1.6+, left here for compatibility with 1.5:
+export GO15VENDOREXPERIMENT=1
+
+# available GOOS/GOARCH permutations are listed at:
+# https://golang.org/doc/install/source#environment
+
+# windows:
+GOOS=windows GOARCH=386 go build \
+    && mv -vf "${ORIG_EXE_NAME}.exe" "${EXE_NAME}.exe"
+if [ $? -ne 0 ]; then exit 1; fi
+print_file_and_shasum "${EXE_NAME}.exe"
+
+# osx (static build):
+SUFFIX="-darwin"
+CGO_ENABLED=0 GOOS=darwin GOARCH=386 go build \
+    && mv -vf "${ORIG_EXE_NAME}" "${EXE_NAME}${SUFFIX}"
+if [ $? -ne 0 ]; then exit 1; fi
+case "$OSTYPE" in
+    darwin*) strip "${EXE_NAME}${SUFFIX}"
+esac
+print_file_and_shasum "${EXE_NAME}${SUFFIX}"
+
+# linux (static build):
+SUFFIX="-linux"
+CGO_ENABLED=0 GOOS=linux GOARCH=386 go build \
+    && mv -vf "${ORIG_EXE_NAME}" "${EXE_NAME}${SUFFIX}"
+if [ $? -ne 0 ]; then exit 1; fi
+case "$OSTYPE" in
+    linux*) strip "${EXE_NAME}${SUFFIX}"
+esac
+print_file_and_shasum "${EXE_NAME}${SUFFIX}"

--- a/cli/_example/main.go
+++ b/cli/_example/main.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"fmt"
+	"github.com/mesosphere/dcos-commons/cli"
+	"gopkg.in/alecthomas/kingpin.v2"
+	"log"
+	"strings"
+)
+
+func main() {
+	app, err := cli.NewApp("0.1.0", "Mesosphere", "Provides an example for DC/OS service developers")
+	if err != nil {
+		log.Fatalf(err.Error())
+	}
+
+	handleExampleSection(app)
+	cli.HandleCommonArgs(app, "example", "Example DC/OS CLI Module")
+
+	// Omit modname:
+	kingpin.MustParse(app.Parse(cli.GetArguments()))
+}
+
+type ExampleCommand struct {
+	echoText        []string
+	echoOmitNewline bool
+}
+
+func (cmd *ExampleCommand) runEcho(c *kingpin.ParseContext) error {
+	if cmd.echoOmitNewline {
+		fmt.Printf(strings.Join(cmd.echoText, " "))
+	} else {
+		fmt.Printf("%s\n", strings.Join(cmd.echoText, " "))
+	}
+	return nil
+}
+
+func handleExampleSection(app *kingpin.Application) {
+	// example echo -n <text>, example ping <host/ip>
+	cmd := &ExampleCommand{}
+	example := app.Command("example", "Example custom commands")
+
+	echo := example.Command("echo", "Echos some text").Action(cmd.runEcho)
+	echo.Arg("text", "What to echo").StringsVar(&cmd.echoText)
+	echo.Flag("no-newline", "Omit newline").Short('n').BoolVar(&cmd.echoOmitNewline)
+}

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -1,0 +1,235 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"gopkg.in/alecthomas/kingpin.v2"
+	"os"
+)
+
+var (
+	Verbose bool
+)
+
+func GetModuleName() (string, error) {
+	if len(os.Args) < 2 {
+		return "", errors.New(fmt.Sprintf(
+			"Must have at least one argument for the CLI module name: %s <modname>", os.Args[0]))
+	}
+	return os.Args[1], nil
+}
+
+func GetArguments() []string {
+	// Exercise validation of argument count:
+	if len(os.Args) < 2 {
+		return make([]string, 0)
+	}
+	return os.Args[2:]
+}
+
+func NewApp(version string, author string, longDescription string) (*kingpin.Application, error) {
+	modName, err := GetModuleName()
+	if err != nil {
+		return nil, err
+	}
+
+	app := kingpin.New(modName, longDescription)
+	app.Version(version)
+	app.Author(author)
+	return app, nil
+}
+
+// Add all of the below arguments and commands
+
+func HandleCommonArgs(app *kingpin.Application, defaultServiceName string, shortDescription string) {
+	HandleCommonFlags(app, defaultServiceName, shortDescription)
+	HandleCommonSections(app)
+}
+
+// Standard Arguments
+
+func HandleCommonFlags(app *kingpin.Application, defaultServiceName string, shortDescription string) {
+	// -h (in addition to --help): standard help
+	app.HelpFlag.Short('h')
+	// -v/--verbose: show extra info about requests being made
+	app.Flag("verbose", "Enable extra logging of requests/responses").Short('v').BoolVar(&Verbose)
+
+	// --custom_auth_token <token> : use provided auth token instead of dcos CLI token
+	app.Flag("custom-auth-token", "Custom auth token to use when querying service").OverrideDefaultFromEnvar("DCOS_AUTH_TOKEN").OverrideDefaultFromEnvar("AUTH_TOKEN").StringVar(&dcosAuthToken)
+	// --custom-dcos-url <url> : use provided cluster url instead of dcos CLI url
+	app.Flag("custom-dcos-url", "Custom cluster URL to use when querying service").OverrideDefaultFromEnvar("DCOS_URI").OverrideDefaultFromEnvar("DCOS_URL").StringVar(&dcosUrl)
+
+	// --info : command to print description (fulfills interface that's expected by DC/OS CLI)
+	app.Flag("info", "Show short description.").PreAction(func(*kingpin.ParseContext) error {
+		fmt.Fprintf(os.Stdout, "%s\n", shortDescription)
+		os.Exit(0)
+		return nil
+	}).Bool()
+
+	// --name <name> : use provided framework name (default to <modulename>.service_name, if available)
+	overrideServiceName, err := RunDCOSCLICommand(
+		"config", "show", fmt.Sprintf("%s.service_name", os.Args[1]))
+	if err == nil {
+		defaultServiceName = overrideServiceName
+	}
+	app.Flag("name", "Name of the service instance to query").Default(defaultServiceName).StringVar(&serviceName)
+}
+
+// All sections
+
+func HandleCommonSections(app *kingpin.Application) {
+	HandleConfigSection(app)
+	HandleConnectionSection(app)
+	HandlePlanSection(app)
+	HandleStateSection(app)
+}
+
+// Config section
+
+type ConfigHandler struct {
+	showId string
+}
+
+func (cmd *ConfigHandler) runList(c *kingpin.ParseContext) error {
+	PrintJSON(HTTPGet("v1/configurations"))
+	return nil
+}
+func (cmd *ConfigHandler) runShow(c *kingpin.ParseContext) error {
+	PrintJSON(HTTPGet(fmt.Sprintf("v1/configurations/%s", cmd.showId)))
+	return nil
+}
+func (cmd *ConfigHandler) runTarget(c *kingpin.ParseContext) error {
+	PrintJSON(HTTPGet("v1/configurations/target"))
+	return nil
+}
+func (cmd *ConfigHandler) runTargetId(c *kingpin.ParseContext) error {
+	PrintJSON(HTTPGet("v1/configurations/targetId"))
+	return nil
+}
+
+func HandleConfigSection(app *kingpin.Application) {
+	// config <list, show, target, target_id>
+	cmd := &ConfigHandler{}
+	config := app.Command("config", "View persisted configurations")
+
+	config.Command("list", "List IDs of all available configurations").Action(cmd.runList)
+
+	show := config.Command("show", "Display a specified configuration").Action(cmd.runShow)
+	show.Arg("config_id", "ID of the configuration to display").Required().StringVar(&cmd.showId)
+
+	config.Command("target", "Display the target configuration").Action(cmd.runTarget)
+
+	config.Command("target_id", "List ID of the target configuration").Action(cmd.runTargetId)
+}
+
+// Connection section
+
+type ConnectionHandler struct {
+	typeName string
+}
+
+func (cmd *ConnectionHandler) runConnection(c *kingpin.ParseContext) error {
+	if len(cmd.typeName) == 0 {
+		// Root endpoint: Always produce JSON
+		PrintJSON(HTTPGet("v1/connection"))
+	} else {
+		// Any custom type endpoints: May be any format, so just print the raw text
+		PrintText(HTTPGet(fmt.Sprintf("v1/connection/%s", cmd.typeName)))
+	}
+	return nil
+}
+
+func HandleConnectionSection(app *kingpin.Application) {
+	// connection [type]
+	cmd := &ConnectionHandler{}
+	connection := app.Command("connection", "View connection information").Action(cmd.runConnection)
+	connection.Arg("type", "Type of connection information to retrieve").StringVar(&cmd.typeName)
+}
+
+// Plan section
+
+type PlanHandler struct {
+}
+
+func (cmd *PlanHandler) runActive(c *kingpin.ParseContext) error {
+	PrintJSON(HTTPGet("v1/plan/status"))
+	return nil
+}
+func (cmd *PlanHandler) runContinue(c *kingpin.ParseContext) error {
+	PrintJSON(HTTPGet("v1/plan/continue"))
+	return nil
+}
+func (cmd *PlanHandler) runForce(c *kingpin.ParseContext) error {
+	PrintJSON(HTTPGet("v1/plan/forceComplete"))
+	return nil
+}
+func (cmd *PlanHandler) runInterrupt(c *kingpin.ParseContext) error {
+	PrintJSON(HTTPGet("v1/plan/interrupt"))
+	return nil
+}
+func (cmd *PlanHandler) runRestart(c *kingpin.ParseContext) error {
+	PrintJSON(HTTPGet("v1/plan/restart"))
+	return nil
+}
+func (cmd *PlanHandler) runShow(c *kingpin.ParseContext) error {
+	// custom behavior: ignore 503 error
+	response := HTTPQuery(CreateHTTPRequest("GET", "v1/plan"), false)
+	if response.StatusCode != 503 &&
+		(response.StatusCode < 200 || response.StatusCode >= 300) {
+		return errors.New(fmt.Sprintf("Got HTTP status: %s", response.Status))
+	}
+	PrintJSON(response)
+	return nil
+}
+
+func HandlePlanSection(app *kingpin.Application) {
+	// plan <active, continue, force, interrupt, restart, show>
+	cmd := &PlanHandler{}
+	plan := app.Command("plan", "Query service plans")
+
+	plan.Command("active", "Display the active operation chain, if any").Action(cmd.runActive)
+	plan.Command("continue", "Continue a currently Waiting operation").Action(cmd.runContinue)
+	plan.Command("force", "Force the current operation to complete").Action(cmd.runForce)
+	plan.Command("interrupt", "Interrupt the current InProgress operation").Action(cmd.runInterrupt)
+	plan.Command("restart", "Restart the current operation").Action(cmd.runRestart)
+	plan.Command("show", "Display the full plan").Action(cmd.runShow)
+}
+
+// State section
+
+type StateHandler struct {
+	TaskName string
+}
+
+func (cmd *StateHandler) runFrameworkId(c *kingpin.ParseContext) error {
+	PrintJSON(HTTPGet("v1/state/frameworkId"))
+	return nil
+}
+func (cmd *StateHandler) runStatus(c *kingpin.ParseContext) error {
+	PrintJSON(HTTPGet(fmt.Sprintf("v1/state/tasks/status/%s", cmd.TaskName)))
+	return nil
+}
+func (cmd *StateHandler) runTask(c *kingpin.ParseContext) error {
+	PrintJSON(HTTPGet(fmt.Sprintf("v1/state/tasks/info/%s", cmd.TaskName)))
+	return nil
+}
+func (cmd *StateHandler) runTasks(c *kingpin.ParseContext) error {
+	PrintJSON(HTTPGet("v1/state/tasks"))
+	return nil
+}
+
+func HandleStateSection(app *kingpin.Application) {
+	// state <framework_id, status, task, tasks>
+	cmd := &StateHandler{}
+	state := app.Command("state", "View persisted state")
+
+	state.Command("framework_id", "Display the mesos framework ID").Action(cmd.runFrameworkId)
+
+	status := state.Command("status", "Display the TaskStatus for a task name").Action(cmd.runStatus)
+	status.Arg("name", "Name of the task to display").Required().StringVar(&cmd.TaskName)
+
+	task := state.Command("task", "Display the TaskInfo for a task name").Action(cmd.runTask)
+	task.Arg("name", "Name of the task to display").Required().StringVar(&cmd.TaskName)
+
+	state.Command("tasks", "List names of all persisted tasks").Action(cmd.runTasks)
+}

--- a/cli/http.go
+++ b/cli/http.go
@@ -1,0 +1,128 @@
+package cli
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"net/http"
+	"net/url"
+	"path"
+)
+
+var (
+	dcosAuthToken string
+	dcosUrl       string
+	serviceName   string
+)
+
+func HTTPGet(urlPath string) *http.Response {
+	return HTTPQuery(CreateHTTPRequest("GET", urlPath), true)
+}
+func HTTPGetData(urlPath, payload, contentType string) *http.Response {
+	return HTTPQuery(CreateHTTPDataRequest("GET", urlPath, payload, contentType), true)
+}
+func HTTPGetJSON(urlPath, jsonPayload string) *http.Response {
+	return HTTPQuery(CreateHTTPJSONRequest("GET", urlPath, jsonPayload), true)
+}
+
+func HTTPDelete(urlPath string) *http.Response {
+	return HTTPQuery(CreateHTTPRequest("DELETE", urlPath), true)
+}
+func HTTPDeleteData(urlPath, payload, contentType string) *http.Response {
+	return HTTPQuery(CreateHTTPDataRequest("DELETE", urlPath, payload, contentType), true)
+}
+func HTTPDeleteJSON(urlPath, jsonPayload string) *http.Response {
+	return HTTPQuery(CreateHTTPJSONRequest("DELETE", urlPath, jsonPayload), true)
+}
+
+func HTTPPost(urlPath string) *http.Response {
+	return HTTPQuery(CreateHTTPRequest("POST", urlPath), true)
+}
+func HTTPPostData(urlPath, payload, contentType string) *http.Response {
+	return HTTPQuery(CreateHTTPDataRequest("POST", urlPath, payload, contentType), true)
+}
+func HTTPPostJSON(urlPath, jsonPayload string) *http.Response {
+	return HTTPQuery(CreateHTTPJSONRequest("POST", urlPath, jsonPayload), true)
+}
+
+func HTTPPut(urlPath string) *http.Response {
+	return HTTPQuery(CreateHTTPRequest("PUT", urlPath), true)
+}
+func HTTPPutData(urlPath, payload, contentType string) *http.Response {
+	return HTTPQuery(CreateHTTPDataRequest("PUT", urlPath, payload, contentType), true)
+}
+func HTTPPutJSON(urlPath, jsonPayload string) *http.Response {
+	return HTTPQuery(CreateHTTPJSONRequest("PUT", urlPath, jsonPayload), true)
+}
+
+func HTTPQuery(request *http.Request, checkResponseStatus bool) *http.Response {
+	client := &http.Client{}
+	response, err := client.Do(request)
+	if err != nil {
+		// err contains method/parsedUrl. avoid repeating ourselves:
+		log.Printf("HTTP Query failed: %s", err)
+		log.Printf("- Is 'core.dcos_url' set correctly? Check 'dcos config show core.dcos_url'.")
+		log.Fatalf("- Is 'core.dcos_acs_token' set correctly? Call 'dcos auth login' to log in.")
+	}
+	if response.StatusCode == 401 {
+		log.Fatalf("Got 401 Unauthorized response from %s. Bad auth token? Call 'dcos auth login' to log in.", request.URL)
+	}
+	if checkResponseStatus {
+		switch {
+		case response.StatusCode == 500:
+			log.Printf("HTTP %s Query for %s failed: %s", request.Method, request.URL, response.Status)
+			log.Printf("- Did you select the correct service name? Use '--name=<name>' to assign the name.")
+			log.Fatalf("- Is the service recently installed and still initializing? Wait a bit and try again.")
+		case response.StatusCode < 200 || response.StatusCode >= 300:
+			log.Fatalf("HTTP %s Query for %s failed: %s", request.Method, request.URL, response.Status)
+		}
+	}
+	if Verbose {
+		log.Printf("Response: %s (%d bytes)", response.Status, response.ContentLength)
+	}
+	return response
+}
+
+func CreateHTTPJSONRequest(method, urlPath, jsonPayload string) *http.Request {
+	return CreateHTTPDataRequest(method, urlPath, jsonPayload, "application/json")
+}
+
+func CreateHTTPRequest(method, urlPath string) *http.Request {
+	return CreateHTTPDataRequest(method, urlPath, "", "")
+}
+
+func CreateHTTPDataRequest(method, urlPath, payload, contentType string) *http.Request {
+	// get data from CLI, if overrides were not provided by user:
+	if len(dcosUrl) == 0 {
+		dcosUrl = GetCheckedDCOSCLIConfigValue(
+			"core.dcos_url",
+			"DC/OS Cluster URL",
+			"Run 'dcos config set core.dcos_url http://your-cluster.com' to configure.")
+	}
+	parsedUrl, err := url.Parse(dcosUrl)
+	if err != nil {
+		log.Fatalf("Unable to parse DC/OS Cluster URL '%s': %s", dcosUrl, err)
+	}
+	if len(dcosAuthToken) == 0 {
+		dcosAuthToken = GetCheckedDCOSCLIConfigValue(
+			"core.dcos_acs_token",
+			"DC/OS Authentication Token",
+			"Run 'dcos auth login' to log in to the cluster.")
+	}
+	parsedUrl.Path = path.Join("service", serviceName, urlPath)
+	if Verbose {
+		log.Printf("HTTP Query: %s %s", method, parsedUrl)
+		if len(payload) != 0 {
+			log.Printf("  Payload: %s", payload)
+		}
+	}
+	request, err := http.NewRequest(method, parsedUrl.String(), bytes.NewReader([]byte(payload)))
+	if err != nil {
+		log.Fatalf("Failed to create HTTP %s request for %s: %s", method, parsedUrl, err)
+	}
+	request.Header.Set("Authorization", fmt.Sprintf("token=%s", dcosAuthToken))
+	if len(contentType) != 0 {
+		request.Header.Set("Content-Type", contentType)
+	}
+	return request
+}

--- a/cli/response.go
+++ b/cli/response.go
@@ -1,0 +1,41 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+)
+
+func PrintText(response *http.Response) {
+	fmt.Fprintf(os.Stdout, "%s\n", GetResponseText(response))
+}
+
+func PrintJSON(response *http.Response) {
+	responseBytes := GetResponseBytes(response)
+	var outBuf bytes.Buffer
+	err := json.Indent(&outBuf, responseBytes, "", "  ")
+	if err != nil {
+		log.Printf("Failed to prettify JSON response data from %s %s query: %s",
+			response.Request.Method, response.Request.URL, err)
+		log.Fatalf("Original data: %s", responseBytes)
+	}
+	fmt.Fprintf(os.Stdout, "%s\n", outBuf.String())
+}
+
+func GetResponseText(response *http.Response) string {
+	return string(GetResponseBytes(response))
+}
+
+func GetResponseBytes(response *http.Response) []byte {
+	defer response.Body.Close()
+	responseBytes, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		log.Fatalf("Failed to read response data from %s %s query: %s",
+			response.Request.Method, response.Request.URL, err)
+	}
+	return responseBytes
+}

--- a/cli/runcli.go
+++ b/cli/runcli.go
@@ -1,0 +1,37 @@
+package cli
+
+import (
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// TODO(nick): Consider breaking this config retrieval out into a separate independent library?
+
+func RunDCOSCLICommand(arg ...string) (string, error) {
+	outBytes, err := exec.Command("dcos", arg...).CombinedOutput()
+	if err != nil {
+		if Verbose {
+			log.Printf("PATH: %s", os.Getenv("PATH"))
+		}
+		return string(outBytes), err
+	}
+	// trim any trailing newline (or any other whitespace) if present:
+	return strings.TrimSpace(string(outBytes)), nil
+}
+
+func GetCheckedDCOSCLIConfigValue(name string, description string, errorInstruction string) string {
+	output, err := RunDCOSCLICommand("config", "show", name)
+	if err != nil {
+		log.Printf("Unable to retrieve configuration value %s (%s) from CLI. %s:",
+			name, description, errorInstruction)
+		log.Printf("Error: %s", err.Error())
+		log.Printf("Output: %s", output)
+	}
+	if len(output) == 0 {
+		log.Fatalf("CLI configuration value %s (%s) is missing/unset. %s",
+			name, description, errorInstruction)
+	}
+	return output
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.daemon=true


### PR DESCRIPTION
The current Python-based CLI modules are very simple (thin convenience wrappers around HTTP endpoints), but building Python binaries is very complicated/brittle. To resolve this, let's use a language that's trivial to cross-compile.
    
Includes:
- Helpers for:
  - Querying the service (with auth token/url automatically pulled from 'dcos config')
  - Pretty-printing data
- Implementations of all common scheduler HTTP endpoints (e.g. plan/config/state)
  - Easy for developers to add custom commands for implementation-specific endpoints.
- 'Example' CLI module which adds an `echo` command on top of the common commands, as a sample of what a framework developer would do.
- Sample `build.sh` for building Lin/Win/Mac binaries from any system which has go tools installed (see README)