### PR TITLE
Fix recovery throttling defect.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,7 @@ ext {
 }
 
 group = "mesosphere"
-version = "0.4.32-SNAPSHOT"
+version = "0.4.33-SNAPSHOT"
 
 task sourceJar(type: Jar) {
   from sourceSets.main.allJava

--- a/src/main/java/org/apache/mesos/scheduler/plan/Block.java
+++ b/src/main/java/org/apache/mesos/scheduler/plan/Block.java
@@ -8,7 +8,7 @@ import java.util.UUID;
 /**
  * Defines the interface for a Block of a {@link Phase}. The block is the base unit of a set of
  * tasks to perform, such as launching a Task, updating a Task, or reconciling Mesos state with
- * Framework state. A Block may be in one of four states: Pending, InProgress, Complete, or Error.
+ * Framework state. A Block may be in one of four states: PENDING, IN_PROGRESS, COMPLETE, or ERROR.
  * <p>
  * See {@Stage} docs for more background.
  */
@@ -20,13 +20,13 @@ public interface Block extends Completable {
     static Status getStatus(Block block) {
         // these should all be mutually exclusive, ordering doesn't matter.
         if (block.isPending()) {
-            return Status.Pending;
+            return Status.PENDING;
         } else if (block.isInProgress()) {
-            return Status.InProgress;
+            return Status.IN_PROGRESS;
         } else if (block.isComplete()) {
-            return Status.Complete;
+            return Status.COMPLETE;
         }
-        return Status.Error;
+        return Status.ERROR;
     }
 
     /**
@@ -64,13 +64,13 @@ public interface Block extends Completable {
     void updateOfferStatus(boolean accepted);
 
     /**
-     * Forcefully restarts the block, putting it into a Pending state, waiting to be resumed with
+     * Forcefully restarts the block, putting it into a PENDING state, waiting to be resumed with
      * a call to {@link start()}.
      */
     void restart();
 
     /**
-     * Forcefully marks the block as Complete, cancelling any work that hasn't started or that's
+     * Forcefully marks the block as COMPLETE, cancelling any work that hasn't started or that's
      * currently in progress.
      */
     void forceComplete();

--- a/src/main/java/org/apache/mesos/scheduler/plan/DefaultInstallStrategy.java
+++ b/src/main/java/org/apache/mesos/scheduler/plan/DefaultInstallStrategy.java
@@ -42,7 +42,7 @@ public class DefaultInstallStrategy implements PhaseStrategy {
 
     @Override
     public boolean isInterrupted() {
-        return getStatus() == Status.Waiting;
+        return getStatus() == Status.WAITING;
     }
 
     @Override
@@ -64,7 +64,7 @@ public class DefaultInstallStrategy implements PhaseStrategy {
     @Override
     public Status getStatus() {
         if (phase == null || phase.getBlocks().isEmpty()) {
-            return Status.Complete;
+            return Status.COMPLETE;
         }
 
         int blockIndex = -1;
@@ -73,18 +73,18 @@ public class DefaultInstallStrategy implements PhaseStrategy {
 
             if (!block.isComplete()) {
                 if (interrupted.get()) {
-                    return Status.Waiting;
+                    return Status.WAITING;
                 }
 
                 if (blockIndex > 0) {
-                    return Status.InProgress;
+                    return Status.IN_PROGRESS;
                 } else {
                     return Block.getStatus(block);
                 }
             }
         }
 
-        return Status.Complete;
+        return Status.COMPLETE;
     }
 
     @Override

--- a/src/main/java/org/apache/mesos/scheduler/plan/DefaultStageManager.java
+++ b/src/main/java/org/apache/mesos/scheduler/plan/DefaultStageManager.java
@@ -97,7 +97,7 @@ public class DefaultStageManager implements StageManager {
 
   @Override
   public boolean isInterrupted() {
-    return getStatus() == Status.Waiting;
+    return getStatus() == Status.WAITING;
   }
 
   @Override
@@ -170,27 +170,27 @@ public class DefaultStageManager implements StageManager {
 
     Status result;
     if (!getErrors().isEmpty()) {
-      result = Status.Error;
+      result = Status.ERROR;
       LOGGER.warn("(status={}) Stage contains errors", result);
     } else if (stage.getPhases().isEmpty()) {
-      result = Status.Complete;
+      result = Status.COMPLETE;
       LOGGER.warn("(status={}) Stage doesn't have any phases", result);
-    } else if (anyHaveStatus(Status.InProgress, stage)) {
-      result = Status.InProgress;
-      LOGGER.info("(status={}) At least one phase has status: {}", result, Status.InProgress);
-    } else if (anyHaveStatus(Status.Waiting, stage)) {
-      result = Status.Waiting;
-      LOGGER.info("(status={}) At least one phase has status: {}", result, Status.Waiting);
-    } else if (allHaveStatus(Status.Complete, stage)) {
-      result = Status.Complete;
-      LOGGER.info("(status={}) All phases have status: {}", result, Status.Complete);
-    } else if (allHaveStatus(Status.Pending, stage)) {
-      result = Status.Pending;
-      LOGGER.info("(status={}) All phases have status: {}", result, Status.Pending);
-    } else if (anyHaveStatus(Status.Complete, stage) && anyHaveStatus(Status.Pending, stage)) {
-      result = Status.InProgress;
+    } else if (anyHaveStatus(Status.IN_PROGRESS, stage)) {
+      result = Status.IN_PROGRESS;
+      LOGGER.info("(status={}) At least one phase has status: {}", result, Status.IN_PROGRESS);
+    } else if (anyHaveStatus(Status.WAITING, stage)) {
+      result = Status.WAITING;
+      LOGGER.info("(status={}) At least one phase has status: {}", result, Status.WAITING);
+    } else if (allHaveStatus(Status.COMPLETE, stage)) {
+      result = Status.COMPLETE;
+      LOGGER.info("(status={}) All phases have status: {}", result, Status.COMPLETE);
+    } else if (allHaveStatus(Status.PENDING, stage)) {
+      result = Status.PENDING;
+      LOGGER.info("(status={}) All phases have status: {}", result, Status.PENDING);
+    } else if (anyHaveStatus(Status.COMPLETE, stage) && anyHaveStatus(Status.PENDING, stage)) {
+      result = Status.IN_PROGRESS;
       LOGGER.info("(status={}) At least one phase has status '{}' and one has status '{}'",
-              result, Status.Complete, Status.Pending);
+              result, Status.COMPLETE, Status.PENDING);
     } else {
       result = null;
       LOGGER.error("(status={}) Unexpected state. Stage: {}", result, stage);
@@ -215,7 +215,7 @@ public class DefaultStageManager implements StageManager {
   @Override
   public Status getPhaseStatus(final UUID phaseId) {
     PhaseStrategy strategy = getStrategy(getPhase(phaseId));
-    return strategy != null ? strategy.getStatus() : Status.Error;
+    return strategy != null ? strategy.getStatus() : Status.ERROR;
   }
 
   @Override

--- a/src/main/java/org/apache/mesos/scheduler/plan/DefaultStageStrategy.java
+++ b/src/main/java/org/apache/mesos/scheduler/plan/DefaultStageStrategy.java
@@ -72,7 +72,7 @@ public class DefaultStageStrategy implements PhaseStrategy {
         logger.info(String.format("Returning block '%s' at position: %d", block.getName(), currPos));
         return block;
       } else {
-        // Waiting for input, don't continue to next block
+        // WAITING for input, don't continue to next block
         return null;
       }
     }
@@ -122,7 +122,7 @@ public class DefaultStageStrategy implements PhaseStrategy {
 
   @Override
   public boolean isInterrupted() {
-    return getStatus() == Status.Waiting;
+    return getStatus() == Status.WAITING;
   }
 
   @Override
@@ -133,18 +133,18 @@ public class DefaultStageStrategy implements PhaseStrategy {
 
       if (!block.isComplete()) {
         if (block.isPending() && hasDecisionPoint(block)) {
-          return Status.Waiting;
+          return Status.WAITING;
         }
 
         if (blockIndex > 0) {
-          return Status.InProgress;
+          return Status.IN_PROGRESS;
         } else {
           return Block.getStatus(block);
         }
       }
     }
 
-    return Status.Complete;
+    return Status.COMPLETE;
   }
 
   @Override

--- a/src/main/java/org/apache/mesos/scheduler/plan/PhaseStrategy.java
+++ b/src/main/java/org/apache/mesos/scheduler/plan/PhaseStrategy.java
@@ -32,7 +32,7 @@ public interface PhaseStrategy {
     void restart(UUID blockId);
 
     /**
-     * Force the block to a status of Complete.
+     * Force the block to a status of COMPLETE.
      * @param blockId The unique id of the block to be completed.
      */
     void forceComplete(UUID blockId);

--- a/src/main/java/org/apache/mesos/scheduler/plan/Stage.java
+++ b/src/main/java/org/apache/mesos/scheduler/plan/Stage.java
@@ -26,7 +26,7 @@ public interface Stage extends Completable {
 
     /**
      * Returns a list of user-visible descriptive error messages which have been encountered while
-     * progressing through this Stage. A non-empty response implies that the Stage is in an Error
+     * progressing through this Stage. A non-empty response implies that the Stage is in an ERROR
      * state.
      */
     List<String> getErrors();

--- a/src/main/java/org/apache/mesos/scheduler/plan/Status.java
+++ b/src/main/java/org/apache/mesos/scheduler/plan/Status.java
@@ -4,9 +4,9 @@ package org.apache.mesos.scheduler.plan;
  * Status of the block. Useful for reporting
  */
 public enum Status {
-  Error,
-  Waiting,
-  Pending,
-  InProgress,
-  Complete
+  ERROR,
+  WAITING,
+  PENDING,
+  IN_PROGRESS,
+  COMPLETE
 }

--- a/src/main/java/org/apache/mesos/scheduler/plan/api/CurrentlyActiveInfo.java
+++ b/src/main/java/org/apache/mesos/scheduler/plan/api/CurrentlyActiveInfo.java
@@ -48,13 +48,13 @@ class CurrentlyActiveInfo {
         this.stageStatus = stageStatus;
     }
 
-    @JsonInclude(JsonInclude.Include.NON_NULL) // omit field when null/Complete
+    @JsonInclude(JsonInclude.Include.NON_NULL) // omit field when null/COMPLETE
     @JsonProperty("block")
     public BlockInfo getBlock() {
       return block;
     }
 
-    @JsonInclude(JsonInclude.Include.NON_NULL) // omit field when null/Complete
+    @JsonInclude(JsonInclude.Include.NON_NULL) // omit field when null/COMPLETE
     @JsonProperty("phase")
     public CurrentlyActivePhaseInfo getPhaseStatus() {
       return phaseStatus;

--- a/src/main/java/org/apache/mesos/scheduler/recovery/DefaultRecoveryRequirement.java
+++ b/src/main/java/org/apache/mesos/scheduler/recovery/DefaultRecoveryRequirement.java
@@ -1,0 +1,27 @@
+package org.apache.mesos.scheduler.recovery;
+
+import org.apache.mesos.offer.OfferRequirement;
+
+/**
+ * This default implementation of the RecoveryRequirement interface contains no logic.  It merely encapsulates and
+ * provides getters for the underlying OfferRequirement and RecoveryType objects.
+ */
+public class DefaultRecoveryRequirement implements RecoveryRequirement {
+    private final OfferRequirement offerRequirement;
+    private final RecoveryType recoveryType;
+
+    public DefaultRecoveryRequirement(OfferRequirement offerRequirement, RecoveryType recoveryType) {
+        this.offerRequirement = offerRequirement;
+        this.recoveryType = recoveryType;
+    }
+
+    @Override
+    public RecoveryType getRecoveryType() {
+        return recoveryType;
+    }
+
+    @Override
+    public OfferRequirement getOfferRequirement() {
+        return offerRequirement;
+    }
+}

--- a/src/main/java/org/apache/mesos/scheduler/recovery/RecoveryRequirement.java
+++ b/src/main/java/org/apache/mesos/scheduler/recovery/RecoveryRequirement.java
@@ -1,0 +1,24 @@
+package org.apache.mesos.scheduler.recovery;
+
+import org.apache.mesos.offer.OfferRequirement;
+
+/**
+ * Implementation of this interface allows RecoverySchedulers to make decisions about the scheduling of recovery of
+ * failed Tasks.
+ */
+public interface RecoveryRequirement {
+    /**
+     * Possible recovery types are NONE, TRANSIENT and PERMANENT.  NONE indicates that no recovery is under way.
+     * TRANSIENT indicates that non-destructive recovery is being attempted.  PERMANENT indicates that a destructive
+     * recovery operation is desired.
+     */
+    enum RecoveryType {
+        NONE,
+        TRANSIENT,
+        PERMANENT
+    }
+
+    RecoveryType getRecoveryType();
+
+    OfferRequirement getOfferRequirement();
+}

--- a/src/main/java/org/apache/mesos/scheduler/recovery/RecoveryRequirementProvider.java
+++ b/src/main/java/org/apache/mesos/scheduler/recovery/RecoveryRequirementProvider.java
@@ -1,7 +1,6 @@
 package org.apache.mesos.scheduler.recovery;
 
 import org.apache.mesos.Protos.TaskInfo;
-import org.apache.mesos.offer.OfferRequirement;
 import org.apache.mesos.scheduler.recovery.monitor.FailureMonitor;
 
 import java.util.List;
@@ -9,29 +8,29 @@ import java.util.List;
 /**
  * Implementations of this know how to relaunch tasks from a framework when those tasks crash or fail.
  * <p>
- * The method {@link RecoveryOfferRequirementProvider#getTransientRecoveryOfferRequirements(List)} is called once a
+ * The method {@link RecoveryRequirementProvider#getTransientRecoveryOfferRequirements(List)} is called once a
  * given Task crashes. The implementation should look at the given {@link List<TaskInfo>} in order to know which Tasks
  * it's replacing, and where that task's resources & data have been reserved.
  * <p>
- * The method {@link RecoveryOfferRequirementProvider#getPermanentRecoveryOfferRequirements(List)} is called once the
+ * The method {@link RecoveryRequirementProvider#getPermanentRecoveryOfferRequirements(List)} is called once the
  * framework's {@link FailureMonitor} decides that a task has permanently failed, and a new location is needed to run
  * it. Typically, this means that if the task represented a database node, the data on that node is permanently lost.
  */
-public interface RecoveryOfferRequirementProvider {
+public interface RecoveryRequirementProvider {
     /**
-     * Returns a {@link List<OfferRequirement>} that will relaunch Tasks which encountered a transient error.  This
+     * Returns a {@link List<RecoveryRequirement>} that will relaunch Tasks which encountered a transient error.  This
      * method should provide OfferRequirements which consume previously reserved Resources. This will only be called
      * when the arguments are in a terminal state, before the {@link FailureMonitor} decides that Tasks are definitely
      * gone forever.
      * @param stoppedTasks The list of Tasks which have encountered a transient failure.
      */
-    List<OfferRequirement> getTransientRecoveryOfferRequirements(List<TaskInfo> stoppedTasks);
+    List<RecoveryRequirement> getTransientRecoveryOfferRequirements(List<TaskInfo> stoppedTasks);
 
     /**
-     * Returns a {@link List<OfferRequirement>} that will replace Tasks whose Resources are no longer available given
+     * Returns a {@link List<RecoveryRequirement>} that will replace Tasks whose Resources are no longer available given
      * the {@link List<TaskInfo>}.
      *
      * @param failedTasks The list of Tasks which have encountered a permanent failure.
      */
-    List<OfferRequirement> getPermanentRecoveryOfferRequirements(List<TaskInfo> failedTasks);
+    List<RecoveryRequirement> getPermanentRecoveryOfferRequirements(List<TaskInfo> failedTasks);
 }

--- a/src/main/java/org/apache/mesos/scheduler/recovery/RecoveryRequirementUtils.java
+++ b/src/main/java/org/apache/mesos/scheduler/recovery/RecoveryRequirementUtils.java
@@ -1,0 +1,27 @@
+package org.apache.mesos.scheduler.recovery;
+
+/**
+ * This class encapsulates utility methods useful for the processing of RecoveryRequirements.
+ */
+public class RecoveryRequirementUtils {
+    public static boolean isPermanent(RecoveryRequirement recoveryRequirement) {
+        return isPermanent(recoveryRequirement.getRecoveryType());
+    }
+
+    public static boolean isTransient(RecoveryRequirement recoveryRequirement) {
+        return isTransient(recoveryRequirement.getRecoveryType());
+    }
+
+    public static boolean isPermanent(RecoveryRequirement.RecoveryType recoveryType) {
+        return isOfType(RecoveryRequirement.RecoveryType.PERMANENT, recoveryType);
+    }
+
+    public static boolean isTransient(RecoveryRequirement.RecoveryType recoveryType) {
+        return isOfType(RecoveryRequirement.RecoveryType.TRANSIENT, recoveryType);
+    }
+
+    private static boolean isOfType(RecoveryRequirement.RecoveryType expectedRecoveryType,
+                                    RecoveryRequirement.RecoveryType actualRecoveryType) {
+        return expectedRecoveryType.equals(actualRecoveryType);
+    }
+}

--- a/src/main/java/org/apache/mesos/scheduler/recovery/constrain/AllLaunchConstrainer.java
+++ b/src/main/java/org/apache/mesos/scheduler/recovery/constrain/AllLaunchConstrainer.java
@@ -1,7 +1,7 @@
 package org.apache.mesos.scheduler.recovery.constrain;
 
 import org.apache.mesos.Protos.Offer.Operation;
-import org.apache.mesos.offer.OfferRequirement;
+import org.apache.mesos.scheduler.recovery.RecoveryRequirement;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -24,16 +24,16 @@ public class AllLaunchConstrainer implements LaunchConstrainer {
     }
 
     @Override
-    public void launchHappened(Operation launchOperation) {
+    public void launchHappened(Operation launchOperation, RecoveryRequirement.RecoveryType recoveryType) {
         for (LaunchConstrainer constrainer : constrainers) {
-            constrainer.launchHappened(launchOperation);
+            constrainer.launchHappened(launchOperation, recoveryType);
         }
     }
 
     @Override
-    public boolean canLaunch(OfferRequirement offerRequirement) {
+    public boolean canLaunch(RecoveryRequirement recoveryRequirement) {
         for (LaunchConstrainer constrainer : constrainers) {
-            if (!constrainer.canLaunch(offerRequirement)) {
+            if (!constrainer.canLaunch(recoveryRequirement)) {
                 return false;
             }
         }

--- a/src/main/java/org/apache/mesos/scheduler/recovery/constrain/LaunchConstrainer.java
+++ b/src/main/java/org/apache/mesos/scheduler/recovery/constrain/LaunchConstrainer.java
@@ -2,9 +2,13 @@ package org.apache.mesos.scheduler.recovery.constrain;
 
 import org.apache.mesos.Protos.Offer.Operation;
 import org.apache.mesos.offer.OfferRequirement;
+import org.apache.mesos.scheduler.recovery.RecoveryRequirement;
 
 /**
- * Created by dgrnbrg on 7/25/16.
+ * This interface provides methods which govern and react to Launch Operations.  It is sometimes desirable to limit the
+ * rate of Launch Operations.  In particular may be desirable to limit the rate of Operations which may be destructive
+ * in reaction to permanent failures.  Notifications regarding launch Operations and desired RecoveryRequirements allow
+ * LaunchConstrainers to throttle Launch Operations.
  */
 public interface LaunchConstrainer {
     /**
@@ -13,9 +17,10 @@ public interface LaunchConstrainer {
      * We take a {@link Operation} so that frameworks can specify additional metadata, in order to smooth the launch
      * rate.
      *
-     * @param launchOperation
+     * @param launchOperation The Launch Operation which occurred.
+     * @param recoveryType The type of the recovery which has been executed.
      */
-    void launchHappened(Operation launchOperation);
+    void launchHappened(Operation launchOperation, RecoveryRequirement.RecoveryType recoveryType);
 
     /**
      * Determines whether the given {@link OfferRequirement} can be launchHappened right now.
@@ -23,5 +28,5 @@ public interface LaunchConstrainer {
      * @param offerRequirement
      * @return True if the offer is safe to launch immediately, false if it should wait
      */
-    boolean canLaunch(OfferRequirement offerRequirement);
+    boolean canLaunch(RecoveryRequirement offerRequirement);
 }

--- a/src/main/java/org/apache/mesos/scheduler/recovery/constrain/TestingLaunchConstrainer.java
+++ b/src/main/java/org/apache/mesos/scheduler/recovery/constrain/TestingLaunchConstrainer.java
@@ -1,7 +1,7 @@
 package org.apache.mesos.scheduler.recovery.constrain;
 
 import org.apache.mesos.Protos.Offer.Operation;
-import org.apache.mesos.offer.OfferRequirement;
+import org.apache.mesos.scheduler.recovery.RecoveryRequirement;
 
 /**
  * {@link LaunchConstrainer} that makes it easy to enable/disable launches for testing.
@@ -20,12 +20,12 @@ public class TestingLaunchConstrainer implements LaunchConstrainer {
     }
 
     @Override
-    public void launchHappened(Operation launchOperation) {
+    public void launchHappened(Operation launchOperation, RecoveryRequirement.RecoveryType recoveryType) {
         // Does nothing when the launch happens
     }
 
     @Override
-    public boolean canLaunch(OfferRequirement offerRequirement) {
+    public boolean canLaunch(RecoveryRequirement recoveryRequirement) {
         return this.canLaunch;
     }
 }

--- a/src/main/java/org/apache/mesos/scheduler/recovery/constrain/UnconstrainedLaunchConstrainer.java
+++ b/src/main/java/org/apache/mesos/scheduler/recovery/constrain/UnconstrainedLaunchConstrainer.java
@@ -1,7 +1,7 @@
 package org.apache.mesos.scheduler.recovery.constrain;
 
 import org.apache.mesos.Protos.Offer.Operation;
-import org.apache.mesos.offer.OfferRequirement;
+import org.apache.mesos.scheduler.recovery.RecoveryRequirement;
 
 /**
  * Implementation of {@link LaunchConstrainer} that always allows launches.
@@ -10,12 +10,12 @@ import org.apache.mesos.offer.OfferRequirement;
  */
 public class UnconstrainedLaunchConstrainer implements LaunchConstrainer {
     @Override
-    public void launchHappened(Operation launchOperation) {
+    public void launchHappened(Operation launchOperation, RecoveryRequirement.RecoveryType recoveryType) {
         //do nothing
     }
 
     @Override
-    public boolean canLaunch(OfferRequirement offerRequirement) {
+    public boolean canLaunch(RecoveryRequirement recoveryRequirement) {
         return true;
     }
 }

--- a/src/test/java/org/apache/mesos/scheduler/plan/DefaultStageManagerTest.java
+++ b/src/test/java/org/apache/mesos/scheduler/plan/DefaultStageManagerTest.java
@@ -69,35 +69,35 @@ public class DefaultStageManagerTest {
     @Test
     public void testGetPhaseStatus() {
         Phase firstPhase = stage.getPhases().get(0);
-        Assert.assertEquals(Status.Pending, stageManager.getPhaseStatus(firstPhase.getId()));
-        firstBlock.setStatus(Status.InProgress);
-        Assert.assertEquals(Status.InProgress, stageManager.getPhaseStatus(firstPhase.getId()));
-        firstBlock.setStatus(Status.Complete);
-        Assert.assertEquals(Status.Complete, stageManager.getPhaseStatus(firstPhase.getId()));
+        Assert.assertEquals(Status.PENDING, stageManager.getPhaseStatus(firstPhase.getId()));
+        firstBlock.setStatus(Status.IN_PROGRESS);
+        Assert.assertEquals(Status.IN_PROGRESS, stageManager.getPhaseStatus(firstPhase.getId()));
+        firstBlock.setStatus(Status.COMPLETE);
+        Assert.assertEquals(Status.COMPLETE, stageManager.getPhaseStatus(firstPhase.getId()));
         // bad id:
-        Assert.assertEquals(Status.Error, stageManager.getPhaseStatus(UUID.randomUUID()));
+        Assert.assertEquals(Status.ERROR, stageManager.getPhaseStatus(UUID.randomUUID()));
     }
 
 
     @Test
     public void testEmptyStageStatus() {
         StageManager emptyManager = new DefaultStageManager(getEmptyStage(), stratFactory);
-        Assert.assertEquals(Status.Complete, emptyManager.getStatus());
+        Assert.assertEquals(Status.COMPLETE, emptyManager.getStatus());
     }
 
     @Test
     public void testGetStatus() {
-        Assert.assertEquals(Status.Pending, stageManager.getStatus());
-        firstBlock.setStatus(Status.Error);
+        Assert.assertEquals(Status.PENDING, stageManager.getStatus());
+        firstBlock.setStatus(Status.ERROR);
         Assert.assertNull(stageManager.getStatus());
-        firstBlock.setStatus(Status.Waiting);
-        Assert.assertNull(stageManager.getStatus()); // error state: Blocks shouldn't be Waiting
-        firstBlock.setStatus(Status.InProgress);
-        Assert.assertEquals(Status.InProgress, stageManager.getStatus());
+        firstBlock.setStatus(Status.WAITING);
+        Assert.assertNull(stageManager.getStatus()); // error state: Blocks shouldn't be WAITING
+        firstBlock.setStatus(Status.IN_PROGRESS);
+        Assert.assertEquals(Status.IN_PROGRESS, stageManager.getStatus());
         completePhase(stage.getPhases().get(0));
-        Assert.assertEquals(Status.InProgress, stageManager.getStatus());
+        Assert.assertEquals(Status.IN_PROGRESS, stageManager.getStatus());
         completePhase(stage.getPhases().get(1));
-        Assert.assertEquals(Status.Complete, stageManager.getStatus());
+        Assert.assertEquals(Status.COMPLETE, stageManager.getStatus());
     }
 
     @Test
@@ -116,7 +116,7 @@ public class DefaultStageManagerTest {
         Assert.assertTrue(reconciliationBlock.isInProgress());
 
         StageManager waitingManager = new DefaultStageManager(waitingStage, new StageStrategyFactory());
-        Assert.assertEquals(Status.InProgress, waitingManager.getStatus());
+        Assert.assertEquals(Status.IN_PROGRESS, waitingManager.getStatus());
     }
 
     @Test
@@ -146,11 +146,11 @@ public class DefaultStageManagerTest {
     public void testRestart() {
         Phase firstPhase = stage.getPhases().get(0);
         Assert.assertTrue(firstBlock.isPending());
-        firstBlock.setStatus(Status.Complete);
+        firstBlock.setStatus(Status.COMPLETE);
         Assert.assertTrue(firstBlock.isComplete());
         stageManager.restart(firstPhase.getId(), firstBlock.getId());
         Assert.assertTrue(firstBlock.isPending());
-        firstBlock.setStatus(Status.InProgress);
+        firstBlock.setStatus(Status.IN_PROGRESS);
         Assert.assertTrue(firstBlock.isInProgress());
         stageManager.restart(firstPhase.getId(), firstBlock.getId());
         Assert.assertTrue(firstBlock.isPending());
@@ -160,7 +160,7 @@ public class DefaultStageManagerTest {
     public void testRestartBadIds() {
         Phase firstPhase = stage.getPhases().get(0);
         Assert.assertTrue(firstBlock.isPending());
-        firstBlock.setStatus(Status.Complete);
+        firstBlock.setStatus(Status.COMPLETE);
         Assert.assertTrue(firstBlock.isComplete());
         stageManager.restart(firstPhase.getId(), UUID.randomUUID()); // bad block
         Assert.assertTrue(firstBlock.isComplete()); // no change
@@ -176,7 +176,7 @@ public class DefaultStageManagerTest {
         Assert.assertTrue(firstBlock.isPending());
         stageManager.forceComplete(firstPhase.getId(), firstBlock.getId());
         Assert.assertTrue(firstBlock.isComplete());
-        firstBlock.setStatus(Status.InProgress);
+        firstBlock.setStatus(Status.IN_PROGRESS);
         Assert.assertTrue(firstBlock.isInProgress());
         stageManager.forceComplete(firstPhase.getId(), firstBlock.getId());
         Assert.assertTrue(firstBlock.isComplete());
@@ -241,7 +241,7 @@ public class DefaultStageManagerTest {
 
     private static void completePhase(Phase phase) {
         for (Block block : phase.getBlocks()) {
-            ((TestBlock)block).setStatus(Status.Complete);
+            ((TestBlock)block).setStatus(Status.COMPLETE);
         }
     }
 

--- a/src/test/java/org/apache/mesos/scheduler/plan/DefaultStageSchedulerTest.java
+++ b/src/test/java/org/apache/mesos/scheduler/plan/DefaultStageSchedulerTest.java
@@ -74,14 +74,14 @@ public class DefaultStageSchedulerTest {
 
     @Test
     public void testNonPendingBlock() {
-        TestBlock block = new TestBlock().setStatus(Status.InProgress);
+        TestBlock block = new TestBlock().setStatus(Status.IN_PROGRESS);
         assertTrue(scheduler.resourceOffers(mockSchedulerDriver, OFFERS, block).isEmpty());
         assertTrue(block.isInProgress());
     }
 
     @Test
     public void testStartNoRequirement() {
-        TestBlock block = new TestOfferBlock(null).setStatus(Status.Pending);
+        TestBlock block = new TestOfferBlock(null).setStatus(Status.PENDING);
         assertTrue(scheduler.resourceOffers(mockSchedulerDriver, OFFERS, block).isEmpty());
         assertTrue(block.isPending());
     }
@@ -90,7 +90,7 @@ public class DefaultStageSchedulerTest {
     public void testEvaluateNoRecommendations() throws InvalidRequirementException {
         OfferRequirement requirement = new OfferRequirement(TASKINFOS);
         TestOfferBlock block =(TestOfferBlock)new TestOfferBlock(requirement)
-                .setStatus(Status.Pending);
+                .setStatus(Status.PENDING);
         when(mockOfferEvaluator.evaluate(requirement, OFFERS)).thenReturn(new ArrayList<>());
 
         assertTrue(scheduler.resourceOffers(mockSchedulerDriver, OFFERS, block).isEmpty());
@@ -104,7 +104,7 @@ public class DefaultStageSchedulerTest {
     public void testEvaluateNoAcceptedOffers() throws InvalidRequirementException {
         OfferRequirement requirement = new OfferRequirement(TASKINFOS);
         TestOfferBlock block =(TestOfferBlock)new TestOfferBlock(requirement)
-                .setStatus(Status.Pending);
+                .setStatus(Status.PENDING);
         when(mockOfferEvaluator.evaluate(requirement, OFFERS)).thenReturn(RECOMMENDATIONS);
         when(mockOfferAccepter.accept(mockSchedulerDriver, RECOMMENDATIONS))
                 .thenReturn(new ArrayList<>());
@@ -121,7 +121,7 @@ public class DefaultStageSchedulerTest {
     public void testEvaluateAcceptedOffers() throws InvalidRequirementException {
         OfferRequirement requirement = new OfferRequirement(TASKINFOS);
         TestOfferBlock block =(TestOfferBlock)new TestOfferBlock(requirement)
-                .setStatus(Status.Pending);
+                .setStatus(Status.PENDING);
         when(mockOfferEvaluator.evaluate(requirement, OFFERS)).thenReturn(RECOMMENDATIONS);
         when(mockOfferAccepter.accept(mockSchedulerDriver, RECOMMENDATIONS))
                 .thenReturn(ACCEPTED_IDS);

--- a/src/test/java/org/apache/mesos/scheduler/plan/DefaultStageStrategyTest.java
+++ b/src/test/java/org/apache/mesos/scheduler/plan/DefaultStageStrategyTest.java
@@ -35,12 +35,12 @@ public class DefaultStageStrategyTest {
         strategy.interrupt();
         Assert.assertEquals(block0, strategy.getCurrentBlock());
 
-        block0.setStatus(Status.Complete);
+        block0.setStatus(Status.COMPLETE);
         Assert.assertEquals(null, strategy.getCurrentBlock());
         strategy.proceed();
         Assert.assertEquals(block1, strategy.getCurrentBlock());
 
-        block1.setStatus(Status.Complete);
+        block1.setStatus(Status.COMPLETE);
         Assert.assertEquals(block1, strategy.getCurrentBlock());
     }
 
@@ -48,7 +48,7 @@ public class DefaultStageStrategyTest {
     public void testRestart() {
         TestBlock block0 = (TestBlock)phase.getBlock(0);
         Assert.assertTrue(block0.isPending());
-        block0.setStatus(Status.Complete);
+        block0.setStatus(Status.COMPLETE);
         Assert.assertTrue(block0.isComplete());
         strategy.restart(block0.getId());
         Assert.assertTrue(block0.isPending());
@@ -67,20 +67,20 @@ public class DefaultStageStrategyTest {
         TestBlock block0 = (TestBlock)phase.getBlock(0);
         TestBlock block1 = (TestBlock)phase.getBlock(1);
 
-        Assert.assertEquals(Status.Waiting, strategy.getStatus());
+        Assert.assertEquals(Status.WAITING, strategy.getStatus());
 
         strategy.proceed();
-        Assert.assertEquals(Status.Pending, strategy.getStatus());
-        block0.setStatus(Status.InProgress);
-        Assert.assertEquals(Status.InProgress, strategy.getStatus());
-        block0.setStatus(Status.Complete);
-        Assert.assertEquals(Status.Waiting, strategy.getStatus());
+        Assert.assertEquals(Status.PENDING, strategy.getStatus());
+        block0.setStatus(Status.IN_PROGRESS);
+        Assert.assertEquals(Status.IN_PROGRESS, strategy.getStatus());
+        block0.setStatus(Status.COMPLETE);
+        Assert.assertEquals(Status.WAITING, strategy.getStatus());
 
         strategy.proceed();
-        Assert.assertEquals(Status.InProgress, strategy.getStatus());
-        block1.setStatus(Status.InProgress);
-        Assert.assertEquals(Status.InProgress, strategy.getStatus());
-        block1.setStatus(Status.Complete);
-        Assert.assertEquals(Status.Complete, strategy.getStatus());
+        Assert.assertEquals(Status.IN_PROGRESS, strategy.getStatus());
+        block1.setStatus(Status.IN_PROGRESS);
+        Assert.assertEquals(Status.IN_PROGRESS, strategy.getStatus());
+        block1.setStatus(Status.COMPLETE);
+        Assert.assertEquals(Status.COMPLETE, strategy.getStatus());
     }
 }

--- a/src/test/java/org/apache/mesos/scheduler/plan/TestBlock.java
+++ b/src/test/java/org/apache/mesos/scheduler/plan/TestBlock.java
@@ -11,7 +11,7 @@ import java.util.UUID;
 public class TestBlock implements Block {
 
     private final UUID id = UUID.randomUUID();
-    private Status status = Status.Pending;
+    private Status status = Status.PENDING;
 
     public TestBlock setStatus(Status newStatus) {
         status = newStatus;
@@ -20,32 +20,32 @@ public class TestBlock implements Block {
 
     @Override
     public void restart() {
-        setStatus(Status.Pending);
+        setStatus(Status.PENDING);
     }
 
     @Override
     public void forceComplete() {
-        setStatus(Status.Complete);
+        setStatus(Status.COMPLETE);
     }
 
     @Override
     public boolean isPending() {
-        return status.equals(Status.Pending);
+        return status.equals(Status.PENDING);
     }
 
     @Override
     public boolean isInProgress() {
-        return status.equals(Status.InProgress);
+        return status.equals(Status.IN_PROGRESS);
     }
 
     @Override
     public boolean isComplete() {
-        return status.equals(Status.Complete);
+        return status.equals(Status.COMPLETE);
     }
 
     @Override
     public OfferRequirement start() {
-        setStatus(Status.InProgress);
+        setStatus(Status.IN_PROGRESS);
         return null; // no requirements
     }
 
@@ -72,9 +72,9 @@ public class TestBlock implements Block {
     @Override
     public void updateOfferStatus(boolean accepted) {
         if (!accepted) {
-            setStatus(Status.Pending);
+            setStatus(Status.PENDING);
         } else {
-            setStatus(Status.InProgress);
+            setStatus(Status.IN_PROGRESS);
         }
     }
 }

--- a/src/test/java/org/apache/mesos/scheduler/plan/api/CurrentlyActiveInfoTest.java
+++ b/src/test/java/org/apache/mesos/scheduler/plan/api/CurrentlyActiveInfoTest.java
@@ -47,7 +47,7 @@ public class CurrentlyActiveInfoTest {
         when(mockStage.getErrors()).thenReturn(stageErrors);
 
         when(mockStageManager.getStage()).thenReturn(mockStage);
-        when(mockStageManager.getStatus()).thenReturn(Status.Waiting);
+        when(mockStageManager.getStatus()).thenReturn(Status.WAITING);
 
         CurrentlyActiveInfo activeInfo = CurrentlyActiveInfo.forStage(mockStageManager);
 
@@ -55,7 +55,7 @@ public class CurrentlyActiveInfoTest {
         assertNull(activeInfo.getPhaseStatus());
         assertEquals(stageErrors, activeInfo.getStageStatus().getErrors());
         assertEquals(Integer.valueOf(2), activeInfo.getStageStatus().getPhaseCount());
-        assertEquals(Status.Waiting, activeInfo.getStageStatus().getStatus());
+        assertEquals(Status.WAITING, activeInfo.getStageStatus().getStatus());
     }
 
     /**
@@ -83,7 +83,7 @@ public class CurrentlyActiveInfoTest {
         when(mockPhase0.getId()).thenReturn(phase0Id);
         String phase0Name = "phase-0";
         when(mockPhase0.getName()).thenReturn(phase0Name);
-        Status phase0Status = Status.Pending;
+        Status phase0Status = Status.PENDING;
         when(mockStageManager.getPhaseStatus(phase0Id)).thenReturn(phase0Status);
         // must use thenAnswer instead of thenReturn to work around java typing of "? extends Block"
         when(mockPhase0.getBlocks()).thenAnswer(new Answer<List<? extends Block>>() {
@@ -110,7 +110,7 @@ public class CurrentlyActiveInfoTest {
         when(mockStageManager.getCurrentBlock()).thenReturn(mockBlock0);
         when(mockStageManager.getCurrentPhase()).thenReturn(mockPhase0);
         when(mockStageManager.getStage()).thenReturn(mockStage);
-        when(mockStageManager.getStatus()).thenReturn(Status.Waiting);
+        when(mockStageManager.getStatus()).thenReturn(Status.WAITING);
 
 
         CurrentlyActiveInfo activeInfo = CurrentlyActiveInfo.forStage(mockStageManager);
@@ -121,7 +121,7 @@ public class CurrentlyActiveInfoTest {
         assertEquals(block0Id.toString(), blockInfo.getId());
         assertEquals(block0Message, blockInfo.getMessage());
         assertEquals(block0Name, blockInfo.getName());
-        assertEquals(Status.Pending, blockInfo.getStatus());
+        assertEquals(Status.PENDING, blockInfo.getStatus());
 
         CurrentlyActivePhaseInfo phaseInfo = activeInfo.getPhaseStatus();
         assertEquals(phase0Id.toString(), phaseInfo.getId());
@@ -132,7 +132,7 @@ public class CurrentlyActiveInfoTest {
         CurrentlyActiveStageInfo stageInfo = activeInfo.getStageStatus();
         assertEquals(stageErrors, stageInfo.getErrors());
         assertEquals(Integer.valueOf(2), stageInfo.getPhaseCount());
-        assertEquals(Status.Waiting, stageInfo.getStatus());
+        assertEquals(Status.WAITING, stageInfo.getStatus());
 
         // exercise equals/hashCode while we're at it:
         assertTrue(activeInfo.equals(activeInfo));

--- a/src/test/java/org/apache/mesos/scheduler/plan/api/StageInfoTest.java
+++ b/src/test/java/org/apache/mesos/scheduler/plan/api/StageInfoTest.java
@@ -55,7 +55,7 @@ public class StageInfoTest {
 
         UUID block1Id = UUID.randomUUID();
         when(mockBlock1.getId()).thenReturn(block1Id);
-        // no explicit status response: produce Status.Error
+        // no explicit status response: produce Status.ERROR
         String block1Name = "block-1";
         when(mockBlock1.getName()).thenReturn(block1Name);
         String block1Message = "hey";
@@ -68,7 +68,7 @@ public class StageInfoTest {
         when(mockPhase0.getId()).thenReturn(phase0Id);
         String phase0Name = "phase-0";
         when(mockPhase0.getName()).thenReturn(phase0Name);
-        Status phase0Status = Status.Pending;
+        Status phase0Status = Status.PENDING;
         when(mockStageManager.getPhaseStatus(phase0Id)).thenReturn(phase0Status);
         // must use thenAnswer instead of thenReturn to work around java typing of "? extends Block"
         when(mockPhase0.getBlocks()).thenAnswer(new Answer<List<? extends Block>>() {
@@ -83,7 +83,7 @@ public class StageInfoTest {
         when(mockPhase1.getId()).thenReturn(phase1Id);
         String phase1Name = "phase-1";
         when(mockPhase1.getName()).thenReturn(phase1Name);
-        Status phase1Status = Status.Complete;
+        Status phase1Status = Status.COMPLETE;
         when(mockStageManager.getPhaseStatus(phase1Id)).thenReturn(phase1Status);
         when(mockPhase1.getBlocks()).thenReturn(new ArrayList<>());
 
@@ -101,14 +101,14 @@ public class StageInfoTest {
         when(mockStage.getErrors()).thenReturn(stageErrors);
 
         when(mockStageManager.getStage()).thenReturn(mockStage);
-        when(mockStageManager.getStatus()).thenReturn(Status.Waiting);
+        when(mockStageManager.getStatus()).thenReturn(Status.WAITING);
 
 
         StageInfo stageInfo = StageInfo.forStage(mockStageManager);
 
 
         assertEquals(stageErrors, stageInfo.getErrors());
-        assertEquals(Status.Waiting, stageInfo.getStatus());
+        assertEquals(Status.WAITING, stageInfo.getStatus());
 
         // phase 0 + 2 blocks
         PhaseInfo phaseInfo = stageInfo.getPhases().get(0);
@@ -122,14 +122,14 @@ public class StageInfoTest {
         assertEquals(block0Id.toString(), blockInfo.getId());
         assertEquals(block0Message, blockInfo.getMessage());
         assertEquals(block0Name, blockInfo.getName());
-        assertEquals(Status.Pending, blockInfo.getStatus());
+        assertEquals(Status.PENDING, blockInfo.getStatus());
 
         blockInfo = phaseInfo.getBlocks().get(1);
         assertEquals(true, blockInfo.getHasDecisionPoint());
         assertEquals(block1Id.toString(), blockInfo.getId());
         assertEquals(block1Message, blockInfo.getMessage());
         assertEquals(block1Name, blockInfo.getName());
-        assertEquals(Status.Error, blockInfo.getStatus());
+        assertEquals(Status.ERROR, blockInfo.getStatus());
 
         // phase 1 + 0 blocks
         phaseInfo = stageInfo.getPhases().get(1);

--- a/src/test/java/org/apache/mesos/scheduler/plan/api/StageResourceTest.java
+++ b/src/test/java/org/apache/mesos/scheduler/plan/api/StageResourceTest.java
@@ -33,7 +33,7 @@ public class StageResourceTest {
         when(mockStageManager.getCurrentBlock()).thenReturn(null);
         when(mockStageManager.getCurrentPhase()).thenReturn(null);
         when(mockStageManager.getStage()).thenReturn(mockStage);
-        when(mockStageManager.getStatus()).thenReturn(Status.Complete);
+        when(mockStageManager.getStatus()).thenReturn(Status.COMPLETE);
         when(mockStage.getPhases()).thenReturn(new ArrayList<>());
         when(mockStage.getErrors()).thenReturn(new ArrayList<>());
 
@@ -42,7 +42,7 @@ public class StageResourceTest {
         assertNull(activeInfo.getBlock());
         assertNull(activeInfo.getPhaseStatus());
         CurrentlyActiveStageInfo stageInfo = activeInfo.getStageStatus();
-        assertEquals(Status.Complete, stageInfo.getStatus());
+        assertEquals(Status.COMPLETE, stageInfo.getStatus());
         assertEquals(Integer.valueOf(0), stageInfo.getPhaseCount());
         assertTrue(stageInfo.getErrors().isEmpty());
     }
@@ -54,7 +54,7 @@ public class StageResourceTest {
         when(mockStageManager.getStage()).thenReturn(mockStage);
         when(mockStage.getPhases()).thenReturn(new ArrayList<>());
         when(mockStage.getErrors()).thenReturn(new ArrayList<>());
-        when(mockStageManager.getStatus()).thenReturn(Status.Pending);
+        when(mockStageManager.getStatus()).thenReturn(Status.PENDING);
 
         Response response = resource.getFullInfo();
 
@@ -69,7 +69,7 @@ public class StageResourceTest {
         when(mockStageManager.getStage()).thenReturn(mockStage);
         when(mockStage.getPhases()).thenReturn(new ArrayList<>());
         when(mockStage.getErrors()).thenReturn(new ArrayList<>());
-        when(mockStageManager.getStatus()).thenReturn(Status.Pending);
+        when(mockStageManager.getStatus()).thenReturn(Status.PENDING);
 
         Response response = resource.getFullInfo();
 

--- a/src/test/java/org/apache/mesos/scheduler/recovery/TimedLaunchConstrainerTest.java
+++ b/src/test/java/org/apache/mesos/scheduler/recovery/TimedLaunchConstrainerTest.java
@@ -1,0 +1,111 @@
+package org.apache.mesos.scheduler.recovery;
+
+import org.apache.mesos.scheduler.recovery.constrain.TimedLaunchConstrainer;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.time.Duration;
+
+/**
+ * This class tests the TimedLaunchConstrainer class.
+ */
+public class TimedLaunchConstrainerTest {
+    private static final Duration MIN_DELAY = Duration.ofMillis(3000);
+    private static final RecoveryRequirement NO_RECOVERY_REQUIREMENT = new DefaultRecoveryRequirement(null, RecoveryRequirement.RecoveryType.NONE);
+    private static final RecoveryRequirement TRANSIENT_RECOVERY_REQUIREMENT = new DefaultRecoveryRequirement(null, RecoveryRequirement.RecoveryType.TRANSIENT);
+    private static final RecoveryRequirement PERMANENT_RECOVERY_REQUIREMENT = new DefaultRecoveryRequirement(null, RecoveryRequirement.RecoveryType.PERMANENT);
+    private TimedLaunchConstrainer timedLaunchConstrainer;
+
+    private static class TestTimedLaunchConstrainer extends TimedLaunchConstrainer {
+        private long currentTime;
+
+        public TestTimedLaunchConstrainer(Duration minDelay) {
+            super(minDelay);
+        }
+
+        public void setCurrentTime(long currentTime) {
+            this.currentTime = currentTime;
+        }
+
+        @Override
+        protected long getCurrentTimeMs() {
+            return currentTime;
+        }
+
+    }
+
+    @Before
+    public void beforeEach() {
+        timedLaunchConstrainer = new TimedLaunchConstrainer(MIN_DELAY);
+    }
+
+    @Test
+    public void testConstruction() {
+        Assert.assertNotNull(timedLaunchConstrainer);
+    }
+
+    @Test
+    public void testCanLaunchNoneAfterNoRecovery() {
+        timedLaunchConstrainer.launchHappened(null, RecoveryRequirement.RecoveryType.NONE);
+        Assert.assertTrue(timedLaunchConstrainer.canLaunch(NO_RECOVERY_REQUIREMENT));
+    }
+
+    @Test
+    public void testCanLaunchTransientAfterNoRecovery() {
+        timedLaunchConstrainer.launchHappened(null, RecoveryRequirement.RecoveryType.NONE);
+        Assert.assertTrue(timedLaunchConstrainer.canLaunch(TRANSIENT_RECOVERY_REQUIREMENT));
+    }
+
+    @Test
+    public void testCanLaunchPermanentAfterNoRecovery() {
+        timedLaunchConstrainer.launchHappened(null, RecoveryRequirement.RecoveryType.NONE);
+        Assert.assertTrue(timedLaunchConstrainer.canLaunch(PERMANENT_RECOVERY_REQUIREMENT));
+    }
+
+    @Test
+    public void testCanLaunchNoneAfterTransientRecovery() {
+        timedLaunchConstrainer.launchHappened(null, RecoveryRequirement.RecoveryType.TRANSIENT);
+        Assert.assertTrue(timedLaunchConstrainer.canLaunch(NO_RECOVERY_REQUIREMENT));
+    }
+
+    @Test
+    public void testCanLaunchPermanentAfterTransientRecovery() {
+        timedLaunchConstrainer.launchHappened(null, RecoveryRequirement.RecoveryType.TRANSIENT);
+        Assert.assertTrue(timedLaunchConstrainer.canLaunch(PERMANENT_RECOVERY_REQUIREMENT));
+    }
+
+    @Test
+    public void testCanLaunchTransientAfterTransientRecovery() {
+        timedLaunchConstrainer.launchHappened(null, RecoveryRequirement.RecoveryType.TRANSIENT);
+        Assert.assertTrue(timedLaunchConstrainer.canLaunch(TRANSIENT_RECOVERY_REQUIREMENT));
+    }
+
+    @Test
+    public void testCanLaunchNoneAfterPermanentRecovery() {
+        timedLaunchConstrainer.launchHappened(null, RecoveryRequirement.RecoveryType.PERMANENT);
+        Assert.assertTrue(timedLaunchConstrainer.canLaunch(NO_RECOVERY_REQUIREMENT));
+    }
+
+    @Test
+    public void testCanLaunchTransientAfterPermanentRecovery() {
+        timedLaunchConstrainer.launchHappened(null, RecoveryRequirement.RecoveryType.PERMANENT);
+        Assert.assertTrue(timedLaunchConstrainer.canLaunch(TRANSIENT_RECOVERY_REQUIREMENT));
+    }
+
+    @Test
+    public void testCannotLaunchPermanentAfterPermanentRecovery() {
+        timedLaunchConstrainer.launchHappened(null, RecoveryRequirement.RecoveryType.PERMANENT);
+        Assert.assertFalse(timedLaunchConstrainer.canLaunch(PERMANENT_RECOVERY_REQUIREMENT));
+    }
+
+    @Test
+    public void testCanLaunchAfterPermanentRecoveryAndDelay() throws InterruptedException {
+        TestTimedLaunchConstrainer testTimedLaunchConstrainer = new TestTimedLaunchConstrainer(MIN_DELAY);
+        testTimedLaunchConstrainer.launchHappened(null, RecoveryRequirement.RecoveryType.PERMANENT);
+        testTimedLaunchConstrainer.setCurrentTime(System.currentTimeMillis());
+        Assert.assertFalse(testTimedLaunchConstrainer.canLaunch(PERMANENT_RECOVERY_REQUIREMENT));
+        testTimedLaunchConstrainer.setCurrentTime(testTimedLaunchConstrainer.getCurrentTimeMs() + MIN_DELAY.toMillis() * 1000 + 1);
+        Assert.assertTrue(testTimedLaunchConstrainer.canLaunch(PERMANENT_RECOVERY_REQUIREMENT));
+    }
+}


### PR DESCRIPTION
The RecoveryScheduler was throttling recovery operations regardless of
whether they were in reaction to a permanent or transient failure.  Only
destructive permanent recovery operations should be throttled.