### PR TITLE
Expose printing json bytes, and have explicit enum for TLS auth modes

### DIFF
--- a/cli/commands.go
+++ b/cli/commands.go
@@ -65,7 +65,7 @@ func HandleCommonFlags(app *kingpin.Application, defaultServiceName string, shor
 		return nil
 	}).Bool()
 
-	app.Flag("force-insecure", "Allow unverified TLS certificates when querying service").BoolVar(&tlsAllowUnverified)
+	app.Flag("force-insecure", "Allow unverified TLS certificates when querying service").BoolVar(&tlsForceInsecure)
 
 	// Overrides of data that we fetch from DC/OS CLI:
 

--- a/cli/response.go
+++ b/cli/response.go
@@ -14,16 +14,19 @@ func PrintText(response *http.Response) {
 	fmt.Fprintf(os.Stdout, "%s\n", GetResponseText(response))
 }
 
-func PrintJSON(response *http.Response) {
-	responseBytes := GetResponseBytes(response)
+func PrintJSONBytes(responseBytes []byte, request *http.Request) {
 	var outBuf bytes.Buffer
 	err := json.Indent(&outBuf, responseBytes, "", "  ")
 	if err != nil {
 		log.Printf("Failed to prettify JSON response data from %s %s query: %s",
-			response.Request.Method, response.Request.URL, err)
+			request.Method, request.URL, err)
 		log.Fatalf("Original data: %s", responseBytes)
 	}
 	fmt.Fprintf(os.Stdout, "%s\n", outBuf.String())
+}
+
+func PrintJSON(response *http.Response) {
+	PrintJSONBytes(GetResponseBytes(response), response.Request)
 }
 
 func GetResponseText(response *http.Response) string {


### PR DESCRIPTION
Fetches the CLI TLS setting once and then caches it.