### PR TITLE
Automatically repairing scheduler implementation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,7 @@ ext {
 }
 
 group = "mesosphere"
-version = "0.4.29-SNAPSHOT"
+version = "0.4.30-SNAPSHOT"
 
 task sourceJar(type: Jar) {
   from sourceSets.main.allJava

--- a/docs/automatic-repair.md
+++ b/docs/automatic-repair.md
@@ -1,0 +1,70 @@
+# Integrating the Automatic Repair Scheduler Feature
+
+dcos-commons provides a framework to add automatic repairs to your scheduler.
+Automatic repairs means that we can detect when a container crashes and restart it attached to the same resources if possible, and otherwise start it elsewhere on the cluster.
+
+## Terminology
+
+Here we'll collect some of the terms used throughout the code.
+
+### Failed task
+
+A task is considered failed when it first transitions to a terminal state.
+Failed tasks might have undergone a transient issue; because of this, they will be attempted to be restarted in place.
+This allows them to use any persistent data they've written to disk--critical for a database!
+
+### Stopped task
+
+A task is considered stopped when it is definitely not going to be launched again in place.
+Stopped tasks represent situations where the machine or data is corrupt, and we need to perform heavier-weight recovery.
+Stopped tasks have lost all their data.
+
+## Usage
+
+The main entrypoint for the automatic repair functionality is the `RepairScheduler`.
+Once you create a `RepairScheduler`, you simple call `resourceOffers` whenever you'd like the repairs to run.
+
+You may also create a `RepairController` to expose an API to interact with the RepairScheduler.
+
+### Developer Steps
+
+To integrate the repair scheduler, you'll first need to implement 2 interfaces: `RepairOfferRequirementProvider` and `TaskFailureListener`.
+These are specific to your framework.
+Then, you should create an `AtomicReference<RepairStatus>` so that you can share it between your API code and the repair scheduler.
+At this point, you'll be able to create a `RepairScheduler`.
+Some users may wish to build custom `LaunchConstrainer`s or `FailureMonitor`s if the included behaviors don't meet your needs.
+
+Most of the parameters to the `RepairScheduler` are self-explanatory.
+We'll elaborate on a few of the APIs specific to the `RepairScheduler`.
+
+### `RepairOfferRequirementProvider`
+
+The `RepairOfferRequirementProvider` has 2 methods to create new `OfferRequirement`s to relaunch stopped and failed tasks.
+
+`getReplacementOfferRequirement` takes the terminated task as an argument and returns a new `OfferRequirement` that will relaunch that task using the resources from the terminated task.
+
+`maybeGetNewOfferRequirement` has the flexibility to decide, based on the current `Block`, the current configuration, and any failed tasks its learned of via the `TaskFailureListener` to make an `OfferRequirement` to relaunch a task.
+If there's nothing it wants to do, it should return an empty `Optional`.
+
+### `TaskFailureListener`
+
+`TaskFailureListener` is used to notify the framework when a failed task transitions to the stopped state.
+This allows the framework to do whatever it needs to do in order be able to provider new offer requirements for relaunching the stopped task.
+
+### `AtomicReference<RepairStatus>`
+
+This reference will be continuously updated to contain the latest sets of stopped and failed tasks.
+This can be consumed by tests for inspecting the internal state of the repair scheduler, and it's consumed by the `RepairController` to provide an API endpoint.
+
+### `FailureMonitor`
+
+The `FailureMonitor` is responsible for determining when a stopped task should transition to the failed state.
+Many frameworks may prefer to use the `TimedFailureMonitor`, which allows you to express how many minutes to wait until the task can be trusted to be never coming back.
+There's also a `TestingFailureMonitor`, which is useful for writing tests to control the behavior of the repair scheduler.
+
+### `LaunchConstrainer`
+
+The `LaunchConstrainer` is repsonsible for enforcing safety and performance constraints when relaunching stopped & failed tasks.
+This way, you can ensure that relaunching doesn't overload the replication mechanisms of the database, or occur at a bad time.
+By default, we include a constrainer that does simple rate limiting, and a constrainer designed for making it easy to write tests.
+You may wish to write your own constrainers that restrict launches to off-peak times, or observe internal database metrics to decide when it's safe to launch.

--- a/src/main/java/org/apache/mesos/config/RepairConfiguration.java
+++ b/src/main/java/org/apache/mesos/config/RepairConfiguration.java
@@ -1,0 +1,93 @@
+package org.apache.mesos.config;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents the repair configuration in JSON.
+ */
+public class RepairConfiguration {
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+        return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        RepairConfiguration that = (RepairConfiguration) o;
+
+        if (gracePeriodMins != that.gracePeriodMins) {
+            return false;
+        }
+        if (repairDelaySecs != that.repairDelaySecs) {
+            return false;
+        }
+        return enableReplacement == that.enableReplacement;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = gracePeriodMins;
+        result = 31 * result + repairDelaySecs;
+        result = 31 * result + (enableReplacement ? 1 : 0);
+        return result;
+    }
+
+    @JsonProperty("repair_in_place_grace_period_mins")
+    private int gracePeriodMins;
+    @JsonProperty("min_delay_between_repairs_secs")
+    private int repairDelaySecs;
+    @JsonProperty("enable_replacement")
+    private boolean enableReplacement;
+
+    public  RepairConfiguration() {}
+
+    @JsonCreator
+    public RepairConfiguration(
+            @JsonProperty("repair_in_place_grace_period_mins") int gracePeriodMins,
+            @JsonProperty("min_delay_between_repairs_secs") int repairDelaySecs,
+            @JsonProperty("enableReplacement") boolean enableReplacement) {
+        this.gracePeriodMins = gracePeriodMins;
+        this.repairDelaySecs = repairDelaySecs;
+        this.enableReplacement = enableReplacement;
+    }
+
+    public boolean isReplacementEnabled() {
+        return enableReplacement;
+    }
+
+    @JsonProperty("enable_replacement")
+    public void setEnableReplacement(boolean enableReplacement) {
+        this.enableReplacement = enableReplacement;
+    }
+
+    public int getRepairDelaySecs() {
+        return repairDelaySecs;
+    }
+
+    @JsonProperty("min_delay_between_repairs_secs")
+    public void setRepairDelaySecs(int repairDelaySecs) {
+        this.repairDelaySecs = repairDelaySecs;
+    }
+
+    public int getGracePeriodMins() {
+        return gracePeriodMins;
+    }
+
+    @JsonProperty("repair_in_place_grace_period_mins")
+    public void setGracePeriodMins(int gracePeriodMins) {
+        this.gracePeriodMins = gracePeriodMins;
+    }
+
+    @Override
+    public String toString() {
+        return "RepairConfiguration{" +
+                "gracePeriodMins=" + gracePeriodMins +
+                ", repairDelaySecs=" + repairDelaySecs +
+                ", enableReplacement=" + enableReplacement +
+                '}';
+    }
+}

