### PR TITLE
Move serialized object members to snake_case

### DIFF
--- a/acme-scheduler-example/src/dist/conf/scheduler.yml
+++ b/acme-scheduler-example/src/dist/conf/scheduler.yml
@@ -1,15 +1,15 @@
-schedulerConfiguration:
+scheduler_configuration:
   service:
     name: ${FRAMEWORK_NAME}
     user: ${USER}
-    placementStrategy: ${PLACEMENT_STRATEGY}
-    phaseStrategy: ${PHASE_STRATEGY}
+    placement_strategy: ${PLACEMENT_STRATEGY}
+    phase_strategy: ${PHASE_STRATEGY}
     role: "${FRAMEWORK_NAME}-role"
     principal: "${FRAMEWORK_NAME}-principal"
 
   acme:
-    zkAddress: "master.mesos:2181"
-    acmeZkUri: "master.mesos:2181/${FRAMEWORK_NAME}"
+    zk_address: "master.mesos:2181"
+    acme_zk_uri: "master.mesos:2181/${FRAMEWORK_NAME}"
 
 
 server:

--- a/acme-scheduler-example/src/main/java/org/apache/mesos/acme/config/AcmeConfiguration.java
+++ b/acme-scheduler-example/src/main/java/org/apache/mesos/acme/config/AcmeConfiguration.java
@@ -12,16 +12,16 @@ import java.util.Objects;
  */
 public class AcmeConfiguration {
 
-  @JsonProperty("acmeZkUri")
+  @JsonProperty("acme_zk_uri")
   private String acmeZkUri;
 
-  @JsonProperty("zkAddress")
+  @JsonProperty("zk_address")
   private String zkAddress;
 
   @JsonCreator
   public AcmeConfiguration(
-    @JsonProperty("acmeZkUri") String acmeZkUri,
-    @JsonProperty("zkAddress") String zkAddress) {
+    @JsonProperty("acme_zk_uri") String acmeZkUri,
+    @JsonProperty("zk_address") String zkAddress) {
     this.acmeZkUri = acmeZkUri;
     this.zkAddress = zkAddress;
   }
@@ -30,7 +30,7 @@ public class AcmeConfiguration {
     return acmeZkUri;
   }
 
-  @JsonProperty("acmeZkUri")
+  @JsonProperty("acme_zk_uri")
   public void setAcmeZkUri(String acmeZkUri) {
     this.acmeZkUri = acmeZkUri;
   }
@@ -39,7 +39,7 @@ public class AcmeConfiguration {
     return zkAddress;
   }
 
-  @JsonProperty("zkAddress")
+  @JsonProperty("zk_address")
   public void setZkAddress(String zkAddress) {
     this.zkAddress = zkAddress;
   }

--- a/acme-scheduler-example/src/main/java/org/apache/mesos/acme/config/DropwizardConfiguration.java
+++ b/acme-scheduler-example/src/main/java/org/apache/mesos/acme/config/DropwizardConfiguration.java
@@ -13,12 +13,12 @@ import java.util.Objects;
  */
 public class DropwizardConfiguration extends Configuration {
 
-  @JsonProperty("schedulerConfiguration")
+  @JsonProperty("scheduler_configuration")
   AcmeSchedulerConfiguration schedulerConfiguration;
 
   @JsonCreator
   public DropwizardConfiguration(
-    @JsonProperty("schedulerConfiguration") AcmeSchedulerConfiguration schedulerConfiguration) {
+    @JsonProperty("scheduler_configuration") AcmeSchedulerConfiguration schedulerConfiguration) {
     this.schedulerConfiguration = schedulerConfiguration;
   }
 
@@ -26,7 +26,7 @@ public class DropwizardConfiguration extends Configuration {
     return schedulerConfiguration;
   }
 
-  @JsonProperty("schedulerConfiguration")
+  @JsonProperty("scheduler_configuration")
   public void setSchedulerConfiguration(AcmeSchedulerConfiguration schedulerConfiguration) {
     this.schedulerConfiguration = schedulerConfiguration;
   }

--- a/acme-scheduler-example/src/main/java/org/apache/mesos/acme/config/ServiceConfiguration.java
+++ b/acme-scheduler-example/src/main/java/org/apache/mesos/acme/config/ServiceConfiguration.java
@@ -18,9 +18,9 @@ public class ServiceConfiguration {
   private String name;
   @JsonProperty("user")
   private String user;
-  @JsonProperty("placementStrategy")
+  @JsonProperty("placement_strategy")
   private String placementStrategy;
-  @JsonProperty("phaseStrategy")
+  @JsonProperty("phase_strategy")
   private String phaseStrategy;
   @JsonProperty("role")
   private String role;
@@ -32,8 +32,8 @@ public class ServiceConfiguration {
     @JsonProperty("count") int count,
     @JsonProperty("name") String name,
     @JsonProperty("user") String user,
-    @JsonProperty("placementStrategy") String placementStrategy,
-    @JsonProperty("phaseStrategy") String phaseStrategy,
+    @JsonProperty("placement_strategy") String placementStrategy,
+    @JsonProperty("phase_strategy") String phaseStrategy,
     @JsonProperty("role") String role,
     @JsonProperty("principal") String principal) {
     this.count = count;
@@ -76,7 +76,7 @@ public class ServiceConfiguration {
     return placementStrategy;
   }
 
-  @JsonProperty("placementStrategy")
+  @JsonProperty("placement_strategy")
   public void setPlacementStrategy(String placementStrategy) {
     this.placementStrategy = placementStrategy;
   }
@@ -85,7 +85,7 @@ public class ServiceConfiguration {
     return phaseStrategy;
   }
 
-  @JsonProperty("phaseStrategy")
+  @JsonProperty("phase_strategy")
   public void setPhaseStrategy(String phaseStrategy) {
     this.phaseStrategy = phaseStrategy;
   }


### PR DESCRIPTION
JSON properties should always be in snake case for consistency. Only the Acme scheduler example is affected here.