### PR TITLE
Reliably, destructively, replace Tasks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -101,7 +101,7 @@ ext {
 }
 
 group = "mesosphere"
-version = "0.7.6-SNAPSHOT"
+version = "0.7.7-SNAPSHOT"
 
 task sourceJar(type: Jar) {
     from sourceSets.main.allJava

--- a/src/main/java/org/apache/mesos/offer/TaskUtils.java
+++ b/src/main/java/org/apache/mesos/offer/TaskUtils.java
@@ -73,8 +73,8 @@ public class TaskUtils {
             case TASK_FAILED:
             case TASK_KILLED:
             case TASK_ERROR:
-                return true;
             case TASK_LOST:
+                return true;
             case TASK_KILLING:
             case TASK_RUNNING:
             case TASK_STAGING:

--- a/src/main/java/org/apache/mesos/offer/TaskUtils.java
+++ b/src/main/java/org/apache/mesos/offer/TaskUtils.java
@@ -95,7 +95,6 @@ public class TaskUtils {
             case TASK_KILLED:
             case TASK_ERROR:
                 return true;
-            case TASK_LOST:
             case TASK_KILLING:
             case TASK_RUNNING:
             case TASK_STAGING:

--- a/src/main/java/org/apache/mesos/offer/TaskUtils.java
+++ b/src/main/java/org/apache/mesos/offer/TaskUtils.java
@@ -65,9 +65,9 @@ public class TaskUtils {
     }
 
     /**
-     * Returns whether the provided {@link TaskStatus} shows that the task is in a terminated state.
+     * Returns whether the provided {@link TaskStatus} shows that the task needs to recover.
      */
-    public static boolean isTerminated(TaskStatus taskStatus) {
+    public static boolean needsRecovery(TaskStatus taskStatus) {
         switch (taskStatus.getState()) {
             case TASK_FINISHED:
             case TASK_FAILED:
@@ -75,6 +75,27 @@ public class TaskUtils {
             case TASK_ERROR:
             case TASK_LOST:
                 return true;
+            case TASK_KILLING:
+            case TASK_RUNNING:
+            case TASK_STAGING:
+            case TASK_STARTING:
+                break;
+        }
+
+        return false;
+    }
+
+    /**
+     * Returns whether the provided {@link TaskStatus} shows that the task has reached a terminal state.
+     */
+    public static boolean isTerminal(TaskStatus taskStatus) {
+        switch (taskStatus.getState()) {
+            case TASK_FINISHED:
+            case TASK_FAILED:
+            case TASK_KILLED:
+            case TASK_ERROR:
+                return true;
+            case TASK_LOST:
             case TASK_KILLING:
             case TASK_RUNNING:
             case TASK_STAGING:

--- a/src/main/java/org/apache/mesos/reconciliation/DefaultReconciler.java
+++ b/src/main/java/org/apache/mesos/reconciliation/DefaultReconciler.java
@@ -45,12 +45,12 @@ public class DefaultReconciler implements Reconciler {
         try {
             taskStatuses.addAll(statuses.getTaskStatuses());
         } catch (Exception e) {
-            throw new RuntimeException("error: bad");
+            throw new RuntimeException("Failed to initialize TaskStatuses for reconciliation with exception: ", e);
         }
 
         synchronized (unreconciled) {
             for (TaskStatus status : taskStatuses) {
-                if (!TaskUtils.isTerminated(status)) {
+                if (!TaskUtils.isTerminal(status)) {
                     unreconciled.put(status.getTaskId().getValue(), status);
                 }
             }

--- a/src/main/java/org/apache/mesos/scheduler/DefaultScheduler.java
+++ b/src/main/java/org/apache/mesos/scheduler/DefaultScheduler.java
@@ -86,19 +86,19 @@ public class DefaultScheduler implements Scheduler {
         return plan;
     }
 
-    private void initialize() throws InterruptedException {
+    private void initialize(SchedulerDriver driver) throws InterruptedException {
         logger.info("Initializing.");
-        initializeGlobals();
+        initializeGlobals(driver);
         initializeRecoveryScheduler();
         initializeDeploymentPlan();
         initializeResources();
     }
 
-    private void initializeGlobals() {
+    private void initializeGlobals(SchedulerDriver driver) {
         logger.info("Initializing globals");
         stateStore = new CuratorStateStore(serviceSpecification.getName(), zkConnectionString);
         taskFailureListener = new DefaultTaskFailureListener(stateStore);
-        taskKiller = new DefaultTaskKiller(stateStore, taskFailureListener);
+        taskKiller = new DefaultTaskKiller(stateStore, taskFailureListener, driver);
         reconciler = new DefaultReconciler(stateStore);
         offerAccepter = new OfferAccepter(Arrays.asList(new PersistentOperationRecorder(stateStore)));
     }
@@ -207,7 +207,7 @@ public class DefaultScheduler implements Scheduler {
     public void registered(SchedulerDriver driver, Protos.FrameworkID frameworkId, Protos.MasterInfo masterInfo) {
         logger.info("Registered framework with frameworkId: " + frameworkId.getValue());
         try {
-            initialize();
+            initialize(driver);
         } catch (InterruptedException e) {
             logger.error("Initialization failed with exception: ", e);
             hardExit(SchedulerErrorCode.INITIALIZATION_FAILURE);
@@ -283,12 +283,6 @@ public class DefaultScheduler implements Scheduler {
                 }
 
                 declineOffers(driver, acceptedOffers, offers);
-
-                // Kill tasks (for configuration update, or user requested Task restart or replace):
-                // It is the normal state of affairs, that in order to update the configuration of a Task it must be
-                // restarted.  In order to drive the restart process, it is necessary to give some component, the
-                // TaskKiller, an opportunity to kill Tasks so that they may be redeployed with a new configuration.
-                taskKiller.process(driver);
             }
         });
     }

--- a/src/main/java/org/apache/mesos/scheduler/DefaultTaskKiller.java
+++ b/src/main/java/org/apache/mesos/scheduler/DefaultTaskKiller.java
@@ -19,10 +19,8 @@ public class DefaultTaskKiller implements TaskKiller {
     private final StateStore stateStore;
     private final TaskFailureListener taskFailureListener;
 
-    private final Object restartLock = new Object();
-    private List<Protos.TaskInfo> tasksToRestart = new ArrayList<>();
-    private final Object rescheduleLock = new Object();
-    private List<Protos.TaskInfo> tasksToReschedule = new ArrayList<>();
+    private final Object killLock = new Object();
+    private List<Protos.TaskInfo> tasksToKill = new ArrayList<>();
 
     public DefaultTaskKiller(StateStore stateStore, TaskFailureListener taskFailureListener) {
         this.stateStore = stateStore;
@@ -49,50 +47,27 @@ public class DefaultTaskKiller implements TaskKiller {
             return;
         }
 
-        if (!taskState.get().getState().equals(Protos.TaskState.TASK_RUNNING)) {
-            logger.warn(String.format("No need to kill: '%s', task state: '%s'", taskName, taskState));
-            return;
+        if (destructive) {
+            taskFailureListener.taskFailed(taskInfo.getTaskId());
         }
 
-        if (destructive) {
-            synchronized (rescheduleLock) {
-                logger.info("Scheduling task to be killed destructively: " + taskInfo);
-                tasksToReschedule.add(taskInfo);
-            }
-        } else {
-            synchronized (restartLock) {
-                logger.info("Scheduling task to be killed with intention to restart: " + taskInfo);
-                tasksToRestart.add(taskInfo);
-            }
+        logger.info(String.format(
+                "Scheduling task to be killed %s: %s",
+                destructive ? "destructively" : "non-destructively",
+                taskInfo));
+
+        synchronized (killLock) {
+            tasksToKill.add(taskInfo);
         }
     }
 
     @Override
     public void process(SchedulerDriver driver) {
-        processTasksToRestart(driver);
-        processTasksToReschedule(driver);
-    }
-
-    private void processTasksToRestart(SchedulerDriver driver) {
-        synchronized (restartLock) {
-            for (Protos.TaskInfo taskInfo : tasksToRestart) {
-                logger.info("Restarting task: " + taskInfo.getTaskId().getValue());
-                driver.killTask(taskInfo.getTaskId());
-            }
-
-            tasksToRestart = new ArrayList<>();
+        for (Protos.TaskInfo taskInfo : tasksToKill) {
+            logger.info("Killing task: " + taskInfo.getTaskId().getValue());
+            driver.killTask(taskInfo.getTaskId());
         }
-    }
 
-    private void processTasksToReschedule(SchedulerDriver driver) {
-        synchronized (rescheduleLock) {
-            for (Protos.TaskInfo taskInfo : tasksToReschedule) {
-                logger.info("Rescheduling task: " + taskInfo.getTaskId().getValue());
-                taskFailureListener.taskFailed(taskInfo.getTaskId());
-                driver.killTask(taskInfo.getTaskId());
-            }
-
-            tasksToReschedule = new ArrayList<>();
-        }
+        tasksToKill = new ArrayList<>();
     }
 }

--- a/src/main/java/org/apache/mesos/scheduler/TaskKiller.java
+++ b/src/main/java/org/apache/mesos/scheduler/TaskKiller.java
@@ -1,7 +1,5 @@
 package org.apache.mesos.scheduler;
 
-import org.apache.mesos.SchedulerDriver;
-
 /**
  * This interface should be implemented to allow components to request the killing of Mesos Tasks.  This is a normal
  * part of restarting a Task, which is a normal part of updating the Configuration of a Task.  This is also useful for
@@ -18,11 +16,4 @@ public interface TaskKiller {
      *                    anticipates a future restart.
      */
     void killTask(String taskName, boolean destructive);
-
-
-    /**
-     * This method is called to provide a Scheduler driver so previously requested Task kills may be processed.
-     * @param driver The SchedulerDriver provided by Mesos.
-     */
-    void process(SchedulerDriver driver);
 }

--- a/src/main/java/org/apache/mesos/scheduler/recovery/DefaultRecoveryScheduler.java
+++ b/src/main/java/org/apache/mesos/scheduler/recovery/DefaultRecoveryScheduler.java
@@ -131,11 +131,11 @@ public class DefaultRecoveryScheduler {
 
         try {
             if (!block.isPresent()) {
-                return stateStore.fetchTerminatedTasks();
+                return stateStore.fetchTasksNeedingRecovery();
             }
 
             String blockName = block.get().getName();
-            for (TaskInfo taskInfo : stateStore.fetchTerminatedTasks()) {
+            for (TaskInfo taskInfo : stateStore.fetchTasksNeedingRecovery()) {
                 if (!taskInfo.getName().equals(blockName)) {
                     filteredTerminatedTasks.add(taskInfo);
                 }
@@ -159,7 +159,7 @@ public class DefaultRecoveryScheduler {
                 .filter(it -> !failureMonitor.hasFailed(it))
                 .collect(Collectors.toList());
 
-        for (TaskInfo terminatedTask : stateStore.fetchTerminatedTasks()) {
+        for (TaskInfo terminatedTask : stateStore.fetchTasksNeedingRecovery()) {
             log.info("Found stopped task: {}", TextFormat.shortDebugString(terminatedTask));
             if (failureMonitor.hasFailed(terminatedTask)) {
                 log.info("Marking stopped task as failed: {}", TextFormat.shortDebugString(terminatedTask));

--- a/src/main/java/org/apache/mesos/scheduler/recovery/monitor/DefaultFailureMonitor.java
+++ b/src/main/java/org/apache/mesos/scheduler/recovery/monitor/DefaultFailureMonitor.java
@@ -1,0 +1,14 @@
+package org.apache.mesos.scheduler.recovery.monitor;
+
+import org.apache.mesos.Protos;
+import org.apache.mesos.scheduler.recovery.FailureUtils;
+
+/**
+ * The DefaultFailureMonitor reports that tasks have Failed permanently when they are so labeled.
+ */
+public class DefaultFailureMonitor implements FailureMonitor {
+    @Override
+    public boolean hasFailed(Protos.TaskInfo task) {
+        return FailureUtils.isLabeledAsFailed(task);
+    }
+}

--- a/src/main/java/org/apache/mesos/state/StateStore.java
+++ b/src/main/java/org/apache/mesos/state/StateStore.java
@@ -127,7 +127,7 @@ public interface StateStore extends TaskStatusProvider {
             if (!statusMap.containsKey(info.getTaskId())) {
                 continue;
             }
-            if (TaskUtils.isTerminated(statusMap.get(info.getTaskId()))) {
+            if (TaskUtils.needsRecovery(statusMap.get(info.getTaskId()))) {
                 results.add(info);
             }
         }

--- a/src/main/java/org/apache/mesos/state/StateStore.java
+++ b/src/main/java/org/apache/mesos/state/StateStore.java
@@ -115,7 +115,7 @@ public interface StateStore extends TaskStatusProvider {
      * @return Terminated TaskInfos
      * @throws StateStoreException
      */
-    default Collection<TaskInfo> fetchTerminatedTasks() throws StateStoreException {
+    default Collection<TaskInfo> fetchTasksNeedingRecovery() throws StateStoreException {
         Collection<TaskInfo> allInfos = fetchTasks();
         Collection<TaskStatus> allStatuses = fetchStatuses();
         Map<Protos.TaskID, TaskStatus> statusMap = new HashMap<>();

--- a/src/test/java/org/apache/mesos/curator/CuratorStateStoreTest.java
+++ b/src/test/java/org/apache/mesos/curator/CuratorStateStoreTest.java
@@ -489,6 +489,20 @@ public class CuratorStateStoreTest {
         store.storeProperty(GOOD_PROPERTY_KEY, null);
     }
 
+    @Test
+    public void testTaskLostIsTerminated() {
+        Protos.TaskInfo testTask = createTask(TASK_NAME);
+        store.storeTasks(Arrays.asList(testTask));
+        assertEquals(0, store.fetchTerminatedTasks().size());
+        store.storeStatus(
+                Protos.TaskStatus.newBuilder()
+                        .setTaskId(testTask.getTaskId())
+                        .setState(Protos.TaskState.TASK_LOST)
+                        .build());
+        assertEquals(1, store.fetchTerminatedTasks().size());
+        assertEquals(testTask, store.fetchTerminatedTasks().iterator().next());
+    }
+
     private static Protos.TaskStatus createTaskStatus(Protos.TaskID taskId) {
         return TASK_STATUS.toBuilder().setTaskId(taskId).build();
     }

--- a/src/test/java/org/apache/mesos/curator/CuratorStateStoreTest.java
+++ b/src/test/java/org/apache/mesos/curator/CuratorStateStoreTest.java
@@ -490,17 +490,17 @@ public class CuratorStateStoreTest {
     }
 
     @Test
-    public void testTaskLostIsTerminated() {
+    public void testTaskLostNeedsRecovery() {
         Protos.TaskInfo testTask = createTask(TASK_NAME);
         store.storeTasks(Arrays.asList(testTask));
-        assertEquals(0, store.fetchTerminatedTasks().size());
+        assertEquals(0, store.fetchTasksNeedingRecovery().size());
         store.storeStatus(
                 Protos.TaskStatus.newBuilder()
                         .setTaskId(testTask.getTaskId())
                         .setState(Protos.TaskState.TASK_LOST)
                         .build());
-        assertEquals(1, store.fetchTerminatedTasks().size());
-        assertEquals(testTask, store.fetchTerminatedTasks().iterator().next());
+        assertEquals(1, store.fetchTasksNeedingRecovery().size());
+        assertEquals(testTask, store.fetchTasksNeedingRecovery().iterator().next());
     }
 
     private static Protos.TaskStatus createTaskStatus(Protos.TaskID taskId) {

--- a/src/test/java/org/apache/mesos/scheduler/recovery/RecoverySchedulerTest.java
+++ b/src/test/java/org/apache/mesos/scheduler/recovery/RecoverySchedulerTest.java
@@ -100,7 +100,7 @@ public class RecoverySchedulerTest {
         List<TaskInfo> infos = Collections.singletonList(TaskTestUtils.getTaskInfo(Arrays.asList(cpus, mem)));
         RecoveryRequirement recoveryRequirement = getRecoveryRequirement(
                 new OfferRequirement(infos, Optional.empty(), Collections.EMPTY_LIST, Collections.EMPTY_LIST));
-        when(stateStore.fetchTerminatedTasks()).thenReturn(infos);
+        when(stateStore.fetchTasksNeedingRecovery()).thenReturn(infos);
         when(recoveryRequirementProvider.getTransientRecoveryRequirements(any())).thenReturn(Arrays.asList(recoveryRequirement));
         launchConstrainer.setCanLaunch(false);
 
@@ -127,7 +127,7 @@ public class RecoverySchedulerTest {
         List<Offer> offers = getOffers(1.0, 1.0);
         List<TaskInfo> infos = Collections.singletonList(TaskTestUtils.getTaskInfo(Arrays.asList(cpus, mem)));
         RecoveryRequirement recoveryRequirement = getRecoveryRequirement(new OfferRequirement(infos, Optional.empty(), Collections.EMPTY_LIST, Collections.EMPTY_LIST));
-        when(stateStore.fetchTerminatedTasks()).thenReturn(infos);
+        when(stateStore.fetchTasksNeedingRecovery()).thenReturn(infos);
         when(recoveryRequirementProvider.getTransientRecoveryRequirements(any())).thenReturn(Arrays.asList(recoveryRequirement));
         when(offerAccepter.accept(any(), any())).thenReturn(Arrays.asList(offers.get(0).getId()));
         launchConstrainer.setCanLaunch(true);
@@ -152,7 +152,7 @@ public class RecoverySchedulerTest {
 
         Block block = mock(Block.class);
         when(block.getName()).thenReturn(TestConstants.taskName);
-        when(stateStore.fetchTerminatedTasks()).thenReturn(infos);
+        when(stateStore.fetchTasksNeedingRecovery()).thenReturn(infos);
 
         List<Protos.OfferID> acceptedOffers =
                 recoveryScheduler.resourceOffers(schedulerDriver, getOffers(1.0, 1.0), Optional.of(block));
@@ -174,7 +174,7 @@ public class RecoverySchedulerTest {
 
         when(recoveryRequirementProvider.getTransientRecoveryRequirements(any())).thenReturn(Arrays.asList(recoveryRequirement));
         when(offerAccepter.accept(any(), any())).thenReturn(Arrays.asList(offers.get(0).getId()));
-        when(stateStore.fetchTerminatedTasks()).thenReturn(infos);
+        when(stateStore.fetchTasksNeedingRecovery()).thenReturn(infos);
 
         Block block = mock(Block.class);
         when(block.getName()).thenReturn("different-name");
@@ -189,7 +189,7 @@ public class RecoverySchedulerTest {
         Resource cpus = ResourceTestUtils.getDesiredCpu(1.0);
         Resource mem = ResourceTestUtils.getDesiredMem(1.0);
         List<TaskInfo> infos = Collections.singletonList(TaskTestUtils.getTaskInfo(Arrays.asList(cpus, mem)));
-        when(stateStore.fetchTerminatedTasks()).thenReturn(infos);
+        when(stateStore.fetchTasksNeedingRecovery()).thenReturn(infos);
         failureMonitor.setFailedList(infos.get(0));
         launchConstrainer.setCanLaunch(false);
 
@@ -212,11 +212,11 @@ public class RecoverySchedulerTest {
         Resource cpus = ResourceTestUtils.getDesiredCpu(1.0);
         Resource mem = ResourceTestUtils.getDesiredMem(1.0);
         List<TaskInfo> infos = Collections.singletonList(TaskTestUtils.getTaskInfo(Arrays.asList(cpus, mem)));
-        when(stateStore.fetchTerminatedTasks()).thenReturn(infos);
+        when(stateStore.fetchTasksNeedingRecovery()).thenReturn(infos);
         List<Offer> offers = getOffers(1.0, 1.0);
         RecoveryRequirement recoveryRequirement = getRecoveryRequirement(new OfferRequirement(infos, Optional.empty(), Collections.EMPTY_LIST, Collections.EMPTY_LIST));
 
-        when(stateStore.fetchTerminatedTasks()).thenReturn(infos);
+        when(stateStore.fetchTasksNeedingRecovery()).thenReturn(infos);
         when(recoveryRequirementProvider.getPermanentRecoveryRequirements(any())).thenReturn(Arrays.asList(recoveryRequirement));
         when(offerAccepter.accept(any(), any())).thenReturn(Arrays.asList(offers.get(0).getId()));
         failureMonitor.setFailedList(infos.get(0));
@@ -253,7 +253,7 @@ public class RecoverySchedulerTest {
 
         List<Offer> insufficientOffers = getOffers(insufficientCpu, insufficientMem);
 
-        when(stateStore.fetchTerminatedTasks()).thenReturn(infos);
+        when(stateStore.fetchTasksNeedingRecovery()).thenReturn(infos);
         when(recoveryRequirementProvider.getPermanentRecoveryRequirements(any())).thenReturn(Arrays.asList(recoveryRequirement));
         failureMonitor.setFailedList(infos.get(0));
         launchConstrainer.setCanLaunch(true);


### PR DESCRIPTION
* Tasks which were in the state `TASK_LOST`, weren't being handled properly by destructive killing.  They weren't getting marked as permanently failed because they were being detected as not needing to be killed because they weren't `TASK_RUNNING`.
* There was also a conflation between Tasks being in states which required recovery and being in a terminal state.  These have been clarified.
* Integration tested by having Kafka consume this change, terminated a AWS instance, had a Broker go to TASK_LOST.  `dcos kafka broker replace <id>` worked as expected.  It did not work as expected before this change.
* It also appears that `dcos kafka broker replace <id>` while suppressed was broken.  So the TaskKiller now takes a SchedulerDriver so it can work anytime, even without an Offer cycle.

Note: test coverage goes from 79.3% to 79.7% in this PR.