### PR TITLE
Remove Optional portion of updateOfferStatus

### DIFF
--- a/src/main/java/org/apache/mesos/scheduler/plan/Block.java
+++ b/src/main/java/org/apache/mesos/scheduler/plan/Block.java
@@ -51,19 +51,19 @@ public interface Block extends Completable {
      * returns {@code true}.
      *
      * @see {@link #isPending()} which is the gate to whether {@code start()} is called
-     * @see {@link #updateOfferStatus(boolean)} which returns the outcome of the
+     * @see {@link #updateOfferStatus(Collection<Offer.Operation>)} which returns the outcome of the
      *      {@link OfferRequirement}
      */
     Optional<OfferRequirement> start();
 
     /**
      * Notifies the Block whether the {@link OfferRequirement} previously returned by
-     * {@link #start()} has been successfully accepted/fulfilled. The {@code accepted} param is
-     * {@code false} when no offers matching the requirement previously returned by {@link #clone()
+     * {@link #start()} has been successfully accepted/fulfilled. The {@code operations} param is
+     * empty when no offers matching the requirement previously returned by {@link #clone()
      * could be found. This is only called if {@link #start()} returned a non-{@code null}
      * {@link OfferRequirement}.
      */
-    void updateOfferStatus(Optional<Collection<Protos.Offer.Operation>> operationsOptional);
+    void updateOfferStatus(Collection<Protos.Offer.Operation> operations);
 
     /**
      * Forcefully restarts the block, putting it into a PENDING state, waiting to be resumed with

--- a/src/main/java/org/apache/mesos/scheduler/plan/DefaultBlock.java
+++ b/src/main/java/org/apache/mesos/scheduler/plan/DefaultBlock.java
@@ -72,9 +72,9 @@ public class DefaultBlock implements Block {
     }
 
     @Override
-    public void updateOfferStatus(Optional<Collection<Protos.Offer.Operation>> operationsOptional) {
-        if (operationsOptional.isPresent()) {
-            setTaskIds(operationsOptional.get());
+    public void updateOfferStatus(Collection<Protos.Offer.Operation> operations) {
+        if (!operations.isEmpty()) {
+            setTaskIds(operations);
             setStatus(Status.IN_PROGRESS);
         }
     }

--- a/src/main/java/org/apache/mesos/scheduler/plan/DefaultPlanScheduler.java
+++ b/src/main/java/org/apache/mesos/scheduler/plan/DefaultPlanScheduler.java
@@ -8,10 +8,7 @@ import org.apache.mesos.scheduler.TaskKiller;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 
 /**
  * Default deployment scheduler. See docs in {@link PlanScheduler} interface.
@@ -58,7 +55,7 @@ public class DefaultPlanScheduler implements PlanScheduler {
         Optional<OfferRequirement> offerRequirementOptional = block.start();
         if (!offerRequirementOptional.isPresent()) {
             logger.info("No OfferRequirement for block: {}", block.getName());
-            block.updateOfferStatus(Optional.empty());
+            block.updateOfferStatus(Collections.emptyList());
             return acceptedOffers;
         }
 
@@ -76,7 +73,7 @@ public class DefaultPlanScheduler implements PlanScheduler {
             logger.warn(
                     "Unable to find any offers which fulfill requirement provided by block {}: {}",
                     block.getName(), offerRequirementOptional.get());
-            block.updateOfferStatus(Optional.empty());
+            block.updateOfferStatus(Collections.emptyList());
             return acceptedOffers;
         }
 
@@ -87,7 +84,7 @@ public class DefaultPlanScheduler implements PlanScheduler {
         } else {
             // If no Operations occurred it may be of interest to the Block.  For example it may want to set it's state
             // to Pending to ensure it will be reattempted on the next Offer cycle.
-            block.updateOfferStatus(Optional.empty());
+            block.updateOfferStatus(Collections.emptyList());
         }
 
         return acceptedOffers;
@@ -100,11 +97,11 @@ public class DefaultPlanScheduler implements PlanScheduler {
         }
     }
 
-    private Optional<Collection<Protos.Offer.Operation>> getOperations(
+    private Collection<Protos.Offer.Operation> getOperations(
             Collection<OfferRecommendation> recommendations) {
 
         if (recommendations.size() == 0) {
-            return Optional.empty();
+            return Collections.emptyList();
         }
 
         List<Protos.Offer.Operation> operations = new ArrayList<>();
@@ -112,6 +109,6 @@ public class DefaultPlanScheduler implements PlanScheduler {
             operations.add(recommendation.getOperation());
         }
 
-        return Optional.of(operations);
+        return operations;
     }
 }

--- a/src/main/java/org/apache/mesos/scheduler/plan/ReconciliationBlock.java
+++ b/src/main/java/org/apache/mesos/scheduler/plan/ReconciliationBlock.java
@@ -1,15 +1,14 @@
 package org.apache.mesos.scheduler.plan;
 
-import java.util.Collection;
-import java.util.Optional;
-import java.util.UUID;
-
 import org.apache.mesos.Protos;
 import org.apache.mesos.offer.OfferRequirement;
 import org.apache.mesos.reconciliation.Reconciler;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+import java.util.Optional;
+import java.util.UUID;
 
 
 /**
@@ -72,8 +71,8 @@ public class ReconciliationBlock implements Block {
     }
 
     @Override
-    public void updateOfferStatus(Optional<Collection<Protos.Offer.Operation>> operationsOptional) {
-        if (operationsOptional.isPresent()) {
+    public void updateOfferStatus(Collection<Protos.Offer.Operation> operations) {
+        if (!operations.isEmpty()) {
             throw new UnsupportedOperationException(
                     "updateOfferStatus() not expected: start() always returns null");
         }

--- a/src/test/java/org/apache/mesos/scheduler/plan/DefaultBlockTest.java
+++ b/src/test/java/org/apache/mesos/scheduler/plan/DefaultBlockTest.java
@@ -10,7 +10,6 @@ import org.mockito.MockitoAnnotations;
 import org.testng.Assert;
 
 import java.util.Arrays;
-import java.util.Optional;
 
 /**
  * This class tests the DefaultBlock class.
@@ -40,7 +39,7 @@ public class DefaultBlockTest {
                                 .setName(TestConstants.taskName)
                                 .setSlaveId(TestConstants.agentId)))
                 .build();
-        block.updateOfferStatus(Optional.of(Arrays.asList(operation)));
+        block.updateOfferStatus(Arrays.asList(operation));
 
         Assert.assertTrue(block.isInProgress());
 

--- a/src/test/java/org/apache/mesos/scheduler/plan/DefaultPlanSchedulerTest.java
+++ b/src/test/java/org/apache/mesos/scheduler/plan/DefaultPlanSchedulerTest.java
@@ -1,28 +1,19 @@
 package org.apache.mesos.scheduler.plan;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
-
-import java.util.*;
-
-import org.apache.mesos.SchedulerDriver;
-import org.apache.mesos.offer.InvalidRequirementException;
-import org.apache.mesos.offer.OfferAccepter;
-import org.apache.mesos.offer.OfferEvaluator;
-import org.apache.mesos.offer.OfferRecommendation;
-import org.apache.mesos.offer.OfferRequirement;
-import org.apache.mesos.offer.TaskUtils;
-import org.apache.mesos.Protos.FrameworkID;
-import org.apache.mesos.Protos.Offer;
+import org.apache.mesos.Protos.*;
 import org.apache.mesos.Protos.Offer.Operation;
-import org.apache.mesos.Protos.OfferID;
-import org.apache.mesos.Protos.SlaveID;
-import org.apache.mesos.Protos.TaskInfo;
+import org.apache.mesos.SchedulerDriver;
+import org.apache.mesos.offer.*;
 import org.apache.mesos.scheduler.TaskKiller;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+
+import java.util.*;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
 
 /**
  * Tests for {@link DefaultPlanScheduler}.
@@ -90,7 +81,7 @@ public class DefaultPlanSchedulerTest {
         when(mockOfferEvaluator.evaluate(requirement, OFFERS)).thenReturn(new ArrayList<>());
 
         assertTrue(scheduler.resourceOffers(mockSchedulerDriver, OFFERS, block).isEmpty());
-        assertFalse(block.operationsOptional.isPresent());
+        assertTrue(block.operations.isEmpty());
         verify(mockOfferEvaluator).evaluate(requirement, OFFERS);
         assertTrue(block.isPending());
     }
@@ -103,7 +94,7 @@ public class DefaultPlanSchedulerTest {
         when(mockOfferAccepter.accept(mockSchedulerDriver, RECOMMENDATIONS)).thenReturn(new ArrayList<>());
 
         assertTrue(scheduler.resourceOffers(mockSchedulerDriver, OFFERS, block).isEmpty());
-        assertFalse(block.operationsOptional.isPresent());
+        assertTrue(block.operations.isEmpty());
         verify(mockOfferAccepter).accept(mockSchedulerDriver, RECOMMENDATIONS);
         assertTrue(block.isPending());
     }
@@ -116,18 +107,18 @@ public class DefaultPlanSchedulerTest {
         when(mockOfferAccepter.accept(mockSchedulerDriver, RECOMMENDATIONS)).thenReturn(ACCEPTED_IDS);
 
         assertEquals(ACCEPTED_IDS, scheduler.resourceOffers(mockSchedulerDriver, OFFERS, block));
-        assertTrue(block.operationsOptional.isPresent());
+        assertFalse(block.operations.isEmpty());
         assertTrue(block.isInProgress());
     }
 
     private static class TestOfferBlock extends TestBlock {
         private final OfferRequirement requirement;
-        private Optional<Collection<Operation>> operationsOptional;
+        private Collection<Operation> operations;
 
         private TestOfferBlock(OfferRequirement requirementToReturn) {
             super();
             this.requirement = requirementToReturn;
-            this.operationsOptional = Optional.empty();
+            this.operations = Collections.emptyList();
         }
 
         @Override
@@ -141,9 +132,9 @@ public class DefaultPlanSchedulerTest {
         }
 
         @Override
-        public void updateOfferStatus(Optional<Collection<Operation>> operationsOptional) {
-            super.updateOfferStatus(operationsOptional);
-            this.operationsOptional = operationsOptional;
+        public void updateOfferStatus(Collection<Operation> operations) {
+            super.updateOfferStatus(operations);
+            this.operations = operations;
         }
     }
 }

--- a/src/test/java/org/apache/mesos/scheduler/plan/ReconciliationBlockTest.java
+++ b/src/test/java/org/apache/mesos/scheduler/plan/ReconciliationBlockTest.java
@@ -10,10 +10,7 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
@@ -117,13 +114,16 @@ public class ReconciliationBlockTest {
     @Test
     public void testUpdateOfferStatusFalseSucceeds() {
         // Expect no exception to be thrown
-        block.updateOfferStatus(Optional.empty());
+        block.updateOfferStatus(Collections.emptyList());
     }
 
     @Test(expected=UnsupportedOperationException.class)
     public void testUpdateOfferStatusTrueFails() {
-        List<Protos.Offer.Operation> operations = new ArrayList<>();
-        block.updateOfferStatus(Optional.of(operations));
+        Protos.Offer.Operation op = Protos.Offer.Operation.newBuilder()
+                .setType(Protos.Offer.Operation.Type.LAUNCH)
+                .build();
+        List<Protos.Offer.Operation> operations = Arrays.asList(op);
+        block.updateOfferStatus(operations);
     }
 
     @Test

--- a/src/test/java/org/apache/mesos/scheduler/plan/TestBlock.java
+++ b/src/test/java/org/apache/mesos/scheduler/plan/TestBlock.java
@@ -52,8 +52,8 @@ public class TestBlock implements Block {
     }
 
     @Override
-    public void updateOfferStatus(Optional<Collection<Protos.Offer.Operation>> operationsOptional) {
-        if (!operationsOptional.isPresent()) {
+    public void updateOfferStatus(Collection<Protos.Offer.Operation> operations) {
+        if (operations.isEmpty()) {
             setStatus(Status.PENDING);
         } else {
             setStatus(Status.IN_PROGRESS);


### PR DESCRIPTION
The Optional portion adds no value.  An empty Collection communicates
the same meaning.