### PR TITLE
Fixed the HealthCheck successTest

### DIFF
--- a/src/main/java/org/apache/mesos/executor/HealthCheckHandler.java
+++ b/src/main/java/org/apache/mesos/executor/HealthCheckHandler.java
@@ -149,6 +149,8 @@ public class HealthCheckHandler {
                     logger.info("Health check: " + commandInfo + " succeeded.");
                     healthCheckStats.succeeded();
                 }
+
+                logger.debug("Health check stats: " + healthCheckStats);
             } catch (Throwable t) {
                 logger.error("Failed to run health check: " + commandInfo + " with throwable: ", t);
                 healthCheckStats.failed();

--- a/src/main/java/org/apache/mesos/executor/HealthCheckStats.java
+++ b/src/main/java/org/apache/mesos/executor/HealthCheckStats.java
@@ -5,9 +5,13 @@ package org.apache.mesos.executor;
  */
 public class HealthCheckStats {
     private final String name;
+
+    private Object failureLock = new Object();
     private long totalFailures = 0;
-    private long totalSuccesses = 0;
     private long consecutiveFailures = 0;
+
+    private Object successLock = new Object();
+    private long totalSuccesses = 0;
     private long consecutiveSuccesses = 0;
 
     public HealthCheckStats(String name) {
@@ -15,15 +19,25 @@ public class HealthCheckStats {
     }
 
     public void failed() {
-        totalFailures++;
-        consecutiveFailures++;
-        consecutiveSuccesses = 0;
+        synchronized (failureLock) {
+            totalFailures++;
+            consecutiveFailures++;
+        }
+
+        synchronized (successLock) {
+            consecutiveSuccesses = 0;
+        }
     }
 
     public void succeeded() {
-        totalSuccesses++;
-        consecutiveSuccesses++;
-        consecutiveFailures = 0;
+        synchronized (successLock) {
+            totalSuccesses++;
+            consecutiveSuccesses++;
+        }
+
+        synchronized (failureLock) {
+            consecutiveFailures = 0;
+        }
     }
 
     public String getName() {
@@ -31,20 +45,28 @@ public class HealthCheckStats {
     }
 
     public long getTotalFailures() {
-        return totalFailures;
+        synchronized (failureLock) {
+            return totalFailures;
+        }
     }
 
     public long getConsecutiveFailures() {
-        return consecutiveFailures;
+        synchronized (failureLock) {
+            return consecutiveFailures;
+        }
     }
 
     public long getTotalSuccesses() {
-        return totalSuccesses;
+        synchronized (successLock) {
+            return totalSuccesses;
+        }
     }
 
 
     public long getConsecutiveSuccesses() {
-        return consecutiveSuccesses;
+        synchronized (successLock) {
+            return consecutiveSuccesses;
+        }
     }
 
     @Override

--- a/src/test/java/org/apache/mesos/executor/HealthCheckHandlerTest.java
+++ b/src/test/java/org/apache/mesos/executor/HealthCheckHandlerTest.java
@@ -2,6 +2,7 @@ package org.apache.mesos.executor;
 
 import org.apache.mesos.Protos;
 import org.awaitility.Awaitility;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -15,14 +16,17 @@ import static org.hamcrest.Matchers.greaterThan;
  * This class tests the HealthCheckHandler class.
  */
 public class HealthCheckHandlerTest {
-    private static final double SHORT_INTERVAL_S = 0.001;
-    private static final double SHORT_DELAY_S = 0.001;
-    private static final double SHORT_GRACE_PERIOD_S = 0.001;
     private ScheduledExecutorService scheduledExecutorService;
 
     @Before
     public void beforeEach() {
         scheduledExecutorService = Executors.newScheduledThreadPool(1);
+    }
+
+    @After
+    public void afterEach() throws InterruptedException {
+        scheduledExecutorService.shutdown();
+        scheduledExecutorService.awaitTermination(5, TimeUnit.SECONDS);
     }
 
     @Test
@@ -85,7 +89,6 @@ public class HealthCheckHandlerTest {
         Assert.assertEquals(0, healthCheckStats.getConsecutiveFailures());
         long consecutiveSuccesses = healthCheckStats.getConsecutiveSuccesses();
         Assert.assertTrue("Found consecutive successes: " + consecutiveSuccesses, consecutiveSuccesses >= 1);
-        Assert.assertEquals(healthCheckStats.getTotalSuccesses(), consecutiveSuccesses);
     }
 
     @Test(expected=HealthCheckHandler.HealthCheckValidationException.class)


### PR DESCRIPTION
I was able to repro the failure in INFINITY-503.
ScheduledExecutorService threadpools weren't being cleaned up for each
test.  If you run enough of them it appears you run out of resources and
health checks aren't scheduled.

@nickbp:  I reproed by looping 1000 times inside the testSuccess test with a new `scheduledExecutorService` each time simulating the test behavior of `beforeEach()`.  I found another test failure too.  You'll never be able to assert that `consecutiveSuccesses == totalSuccesses` as  you can't access them transactionally from outside the class.