### PR TITLE
Fix test flakes

### DIFF
--- a/src/test/java/org/apache/mesos/executor/HealthCheckHandlerTest.java
+++ b/src/test/java/org/apache/mesos/executor/HealthCheckHandlerTest.java
@@ -3,6 +3,7 @@ package org.apache.mesos.executor;
 import org.apache.mesos.Protos;
 import org.awaitility.Awaitility;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.util.concurrent.*;
@@ -17,7 +18,12 @@ public class HealthCheckHandlerTest {
     private static final double SHORT_INTERVAL_S = 0.001;
     private static final double SHORT_DELAY_S = 0.001;
     private static final double SHORT_GRACE_PERIOD_S = 0.001;
-    private static final ScheduledExecutorService scheduledExecutorService = Executors.newScheduledThreadPool(1);
+    private ScheduledExecutorService scheduledExecutorService;
+
+    @Before
+    public void beforeEach() {
+        scheduledExecutorService = Executors.newScheduledThreadPool(1);
+    }
 
     @Test
     public void testSingleFailure() throws HealthCheckHandler.HealthCheckValidationException, ExecutionException, InterruptedException {

--- a/src/test/java/org/apache/mesos/scheduler/DefaultSchedulerTest.java
+++ b/src/test/java/org/apache/mesos/scheduler/DefaultSchedulerTest.java
@@ -132,7 +132,7 @@ public class DefaultSchedulerTest {
         Assert.assertEquals(3, countOperationType(Protos.Offer.Operation.Type.RESERVE, operations));
         Assert.assertEquals(1, countOperationType(Protos.Offer.Operation.Type.CREATE, operations));
         Assert.assertEquals(1, countOperationType(Protos.Offer.Operation.Type.LAUNCH, operations));
-        Assert.assertTrue(blockTaskA0.isInProgress());
+        Awaitility.await().atMost(1, TimeUnit.SECONDS).untilCall(to(blockTaskA0).isInProgress(), equalTo(true));
 
         // Sent TASK_RUNNING status
         Protos.TaskID launchedTaskId = getTaskId(operations);
@@ -172,7 +172,7 @@ public class DefaultSchedulerTest {
         Assert.assertEquals(3, countOperationType(Protos.Offer.Operation.Type.RESERVE, operations));
         Assert.assertEquals(1, countOperationType(Protos.Offer.Operation.Type.CREATE, operations));
         Assert.assertEquals(1, countOperationType(Protos.Offer.Operation.Type.LAUNCH, operations));
-        Assert.assertTrue(blockTaskB0.isInProgress());
+        Awaitility.await().atMost(1, TimeUnit.SECONDS).untilCall(to(blockTaskB0).isInProgress(), equalTo(true));
 
         // Sent TASK_RUNNING status
         Protos.TaskID launchedTaskId = getTaskId(operations);


### PR DESCRIPTION
1. The DefaultSchedulerTest had a race.  It's possible Offers are
accepted, and the test validates their contents and then tries to
validate Block state before the Block has been called back alerting it
to the success or failure of it's launch.

2. Hard to say why the HealthCheck testSuccess was failing.  There was a
shared threadpool for all tests with a single thread.  Perhaps this was
causing trouble as it dealth with handling failed threads and starting
new ones.  In practice the HealthCheck threadpool should be
substantially larger than 1, and probably dynamically sized so each
health-check has it's own Thread.  I have given each test it's own
single threaded thread pool now.