--- a/src/main/java/org/apache/mesos/scheduler/repair/RepairOfferRequirementProvider.java
+++ b/src/main/java/org/apache/mesos/scheduler/repair/RepairOfferRequirementProvider.java
@@ -1,0 +1,51 @@
+package org.apache.mesos.scheduler.repair;
+
+import org.apache.mesos.Protos.TaskInfo;
+import org.apache.mesos.config.ConfigStoreException;
+import org.apache.mesos.offer.InvalidRequirementException;
+import org.apache.mesos.offer.OfferRequirement;
+import org.apache.mesos.scheduler.plan.Block;
+import org.apache.mesos.scheduler.repair.monitor.FailureMonitor;
+
+import java.util.Optional;
+
+/**
+ * Implementions of this know how to relaunch tasks from a framework when those tasks crash or fail.
+ * <p>
+ * The method {@link RepairOfferRequirementProvider#getReplacementOfferRequirement(TaskInfo)} is called once a given
+ * task crashes. The implementation should look at the given {@link TaskInfo} in order to know which task it's
+ * replacing, and where that task's resources & data have been reserved.
+ * <p>
+ * The method {@link RepairOfferRequirementProvider#maybeGetNewOfferRequirement(String, Block)} is called once the
+ * framework's {@link FailureMonitor} decides that a task has permanently failed, and we should try to find a new
+ * location to run it. Typicaly, this means that if the task represented a database, the data on that node is
+ * permanently lost.
+ */
+public interface RepairOfferRequirementProvider {
+    /**
+     * Possibly returns an {@link OfferRequirement} that will replace a missing task.
+     * <p>
+     * Implementations should not try to relaunch the current {@link Block}'s task.
+     *
+     * @param targetConfigName The current configuration we're moving towards
+     * @param currentBlock     The current {@link Block} being executed
+     * @return {@link OfferRequirement} to relaunch a failed task, or none if all tasks are present
+     * @throws InvalidRequirementException
+     * @throws ConfigStoreException
+     */
+    Optional<OfferRequirement> maybeGetNewOfferRequirement(String targetConfigName, Block currentBlock)
+            throws InvalidRequirementException, ConfigStoreException;
+
+    /**
+     * Computes a new {@link OfferRequirement} that will relaunch-in-place the given {@link TaskInfo}.
+     * <p>
+     * This will only be called when the argument is in a terminal state, before the {@link FailureMonitor} decides that
+     * task is definitely gone forever. The implementation should ensure it's reusing the resources that were reserved
+     * by the given {@literal terminatedTask}.
+     *
+     * @param terminatedTask The task that has stopped and needs to be relaunched.
+     * @return {@link OfferRequirement} to relaunch the stopped task in place
+     * @throws InvalidRequirementException
+     */
+    OfferRequirement getReplacementOfferRequirement(TaskInfo terminatedTask) throws InvalidRequirementException;
+}

--- a/src/main/java/org/apache/mesos/scheduler/repair/RepairResource.java
+++ b/src/main/java/org/apache/mesos/scheduler/repair/RepairResource.java
@@ -1,0 +1,37 @@
+package org.apache.mesos.scheduler.repair;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Simple endpoint to expose repair state information.
+ * <p>
+ * Renders the stopped tasks and failed tasks as JSON, so that the operator can understand the status of the system.
+ */
+@Path("/v1/repair")
+public class RepairResource {
+    private static final Log log = LogFactory.getLog(RepairResource.class);
+
+    private final AtomicReference<RepairStatus> repairStatus;
+
+    public RepairResource(AtomicReference<RepairStatus> repairStatus) {
+        this.repairStatus = repairStatus;
+    }
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public RepairStatus repair() {
+        try {
+            return repairStatus.get();
+        } catch (Exception ex) {
+            log.error("Failed to fetch data with exception:", ex);
+            throw ex;
+        }
+    }
+}

--- a/src/main/java/org/apache/mesos/scheduler/repair/RepairScheduler.java
+++ b/src/main/java/org/apache/mesos/scheduler/repair/RepairScheduler.java
@@ -1,0 +1,177 @@
+package org.apache.mesos.scheduler.repair;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.mesos.Protos.Offer;
+import org.apache.mesos.Protos.Offer.Operation;
+import org.apache.mesos.Protos.OfferID;
+import org.apache.mesos.Protos.TaskInfo;
+import org.apache.mesos.SchedulerDriver;
+import org.apache.mesos.offer.OfferAccepter;
+import org.apache.mesos.offer.OfferEvaluator;
+import org.apache.mesos.offer.OfferRecommendation;
+import org.apache.mesos.offer.OfferRequirement;
+import org.apache.mesos.scheduler.plan.Block;
+import org.apache.mesos.scheduler.repair.constrain.LaunchConstrainer;
+import org.apache.mesos.scheduler.repair.monitor.FailureMonitor;
+import org.apache.mesos.state.StateStore;
+
+import java.util.*;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
+/**
+ * This class provides the core functionality of the automatic repair mechanisms.
+ */
+public class RepairScheduler {
+    private final Log log = LogFactory.getLog(getClass());
+
+    private final String targetConfigName;
+    private final StateStore stateStore;
+    private final OfferAccepter offerAccepter;
+    private final TaskFailureListener failureListener;
+    private final RepairOfferRequirementProvider offerReqProvider;
+    private final FailureMonitor failureMonitor;
+    private final LaunchConstrainer launchConstrainer;
+    private final AtomicReference<RepairStatus> repairStatusRef;
+
+    public RepairScheduler(
+            String targetConfigName,
+            StateStore stateStore,
+            TaskFailureListener failureListener,
+            RepairOfferRequirementProvider offerReqProvider,
+            OfferAccepter offerAccepter,
+            LaunchConstrainer launchConstrainer,
+            FailureMonitor failureMonitor,
+            AtomicReference<RepairStatus> repairStatusRef) {
+        this.targetConfigName = targetConfigName;
+        this.stateStore = stateStore;
+        this.offerReqProvider = offerReqProvider;
+        this.offerAccepter = offerAccepter;
+        this.failureMonitor = failureMonitor;
+        this.launchConstrainer = launchConstrainer;
+        this.repairStatusRef = repairStatusRef;
+        this.failureListener = failureListener;
+    }
+
+    /**
+     * This function runs the repair logic. It should be invoked periodically.
+     *
+     * This function is synchronized in order to avoid launchConstrainer race conditions.
+     * The situation we need to avoid is 2 threads getting approval from the launchConstrainer, when only one should
+     * have been allowed to proceed. If this issue was dealt with via another mechanism, we could make this function
+     * unsynchronized.
+     *
+     * @param driver The current SchedulerDriver
+     * @param offers A list of offers to use to launch tasks
+     * @param block The current block, or null if there isn't any
+     * @return IDs of accepted offers
+     * @throws Exception
+     */
+    public synchronized List<OfferID> resourceOffers(SchedulerDriver driver, List<Offer> offers, Block block)
+            throws Exception {
+        List<OfferID> acceptedOffers = new ArrayList<>();
+        List<TaskInfo> terminatedTasks = new ArrayList<>(getTerminatedTasks(block));
+
+        // Compute the stopped and failed pool for UI
+        RepairStatus oldStatus = repairStatusRef.get();
+        if (oldStatus == null) {
+            oldStatus = new RepairStatus(Collections.emptyList(), Collections.emptyList());
+        }
+        List<String> oldFailed = oldStatus.getFailed();
+        List<String> newFailed = new ArrayList<>(terminatedTasks.stream()
+                .filter(failureMonitor::hasFailed)
+                .map(TaskInfo::getName)
+                .collect(Collectors.toList()));
+        newFailed.addAll(oldFailed);
+        //TODO (ghartman) possibly write this list down in ZK, to ensure the UI doesn't change upon restart
+        newFailed = newFailed.stream().distinct().collect(Collectors.toList());
+        List<String> newStopped = terminatedTasks.stream()
+                .filter(it -> !failureMonitor.hasFailed(it))
+                .map(TaskInfo::getName)
+                .collect(Collectors.toList());
+
+        Optional<OfferRequirement> offerReq = Optional.empty();
+        boolean replacingFailed = false;
+
+        if (terminatedTasks.size() > 0) {
+            TaskInfo terminatedTask = terminatedTasks.get(new Random().nextInt(terminatedTasks.size()));
+            log.info("Found stopped task");
+            if (failureMonitor.hasFailed(terminatedTask)) {
+                log.info("Marking stopped task as failed");
+                failureListener.taskFailed(terminatedTask.getTaskId());
+            } else {
+                log.info("Relaunching stopped task in place");
+                offerReq = Optional.of(offerReqProvider.getReplacementOfferRequirement(terminatedTask));
+            }
+        } else {
+            log.info("Launching a failed task");
+            replacingFailed = true;
+            offerReq = offerReqProvider.maybeGetNewOfferRequirement(targetConfigName, block);
+        }
+
+        if (offerReq.isPresent() && launchConstrainer.canLaunch(offerReq.get())) {
+            log.info("Preparing to launch task");
+            OfferEvaluator offerEvaluator = new OfferEvaluator();
+            List<OfferRecommendation> recommendations = offerEvaluator.evaluate(offerReq.get(), offers);
+            if (!recommendations.isEmpty()) {
+                // we're replacing some task(s)
+                Set<String> relaunchedTasks = recommendations.stream()
+                        .filter(it -> it.getOperation().hasLaunch())
+                        .flatMap(it -> it.getOperation().getLaunch().getTaskInfosList().stream())
+                        .map(TaskInfo::getName)
+                        .collect(Collectors.toSet());
+                if (replacingFailed) {
+                    // we'll filter their names out of the failed pool
+                    newFailed = newFailed.stream()
+                            .filter(it -> !relaunchedTasks.contains(it))
+                            .collect(Collectors.toList());
+                } else {
+                    // we'll filter their names out of the stopped pool
+                    newStopped = newStopped.stream()
+                            .filter(it -> !relaunchedTasks.contains(it))
+                            .collect(Collectors.toList());
+                }
+            }
+            List<Operation> launchOperations = recommendations.stream()
+                    .map(OfferRecommendation::getOperation)
+                    .filter(Operation::hasLaunch)
+                    .collect(Collectors.toList());
+            if (launchOperations.size() > 1) {
+                throw new IllegalArgumentException("Repairs should only launch one task at a time, found "
+                        + launchOperations.size() + " tasks");
+            }
+            acceptedOffers = offerAccepter.accept(driver, recommendations);
+            if (launchOperations.size() == 1) {
+                // We could've launched nothing if the offer didn't fit
+                launchConstrainer.launchHappened(launchOperations.get(0));
+            }
+        }
+
+        repairStatusRef.set(new RepairStatus(newStopped, newFailed));
+
+        return acceptedOffers;
+    }
+
+    private Collection<TaskInfo> getTerminatedTasks(Block block) {
+        List<TaskInfo> filteredTerminatedTasks = new ArrayList<TaskInfo>();
+
+        try {
+            if (block == null) {
+                return stateStore.fetchTerminatedTasks();
+            }
+
+            String blockName = block.getName();
+            for (TaskInfo taskInfo : stateStore.fetchTerminatedTasks()) {
+                if (!taskInfo.getName().equals(blockName)) {
+                    filteredTerminatedTasks.add(taskInfo);
+                }
+            }
+        } catch (Exception ex) {
+            log.error("Stopped to fetch terminated tasks.");
+        }
+
+        return filteredTerminatedTasks;
+    }
+
+}

