### PR TITLE
Supply Reconciler with TaskStatusProvider in constructor and remove from arguments in start method

### DIFF
--- a/acme-scheduler-example/src/main/java/org/apache/mesos/acme/scheduler/AcmeScheduler.java
+++ b/acme-scheduler-example/src/main/java/org/apache/mesos/acme/scheduler/AcmeScheduler.java
@@ -60,11 +60,11 @@ public class AcmeScheduler extends Observable implements Scheduler, Runnable {
     // this would store errors discovered in config validation step (which is missing from this example.
     List<String> stageErrors = new ArrayList<>();
 
-    // 1.  create a reconciler
-    reconciler = new DefaultReconciler();  // from dcos-commons
-
-    // 2.  the system depends on storing task info into a store. we use zk.
+    // 1.  the system depends on storing task info into a store. we use zk.
     acmeState = new AcmeStateServiceFactory().getStateService();
+
+    // 2.  create a reconciler
+    reconciler = new DefaultReconciler(acmeState);  // from dcos-commons
 
     // 3. the state object will update task status updates
     // this is an important part of the stage life-cycle. This is where task status are updated in the store.
@@ -84,8 +84,7 @@ public class AcmeScheduler extends Observable implements Scheduler, Runnable {
       new SandboxOfferRequirementProvider(acmeState);*///TODO(nick): fixbugs
 
     // 6. create a list of phases (this example uses the provided reconciliation phase)
-    List<Phase> phases = Arrays.asList(
-      ReconciliationPhase.create(reconciler, acmeState));  // add more Phases of blocks here!
+    List<Phase> phases = Arrays.asList(ReconciliationPhase.create(reconciler));  // add more Phases of blocks here!
 
     // 7. create a stage
     Stage stage = stageErrors.isEmpty()

--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,7 @@ ext {
 }
 
 group = "mesosphere"
-version = "0.4.37-SNAPSHOT"
+version = "0.5.0-SNAPSHOT"
 
 task sourceJar(type: Jar) {
   from sourceSets.main.allJava

--- a/src/main/java/org/apache/mesos/curator/CuratorStateStore.java
+++ b/src/main/java/org/apache/mesos/curator/CuratorStateStore.java
@@ -15,9 +15,7 @@ import org.apache.zookeeper.KeeperException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
+import java.util.*;
 
 /**
  * CuratorStateStore is an implementation of {@link StateStore} which persists data in Zookeeper.
@@ -297,6 +295,11 @@ public class CuratorStateStore implements StateStore {
             }
         }
         return taskStatuses;
+    }
+
+    @Override
+    public Set<Protos.TaskStatus> getTaskStatuses() throws StateStoreException {
+        return new HashSet<>(fetchStatuses());
     }
 
     @Override

--- a/src/main/java/org/apache/mesos/reconciliation/Reconciler.java
+++ b/src/main/java/org/apache/mesos/reconciliation/Reconciler.java
@@ -3,7 +3,6 @@ package org.apache.mesos.reconciliation;
 import org.apache.mesos.Protos.TaskStatus;
 import org.apache.mesos.SchedulerDriver;
 
-import java.util.Collection;
 import java.util.Set;
 
 /**
@@ -20,7 +19,7 @@ public interface Reconciler {
      *
      * @param tasks Current set of tasks known by the Scheduler, which will be reconciled with Mesos
      */
-    void start(final Collection<TaskStatus> tasks);
+    void start();
 
     /**
      * Triggers any needed reconciliation against the provided {@code driver}. This call is expected

--- a/src/main/java/org/apache/mesos/scheduler/plan/ReconciliationBlock.java
+++ b/src/main/java/org/apache/mesos/scheduler/plan/ReconciliationBlock.java
@@ -5,7 +5,6 @@ import java.util.UUID;
 import org.apache.mesos.Protos;
 import org.apache.mesos.offer.OfferRequirement;
 import org.apache.mesos.reconciliation.Reconciler;
-import org.apache.mesos.reconciliation.TaskStatusProvider;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -21,7 +20,6 @@ public class ReconciliationBlock implements Block {
     private static final Logger logger = LoggerFactory.getLogger(ReconciliationBlock.class);
 
     private final Reconciler reconciler;
-    private final TaskStatusProvider taskProvider;
     private final UUID id = UUID.randomUUID();
     private boolean isPending = true; // reconciler hasn't start()ed yet
 
@@ -30,15 +28,12 @@ public class ReconciliationBlock implements Block {
      * @param reconciler The reconciler to use for reconciliation.
      * @return A new ReconciliationBlock
      */
-    public static final ReconciliationBlock create(
-            Reconciler reconciler, TaskStatusProvider taskProvider) {
-        return new ReconciliationBlock(reconciler, taskProvider);
+    public static final ReconciliationBlock create(Reconciler reconciler) {
+        return new ReconciliationBlock(reconciler);
     }
 
-    private ReconciliationBlock(
-            final Reconciler reconciler, final TaskStatusProvider taskProvider) {
+    private ReconciliationBlock(final Reconciler reconciler) {
         this.reconciler = reconciler;
-        this.taskProvider = taskProvider;
     }
 
     @Override
@@ -65,7 +60,7 @@ public class ReconciliationBlock implements Block {
     @Override
     public OfferRequirement start() {
         try {
-            reconciler.start(taskProvider.getTaskStatuses());
+            reconciler.start();
             isPending = false;
         } catch (Exception ex) {
             isPending = true; // try again later

--- a/src/main/java/org/apache/mesos/scheduler/plan/ReconciliationPhase.java
+++ b/src/main/java/org/apache/mesos/scheduler/plan/ReconciliationPhase.java
@@ -1,7 +1,6 @@
 package org.apache.mesos.scheduler.plan;
 
 import org.apache.mesos.reconciliation.Reconciler;
-import org.apache.mesos.reconciliation.TaskStatusProvider;
 
 import java.util.Arrays;
 import java.util.UUID;
@@ -12,14 +11,13 @@ import java.util.UUID;
  */
 public final class ReconciliationPhase extends DefaultPhase {
 
-    public static ReconciliationPhase create(
-            Reconciler reconciler, TaskStatusProvider taskProvider) {
-        return new ReconciliationPhase(reconciler, taskProvider);
+    public static ReconciliationPhase create(Reconciler reconciler) {
+        return new ReconciliationPhase(reconciler);
     }
 
-    private ReconciliationPhase(Reconciler reconciler, TaskStatusProvider taskProvider) {
+    private ReconciliationPhase(Reconciler reconciler) {
         super(UUID.randomUUID(),
                 "Reconciliation",
-                Arrays.asList(ReconciliationBlock.create(reconciler, taskProvider)));
+                Arrays.asList(ReconciliationBlock.create(reconciler)));
     }
 }

--- a/src/main/java/org/apache/mesos/state/StateStore.java
+++ b/src/main/java/org/apache/mesos/state/StateStore.java
@@ -4,6 +4,7 @@ import org.apache.mesos.Protos;
 import org.apache.mesos.Protos.TaskInfo;
 import org.apache.mesos.Protos.TaskStatus;
 import org.apache.mesos.offer.TaskUtils;
+import org.apache.mesos.reconciliation.TaskStatusProvider;
 
 import java.util.*;
 
@@ -17,7 +18,7 @@ import java.util.*;
  * TaskStatus is reported by Mesos to Frameworks at various points including at Task Reconciliation and when Tasks
  * change state.  The TaskStatus of a Task should be recorded so that the state of a Framework's Tasks can be queried.
  */
-public interface StateStore {
+public interface StateStore extends TaskStatusProvider {
 
 
     // Write Framework ID

--- a/src/test/java/org/apache/mesos/executor/HealthCheckHandlerTest.java
+++ b/src/test/java/org/apache/mesos/executor/HealthCheckHandlerTest.java
@@ -65,7 +65,6 @@ public class HealthCheckHandlerTest {
 
     @Test
     public void testSuccess() throws HealthCheckHandler.HealthCheckValidationException, ExecutionException, InterruptedException {
-        int maxConsecutiveFailures = 1;
         Protos.TaskInfo failureTask = HealthCheckTestUtils.getSuccesfulTask();
         HealthCheckStats healthCheckStats = new HealthCheckStats("test");
         HealthCheckHandler healthCheckHandler = HealthCheckHandler.create(
@@ -74,7 +73,7 @@ public class HealthCheckHandlerTest {
                 healthCheckStats);
 
         healthCheckHandler.start();
-        Awaitility.await().atMost(1, TimeUnit.SECONDS).untilCall(to(healthCheckStats).getTotalSuccesses(), greaterThan(1L));
+        Awaitility.await().atMost(5, TimeUnit.SECONDS).untilCall(to(healthCheckStats).getTotalSuccesses(), greaterThan(1L));
 
         Assert.assertEquals(0, healthCheckStats.getTotalFailures());
         Assert.assertEquals(0, healthCheckStats.getConsecutiveFailures());

--- a/src/test/java/org/apache/mesos/executor/ProcessTaskTest.java
+++ b/src/test/java/org/apache/mesos/executor/ProcessTaskTest.java
@@ -12,6 +12,8 @@ import org.mockito.Mockito;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import static org.mockito.Mockito.timeout;
+
 public class ProcessTaskTest {
     private static final String EXECUTOR_NAME = "TEST_EXECUTOR";
     private static final String TASK_NAME = "TEST_TASK";
@@ -99,7 +101,6 @@ public class ProcessTaskTest {
         final ExecutorService executorService = Executors.newCachedThreadPool();
         executorService.submit(failingProcessTask);
 
-        Thread.sleep(100);
-        Mockito.verify(mockExecutorDriver).sendStatusUpdate(Mockito.any());
+        Mockito.verify(mockExecutorDriver, timeout(1000)).sendStatusUpdate(Mockito.any());
     }
 }

--- a/src/test/java/org/apache/mesos/scheduler/plan/DefaultStageManagerTest.java
+++ b/src/test/java/org/apache/mesos/scheduler/plan/DefaultStageManagerTest.java
@@ -3,7 +3,6 @@ package org.apache.mesos.scheduler.plan;
 import org.apache.mesos.Protos;
 import org.apache.mesos.protobuf.TaskStatusBuilder;
 import org.apache.mesos.reconciliation.Reconciler;
-import org.apache.mesos.reconciliation.TaskStatusProvider;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.Assert;
@@ -30,9 +29,6 @@ public class DefaultStageManagerTest {
 
     @Mock
     Reconciler reconciler;
-
-    @Mock
-    TaskStatusProvider taskProvider;
 
     @Before
     public void beforeEach() {
@@ -103,7 +99,7 @@ public class DefaultStageManagerTest {
     @Test
     public void testInProgressStatus() {
         when(reconciler.isReconciled()).thenReturn(false);
-        ReconciliationPhase reconciliationPhase = ReconciliationPhase.create(reconciler, taskProvider);
+        ReconciliationPhase reconciliationPhase = ReconciliationPhase.create(reconciler);
         Stage waitingStage = DefaultStage.fromArgs(
                 reconciliationPhase,
                 DefaultPhase.create(

--- a/src/test/java/org/apache/mesos/scheduler/plan/ReconciliationBlockTest.java
+++ b/src/test/java/org/apache/mesos/scheduler/plan/ReconciliationBlockTest.java
@@ -1,6 +1,7 @@
 package org.apache.mesos.scheduler.plan;
 
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
@@ -9,7 +10,6 @@ import java.util.Set;
 import org.apache.mesos.Protos.TaskState;
 import org.apache.mesos.Protos.TaskStatus;
 import org.apache.mesos.reconciliation.Reconciler;
-import org.apache.mesos.reconciliation.TaskStatusProvider;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -26,34 +26,31 @@ public class ReconciliationBlockTest {
             createTaskStatus("status1"), createTaskStatus("status2"));
 
     @Mock private Reconciler mockReconciler;
-    @Mock private TaskStatusProvider mockTaskStatusProvider;
 
     private ReconciliationBlock block;
 
     @Before
     public void beforeEach() {
         MockitoAnnotations.initMocks(this);
-        block = ReconciliationBlock.create(mockReconciler, mockTaskStatusProvider);
+        block = ReconciliationBlock.create(mockReconciler);
     }
 
     @Test
     public void testStartsPending() {
         assertTrue(block.isPending());
         assertTrue(block.getMessage().contains("pending"));
-        verifyZeroInteractions(mockReconciler, mockTaskStatusProvider);
-    }
-
-    @Test
-    public void testStart_statusProviderFailure() throws Exception {
-        when(mockTaskStatusProvider.getTaskStatuses()).thenThrow(new Exception("hello"));
-        assertNull(block.start());
-        assertTrue(block.isPending());
         verifyZeroInteractions(mockReconciler);
     }
 
     @Test
+    public void testStart_statusProviderFailure() throws Exception {
+        doThrow(new RuntimeException("hello")).when(mockReconciler).start();
+        assertNull(block.start());
+        assertTrue(block.isPending());
+    }
+
+    @Test
     public void testStart() throws Exception {
-        when(mockTaskStatusProvider.getTaskStatuses()).thenReturn(STATUSES);
         assertNull(block.start());
         assertFalse(block.isPending());
 
@@ -67,7 +64,6 @@ public class ReconciliationBlockTest {
 
     @Test
     public void testStartInProgressRestart() throws Exception {
-        when(mockTaskStatusProvider.getTaskStatuses()).thenReturn(STATUSES);
         assertNull(block.start());
 
         when(mockReconciler.isReconciled()).thenReturn(false);
@@ -78,7 +74,6 @@ public class ReconciliationBlockTest {
 
     @Test
     public void testStartCompleteRestart() throws Exception {
-        when(mockTaskStatusProvider.getTaskStatuses()).thenReturn(STATUSES);
         assertNull(block.start());
         assertFalse(block.isPending());
 
@@ -99,7 +94,6 @@ public class ReconciliationBlockTest {
 
     @Test
     public void testForceCompleteFromInProgress() throws Exception {
-        when(mockTaskStatusProvider.getTaskStatuses()).thenReturn(STATUSES);
         assertNull(block.start());
         when(mockReconciler.isReconciled()).thenReturn(false);
         assertTrue(block.isInProgress());
@@ -111,7 +105,6 @@ public class ReconciliationBlockTest {
 
     @Test
     public void testForceCompleteFromComplete() throws Exception {
-        when(mockTaskStatusProvider.getTaskStatuses()).thenReturn(STATUSES);
         assertNull(block.start());
         when(mockReconciler.isReconciled()).thenReturn(true);
         assertTrue(block.isComplete());


### PR DESCRIPTION
To ensure that task statuses are all coming from a single source of truth, this alters the `Reconciler` interface so that the `start()` method no longer accepts a list of `TaskStatus` protos. Instead, it is expected that the implementing class will accept a `TaskStatusProvider` in its constructor, which it will consult to fetch a collection of all task statuses currently known by the scheduler. To this end, the `StateStore` interface now extends the `TaskStatusProvider` interface with its `getTaskStatuses()` method. All default implementations of these interfaces now reflect the new semantics.