### PR TITLE
Fix version check for case of "1.8-dev"

### DIFF
--- a/src/main/java/org/apache/mesos/dcos/Capabilities.java
+++ b/src/main/java/org/apache/mesos/dcos/Capabilities.java
@@ -3,10 +3,15 @@ package org.apache.mesos.dcos;
 import java.io.IOException;
 import java.net.URISyntaxException;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * This class represents a set of capabilities that may or may not be supported in a given version of DC/OS.
  */
 public class Capabilities {
+    private static final Logger LOGGER = LoggerFactory.getLogger(Capabilities.class);
+
     private DcosCluster dcosCluster;
 
     public Capabilities(DcosCluster dcosCluster) {
@@ -14,22 +19,16 @@ public class Capabilities {
     }
 
     public boolean supportsNamedVips() throws IOException, URISyntaxException {
-        // Named Vips are supported by DC/OS 1.8 upwards.
-        String[] version = dcosCluster.getDcosVersion().getVersion().split("\\.");
-
-        if (version.length < 2) {
-            // incorrect version string. Todo(joerg84): Consider throwing an exception here.
-            return false;
-        }
-
+        DcosVersion dcosVersion = dcosCluster.getDcosVersion();
         try {
-            if (Integer.parseInt(version[0]) >= 2 || Integer.parseInt(version[1]) >= 8) {
-                return true;
-            } else {
-                return false;
+            // Named Vips are supported by DC/OS 1.8 upwards.
+            if (dcosVersion.getVersionFirstElement() == 1) {
+                return dcosVersion.getVersionSecondElement() >= 8;
             }
+            return dcosVersion.getVersionFirstElement() > 1;
         } catch (NumberFormatException ex) {
             // incorrect version string. Todo(joerg84): Consider throwing an exception here.
+            LOGGER.warn("Unable to parse version string for Named Vip", ex);
             return false;
         }
     }

--- a/src/main/java/org/apache/mesos/dcos/Capabilities.java
+++ b/src/main/java/org/apache/mesos/dcos/Capabilities.java
@@ -19,13 +19,13 @@ public class Capabilities {
     }
 
     public boolean supportsNamedVips() throws IOException, URISyntaxException {
-        DcosVersion dcosVersion = dcosCluster.getDcosVersion();
+        DcosVersion.Elements versionElements = dcosCluster.getDcosVersion().getElements();
         try {
             // Named Vips are supported by DC/OS 1.8 upwards.
-            if (dcosVersion.getVersionFirstElement() == 1) {
-                return dcosVersion.getVersionSecondElement() >= 8;
+            if (versionElements.getFirstElement() == 1) {
+                return versionElements.getSecondElement() >= 8;
             }
-            return dcosVersion.getVersionFirstElement() > 1;
+            return versionElements.getFirstElement() > 1;
         } catch (NumberFormatException ex) {
             // incorrect version string. Todo(joerg84): Consider throwing an exception here.
             LOGGER.warn("Unable to parse version string for Named Vip", ex);

--- a/src/main/java/org/apache/mesos/dcos/DcosVersion.java
+++ b/src/main/java/org/apache/mesos/dcos/DcosVersion.java
@@ -25,6 +25,7 @@ public class DcosVersion {
     private static final String BOOTSTRAP_ID_KEY = "bootstrap-id";
     private static final String DCOS_IMAGE_COMMIT = "dcos-image-commit";
     private static final String VERSION_KEY = "version";
+    private static final String DEV_VERSION_SUFFIX = "-dev";
 
     private final String bootstrapId;
     private final String dcosImageCommit;
@@ -52,5 +53,27 @@ public class DcosVersion {
 
     public String getVersion() {
         return version;
+    }
+
+    public int getVersionFirstElement() throws NumberFormatException {
+        return Integer.parseInt(getVersionElement(version, 0));
+    }
+
+    public int getVersionSecondElement() throws NumberFormatException {
+        String secondElem = getVersionElement(version, 1);
+        // Trim "-dev" suffix if present:
+        if (secondElem.endsWith(DEV_VERSION_SUFFIX)) {
+            secondElem = secondElem.substring(0, secondElem.length() - DEV_VERSION_SUFFIX.length());
+        }
+        return Integer.parseInt(secondElem);
+    }
+
+    private static String getVersionElement(String version, int index) {
+        String[] elements = version.split("\\.");
+        if (elements.length <= index) {
+            throw new NumberFormatException(String.format(
+                    "Expected at least %d dot-delimited element(s): %s", index, version));
+        }
+        return elements[index];
     }
 }

--- a/src/main/java/org/apache/mesos/dcos/DcosVersion.java
+++ b/src/main/java/org/apache/mesos/dcos/DcosVersion.java
@@ -22,6 +22,36 @@ import org.json.JSONObject;
  *     }
  */
 public class DcosVersion {
+
+    /**
+     * A broken-down representation of a version string's elements.
+     */
+    public static class Elements {
+        private final String version;
+
+        private Elements(String version) {
+            this.version = version;
+        }
+
+        public int getFirstElement() throws NumberFormatException {
+            return Integer.parseInt(getVersionElement(version, 0));
+        }
+
+        public int getSecondElement() throws NumberFormatException {
+            String secondElem = getVersionElement(version, 1);
+            // Trim "-dev" suffix if present:
+            if (secondElem.endsWith(DEV_VERSION_SUFFIX)) {
+                secondElem = secondElem.substring(0, secondElem.length() - DEV_VERSION_SUFFIX.length());
+            }
+            return Integer.parseInt(secondElem);
+        }
+
+        @Override
+        public String toString() {
+            return version;
+        }
+    }
+
     private static final String BOOTSTRAP_ID_KEY = "bootstrap-id";
     private static final String DCOS_IMAGE_COMMIT = "dcos-image-commit";
     private static final String VERSION_KEY = "version";
@@ -55,17 +85,8 @@ public class DcosVersion {
         return version;
     }
 
-    public int getVersionFirstElement() throws NumberFormatException {
-        return Integer.parseInt(getVersionElement(version, 0));
-    }
-
-    public int getVersionSecondElement() throws NumberFormatException {
-        String secondElem = getVersionElement(version, 1);
-        // Trim "-dev" suffix if present:
-        if (secondElem.endsWith(DEV_VERSION_SUFFIX)) {
-            secondElem = secondElem.substring(0, secondElem.length() - DEV_VERSION_SUFFIX.length());
-        }
-        return Integer.parseInt(secondElem);
+    public Elements getElements() {
+        return new Elements(version);
     }
 
     private static String getVersionElement(String version, int index) {

--- a/src/test/java/org/apache/mesos/dcos/CapabilitiesTest.java
+++ b/src/test/java/org/apache/mesos/dcos/CapabilitiesTest.java
@@ -12,7 +12,6 @@ import java.net.URISyntaxException;
  */
 public class CapabilitiesTest {
     private MockDcosCluster mockDcosCluster;
-    private DcosCluster dcosCluster;
 
     @After
     public void afterEach() {
@@ -22,34 +21,65 @@ public class CapabilitiesTest {
     }
 
     @Test
-    public void testHasNamedVipsFails() throws URISyntaxException, IOException {
-        mockDcosCluster =  MockDcosCluster.create("1.7.0");
-        dcosCluster = mockDcosCluster.getDcosCluster();
-        Capabilities capabilities = new Capabilities(dcosCluster);
+    public void testHasNamedVipsFails_0_9() throws URISyntaxException, IOException {
+        mockDcosCluster = MockDcosCluster.create("0.9.0");
+        Capabilities capabilities = new Capabilities(mockDcosCluster.getDcosCluster());
+        Assert.assertFalse(capabilities.supportsNamedVips());
+    }
+
+    @Test
+    public void testHasNamedVipsFails_1_7() throws URISyntaxException, IOException {
+        mockDcosCluster = MockDcosCluster.create("1.7.0");
+        Capabilities capabilities = new Capabilities(mockDcosCluster.getDcosCluster());
+        Assert.assertFalse(capabilities.supportsNamedVips());
+    }
+
+    @Test
+    public void testHasNamedVipsFails_1_7dev() throws URISyntaxException, IOException {
+        mockDcosCluster = MockDcosCluster.create("1.7-dev");
+        Capabilities capabilities = new Capabilities(mockDcosCluster.getDcosCluster());
         Assert.assertFalse(capabilities.supportsNamedVips());
     }
 
     @Test
     public void testHasNamedVipsSucceeds_1_8() throws URISyntaxException, IOException {
-        mockDcosCluster =  MockDcosCluster.create("1.8.0");
-        dcosCluster = mockDcosCluster.getDcosCluster();
-        Capabilities capabilities = new Capabilities(dcosCluster);
+        mockDcosCluster = MockDcosCluster.create("1.8.0");
+        Capabilities capabilities = new Capabilities(mockDcosCluster.getDcosCluster());
+        Assert.assertTrue(capabilities.supportsNamedVips());
+    }
+
+    @Test
+    public void testHasNamedVipsSucceeds_1_8dev() throws URISyntaxException, IOException {
+        mockDcosCluster = MockDcosCluster.create("1.8-dev");
+        Capabilities capabilities = new Capabilities(mockDcosCluster.getDcosCluster());
         Assert.assertTrue(capabilities.supportsNamedVips());
     }
 
     @Test
     public void testHasNamedVipsSucceeds_1_9() throws URISyntaxException, IOException {
-        mockDcosCluster =  MockDcosCluster.create("1.9.0");
-        dcosCluster = mockDcosCluster.getDcosCluster();
-        Capabilities capabilities = new Capabilities(dcosCluster);
+        mockDcosCluster = MockDcosCluster.create("1.9.0");
+        Capabilities capabilities = new Capabilities(mockDcosCluster.getDcosCluster());
+        Assert.assertTrue(capabilities.supportsNamedVips());
+    }
+
+    @Test
+    public void testHasNamedVipsSucceeds_1_9dev() throws URISyntaxException, IOException {
+        mockDcosCluster = MockDcosCluster.create("1.9-dev");
+        Capabilities capabilities = new Capabilities(mockDcosCluster.getDcosCluster());
         Assert.assertTrue(capabilities.supportsNamedVips());
     }
 
     @Test
     public void testHasNamedVipsSucceeds_2_0() throws URISyntaxException, IOException {
-        mockDcosCluster =  MockDcosCluster.create("2.0.0");
-        dcosCluster = mockDcosCluster.getDcosCluster();
-        Capabilities capabilities = new Capabilities(dcosCluster);
+        mockDcosCluster = MockDcosCluster.create("2.0.0");
+        Capabilities capabilities = new Capabilities(mockDcosCluster.getDcosCluster());
+        Assert.assertTrue(capabilities.supportsNamedVips());
+    }
+
+    @Test
+    public void testHasNamedVipsSucceeds_2_0dev() throws URISyntaxException, IOException {
+        mockDcosCluster =  MockDcosCluster.create("2.0-dev");
+        Capabilities capabilities = new Capabilities(mockDcosCluster.getDcosCluster());
         Assert.assertTrue(capabilities.supportsNamedVips());
     }
 }

--- a/src/test/java/org/apache/mesos/dcos/DcosClusterTest.java
+++ b/src/test/java/org/apache/mesos/dcos/DcosClusterTest.java
@@ -13,33 +13,93 @@ import java.net.URISyntaxException;
  */
 public class DcosClusterTest {
     private MockDcosCluster mockDcosCluster;
-    private DcosCluster dcosCluster;
     private static final String TEST_VERSION = "1.8-dev";
 
     @Before
     public void beforeEach() throws URISyntaxException {
-        mockDcosCluster = MockDcosCluster.create(TEST_VERSION);
-        dcosCluster = mockDcosCluster.getDcosCluster();
+        mockDcosCluster = null;
     }
 
     @After
     public void afterEach() {
-        mockDcosCluster.stop();
+        if (mockDcosCluster != null) {
+            mockDcosCluster.stop();
+        }
+        mockDcosCluster = null;
+    }
+
+    @Test
+    public void testGetImageInfo() throws IOException, URISyntaxException {
+        mockDcosCluster = MockDcosCluster.create(TEST_VERSION);
+        DcosVersion dcosVersion = mockDcosCluster.getDcosCluster().getDcosVersion();
+        Assert.assertNotNull(dcosVersion);
+        Assert.assertEquals(MockDcosCluster.TEST_BOOTSTRAP_ID, dcosVersion.getBootstrapId());
+        Assert.assertEquals(MockDcosCluster.TEST_DCOS_IMAGE_COMMIT, dcosVersion.getDcosImageCommit());
     }
 
     @Test
     public void testGetVersion() throws IOException, URISyntaxException {
-        DcosVersion dcosVersion = dcosCluster.getDcosVersion();
+        mockDcosCluster = MockDcosCluster.create(TEST_VERSION);
+        DcosVersion dcosVersion = mockDcosCluster.getDcosCluster().getDcosVersion();
         Assert.assertNotNull(dcosVersion);
-        Assert.assertEquals(MockDcosCluster.TEST_BOOTSTRAP_ID, dcosVersion.getBootstrapId());
-        Assert.assertEquals(MockDcosCluster.TEST_DCOS_IMAGE_COMMIT, dcosVersion.getDcosImageCommit());
         Assert.assertEquals(TEST_VERSION, dcosVersion.getVersion());
         Assert.assertEquals(1, dcosVersion.getElements().getFirstElement());
         Assert.assertEquals(8, dcosVersion.getElements().getSecondElement());
     }
 
+    @Test(expected = NumberFormatException.class)
+    public void testGetBadVersionInt() throws IOException, URISyntaxException {
+        mockDcosCluster = MockDcosCluster.create("5");
+        DcosVersion dcosVersion = mockDcosCluster.getDcosCluster().getDcosVersion();
+        Assert.assertNotNull(dcosVersion);
+        Assert.assertEquals("5", dcosVersion.getVersion());
+        Assert.assertEquals(5, dcosVersion.getElements().getFirstElement());
+        dcosVersion.getElements().getSecondElement();
+    }
+
+    @Test(expected = NumberFormatException.class)
+    public void testGetBadVersionIntDot() throws IOException, URISyntaxException {
+        mockDcosCluster = MockDcosCluster.create("0.");
+        DcosVersion dcosVersion = mockDcosCluster.getDcosCluster().getDcosVersion();
+        Assert.assertNotNull(dcosVersion);
+        Assert.assertEquals("0.", dcosVersion.getVersion());
+        Assert.assertEquals(0, dcosVersion.getElements().getFirstElement());
+        dcosVersion.getElements().getSecondElement();
+    }
+
+    @Test(expected = NumberFormatException.class)
+    public void testGetBadVersionDot() throws IOException, URISyntaxException {
+        mockDcosCluster = MockDcosCluster.create(".");
+        DcosVersion dcosVersion = mockDcosCluster.getDcosCluster().getDcosVersion();
+        Assert.assertNotNull(dcosVersion);
+        Assert.assertEquals(".", dcosVersion.getVersion());
+        dcosVersion.getElements().getFirstElement();
+    }
+
+    @Test(expected = NumberFormatException.class)
+    public void testGetBadVersionString() throws IOException, URISyntaxException {
+        mockDcosCluster = MockDcosCluster.create("0.hello");
+        DcosVersion dcosVersion = mockDcosCluster.getDcosCluster().getDcosVersion();
+        Assert.assertNotNull(dcosVersion);
+        Assert.assertEquals("0.hello", dcosVersion.getVersion());
+        Assert.assertEquals(0, dcosVersion.getElements().getFirstElement());
+        dcosVersion.getElements().getSecondElement();
+    }
+
+    @Test(expected = NumberFormatException.class)
+    public void testGetBadVersionSuffix() throws IOException, URISyntaxException {
+        mockDcosCluster = MockDcosCluster.create("0.5-hey");
+        DcosVersion dcosVersion = mockDcosCluster.getDcosCluster().getDcosVersion();
+        Assert.assertNotNull(dcosVersion);
+        Assert.assertEquals("0.5-hey", dcosVersion.getVersion());
+        Assert.assertEquals(0, dcosVersion.getElements().getFirstElement());
+        dcosVersion.getElements().getSecondElement();
+    }
+
     @Test
     public void testGetUri() throws IOException, URISyntaxException {
-        Assert.assertEquals(mockDcosCluster.getUri(), dcosCluster.getDcosUri());
+        mockDcosCluster = MockDcosCluster.create(TEST_VERSION);
+        Assert.assertEquals(
+                mockDcosCluster.getUri(), mockDcosCluster.getDcosCluster().getDcosUri());
     }
 }

--- a/src/test/java/org/apache/mesos/dcos/DcosClusterTest.java
+++ b/src/test/java/org/apache/mesos/dcos/DcosClusterTest.java
@@ -14,7 +14,7 @@ import java.net.URISyntaxException;
 public class DcosClusterTest {
     private MockDcosCluster mockDcosCluster;
     private DcosCluster dcosCluster;
-    private static final String TEST_VERSION = "test-version";
+    private static final String TEST_VERSION = "1.8-dev";
 
     @Before
     public void beforeEach() throws URISyntaxException {
@@ -34,6 +34,8 @@ public class DcosClusterTest {
         Assert.assertEquals(MockDcosCluster.TEST_BOOTSTRAP_ID, dcosVersion.getBootstrapId());
         Assert.assertEquals(MockDcosCluster.TEST_DCOS_IMAGE_COMMIT, dcosVersion.getDcosImageCommit());
         Assert.assertEquals(TEST_VERSION, dcosVersion.getVersion());
+        Assert.assertEquals(1, dcosVersion.getVersionFirstElement());
+        Assert.assertEquals(8, dcosVersion.getVersionSecondElement());
     }
 
     @Test

--- a/src/test/java/org/apache/mesos/dcos/DcosClusterTest.java
+++ b/src/test/java/org/apache/mesos/dcos/DcosClusterTest.java
@@ -34,8 +34,8 @@ public class DcosClusterTest {
         Assert.assertEquals(MockDcosCluster.TEST_BOOTSTRAP_ID, dcosVersion.getBootstrapId());
         Assert.assertEquals(MockDcosCluster.TEST_DCOS_IMAGE_COMMIT, dcosVersion.getDcosImageCommit());
         Assert.assertEquals(TEST_VERSION, dcosVersion.getVersion());
-        Assert.assertEquals(1, dcosVersion.getVersionFirstElement());
-        Assert.assertEquals(8, dcosVersion.getVersionSecondElement());
+        Assert.assertEquals(1, dcosVersion.getElements().getFirstElement());
+        Assert.assertEquals(8, dcosVersion.getElements().getSecondElement());
     }
 
     @Test


### PR DESCRIPTION
Stays pretty strict for now, supporting only '-dev', and only on the second element.

Moves version element extraction upstream in case other utils need it someday.