--- a/src/main/java/org/apache/mesos/scheduler/repair/RepairStatus.java
+++ b/src/main/java/org/apache/mesos/scheduler/repair/RepairStatus.java
@@ -1,0 +1,64 @@
+package org.apache.mesos.scheduler.repair;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Objects;
+
+import java.util.List;
+
+/**
+ * Represents the collection of nodes in the stopped and failed pools.
+ * <p>
+ * Failed nodes are ones whose task is no longer running, but we believe may be restarted. This allows them to recover
+ * data persisted to disk.
+ * <p>
+ * Stopped nodes are ones we believe are completely gone, and must be restarted elsewhere.
+ */
+public class RepairStatus {
+    private final List<String> stopped;
+    private final List<String> failed;
+
+    @JsonCreator
+    public RepairStatus(
+            @JsonProperty("stopped") List<String> stopped,
+            @JsonProperty("failed") List<String> failed) {
+        this.stopped = stopped;
+        this.failed = failed;
+    }
+
+    @JsonProperty
+    public List<String> getStopped() {
+        return stopped;
+    }
+
+    @JsonProperty
+    public List<String> getFailed() {
+        return failed;
+    }
+
+    @Override
+    public String toString() {
+        return "RepairStatus{" +
+                "stopped=" + stopped +
+                ", failed=" + failed +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        RepairStatus that = (RepairStatus) o;
+        return Objects.equal(stopped, that.stopped) &&
+                Objects.equal(failed, that.failed);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(stopped, failed);
+    }
+}

--- a/src/main/java/org/apache/mesos/scheduler/repair/TaskFailureListener.java
+++ b/src/main/java/org/apache/mesos/scheduler/repair/TaskFailureListener.java
@@ -1,0 +1,15 @@
+package org.apache.mesos.scheduler.repair;
+
+import org.apache.mesos.Protos.TaskID;
+
+/**
+ * Exposes simple task-oriented API for components that need to interact with the framework as a whole.
+ */
+public interface TaskFailureListener {
+    /**
+     * Notifies that the task identified by the given {@link TaskID} has failed.
+     *
+     * @param taskId The ID of the task to delete
+     */
+    void taskFailed(TaskID taskId);
+}

