### PR TITLE
Allow access to configured service name, and split url vs request creation

### DIFF
--- a/cli/commands.go
+++ b/cli/commands.go
@@ -70,18 +70,18 @@ func HandleCommonFlags(app *kingpin.Application, defaultServiceName string, shor
 	// Overrides of data that we fetch from DC/OS CLI:
 
 	// Support using "DCOS_AUTH_TOKEN" or "AUTH_TOKEN" when available
-	app.Flag("custom-auth-token", "Custom auth token to use when querying service").OverrideDefaultFromEnvar("DCOS_AUTH_TOKEN").PlaceHolder("DCOS_AUTH_TOKEN").StringVar(&dcosAuthToken)
+	app.Flag("custom-auth-token", "Custom auth token to use when querying service").Envar("DCOS_AUTH_TOKEN").PlaceHolder("DCOS_AUTH_TOKEN").StringVar(&dcosAuthToken)
 	// Support using "DCOS_URI" or "DCOS_URL" when available
-	app.Flag("custom-dcos-url", "Custom cluster URL to use when querying service").OverrideDefaultFromEnvar("DCOS_URI").OverrideDefaultFromEnvar("DCOS_URL").PlaceHolder("DCOS_URI/DCOS_URL").StringVar(&dcosUrl)
+	app.Flag("custom-dcos-url", "Custom cluster URL to use when querying service").Envar("DCOS_URI").Envar("DCOS_URL").PlaceHolder("DCOS_URI/DCOS_URL").StringVar(&dcosUrl)
 	// Support using "DCOS_CA_PATH" or "DCOS_CERT_PATH" when available
-	app.Flag("custom-cert-path", "Custom TLS CA certificate file to use when querying service").OverrideDefaultFromEnvar("DCOS_CA_PATH").OverrideDefaultFromEnvar("DCOS_CERT_PATH").PlaceHolder("DCOS_CA_PATH/DCOS_CERT_PATH").StringVar(&tlsCACertPath)
+	app.Flag("custom-cert-path", "Custom TLS CA certificate file to use when querying service").Envar("DCOS_CA_PATH").Envar("DCOS_CERT_PATH").PlaceHolder("DCOS_CA_PATH/DCOS_CERT_PATH").StringVar(&tlsCACertPath)
 
 	// Default to --name <name> : use provided framework name (default to <modulename>.service_name, if available)
 	overrideServiceName := OptionalCLIConfigValue(fmt.Sprintf("%s.service_name", os.Args[1]))
 	if len(overrideServiceName) != 0 {
 		defaultServiceName = overrideServiceName
 	}
-	app.Flag("name", "Name of the service instance to query").Default(defaultServiceName).StringVar(&serviceName)
+	app.Flag("name", "Name of the service instance to query").Default(defaultServiceName).StringVar(&ServiceName)
 }
 
 // All sections


### PR DESCRIPTION
Nothing that should break compatibility for current API users,
effectively adding hooks into existing code