--- a/src/main/java/org/apache/mesos/scheduler/repair/constrain/AllLaunchConstrainer.java
+++ b/src/main/java/org/apache/mesos/scheduler/repair/constrain/AllLaunchConstrainer.java
@@ -1,0 +1,42 @@
+package org.apache.mesos.scheduler.repair.constrain;
+
+import org.apache.mesos.Protos.Offer.Operation;
+import org.apache.mesos.offer.OfferRequirement;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A {@link LaunchConstrainer} combinator that ensures that all the given constrainers are satisfied before launching a
+ * task. Useful to create policies that need to limit launches to a certain rate, and when it's an off-peak time.
+ * <p>
+ * N.B. When determining whether a launch can happen, this object will short-circuit if any of its {@link
+ * LaunchConstrainer}s reject the task.
+ */
+public class AllLaunchConstrainer implements LaunchConstrainer {
+    private List<LaunchConstrainer> constrainers;
+
+    public AllLaunchConstrainer(LaunchConstrainer... constrainers) {
+        this.constrainers = new ArrayList<>();
+        for (LaunchConstrainer constrainer : constrainers) {
+            this.constrainers.add(constrainer);
+        }
+    }
+
+    @Override
+    public void launchHappened(Operation launchOperation) {
+        for (LaunchConstrainer constrainer : constrainers) {
+            constrainer.launchHappened(launchOperation);
+        }
+    }
+
+    @Override
+    public boolean canLaunch(OfferRequirement offerRequirement) {
+        for (LaunchConstrainer constrainer : constrainers) {
+            if (!constrainer.canLaunch(offerRequirement)) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/src/main/java/org/apache/mesos/scheduler/repair/constrain/LaunchConstrainer.java
+++ b/src/main/java/org/apache/mesos/scheduler/repair/constrain/LaunchConstrainer.java
@@ -1,0 +1,27 @@
+package org.apache.mesos.scheduler.repair.constrain;
+
+import org.apache.mesos.Protos.Offer.Operation;
+import org.apache.mesos.offer.OfferRequirement;
+
+/**
+ * Created by dgrnbrg on 7/25/16.
+ */
+public interface LaunchConstrainer {
+    /**
+     * Invoked every time a task is launchHappened.
+     * <p>
+     * We take a {@link Operation} so that frameworks can specify additional metadata, in order to smooth the launch
+     * rate.
+     *
+     * @param launchOperation
+     */
+    void launchHappened(Operation launchOperation);
+
+    /**
+     * Determines whether the given {@link OfferRequirement} can be launchHappened right now.
+     *
+     * @param offerRequirement
+     * @return True if the offer is safe to launch immediately, false if it should wait
+     */
+    boolean canLaunch(OfferRequirement offerRequirement);
+}

--- a/src/main/java/org/apache/mesos/scheduler/repair/constrain/TestingLaunchConstrainer.java
+++ b/src/main/java/org/apache/mesos/scheduler/repair/constrain/TestingLaunchConstrainer.java
@@ -1,0 +1,31 @@
+package org.apache.mesos.scheduler.repair.constrain;
+
+import org.apache.mesos.Protos.Offer.Operation;
+import org.apache.mesos.offer.OfferRequirement;
+
+/**
+ * {@link LaunchConstrainer} that makes it easy to enable/disable launches for testing.
+ * <p>
+ * Defaults to allowing all launches.
+ */
+public class TestingLaunchConstrainer implements LaunchConstrainer {
+    private boolean canLaunch;
+
+    public TestingLaunchConstrainer() {
+        this.canLaunch = false;
+    }
+
+    public void setCanLaunch(boolean canLaunch) {
+        this.canLaunch = canLaunch;
+    }
+
+    @Override
+    public void launchHappened(Operation launchOperation) {
+        // Does nothing when the launch happens
+    }
+
+    @Override
+    public boolean canLaunch(OfferRequirement offerRequirement) {
+        return this.canLaunch;
+    }
+}

--- a/src/main/java/org/apache/mesos/scheduler/repair/constrain/TimedLaunchConstrainer.java
+++ b/src/main/java/org/apache/mesos/scheduler/repair/constrain/TimedLaunchConstrainer.java
@@ -1,0 +1,38 @@
+package org.apache.mesos.scheduler.repair.constrain;
+
+import org.apache.mesos.Protos.Offer.Operation;
+import org.apache.mesos.offer.OfferRequirement;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Implements a {@link LaunchConstrainer} that requires a minimum number of seconds to elapse between launches, for
+ * rate-limiting purposes.
+ */
+public class TimedLaunchConstrainer implements LaunchConstrainer {
+    private AtomicLong lastLaunch;
+    private long minDelaySeconds;
+
+    /**
+     * Create a new constrainer with the given required minimum delay between recovery operations.
+     *
+     * @param minDelaySeconds Minimum number of seconds between each launch
+     */
+    public TimedLaunchConstrainer(long minDelaySeconds) {
+        this.minDelaySeconds = minDelaySeconds;
+        this.lastLaunch = new AtomicLong(0);
+    }
+
+    @Override
+    public void launchHappened(Operation launchOperation) {
+        if (!canLaunch(null)) {
+            throw new RuntimeException("It hasn't been long enough since the last launch");
+        }
+        lastLaunch.compareAndSet(lastLaunch.get(), System.currentTimeMillis());
+    }
+
+    @Override
+    public boolean canLaunch(OfferRequirement offerRequirement) {
+        return (lastLaunch.get() + minDelaySeconds * 1000) < System.currentTimeMillis();
+    }
+}

--- a/src/main/java/org/apache/mesos/scheduler/repair/constrain/UnconstrainedLaunchConstrainer.java
+++ b/src/main/java/org/apache/mesos/scheduler/repair/constrain/UnconstrainedLaunchConstrainer.java
@@ -1,0 +1,21 @@
+package org.apache.mesos.scheduler.repair.constrain;
+
+import org.apache.mesos.Protos.Offer.Operation;
+import org.apache.mesos.offer.OfferRequirement;
+
+/**
+ * Implementation of {@link LaunchConstrainer} that always allows launches.
+ * <p>
+ * This is equivalent to disabling the launch constraining feature.
+ */
+public class UnconstrainedLaunchConstrainer implements LaunchConstrainer {
+    @Override
+    public void launchHappened(Operation launchOperation) {
+        //do nothing
+    }
+
+    @Override
+    public boolean canLaunch(OfferRequirement offerRequirement) {
+        return true;
+    }
+}

--- a/src/main/java/org/apache/mesos/scheduler/repair/monitor/FailureMonitor.java
+++ b/src/main/java/org/apache/mesos/scheduler/repair/monitor/FailureMonitor.java
@@ -1,0 +1,19 @@
+package org.apache.mesos.scheduler.repair.monitor;
+
+import org.apache.mesos.Protos.TaskInfo;
+
+/**
+ * Instances of this class are used to determine when a stopped task has failed and should be restarted elsewhere.
+ */
+public interface FailureMonitor {
+    /**
+     * Determines whether the given {@link TaskInfo}has failed forever or not. This hook will be first called with a
+     * given {@link TaskInfo} the first time that {@link TaskInfo} stops running. It may be called additional times
+     * after that.
+     *
+     * @param task The {@link TaskInfo} that is no longer running
+     * @return true if the {@link TaskInfo} should be considered permanently lost & restarted elsewhere, false if it's
+     * machine might still come back
+     */
+    boolean hasFailed(TaskInfo task);
+}

--- a/src/main/java/org/apache/mesos/scheduler/repair/monitor/NeverFailureMonitor.java
+++ b/src/main/java/org/apache/mesos/scheduler/repair/monitor/NeverFailureMonitor.java
@@ -1,0 +1,16 @@
+package org.apache.mesos.scheduler.repair.monitor;
+
+import org.apache.mesos.Protos;
+
+/**
+ * A special {@link FailureMonitor} that never fails tasks.
+ *
+ * This is equivalent to disabling the failure detection feature.
+ */
+public class NeverFailureMonitor implements FailureMonitor {
+
+    @Override
+    public boolean hasFailed(Protos.TaskInfo task) {
+        return false;
+    }
+}

--- a/src/main/java/org/apache/mesos/scheduler/repair/monitor/TestingFailureMonitor.java
+++ b/src/main/java/org/apache/mesos/scheduler/repair/monitor/TestingFailureMonitor.java
@@ -1,0 +1,37 @@
+package org.apache.mesos.scheduler.repair.monitor;
+
+import org.apache.mesos.Protos.TaskInfo;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Simple API to enable testing of failure conditions in frameworks.
+ * <p>
+ * Allows you to specify which {@link TaskInfo}s will be treated as having failed. Any non-specified {@link TaskInfo}s
+ * will be treated as stopped.
+ */
+public class TestingFailureMonitor implements FailureMonitor {
+    private List<TaskInfo> failedList;
+
+    public TestingFailureMonitor(TaskInfo... failed) {
+        failedList = new ArrayList<>();
+        for (TaskInfo info : failed) {
+            failedList.add(info);
+        }
+    }
+
+    public void setFailedList(TaskInfo... failed) {
+        failedList = new ArrayList<>();
+        for (TaskInfo info : failed) {
+            failedList.add(info);
+        }
+    }
+
+    @Override
+    public boolean hasFailed(TaskInfo task) {
+        System.out.println("looking at " + task);
+        System.out.println("have " + failedList);
+        return failedList.stream().anyMatch(task::equals);
+    }
+}

--- a/src/main/java/org/apache/mesos/scheduler/repair/monitor/TimedFailureMonitor.java
+++ b/src/main/java/org/apache/mesos/scheduler/repair/monitor/TimedFailureMonitor.java
@@ -1,0 +1,66 @@
+package org.apache.mesos.scheduler.repair.monitor;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.mesos.Protos.TaskID;
+import org.apache.mesos.Protos.TaskInfo;
+
+import java.util.Date;
+import java.util.HashMap;
+
+import static java.util.concurrent.TimeUnit.MINUTES;
+
+/**
+ * Implements a {@link FailureMonitor} with a time-based policy.
+ * <p>
+ * Note that, for safety reasons, this only sets a lower bound on when task is determined failed. Since during an outage
+ * system clocks can be accidentally misconfigured (for instance, when adding new nodes), we cannot rely on system time
+ * (since we might underestimate the wait), and so we must reset our clock from zero when the framework restarts. This
+ * unfortunately means that if the framework is also being frequently restarted, this detector may never trigger. A
+ * monotonic clock built on ZooKeeper could solve this, by recording each passing second, so that we only need to rely
+ * on the fact that the clock proceeds at 1 second per second, rather than on the clocks being synchronized across
+ * machines.
+ */
+public class TimedFailureMonitor implements FailureMonitor {
+    private static final Log log = LogFactory.getLog(TimedFailureMonitor.class);
+    // This map stores the time when we first noticed the failure
+    private final HashMap<TaskID, Date> firstFailureDetected;
+    private final long minutesUntilFailed;
+
+    /**
+     * Creates a new {@link FailureMonitor} that waits for at least a specified duration before deciding that the task
+     * has failed.
+     *
+     * @param minutesUntilFailed The number of minutes that a task could
+     */
+    public TimedFailureMonitor(long minutesUntilFailed) {
+        this.firstFailureDetected = new HashMap<>();
+        this.minutesUntilFailed = minutesUntilFailed;
+    }
+
+    /**
+     * Determines whether the given task has failed, by tracking the time delta between the first observed failure and
+     * the current time.
+     * <p>
+     * The first time a task is noticed to be failed, we record that time into a map, keyed by the task's {@link
+     * TaskID}. Then, we return true if at least the configured amount of time has passed since then.
+     *
+     * @param terminatedTask The task that stopped and might be failed
+     * @return true if the task has been stopped for at least the configured interval
+     */
+    @Override
+    public boolean hasFailed(TaskInfo terminatedTask) {
+        Date taskLaunchedTime;
+        synchronized (firstFailureDetected) {
+            if (!firstFailureDetected.containsKey(terminatedTask.getTaskId())) {
+                firstFailureDetected.put(terminatedTask.getTaskId(), new Date());
+            }
+            taskLaunchedTime = firstFailureDetected.get(terminatedTask.getTaskId());
+        }
+        Date taskExpiredTime = new Date(taskLaunchedTime.getTime() + MINUTES.toMillis(minutesUntilFailed));
+        Date now = new Date();
+        log.info("Looking at " + terminatedTask.getName() + " launchHappened at " + taskLaunchedTime + ", expires at "
+                + taskExpiredTime + " which is " + now.after(taskExpiredTime));
+        return now.after(taskExpiredTime);
+    }
+}

--- a/src/main/java/org/apache/mesos/state/StateStore.java
+++ b/src/main/java/org/apache/mesos/state/StateStore.java
@@ -1,21 +1,21 @@
 package org.apache.mesos.state;
 
 import org.apache.mesos.Protos;
+import org.apache.mesos.Protos.TaskInfo;
+import org.apache.mesos.Protos.TaskStatus;
 import org.apache.mesos.offer.TaskUtils;
 
-import java.util.Collection;
+import java.util.*;
 
 /**
- * This interface should be implemented in order to store and fetch TaskInfo
- * and TaskStatus information on a per Task basis. Each distinct Task is expected to
- * have a unique Task Name, determined by the framework developer.
- *
- * TaskInfo objects should be persisted when a Task is launched or when reserved
- * resources associated with a potential future Task launch should be recorded.
- *
- * TaskStatus is reported by Mesos to Frameworks at various points including at Task
- * Reconciliation and when Tasks change state.  The TaskStatus of a Task should be
- * recorded so that the state of a Framework's Tasks can be queried.
+ * This interface should be implemented in order to store and fetch TaskInfo and TaskStatus information on a per Task
+ * basis. Each distinct Task is expected to have a unique Task Name, determined by the framework developer.
+ * <p>
+ * TaskInfo objects should be persisted when a Task is launched or when reserved resources associated with a potential
+ * future Task launch should be recorded.
+ * <p>
+ * TaskStatus is reported by Mesos to Frameworks at various points including at Task Reconciliation and when Tasks
+ * change state.  The TaskStatus of a Task should be recorded so that the state of a Framework's Tasks can be queried.
  */
 public interface StateStore {
 
@@ -24,8 +24,7 @@ public interface StateStore {
 
 
     /**
-     * Stores the FrameworkID for a framework so on Scheduler restart re-registration
-     * may occur.
+     * Stores the FrameworkID for a framework so on Scheduler restart re-registration may occur.
      *
      * @param fwkId FrameworkID to be store
      * @throws StateStoreException when storing the FrameworkID fails
@@ -34,8 +33,7 @@ public interface StateStore {
 
 
     /**
-     * Removes any previously stored FrameworkID or does nothing if no FrameworkID
-     * was previously stored.
+     * Removes any previously stored FrameworkID or does nothing if no FrameworkID was previously stored.
      *
      * @throws StateStoreException when clearing a FrameworkID fails
      */
@@ -49,8 +47,7 @@ public interface StateStore {
      * Fetches the previously stored FrameworkID.
      *
      * @return The previously stored FrameworkID
-     * @throws StateStoreException if no data was found (not set yet), or when fetching the
-     *                             FrameworkID otherwise fails
+     * @throws StateStoreException if no data was found (not set yet), or when fetching the FrameworkID otherwise fails
      */
     Protos.FrameworkID fetchFrameworkId() throws StateStoreException;
 
@@ -59,31 +56,29 @@ public interface StateStore {
 
 
     /**
-     * Stores TaskInfo objects representing tasks which are desired by the framework. This must be
-     * called before {@link #storeStatus(TaskStatus)} for any given task id.
+     * Stores TaskInfo objects representing tasks which are desired by the framework. This must be called before {@link
+     * #storeStatus(TaskStatus)} for any given task id.
      *
      * @param tasks Tasks to be stored, which each meet the above requirements
-     * @throws StateStoreException when persisting TaskInfo information fails, or if its TaskId is
-     * malformed
+     * @throws StateStoreException when persisting TaskInfo information fails, or if its TaskId is malformed
      */
-    void storeTasks(Collection<Protos.TaskInfo> tasks) throws StateStoreException;
+    void storeTasks(Collection<TaskInfo> tasks) throws StateStoreException;
 
 
     /**
-     * Stores the TaskStatus of a particular Task. The {@link TaskInfo} for this exact task MUST
-     * have already been written via {@link #storeTasks(Collection)} beforehand. The TaskId must be
-     * well-formatted as produced by {@link TaskUtils#toTaskId(String)}.
+     * Stores the TaskStatus of a particular Task. The {@link TaskInfo} for this exact task MUST have already been
+     * written via {@link #storeTasks(Collection)} beforehand. The TaskId must be well-formatted as produced by {@link
+     * TaskUtils#toTaskId(String)}.
      *
      * @param status The status to be stored, which meets the above requirements
-     * @throws StateStoreException if storing the TaskStatus fails, or if its TaskId is malformed,
-     * or if its matching TaskInfo wasn't stored first
+     * @throws StateStoreException if storing the TaskStatus fails, or if its TaskId is malformed, or if its matching
+     *                             TaskInfo wasn't stored first
      */
-    void storeStatus(Protos.TaskStatus status) throws StateStoreException;
+    void storeStatus(TaskStatus status) throws StateStoreException;
 
 
     /**
-     * Removes all data associated with a particular Task including any stored TaskInfo and/or
-     * TaskStatus.
+     * Removes all data associated with a particular Task including any stored TaskInfo and/or TaskStatus.
      *
      * @param taskName The name of the task to be cleared
      * @throws StateStoreException when clearing the indicated Task's informations fails
@@ -95,8 +90,8 @@ public interface StateStore {
 
 
     /**
-     * Fetches all the Task names listed in the underlying storage. Note that these should always
-     * have a TaskInfo, but may lack TaskStatus.
+     * Fetches all the Task names listed in the underlying storage. Note that these should always have a TaskInfo, but
+     * may lack TaskStatus.
      *
      * @return All the Task names stored so far, or an empty list if none are found
      * @throws StateStoreException when fetching the data fails
@@ -105,14 +100,38 @@ public interface StateStore {
 
 
     /**
-     * Fetches and returns all {@link TaskInfo}s from the underlying storage, or an empty list if
-     * none are found. This list should be a superset of the list returned by
-     * {@link #fetchStatuses()}.
+     * Fetches and returns all {@link TaskInfo}s from the underlying storage, or an empty list if none are found. This
+     * list should be a superset of the list returned by {@link #fetchStatuses()}.
      *
      * @return All TaskInfos
      * @throws StateStoreException if fetching the TaskInfo information otherwise fails
      */
-    Collection<Protos.TaskInfo> fetchTasks() throws StateStoreException;
+    Collection<TaskInfo> fetchTasks() throws StateStoreException;
+
+    /**
+     * Fetches and returns all {@link TaskInfo}s from underlying storage that are currently in a terminal state.
+     *
+     * @return Terminated TaskInfos
+     * @throws StateStoreException
+     */
+    default Collection<TaskInfo> fetchTerminatedTasks() throws StateStoreException {
+        Collection<TaskInfo> allInfos = fetchTasks();
+        Collection<TaskStatus> allStatuses = fetchStatuses();
+        Map<Protos.TaskID, TaskStatus> statusMap = new HashMap<>();
+        for (TaskStatus status : allStatuses) {
+            statusMap.put(status.getTaskId(), status);
+        }
+        List<TaskInfo> results = new ArrayList<>();
+        for (TaskInfo info : allInfos) {
+            if (!statusMap.containsKey(info.getTaskId())) {
+                continue;
+            }
+            if (TaskUtils.isTerminated(statusMap.get(info.getTaskId()))) {
+                results.add(info);
+            }
+        }
+        return results;
+    }
 
 
     /**
@@ -120,33 +139,32 @@ public interface StateStore {
      *
      * @param taskName The name of the Task
      * @return The corresponding TaskInfo object
-     * @throws StateStoreException if no data was found for the requested name, or if fetching the
-     *                             TaskInfo otherwise fails
+     * @throws StateStoreException if no data was found for the requested name, or if fetching the TaskInfo otherwise
+     *                             fails
      */
-    Protos.TaskInfo fetchTask(String taskName) throws StateStoreException;
+    TaskInfo fetchTask(String taskName) throws StateStoreException;
 
 
     /**
-     * Fetches all {@link TaskStatus}es from the underlying storage, or an empty list if none are
-     * found. Note that this list may have fewer entries than {@link #fetchTasks()} if some tasks
-     * are lacking statuses.
+     * Fetches all {@link TaskStatus}es from the underlying storage, or an empty list if none are found. Note that this
+     * list may have fewer entries than {@link #fetchTasks()} if some tasks are lacking statuses.
      *
      * @return The TaskStatus objects associated with all tasks
      * @throws StateStoreException if fetching the TaskStatus information fails
      */
-    Collection<Protos.TaskStatus> fetchStatuses() throws StateStoreException;
+    Collection<TaskStatus> fetchStatuses() throws StateStoreException;
 
 
     /**
-     * Fetches the TaskStatus for a particular Task, or throws an error if no matching status is
-     * found. A given task may sometimes have {@link TaskInfo} while lacking {@link TaskStatus}.
+     * Fetches the TaskStatus for a particular Task, or throws an error if no matching status is found. A given task may
+     * sometimes have {@link TaskInfo} while lacking {@link TaskStatus}.
      *
      * @param taskName The name of the Task which should have its status retrieved
      * @return The TaskStatus associated with a particular Task
-     * @throws StateStoreException if no data was found for the requested name, or if fetching the
-     *                             TaskStatus information otherwise fails
+     * @throws StateStoreException if no data was found for the requested name, or if fetching the TaskStatus
+     *                             information otherwise fails
      */
-    Protos.TaskStatus fetchStatus(String taskName) throws StateStoreException;
+    TaskStatus fetchStatus(String taskName) throws StateStoreException;
 
 
     // Read/Write Properties
@@ -155,22 +173,20 @@ public interface StateStore {
     /**
      * Stores an arbitrary key/value pair.
      *
-     * @param key must be a non-blank String without any forward slashes ('/')
+     * @param key   must be a non-blank String without any forward slashes ('/')
      * @param value The value should be a byte array no larger than 1MB (1024 * 1024 bytes)
-     * @throw StateStoreException if the key or value fail validation, or if storing the data
-     *                            otherwise fails
+     * @throw StateStoreException if the key or value fail validation, or if storing the data otherwise fails
      * @see StateStoreUtils#validateKey(String)
-     * @see StateStoreUtils#validateValue(String)
+     * @see StateStoreUtils#validateValue(byte[])
      */
     void storeProperty(String key, byte[] value) throws StateStoreException;
 
     /**
-     * Fetches the value byte array, stored against the Property {@code key}, or throws an error if
-     * no matching {@code key} is found.
+     * Fetches the value byte array, stored against the Property {@code key}, or throws an error if no matching {@code
+     * key} is found.
      *
      * @param key must be a non-blank String without any forward slashes ('/')
-     * @throw StateStoreException if no data was found for the requested key, or if fetching the
-     *                            data otherwise fails
+     * @throw StateStoreException if no data was found for the requested key, or if fetching the data otherwise fails
      * @see StateStoreUtils#validateKey(String)
      */
     byte[] fetchProperty(String key) throws StateStoreException;

--- a/src/test/java/org/apache/mesos/scheduler/RepairSchedulerTest.java
+++ b/src/test/java/org/apache/mesos/scheduler/RepairSchedulerTest.java
@@ -1,0 +1,271 @@
+package org.apache.mesos.scheduler;
+
+import org.apache.mesos.Protos.Offer;
+import org.apache.mesos.Protos.Resource;
+import org.apache.mesos.Protos.TaskID;
+import org.apache.mesos.Protos.TaskInfo;
+import org.apache.mesos.SchedulerDriver;
+import org.apache.mesos.offer.OfferAccepter;
+import org.apache.mesos.offer.OfferRequirement;
+import org.apache.mesos.offer.ResourceTestUtils;
+import org.apache.mesos.offer.ResourceUtils;
+import org.apache.mesos.protobuf.OfferBuilder;
+import org.apache.mesos.protobuf.TaskInfoBuilder;
+import org.apache.mesos.scheduler.plan.Block;
+import org.apache.mesos.scheduler.repair.RepairOfferRequirementProvider;
+import org.apache.mesos.scheduler.repair.RepairScheduler;
+import org.apache.mesos.scheduler.repair.RepairStatus;
+import org.apache.mesos.scheduler.repair.TaskFailureListener;
+import org.apache.mesos.scheduler.repair.constrain.TestingLaunchConstrainer;
+import org.apache.mesos.scheduler.repair.monitor.TestingFailureMonitor;
+import org.apache.mesos.state.StateStore;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.*;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Mockito.*;
+
+/**
+ * Our goal is verify the following pieces of functionality:
+ * <p>
+ * - If it has failed tasks, it will not attempt to launch stopped tasks. - If a block is currently running with the
+ * same name as a terminated task, it will not appear as terminated. - If a task is failed, it can transition to stopped
+ * when the failure detector decides - If a task is stopped, it can be restarted (or maybe not, depending on offer) -
+ * Launches will only occur when the constrainer allows it - When a task is failed, it shows up as failed for multiple
+ * cycles if nothing changes - When a task is stopped, it shows up as stopped for multiple cycles if nothing changes -
+ * When a stopped task launches, it no longer shows up as stopped - When a failed task launches, it no longer shows up
+ * as failed
+ */
+public class RepairSchedulerTest {
+    private RepairScheduler repairScheduler;
+    private TaskFailureListener taskFailureListener;
+    private RepairOfferRequirementProvider repairOfferRequirementProvider;
+    private OfferAccepter offerAccepter;
+    private StateStore stateStore;
+    private SchedulerDriver schedulerDriver;
+    private TestingFailureMonitor failureMonitor;
+    private TestingLaunchConstrainer launchConstrainer;
+    private AtomicReference<RepairStatus> repairStatusRef;
+
+    public static TaskInfo makeTaskInfo(Resource... resources) {
+        TaskInfoBuilder infoBuilder = new TaskInfoBuilder(
+                ResourceTestUtils.testTaskId,
+                ResourceTestUtils.testTaskName,
+                ResourceTestUtils.testSlaveId);
+        for (Resource r : resources) {
+            infoBuilder.addResource(r);
+        }
+        return infoBuilder.build();
+    }
+
+    public static Resource makeDesiredScalar(String name, double value) {
+        return ResourceUtils.getDesiredScalar("test", "test", name, value);
+    }
+
+    public static Resource makeExpectedScalar(String name, double value) {
+        return ResourceUtils.getExpectedScalar(name, value, UUID.randomUUID().toString(), "test", "test");
+    }
+
+    private List<Offer> getOffers(double cpus, double mem) {
+        OfferBuilder builder = new OfferBuilder(
+                ResourceTestUtils.testOfferId,
+                ResourceTestUtils.testFrameworkId,
+                ResourceTestUtils.testSlaveId,
+                ResourceTestUtils.testHostname);
+        builder.addResource(ResourceUtils.getUnreservedScalar("cpus", cpus));
+        builder.addResource(ResourceUtils.getUnreservedScalar("mem", mem));
+        return Arrays.asList(builder.build());
+    }
+
+
+    @Before
+    public void setupTest() {
+        failureMonitor = new TestingFailureMonitor();
+        launchConstrainer = spy(new TestingLaunchConstrainer());
+        repairStatusRef = new AtomicReference<>(new RepairStatus(Collections.emptyList(), Collections.emptyList()));
+        taskFailureListener = mock(TaskFailureListener.class);
+        offerAccepter = mock(OfferAccepter.class);
+        repairOfferRequirementProvider = mock(RepairOfferRequirementProvider.class);
+        stateStore = mock(StateStore.class);
+        repairScheduler = spy(new RepairScheduler("test", stateStore, taskFailureListener,
+                repairOfferRequirementProvider, offerAccepter,
+                launchConstrainer, failureMonitor, repairStatusRef));
+        schedulerDriver = mock(SchedulerDriver.class);
+    }
+
+    @After
+    public void teardownTest() {
+        taskFailureListener = null;
+        repairOfferRequirementProvider = null;
+        offerAccepter = null;
+    }
+
+    @Test
+    public void ifStoppedTryToRelaunch() throws Exception {
+        Resource cpus = makeDesiredScalar("cpus", 1.0);
+        Resource mem = makeDesiredScalar("mem", 1.0);
+        List<TaskInfo> infos = Collections.singletonList(makeTaskInfo(cpus, mem));
+        OfferRequirement req = new OfferRequirement(infos, null, Collections.EMPTY_LIST, Collections.EMPTY_LIST);
+        when(stateStore.fetchTerminatedTasks()).thenReturn(infos);
+        when(repairOfferRequirementProvider.getReplacementOfferRequirement(any())).thenReturn(req);
+        launchConstrainer.setCanLaunch(false);
+
+        repairScheduler.resourceOffers(schedulerDriver, getOffers(1.0, 1.0), null);
+
+        //launch failed tasks
+        verify(repairOfferRequirementProvider, times(1)).getReplacementOfferRequirement(any());
+        //don't launch stop when a task is failed
+        verify(repairOfferRequirementProvider, never()).maybeGetNewOfferRequirement(any(), any());
+        //we tried to launch it
+        assertFalse(verify(launchConstrainer, times(1)).canLaunch(any()));
+
+        //verify that the UI remains stable
+        for (int i = 0; i < 10; i++) {
+            repairScheduler.resourceOffers(schedulerDriver, getOffers(1.0, 1.0), null);
+            //verify the UI
+            assertEquals(Collections.singletonList(ResourceTestUtils.testTaskName), repairStatusRef.get().getStopped());
+            assertEquals(Collections.EMPTY_LIST, repairStatusRef.get().getFailed());
+        }
+    }
+
+    @Test
+    public void ifStoppededDoRelaunch() throws Exception {
+        Resource cpus = makeDesiredScalar("cpus", 1.0);
+        Resource mem = makeDesiredScalar("mem", 1.0);
+        List<TaskInfo> infos = Collections.singletonList(makeTaskInfo(cpus, mem));
+        OfferRequirement req = new OfferRequirement(infos, null, Collections.EMPTY_LIST, Collections.EMPTY_LIST);
+        when(stateStore.fetchTerminatedTasks()).thenReturn(infos);
+        when(repairOfferRequirementProvider.getReplacementOfferRequirement(any())).thenReturn(req);
+        launchConstrainer.setCanLaunch(true);
+
+        repairScheduler.resourceOffers(schedulerDriver, getOffers(1.0, 1.0), null);
+
+        //launch failed tasks
+        verify(repairOfferRequirementProvider, times(1)).getReplacementOfferRequirement(any());
+        //don't launch stop when a task is failed
+        verify(repairOfferRequirementProvider, never()).maybeGetNewOfferRequirement(any(), any());
+        //we tried to launch it (the assertFalse below should actually be true,
+        //                       but this seems to be an issue w/ how we're using mockito)
+        assertFalse(verify(launchConstrainer, times(1)).canLaunch(any()));
+
+        // Verify we ran launching code
+        verify(offerAccepter, times(1)).accept(any(), any());
+        verify(launchConstrainer, times(1)).launchHappened(any());
+
+        // Verify the UI
+        assertEquals(Collections.EMPTY_LIST, repairStatusRef.get().getFailed());
+        assertEquals(Collections.EMPTY_LIST, repairStatusRef.get().getStopped());
+    }
+
+    @Test
+    public void blockWithSameNameHidden() throws Exception {
+        Resource cpus = makeDesiredScalar("cpus", 1.0);
+        Resource mem = makeDesiredScalar("mem", 1.0);
+        List<TaskInfo> infos = Collections.singletonList(makeTaskInfo(cpus, mem));
+        when(stateStore.fetchTerminatedTasks()).thenReturn(infos);
+        when(repairOfferRequirementProvider.getReplacementOfferRequirement(any())).thenReturn(null);
+        launchConstrainer.setCanLaunch(false);
+        Block block = mock(Block.class);
+        when(block.getName()).thenReturn(ResourceTestUtils.testTaskName);
+        when(repairOfferRequirementProvider.maybeGetNewOfferRequirement(any(), eq(block))).thenReturn(Optional.empty());
+
+        repairScheduler.resourceOffers(schedulerDriver, getOffers(1.0, 1.0), block);
+
+        // Verify the UI shows no tasks
+        assertEquals(Collections.EMPTY_LIST, repairStatusRef.get().getFailed());
+        assertEquals(Collections.EMPTY_LIST, repairStatusRef.get().getStopped());
+    }
+
+    @Test
+    public void stoppedTaskTransitionsToFailed() throws Exception {
+        Resource cpus = makeDesiredScalar("cpus", 1.0);
+        Resource mem = makeDesiredScalar("mem", 1.0);
+        List<TaskInfo> infos = Collections.singletonList(makeTaskInfo(cpus, mem));
+        when(stateStore.fetchTerminatedTasks()).thenReturn(infos);
+        failureMonitor.setFailedList(infos.get(0));
+        launchConstrainer.setCanLaunch(false);
+
+        repairScheduler.resourceOffers(schedulerDriver, getOffers(1.0, 1.0), null);
+
+        // Verify we deleted the task
+        verify(taskFailureListener).taskFailed(TaskID.newBuilder().setValue(ResourceTestUtils.testTaskId).build());
+
+        //verify that the UI remains stable
+        for (int i = 0; i < 10; i++) {
+            repairScheduler.resourceOffers(schedulerDriver, getOffers(1.0, 1.0), null);
+            // verify the transition to stopped
+            assertEquals(Collections.EMPTY_LIST, repairStatusRef.get().getStopped());
+            assertEquals(Collections.singletonList(ResourceTestUtils.testTaskName), repairStatusRef.get().getFailed());
+        }
+    }
+
+    @Test
+    public void failedTaskCanBeRestarted() throws Exception {
+        Resource cpus = makeDesiredScalar("cpus", 1.0);
+        Resource mem = makeDesiredScalar("mem", 1.0);
+        List<TaskInfo> infos = Collections.singletonList(makeTaskInfo(cpus, mem));
+        OfferRequirement req = new OfferRequirement(infos, null, Collections.EMPTY_LIST, Collections.EMPTY_LIST);
+        when(stateStore.fetchTerminatedTasks()).thenReturn(infos).thenReturn(Collections.EMPTY_LIST);
+        when(repairOfferRequirementProvider.maybeGetNewOfferRequirement(any(), any())).thenReturn(Optional.of(req));
+        failureMonitor.setFailedList(infos.get(0));
+        launchConstrainer.setCanLaunch(true);
+
+        repairScheduler.resourceOffers(schedulerDriver, getOffers(1.0, 1.0), null);
+
+        // Verify we deleted the task
+        verify(taskFailureListener).taskFailed(TaskID.newBuilder().setValue(ResourceTestUtils.testTaskId).build());
+
+        // Verify we transitioned the task to failed
+        assertEquals(Collections.EMPTY_LIST, repairStatusRef.get().getStopped());
+        assertEquals(Collections.singletonList(ResourceTestUtils.testTaskName), repairStatusRef.get().getFailed());
+
+        repairScheduler.resourceOffers(schedulerDriver, getOffers(1.0, 1.0), null);
+
+        // Verify we launched the task
+        verify(offerAccepter, times(1)).accept(any(), any());
+        verify(launchConstrainer, times(1)).launchHappened(any());
+
+        // Verify the UI
+        assertEquals(Collections.EMPTY_LIST, repairStatusRef.get().getFailed());
+        assertEquals(Collections.EMPTY_LIST, repairStatusRef.get().getStopped());
+    }
+
+    @Test
+    public void failedTasksAreNotMarkedLaunchedWithInsufficientResources() throws Exception {
+        Resource cpus = makeDesiredScalar("cpus", 1.0);
+        Resource mem = makeDesiredScalar("mem", 1.0);
+        List<TaskInfo> infos = Collections.singletonList(makeTaskInfo(cpus, mem));
+        OfferRequirement req = new OfferRequirement(infos, null, Collections.EMPTY_LIST, Collections.EMPTY_LIST);
+        when(stateStore.fetchTerminatedTasks()).thenReturn(infos).thenReturn(Collections.EMPTY_LIST);
+        when(repairOfferRequirementProvider.maybeGetNewOfferRequirement(any(), any())).thenReturn(Optional.of(req));
+        failureMonitor.setFailedList(infos.get(0));
+        launchConstrainer.setCanLaunch(true);
+
+        repairScheduler.resourceOffers(schedulerDriver, getOffers(1.0, 1.0), null);
+
+        // Verify we deleted the task
+        verify(taskFailureListener).taskFailed(TaskID.newBuilder().setValue(ResourceTestUtils.testTaskId).build());
+
+        // Verify we transitioned the task to failed
+        assertEquals(Collections.EMPTY_LIST, repairStatusRef.get().getStopped());
+        assertEquals(Collections.singletonList(ResourceTestUtils.testTaskName), repairStatusRef.get().getFailed());
+
+        System.out.println("Here we are at round 2");
+        // This is insufficient resources
+        repairScheduler.resourceOffers(schedulerDriver, getOffers(0.5, 1.0), null);
+
+        // Verify we didn't launch the task
+        verify(offerAccepter, times(1)).accept(any(), eq(Collections.EMPTY_LIST));
+        verify(launchConstrainer, never()).launchHappened(any());
+
+        // Verify the UI
+        assertEquals(Collections.EMPTY_LIST, repairStatusRef.get().getStopped());
+        assertEquals(Collections.singletonList(ResourceTestUtils.testTaskName), repairStatusRef.get().getFailed());
+
+    }
+}


### PR DESCRIPTION
This PR implements a new scheduler called `RepairScheduler`. This helps frameworks handle failure & restarts for persistent-disk based applications.

This is implementation complete, but still needs tests that do not depend on the proprietary libraries they were originally developed against.