### PR TITLE
[IGNOREME] Original Placement Constraints PR

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -101,7 +101,7 @@ ext {
 }
 
 group = "mesosphere"
-version = "0.7.7-SNAPSHOT"
+version = "0.7.8-SNAPSHOT"
 
 task sourceJar(type: Jar) {
     from sourceSets.main.allJava

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 // Config shared by the dcos-commons library and the examples:
 
 plugins {
+    id 'com.github.johnrengelman.shadow' version '1.2.3'
     id 'com.github.ksoichiro.console.reporter' version '0.4.0'
 }
 
@@ -170,6 +171,16 @@ dependencies {
     testCompile "org.mock-server:mockserver-netty:${mockServerVer}"
     testCompile "org.springframework.integration:spring-integration-http:${springVer}"
     testCompile "org.awaitility:awaitility:${awaitilityVer}"
+}
+
+shadowJar {
+    classifier = 'uber'
+
+    mergeServiceFiles()
+
+    exclude 'META-INF/*.SF'
+    exclude 'META-INF/*.DSA'
+    exclude 'META-INF/*.RSA'
 }
 
 distributions {

--- a/src/main/java/org/apache/mesos/offer/AttributeStringUtils.java
+++ b/src/main/java/org/apache/mesos/offer/AttributeStringUtils.java
@@ -1,0 +1,110 @@
+package org.apache.mesos.offer;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringJoiner;
+import java.util.StringTokenizer;
+
+import org.apache.mesos.Protos.Attribute;
+import org.apache.mesos.Protos.Value;
+
+/**
+ * Tools for converting {@link Attribute}s into strings. Spec is defined by Mesos documentation at:
+ * http://mesos.apache.org/documentation/latest/attributes-resources/
+ */
+public class AttributeStringUtils {
+
+    private static final String ATTRIBUTE_LIST_SEPARATOR = ";";
+    private static final char ATTRIBUTE_KEYVAL_SEPARATOR = ':';
+
+    private AttributeStringUtils() {
+        // do not instantiate
+    }
+
+    public static List<String> toStringList(String joinedAttributes) {
+        StringTokenizer tokenizer = new StringTokenizer(joinedAttributes, ATTRIBUTE_LIST_SEPARATOR);
+        List<String> tokens = new ArrayList<>();
+        while (tokenizer.hasMoreTokens()) {
+            tokens.add(tokenizer.nextToken());
+        }
+        return tokens;
+    }
+
+    /**
+     * Converts the provided list of zero or more attributes into a string suitable for parsing by
+     * {@link #parseString(String)}.
+     *
+     * @throws IllegalArgumentException if some part of the provided attributes couldn't be
+     * serialized
+     */
+    public static String toString(List<Attribute> attributes) throws IllegalArgumentException {
+        StringJoiner joiner = new StringJoiner(ATTRIBUTE_LIST_SEPARATOR);
+        for (Attribute attribute : attributes) {
+            joiner.add(toString(attribute));
+        }
+        return joiner.toString();
+    }
+
+    /**
+     * Converts the provided attribute into a string which follows the format defined by Mesos:
+     * <code>
+     * attributes : attribute ( ";" attribute )*
+     * attribute : text ":" ( scalar | range | text )
+     * text : [a-zA-Z0-9_/.-]
+     * scalar : floatValue
+     * floatValue : ( intValue ( "." intValue )? ) | ...
+     * intValue : [0-9]+
+     * range : "[" rangeValue ( "," rangeValue )* "]"
+     * rangeValue : scalar "-" scalar
+     * set : "{" text ( "," text )* "}"
+     * </code>
+     *
+     * NOTE that it is difficult if not impossible to consistently perform the inverse of this
+     * operation. For example, how can you tell if something is supposed to be a SCALAR value or a
+     * TEXT value? [0-9.]+ is valid in both cases! Your best hope is to consistently convert to
+     * string, and then convert strings...
+     *
+     * @throws IllegalArgumentException if some part of the provided attributes couldn't be
+     * serialized
+     */
+    public static String toString(Attribute attribute) throws IllegalArgumentException {
+        StringBuffer buf = new StringBuffer();
+        buf.append(attribute.getName());
+        buf.append(ATTRIBUTE_KEYVAL_SEPARATOR);
+        switch (attribute.getType()) {
+        case RANGES: {
+            // "ports:[21000-24000,30000-34000]"
+            buf.append('[');
+            StringJoiner joiner = new StringJoiner(",");
+            for (Value.Range range : attribute.getRanges().getRangeList()) {
+                joiner.add(String.format("%d-%d", range.getBegin(), range.getEnd()));
+            }
+            buf.append(joiner.toString());
+            buf.append(']');
+            break;
+        }
+        case SCALAR:
+            // according to mesos.proto: "Mesos keeps three decimal digits of precision ..."
+            // let's just ensure that we're producing consistent strings.
+            buf.append(String.format("%.3f", attribute.getScalar().getValue()));
+            break;
+        case SET:
+            // "bugs(debug_role):{a,b,c}"
+            buf.append('{');
+            StringJoiner joiner = new StringJoiner(",");
+            for (String item : attribute.getSet().getItemList()) {
+                joiner.add(item);
+            }
+            buf.append(joiner.toString());
+            buf.append('}');
+            break;
+        case TEXT:
+            // "key:value"
+            buf.append(attribute.getText().getValue());
+            break;
+        default:
+            throw new IllegalArgumentException("Unsupported attribute value type: " + attribute);
+        }
+        return buf.toString();
+    }
+}

--- a/src/main/java/org/apache/mesos/offer/DefaultOfferRequirementProvider.java
+++ b/src/main/java/org/apache/mesos/offer/DefaultOfferRequirementProvider.java
@@ -25,7 +25,10 @@ public class DefaultOfferRequirementProvider implements OfferRequirementProvider
                 .addAllResources(getNewResources(taskSpecification))
                 .build();
 
-        return new OfferRequirement(Arrays.asList(taskInfo));
+        return new OfferRequirement(
+                Arrays.asList(taskInfo),
+                Optional.empty(),
+                taskSpecification.getPlacement());
     }
 
     @Override
@@ -60,7 +63,10 @@ public class DefaultOfferRequirementProvider implements OfferRequirementProvider
                 .setTaskId(TaskUtils.emptyTaskId())
                 .setSlaveId(TaskUtils.emptyAgentId());
 
-        return new OfferRequirement(Arrays.asList(taskBuilder.build()));
+        return new OfferRequirement(
+                Arrays.asList(taskBuilder.build()),
+                Optional.empty(),
+                taskSpecification.getPlacement());
     }
 
     private void validateVolumes(Protos.TaskInfo taskInfo, TaskSpecification taskSpecification)

--- a/src/main/java/org/apache/mesos/offer/LaunchOfferRecommendation.java
+++ b/src/main/java/org/apache/mesos/offer/LaunchOfferRecommendation.java
@@ -5,8 +5,6 @@ import org.apache.mesos.Protos.Offer;
 import org.apache.mesos.Protos.Offer.Operation;
 import org.apache.mesos.Protos.TaskInfo;
 
-import java.util.Arrays;
-
 /**
  * This {@link OfferRecommendation} encapsulates a Mesos {@code LAUNCH} Operation.
  */
@@ -20,9 +18,9 @@ public class LaunchOfferRecommendation implements OfferRecommendation {
         this.operation = Operation.newBuilder()
                 .setType(Operation.Type.LAUNCH)
                 .setLaunch(Operation.Launch.newBuilder()
-                        .addAllTaskInfos(Arrays.asList(TaskInfo.newBuilder(taskInfo)
+                        .addTaskInfos(TaskInfo.newBuilder(taskInfo)
                                 .setSlaveId(offer.getSlaveId())
-                                .build())))
+                                .build()))
                 .build();
         this.mesosTask = new MesosTask(taskInfo);
     }

--- a/src/main/java/org/apache/mesos/offer/OfferEvaluator.java
+++ b/src/main/java/org/apache/mesos/offer/OfferEvaluator.java
@@ -24,7 +24,7 @@ import java.util.*;
 /**
  * The OfferEvaluator processes {@link Offer}s and produces {@link OfferRecommendation}s.
  * The determination of what {@link OfferRecommendation}s, if any should be made are made
- * in reference to the {@link OfferRequirement with which it was constructed.    In the
+ * in reference to the {@link OfferRequirement with which it was constructed.  In the
  * case where an OfferRequirement has not been provided no {@link OfferRecommendation}s
  * are ever returned.
  */
@@ -51,7 +51,12 @@ public class OfferEvaluator {
             List<OfferRecommendation> recommendations =
                     evaluateInternal(offerRequirement, offer, placementRule);
             if (recommendations != null && !recommendations.isEmpty()) {
+                logger.info("Offer produced {} recommendations: {}",
+                        recommendations.size(), TextFormat.shortDebugString(offer));
                 return recommendations;
+            } else {
+                logger.info("Offer did not pass constraints and/or resource requirements: {}",
+                        TextFormat.shortDebugString(offer));
             }
         }
         return Collections.emptyList();
@@ -101,6 +106,8 @@ public class OfferEvaluator {
                                 pool);
 
                 if (fulfilledExecutorRequirement == null) {
+                    logger.info("Offer: '{}' does not fulfill the executor Resource Requirements: '{}'",
+                            offer.getId().getValue(), execReq.get().getResourceRequirements());
                     return Collections.emptyList();
                 }
 
@@ -129,6 +136,8 @@ public class OfferEvaluator {
                 FulfilledRequirement.fulfillRequirement(taskReq.getResourceRequirements(), offer, pool);
 
             if (fulfilledTaskRequirement == null) {
+                logger.info("Offer: '{}' does not fulfill the task Resource Requirements: '{}'",
+                        offer.getId().getValue(), taskReq.getResourceRequirements());
                 return Collections.emptyList();
             }
 

--- a/src/main/java/org/apache/mesos/offer/OfferEvaluator.java
+++ b/src/main/java/org/apache/mesos/offer/OfferEvaluator.java
@@ -10,6 +10,10 @@ import org.apache.mesos.Protos.Resource.ReservationInfo;
 import org.apache.mesos.Protos.TaskInfo;
 import org.apache.mesos.Protos.Value;
 import org.apache.mesos.executor.ExecutorUtils;
+import org.apache.mesos.offer.constrain.PlacementRule;
+import org.apache.mesos.offer.constrain.PlacementRuleGenerator;
+import org.apache.mesos.state.StateStore;
+import org.apache.mesos.state.StateStoreException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -25,13 +29,21 @@ import java.util.*;
  * are ever returned.
  */
 public class OfferEvaluator {
+
     private static final Logger logger = LoggerFactory.getLogger(OfferEvaluator.class);
 
-    public OfferEvaluator() { }
+    private final StateStore stateStore;
 
-    public List<OfferRecommendation> evaluate(OfferRequirement offerRequirement, List<Offer> offers) {
+    public OfferEvaluator(StateStore stateStore) {
+        this.stateStore = stateStore;
+    }
+
+    public List<OfferRecommendation> evaluate(OfferRequirement offerRequirement, List<Offer> offers)
+            throws StateStoreException {
+        Optional<PlacementRule> placementRule = getPlacementRule(offerRequirement, stateStore);
         for (Offer offer : offers) {
-            List<OfferRecommendation> recommendations = evaluate(offerRequirement, offer);
+            List<OfferRecommendation> recommendations =
+                    evaluateInternal(offerRequirement, offer, placementRule);
             if (recommendations != null && !recommendations.isEmpty()) {
                 return recommendations;
             }
@@ -39,32 +51,20 @@ public class OfferEvaluator {
         return Collections.emptyList();
     }
 
-    private boolean offerMeetsPlacementConstraints(OfferRequirement offerReq, Offer offer) {
-        if (offerReq.getAvoidAgents().contains(offer.getSlaveId())) {
-            return false;
-        }
-
-        if (offerReq.getColocateAgents().size() > 0 &&
-                !offerReq.getColocateAgents().contains(offer.getSlaveId())) {
-            return false;
-        }
-
-        return true;
+    public List<OfferRecommendation> evaluate(OfferRequirement offerRequirement, Offer offer)
+            throws StateStoreException {
+        return evaluateInternal(
+                offerRequirement, offer, getPlacementRule(offerRequirement, stateStore));
     }
 
-    private boolean hasExpectedExecutorId(Offer offer, Protos.ExecutorID executorID) {
-        for (Protos.ExecutorID execId : offer.getExecutorIdsList()) {
-            if (execId.equals(executorID)) {
-                return true;
+    private List<OfferRecommendation> evaluateInternal(
+            OfferRequirement offerRequirement, Offer offer, Optional<PlacementRule> placementRule) {
+        if (placementRule.isPresent()) {
+            offer = placementRule.get().filter(offer);
+            if (offer.getResourcesCount() == 0) {
+                // Placement rule filtered all resources, short-circuit.
+                return Collections.emptyList();
             }
-        }
-
-        return false;
-    }
-
-    public List<OfferRecommendation> evaluate(OfferRequirement offerRequirement, Offer offer) {
-        if (!offerMeetsPlacementConstraints(offerRequirement, offer)) {
-            return Collections.emptyList();
         }
 
         MesosResourcePool pool = new MesosResourcePool(offer);
@@ -74,12 +74,14 @@ public class OfferEvaluator {
         List<OfferRecommendation> creates = new ArrayList<>();
         List<OfferRecommendation> launches = new ArrayList<>();
 
-        ExecutorRequirement execReq = offerRequirement.getExecutorRequirement();
+        Optional<ExecutorRequirement> execReq = offerRequirement.getExecutorRequirement();
         FulfilledRequirement fulfilledExecutorRequirement = null;
-        if (execReq != null) {
-            if (execReq.desiresResources() || execReq.getExecutorInfo().getExecutorId().getValue().isEmpty()) {
+        ExecutorInfo execInfo = null;
+        if (execReq.isPresent()) {
+            if (execReq.get().desiresResources() ||
+                    execReq.get().getExecutorInfo().getExecutorId().getValue().isEmpty()) {
                 fulfilledExecutorRequirement = FulfilledRequirement.fulfillRequirement(
-                                execReq.getResourceRequirements(),
+                                execReq.get().getResourceRequirements(),
                                 offer,
                                 pool);
 
@@ -91,18 +93,15 @@ public class OfferEvaluator {
                 reserves.addAll(fulfilledExecutorRequirement.getReserveRecommendations());
                 creates.addAll(fulfilledExecutorRequirement.getCreateRecommendations());
             } else {
-                Protos.ExecutorID expectedExecutorId = execReq.getExecutorInfo().getExecutorId();
+                Protos.ExecutorID expectedExecutorId = execReq.get().getExecutorInfo().getExecutorId();
                 if (!hasExpectedExecutorId(offer, expectedExecutorId)) {
                     logger.info("Offer: '{}' does not contain the needed ExecutorID: '{}'",
                                     offer.getId().getValue(), expectedExecutorId.getValue());
                     return Collections.emptyList();
                 }
             }
-        }
 
-        ExecutorInfo execInfo = null;
-        if (execReq != null) {
-            execInfo = execReq.getExecutorInfo();
+            execInfo = execReq.get().getExecutorInfo();
             if (execInfo.getExecutorId().getValue().isEmpty()) {
                 execInfo = ExecutorInfo.newBuilder(execInfo)
                                 .setExecutorId(ExecutorUtils.toExecutorId(execInfo.getName()))
@@ -129,7 +128,8 @@ public class OfferEvaluator {
                         taskReq,
                         fulfilledTaskRequirement,
                         execInfo,
-                        fulfilledExecutorRequirement)));
+                        fulfilledExecutorRequirement,
+                        offer)));
         }
 
         List<OfferRecommendation> recommendations = new ArrayList<OfferRecommendation>();
@@ -266,6 +266,24 @@ public class OfferEvaluator {
         }
     }
 
+    private static Optional<PlacementRule> getPlacementRule(
+            OfferRequirement offerRequirement, StateStore stateStore)
+                    throws StateStoreException {
+        Optional<PlacementRuleGenerator> placementRuleGenerator =
+                offerRequirement.getPlacementRuleGenerator();
+        return placementRuleGenerator.isPresent()
+            ? Optional.of(placementRuleGenerator.get().generate(stateStore.fetchTasks()))
+            : Optional.empty();
+    }
+
+    private static boolean hasExpectedExecutorId(Offer offer, Protos.ExecutorID executorID) {
+        for (Protos.ExecutorID execId : offer.getExecutorIdsList()) {
+            if (execId.equals(executorID)) {
+                return true;
+            }
+        }
+        return false;
+    }
 
     private static boolean expectedValueChanged(ResourceRequirement resReq, MesosResource mesRes) {
         return !ValueUtils.equal(resReq.getValue(), mesRes.getValue());
@@ -328,23 +346,21 @@ public class OfferEvaluator {
         }
     }
 
-    private TaskInfo getFulfilledTaskInfo(
+    private static TaskInfo getFulfilledTaskInfo(
             TaskRequirement taskReq,
             FulfilledRequirement fulfilledTaskRequirement,
             ExecutorInfo execInfo,
-            FulfilledRequirement fulfilledExecutorRequirement) {
+            FulfilledRequirement fulfilledExecutorRequirement,
+            Offer launchOffer) {
 
         TaskInfo taskInfo = taskReq.getTaskInfo();
         List<Resource> fulfilledTaskResources = fulfilledTaskRequirement.getFulfilledResources();
-        TaskInfo.Builder taskBuilder =
-            TaskInfo.newBuilder(taskInfo)
-            .clearResources()
-            .addAllResources(fulfilledTaskResources);
+        TaskInfo.Builder taskBuilder = TaskInfo.newBuilder(taskInfo)
+                .clearResources()
+                .addAllResources(fulfilledTaskResources);
 
         if (execInfo != null) {
-            ExecutorInfo.Builder execBuilder =
-                            ExecutorInfo.newBuilder(execInfo)
-                                            .clearResources();
+            ExecutorInfo.Builder execBuilder = ExecutorInfo.newBuilder(execInfo).clearResources();
 
             if (fulfilledExecutorRequirement != null) {
                 List<Resource> fulfilledExecutorResources = fulfilledExecutorRequirement.getFulfilledResources();
@@ -355,6 +371,9 @@ public class OfferEvaluator {
 
             taskBuilder.setExecutor(execBuilder.build());
         }
+
+        // Store the Attributes from the Offer in the TaskInfo for later access by constraint filters:
+        taskBuilder = TaskUtils.setOfferAttributes(taskBuilder, launchOffer);
 
         return taskBuilder.build();
     }

--- a/src/main/java/org/apache/mesos/offer/OfferEvaluator.java
+++ b/src/main/java/org/apache/mesos/offer/OfferEvaluator.java
@@ -153,7 +153,8 @@ public class OfferEvaluator {
                         fulfilledTaskRequirement,
                         execInfo,
                         fulfilledExecutorRequirement,
-                        offer)));
+                        offer,
+                        "TODO TASK TYPE"))); // TODO(nick): add once plumbed through
         }
 
         List<OfferRecommendation> recommendations = new ArrayList<OfferRecommendation>();
@@ -375,7 +376,8 @@ public class OfferEvaluator {
             FulfilledRequirement fulfilledTaskRequirement,
             ExecutorInfo execInfo,
             FulfilledRequirement fulfilledExecutorRequirement,
-            Offer launchOffer) {
+            Offer launchOffer,
+            String taskType) {
 
         TaskInfo taskInfo = taskReq.getTaskInfo();
         List<Resource> fulfilledTaskResources = fulfilledTaskRequirement.getFulfilledResources();
@@ -398,6 +400,7 @@ public class OfferEvaluator {
 
         // Store the Attributes from the Offer in the TaskInfo for later access by constraint filters:
         taskBuilder = TaskUtils.setOfferAttributes(taskBuilder, launchOffer);
+        taskBuilder = TaskUtils.setTaskType(taskBuilder, taskType);
 
         return taskBuilder.build();
     }

--- a/src/main/java/org/apache/mesos/offer/constrain/AgentRule.java
+++ b/src/main/java/org/apache/mesos/offer/constrain/AgentRule.java
@@ -1,0 +1,95 @@
+package org.apache.mesos.offer.constrain;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import org.apache.mesos.Protos.Offer;
+
+/**
+ * This rule enforces that a task be placed on a provided agent ID, or enforces that the task avoid
+ * that agent ID.
+ */
+public class AgentRule implements PlacementRule {
+
+    private final String agentId;
+
+    public AgentRule(String agentId) {
+        this.agentId = agentId;
+    }
+
+    @Override
+    public Offer filter(Offer offer) {
+        if (offer.getSlaveId().getValue().equals(agentId)) {
+            return offer;
+        } else {
+            // agent mismatch: return empty offer
+            return offer.toBuilder().clearResources().build();
+        }
+    }
+
+    @Override
+    public String toString() {
+        return String.format("AgentRule{agentId=%s}", agentId);
+    }
+
+    /**
+     * Ensures that the given Offer is colocated with the specified agent ID.
+     */
+    public static class ColocateAgentGenerator extends PassthroughGenerator {
+
+        public ColocateAgentGenerator(String agentId) {
+            super(new AgentRule(agentId));
+        }
+    }
+
+    /**
+     * Ensures that the given Offer is NOT colocated with the specified agent ID.
+     */
+    public static class AvoidAgentGenerator extends PassthroughGenerator {
+
+        public AvoidAgentGenerator(String agentId) {
+            super(new NotRule(new AgentRule(agentId)));
+        }
+    }
+
+    /**
+     * Ensures that the given Offer is colocated with one of the specified agent IDs.
+     */
+    public static class ColocateAgentsGenerator extends PassthroughGenerator {
+
+        public ColocateAgentsGenerator(Collection<String> agentIds) {
+            super(new OrRule(toAgentRules(agentIds)));
+        }
+
+        public ColocateAgentsGenerator(String... agentIds) {
+            this(Arrays.asList(agentIds));
+        }
+    }
+
+    /**
+     * Ensures that the given Offer is NOT colocated with any of the specified agent IDs.
+     */
+    public static class AvoidAgentsGenerator extends PassthroughGenerator {
+
+        public AvoidAgentsGenerator(Collection<String> agentIds) {
+            super(new NotRule(new OrRule(toAgentRules(agentIds))));
+        }
+
+        public AvoidAgentsGenerator(String... agentIds) {
+            this(Arrays.asList(agentIds));
+        }
+    }
+
+    /**
+     * Converts the provided agent ids into {@link AgentRule}s.
+     */
+    private static Collection<PlacementRule> toAgentRules(Collection<String> agentIds) {
+        List<PlacementRule> rules = new ArrayList<>();
+        for (String agentId : agentIds) {
+            rules.add(new AgentRule(agentId));
+        }
+        return rules;
+    }
+}

--- a/src/main/java/org/apache/mesos/offer/constrain/AndRule.java
+++ b/src/main/java/org/apache/mesos/offer/constrain/AndRule.java
@@ -1,0 +1,88 @@
+package org.apache.mesos.offer.constrain;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.mesos.Protos.Offer;
+import org.apache.mesos.Protos.Resource;
+import org.apache.mesos.Protos.TaskInfo;
+
+/**
+ * Wrapper for one or more another rules which returns the AND/intersection of those rules.
+ */
+public class AndRule implements PlacementRule {
+
+    private final Collection<PlacementRule> rules;
+
+    public AndRule(Collection<PlacementRule> rules) {
+        this.rules = rules;
+    }
+
+    public AndRule(PlacementRule... rules) {
+        this(Arrays.asList(rules));
+    }
+
+    @Override
+    public Offer filter(Offer offer) {
+        // Counts of how often each Resource passed each filter:
+        Map<Resource, Integer> resourceCounts = new HashMap<>();
+        for (PlacementRule rule : rules) {
+            Offer filtered = rule.filter(offer);
+            for (Resource resource : filtered.getResourcesList()) {
+                Integer val = resourceCounts.get(resource);
+                if (val == null) {
+                    val = 0;
+                }
+                val++;
+                resourceCounts.put(resource, val);
+            }
+        }
+        if (resourceCounts.size() == 0) {
+            // shortcut: all resources were filtered out, so return no resources
+            return offer.toBuilder().clearResources().build();
+        }
+        // preserve original ordering (and any original duplicates): test the original list in order
+        Offer.Builder offerBuilder = offer.toBuilder().clearResources();
+        for (Resource resource : offer.getResourcesList()) {
+            Integer val = resourceCounts.get(resource);
+            if (val != null && val == rules.size()) {
+                offerBuilder.addResources(resource);
+            }
+        }
+        return offerBuilder.build();
+    }
+
+    @Override
+    public String toString() {
+        return String.format("AndRule{rules=%s}", rules);
+    }
+
+    /**
+     * Wraps the result of the provided {@link PlacementRuleGenerator}s in an {@link AndRule}.
+     */
+    public static class Generator implements PlacementRuleGenerator {
+
+        private final Collection<PlacementRuleGenerator> generators;
+
+        public Generator(Collection<PlacementRuleGenerator> ruleGenerators) {
+            this.generators = ruleGenerators;
+        }
+
+        public Generator(PlacementRuleGenerator... ruleGenerators) {
+            this(Arrays.asList(ruleGenerators));
+        }
+
+        @Override
+        public PlacementRule generate(Collection<TaskInfo> tasks) {
+            List<PlacementRule> rules = new ArrayList<>();
+            for (PlacementRuleGenerator ruleGenerator : generators) {
+                rules.add(ruleGenerator.generate(tasks));
+            }
+            return new AndRule(rules);
+        }
+    }
+}

--- a/src/main/java/org/apache/mesos/offer/constrain/AttributeRule.java
+++ b/src/main/java/org/apache/mesos/offer/constrain/AttributeRule.java
@@ -1,0 +1,46 @@
+package org.apache.mesos.offer.constrain;
+
+import org.apache.mesos.Protos.Attribute;
+import org.apache.mesos.Protos.Offer;
+import org.apache.mesos.offer.AttributeStringUtils;
+
+/**
+ * Requires that the Offer contain an attribute whose string representation matches the provided string.
+ *
+ * @see AttributeStringUtils#toString(Attribute)
+ */
+public class AttributeRule implements PlacementRule {
+
+    private final AttributeSelector attributeSelector;
+
+    public AttributeRule(AttributeSelector attributeSelector) {
+        this.attributeSelector = attributeSelector;
+    }
+
+    @Override
+    public Offer filter(Offer offer) {
+        for (Attribute attributeProto : offer.getAttributesList()) {
+            String attributeString = AttributeStringUtils.toString(attributeProto);
+            if (attributeSelector.select(attributeString)) {
+                // match found. return entire offer as-is
+                return offer;
+            }
+        }
+        // match not found: return empty offer
+        return offer.toBuilder().clearResources().build();
+    }
+
+    @Override
+    public String toString() {
+        return String.format("AttributeRule{selector=%s}", attributeSelector);
+    }
+
+    /**
+     * A generator which returns an {@link AttributeRule} for the provided attribute.
+     */
+    public static class Generator extends PassthroughGenerator {
+        public Generator(AttributeSelector attributeSelector) {
+            super(new AttributeRule(attributeSelector));
+        }
+    }
+}

--- a/src/main/java/org/apache/mesos/offer/constrain/AttributeSelector.java
+++ b/src/main/java/org/apache/mesos/offer/constrain/AttributeSelector.java
@@ -4,22 +4,28 @@ import java.util.regex.Pattern;
 
 /**
  * Implements a check against a provided attribute string, determining whether it matches some
- * criteria.
+ * criteria. Checks are only performed against the string representations of attributes.
+ *
+ * @see org.apache.mesos.offer.AttributeStringUtils#toString(org.apache.mesos.Protos.Attribute)
  */
 public interface AttributeSelector {
     public boolean select(String attributeString);
 
     /**
-     * Returns a new {@link AttributeSelector} which selects attributes that exactly match the
-     * provided string.
+     * Returns a new {@link AttributeSelector} which selects attributes whose string representation
+     * exactly matches the provided string.
+     *
+     * @see org.apache.mesos.offer.AttributeStringUtils#toString(org.apache.mesos.Protos.Attribute)
      */
     public static AttributeSelector createStringSelector(String str) {
         return new StringSelector(str);
     }
 
     /**
-     * Returns a new {@link AttributeSelector} which selects attributes that match the provided
-     * regular expression.
+     * Returns a new {@link AttributeSelector} which selects attributes whose string representation
+     * match the provided regular expression.
+     *
+     * @see org.apache.mesos.offer.AttributeStringUtils#toString(org.apache.mesos.Protos.Attribute)
      */
     public static AttributeSelector createRegexSelector(String pattern) {
         return new RegexSelector(pattern);

--- a/src/main/java/org/apache/mesos/offer/constrain/AttributeSelector.java
+++ b/src/main/java/org/apache/mesos/offer/constrain/AttributeSelector.java
@@ -46,6 +46,11 @@ public interface AttributeSelector {
         public boolean select(String attribute) {
             return str.equals(attribute);
         }
+
+        @Override
+        public String toString() {
+            return String.format("StringSelector{str=%s}", str);
+        }
     }
 
     /**
@@ -62,6 +67,11 @@ public interface AttributeSelector {
         @Override
         public boolean select(String attribute) {
             return pattern.matcher(attribute).matches();
+        }
+
+        @Override
+        public String toString() {
+            return String.format("RegexSelector{pattern=%s}", pattern);
         }
     }
 }

--- a/src/main/java/org/apache/mesos/offer/constrain/AttributeSelector.java
+++ b/src/main/java/org/apache/mesos/offer/constrain/AttributeSelector.java
@@ -1,0 +1,61 @@
+package org.apache.mesos.offer.constrain;
+
+import java.util.regex.Pattern;
+
+/**
+ * Implements a check against a provided attribute string, determining whether it matches some
+ * criteria.
+ */
+public interface AttributeSelector {
+    public boolean select(String attributeString);
+
+    /**
+     * Returns a new {@link AttributeSelector} which selects attributes that exactly match the
+     * provided string.
+     */
+    public static AttributeSelector createStringSelector(String str) {
+        return new StringSelector(str);
+    }
+
+    /**
+     * Returns a new {@link AttributeSelector} which selects attributes that match the provided
+     * regular expression.
+     */
+    public static AttributeSelector createRegexSelector(String pattern) {
+        return new RegexSelector(pattern);
+    }
+
+    /**
+     * Implements exact string matching support for agent attribute comparisons.
+     */
+    public static class StringSelector implements AttributeSelector {
+
+        private final String str;
+
+        private StringSelector(String str) {
+            this.str = str;
+        }
+
+        @Override
+        public boolean select(String attribute) {
+            return str.equals(attribute);
+        }
+    }
+
+    /**
+     * Implements regex support for agent attribute comparisons.
+     */
+    public static class RegexSelector implements AttributeSelector {
+
+        private final Pattern pattern;
+
+        private RegexSelector(String pattern) {
+            this.pattern = Pattern.compile(pattern);
+        }
+
+        @Override
+        public boolean select(String attribute) {
+            return pattern.matcher(attribute).matches();
+        }
+    }
+}

--- a/src/main/java/org/apache/mesos/offer/constrain/MaxPerAttributeGenerator.java
+++ b/src/main/java/org/apache/mesos/offer/constrain/MaxPerAttributeGenerator.java
@@ -83,7 +83,8 @@ public class MaxPerAttributeGenerator implements PlacementRuleGenerator {
         switch (blockedAttributes.size()) {
         case 0:
             // nothing is full, don't filter any offers.
-            return PassthroughRule.getInstance();
+            return new PassthroughRule(
+                    String.format("no matching attributes are full: %s", attributeSelector));
         case 1:
             // shortcut: no OrRule needed, just block the one attribute
             return new NotRule(blockedAttributes.get(0));

--- a/src/main/java/org/apache/mesos/offer/constrain/MaxPerAttributeGenerator.java
+++ b/src/main/java/org/apache/mesos/offer/constrain/MaxPerAttributeGenerator.java
@@ -1,0 +1,74 @@
+package org.apache.mesos.offer.constrain;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.mesos.Protos.TaskInfo;
+import org.apache.mesos.offer.TaskUtils;
+
+/**
+ * Ensures that the given Offer’s attributes each have no more than N instances of the task type
+ * running on them.
+ *
+ * For example, this can ensure that no more than 3 tasks are running against the 'rack:foo'
+ * attribute.
+ */
+public class MaxPerAttributeGenerator implements PlacementRuleGenerator {
+
+    private final int maxTasksPerSelectedAttribute;
+    private final AttributeSelector attributeSelector;
+
+    /**
+     * Creates a new rule generator which will block deployment on tasks which already have N
+     * instances running against a specified attribute.
+     */
+    public MaxPerAttributeGenerator(
+            int maxTasksPerSelectedAttribute, AttributeSelector attributeSelector) {
+        this.maxTasksPerSelectedAttribute = maxTasksPerSelectedAttribute;
+        this.attributeSelector = attributeSelector;
+    }
+
+    @Override
+    public PlacementRule generate(Collection<TaskInfo> tasks) {
+        // map: enforced attribute => # tasks which were launched against attribute
+        Map<String, Integer> selectedAttrTaskCounts = new HashMap<>();
+        for (TaskInfo task : tasks) {
+            for (String attribute : TaskUtils.getOfferAttributeStrings(task)) {
+                // only enforce attribute(s) that match (eg 'rack:.*'):
+                if (!attributeSelector.select(attribute)) {
+                    continue;
+                }
+                // increment the count for this exact attribute (eg 'rack:9'):
+                Integer val = selectedAttrTaskCounts.get(attribute);
+                if (val == null) {
+                    val = 0;
+                }
+                val++;
+                selectedAttrTaskCounts.put(attribute, val);
+            }
+        }
+        // find the attributes which meet or exceed the limit and block any offers with those
+        // (EXACT) attributes from the next launch.
+        List<PlacementRule> blockedAttributes = new ArrayList<>();
+        for (Map.Entry<String, Integer> entry : selectedAttrTaskCounts.entrySet()) {
+            if (entry.getValue() >= maxTasksPerSelectedAttribute) {
+                blockedAttributes.add(
+                        new AttributeRule(AttributeSelector.createStringSelector(entry.getKey())));
+            }
+        }
+        switch (blockedAttributes.size()) {
+        case 0:
+            // nothing is full, don't filter any offers.
+            return PassthroughRule.getInstance();
+        case 1:
+            // shortcut: no OrRule needed, just block the one attribute
+            return new NotRule(blockedAttributes.get(0));
+        default:
+            // filter out any offers which contain the full attributes.
+            return new NotRule(new OrRule(blockedAttributes));
+        }
+    }
+}

--- a/src/main/java/org/apache/mesos/offer/constrain/MaxPerAttributeGenerator.java
+++ b/src/main/java/org/apache/mesos/offer/constrain/MaxPerAttributeGenerator.java
@@ -13,8 +13,29 @@ import org.apache.mesos.offer.TaskUtils;
  * Ensures that the given Offer’s attributes each have no more than N instances of the task type
  * running on them.
  *
- * For example, this can ensure that no more than 3 tasks are running against the 'rack:foo'
- * attribute.
+ * For example, this can ensure that no more than N tasks are running against the 'rack:foo'
+ * attribute (exact match), or it can ensure that no distinct 'rack:.*' value has more than N tasks
+ * running against it (wildcarded grouping).
+ *
+ * To illustrate, let's look at a deployment scenario of 5 agents with 3 distinct 'rack' values:
+ *  agent |  attr  | # tasks
+ * -------+--------+---------
+ *    1   | rack:a |   3
+ *    2   | rack:b |   2
+ *    3   | rack:c |   1
+ *    4   | rack:a |   2
+ *    5   | rack:b |   2
+ *
+ * Given a {@link MaxPerAttributeGenerator} with a limit of 5 and a regex of 'rack:.*', let's see
+ * what PlacementRule would be produced:
+ *
+ * In this example, the regex of 'rack:.*' will result in grouping the task counts as follows:
+ * - rack:a: 5 tasks
+ * - rack:b: 4 tasks
+ * - rack:c: 1 task
+ *
+ * With the limit value of 5, this would result in a PlacementRule that blocks any offers with
+ * 'rack:a' from future deployments.
  */
 public class MaxPerAttributeGenerator implements PlacementRuleGenerator {
 

--- a/src/main/java/org/apache/mesos/offer/constrain/NotRule.java
+++ b/src/main/java/org/apache/mesos/offer/constrain/NotRule.java
@@ -1,0 +1,66 @@
+package org.apache.mesos.offer.constrain;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.apache.mesos.Protos.Offer;
+import org.apache.mesos.Protos.Resource;
+import org.apache.mesos.Protos.TaskInfo;
+
+/**
+ * Wrapper for another rule which returns the NOT result: Resources which the wrapped rule removed.
+ */
+public class NotRule implements PlacementRule {
+
+    private final PlacementRule rule;
+
+    public NotRule(PlacementRule rule) {
+        this.rule = rule;
+    }
+
+    @Override
+    public Offer filter(Offer offer) {
+        Offer filtered = rule.filter(offer);
+        if (filtered.getResourcesCount() == 0) {
+            // shortcut: all resources were filtered out, so return all resources
+            return offer;
+        } else if (filtered.getResourcesCount() == offer.getResourcesCount()) {
+            // other shortcut: no resources were filtered out, so return no resources
+            return offer.toBuilder().clearResources().build();
+        }
+        Set<Resource> resourcesToOmit = new HashSet<>();
+        for (Resource resource : filtered.getResourcesList()) {
+            resourcesToOmit.add(resource);
+        }
+        Offer.Builder offerBuilder = offer.toBuilder().clearResources();
+        for (Resource resource : offer.getResourcesList()) {
+            if (!resourcesToOmit.contains(resource)) {
+                offerBuilder.addResources(resource);
+            }
+        }
+        return offerBuilder.build();
+    }
+
+    @Override
+    public String toString() {
+        return String.format("NotRule{rule=%s}", rule);
+    }
+
+    /**
+     * Wraps the result of the provided {@link PlacementRuleGenerator} in a {@link NotRule}.
+     */
+    public static class Generator implements PlacementRuleGenerator {
+
+        private final PlacementRuleGenerator generator;
+
+        public Generator(PlacementRuleGenerator generator) {
+            this.generator = generator;
+        }
+
+        @Override
+        public PlacementRule generate(Collection<TaskInfo> tasks) {
+            return new NotRule(generator.generate(tasks));
+        }
+    }
+}

--- a/src/main/java/org/apache/mesos/offer/constrain/OrRule.java
+++ b/src/main/java/org/apache/mesos/offer/constrain/OrRule.java
@@ -1,0 +1,85 @@
+package org.apache.mesos.offer.constrain;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.mesos.Protos.Offer;
+import org.apache.mesos.Protos.Resource;
+import org.apache.mesos.Protos.TaskInfo;
+
+/**
+ * Wrapper for one or more another rules which returns the OR/union of those rules.
+ */
+public class OrRule implements PlacementRule {
+
+    private final Collection<PlacementRule> rules;
+
+    public OrRule(Collection<PlacementRule> rules) {
+        this.rules = rules;
+    }
+
+    public OrRule(PlacementRule... rules) {
+        this(Arrays.asList(rules));
+    }
+
+    @Override
+    public Offer filter(Offer offer) {
+        Set<Resource> resourceUnion = new HashSet<>();
+        for (PlacementRule rule : rules) {
+            Offer filtered = rule.filter(offer);
+            for (Resource resource : filtered.getResourcesList()) {
+                resourceUnion.add(resource);
+            }
+            if (resourceUnion.size() == offer.getResourcesCount()) {
+                // shortcut: all resources passing one or more filters, so return all resources
+                return offer;
+            }
+        }
+        if (resourceUnion.size() == 0) {
+            // shortcut: all resources were filtered out, so return no resources
+            return offer.toBuilder().clearResources().build();
+        }
+        // preserve original ordering (and any original duplicates): test the original list in order
+        Offer.Builder offerBuilder = offer.toBuilder().clearResources();
+        for (Resource resource : offer.getResourcesList()) {
+            if (resourceUnion.contains(resource)) {
+                offerBuilder.addResources(resource);
+            }
+        }
+        return offerBuilder.build();
+    }
+
+    @Override
+    public String toString() {
+        return String.format("OrRule{rules=%s}", rules);
+    }
+
+    /**
+     * Wraps the result of the provided {@link PlacementRuleGenerator}s in an {@link OrRule}.
+     */
+    public static class Generator implements PlacementRuleGenerator {
+
+        private final Collection<PlacementRuleGenerator> generators;
+
+        public Generator(Collection<PlacementRuleGenerator> ruleGenerators) {
+            this.generators = ruleGenerators;
+        }
+
+        public Generator(PlacementRuleGenerator... ruleGenerators) {
+            this(Arrays.asList(ruleGenerators));
+        }
+
+        @Override
+        public PlacementRule generate(Collection<TaskInfo> tasks) {
+            List<PlacementRule> rules = new ArrayList<>();
+            for (PlacementRuleGenerator ruleGenerator : generators) {
+                rules.add(ruleGenerator.generate(tasks));
+            }
+            return new OrRule(rules);
+        }
+    }
+}

--- a/src/main/java/org/apache/mesos/offer/constrain/PassthroughGenerator.java
+++ b/src/main/java/org/apache/mesos/offer/constrain/PassthroughGenerator.java
@@ -1,0 +1,26 @@
+package org.apache.mesos.offer.constrain;
+
+import java.util.Collection;
+
+import org.apache.mesos.Protos.TaskInfo;
+
+/**
+ * Directly returns the provided rule when invoked.
+ */
+public class PassthroughGenerator implements PlacementRuleGenerator {
+    private final PlacementRule ruleToReturn;
+
+    public PassthroughGenerator(PlacementRule ruleToReturn) {
+        this.ruleToReturn = ruleToReturn;
+    }
+
+    @Override
+    public PlacementRule generate(Collection<TaskInfo> tasks) {
+        return ruleToReturn;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("PassthroughGenerator{rule=%s}", ruleToReturn);
+    }
+}

--- a/src/main/java/org/apache/mesos/offer/constrain/PassthroughRule.java
+++ b/src/main/java/org/apache/mesos/offer/constrain/PassthroughRule.java
@@ -1,0 +1,25 @@
+package org.apache.mesos.offer.constrain;
+
+import org.apache.mesos.Protos.Offer;
+
+/**
+ * A {@link PlacementRule} which performs no filtering. Just returns the offers it's given as-is.
+ */
+public class PassthroughRule implements PlacementRule {
+
+    private static final PassthroughRule INSTANCE = new PassthroughRule();
+
+    public static PassthroughRule getInstance() {
+        return INSTANCE;
+    }
+
+    @Override
+    public Offer filter(Offer offer) {
+        return offer;
+    }
+
+    @Override
+    public String toString() {
+        return "PassthroughRule{}";
+    }
+}

--- a/src/main/java/org/apache/mesos/offer/constrain/PassthroughRule.java
+++ b/src/main/java/org/apache/mesos/offer/constrain/PassthroughRule.java
@@ -7,10 +7,15 @@ import org.apache.mesos.Protos.Offer;
  */
 public class PassthroughRule implements PlacementRule {
 
-    private static final PassthroughRule INSTANCE = new PassthroughRule();
+    private final String label;
 
-    public static PassthroughRule getInstance() {
-        return INSTANCE;
+    /**
+     * Creates a new PassthroughRule, which accepts everything it's provided.
+     *
+     * @param label a label describing the source of this passthrough to include in toString()
+     */
+    public PassthroughRule(String label) {
+        this.label = label;
     }
 
     @Override
@@ -20,6 +25,6 @@ public class PassthroughRule implements PlacementRule {
 
     @Override
     public String toString() {
-        return "PassthroughRule{}";
+        return String.format("PassthroughRule{label=%s}", label);
     }
 }

--- a/src/main/java/org/apache/mesos/offer/constrain/PlacementRule.java
+++ b/src/main/java/org/apache/mesos/offer/constrain/PlacementRule.java
@@ -1,0 +1,26 @@
+package org.apache.mesos.offer.constrain;
+
+import org.apache.mesos.Protos.Offer;
+
+/**
+ * Implements placement constraint logic on an offer, filtering out the Resources which are not
+ * to be used according to the filter logic.
+ *
+ * Accepts an Offer and returns a copy of that Offer with any disallowed Resources filtered out, or
+ * may return the original Offer without copying if everything passes the filter. If the entire
+ * Offer is rejected, the return value will be a non-{@code null} Offer with zero Resources. A
+ * PlacementRule may contain multiple internal checks, and may even be composed of other sub-Rules.
+ */
+public interface PlacementRule {
+
+    /**
+     * Returns a copy of that Offer with any disallowed Resources filtered out, or may return the
+     * original Offer without copying if everything passes the filter. If the entire Offer is
+     * rejected, the return value will be a non-{@code null} Offer with zero Resources.
+     *
+     * @param offer the offer to be examined
+     * @return either the uncopied input as-is, or a copy of the input with zero or more Resources
+     *     stripped out
+     */
+    public Offer filter(Offer offer);
+}

--- a/src/main/java/org/apache/mesos/offer/constrain/PlacementRuleGenerator.java
+++ b/src/main/java/org/apache/mesos/offer/constrain/PlacementRuleGenerator.java
@@ -1,0 +1,21 @@
+package org.apache.mesos.offer.constrain;
+
+import java.util.Collection;
+
+import org.apache.mesos.Protos.TaskInfo;
+
+/**
+ * Dynamically creates {@link PlacementRule}s which depend on the current deployed state of the
+ * system.
+ */
+public interface PlacementRuleGenerator {
+
+    /**
+     * Returns a new {@link PlacementRule} which defines where a task may be placed given the
+     * current deployed state of the system. The returned {@link PlacementRule} may then be tested
+     * against one or more {@link Offer}s to find offered resources which match the constraints.
+     *
+     * @param tasks all currently deployed tasks, against which the returned value is generated
+     */
+    public PlacementRule generate(Collection<TaskInfo> tasks);
+}

--- a/src/main/java/org/apache/mesos/offer/constrain/RoleRule.java
+++ b/src/main/java/org/apache/mesos/offer/constrain/RoleRule.java
@@ -1,0 +1,41 @@
+package org.apache.mesos.offer.constrain;
+
+import org.apache.mesos.Protos.Offer;
+import org.apache.mesos.Protos.Resource;
+
+/**
+ * Requires that the Offer's resources be assigned to a provided role.
+ */
+public class RoleRule implements PlacementRule {
+    private final String role;
+
+    public RoleRule(String role) {
+        this.role = role;
+    }
+
+    @Override
+    public Offer filter(Offer offer) {
+        Offer.Builder offerBuilder = offer.toBuilder().clearResources();
+        for (Resource resource : offer.getResourcesList()) {
+            // include only resources with matching role
+            if (resource.getRole().equals(role)) {
+                offerBuilder.addResources(resource);
+            }
+        }
+        return offerBuilder.build();
+    }
+
+    @Override
+    public String toString() {
+        return String.format("RoleRule{role=%s}", role);
+    }
+
+    /**
+     * A generator which returns a {@link RoleRule} for the provided role.
+     */
+    public static class Generator extends PassthroughGenerator {
+        public Generator(String role) {
+            super(new RoleRule(role));
+        }
+    }
+}

--- a/src/main/java/org/apache/mesos/offer/constrain/TaskTypeGenerator.java
+++ b/src/main/java/org/apache/mesos/offer/constrain/TaskTypeGenerator.java
@@ -1,0 +1,163 @@
+package org.apache.mesos.offer.constrain;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.mesos.Protos;
+import org.apache.mesos.Protos.TaskInfo;
+import org.apache.mesos.executor.DcosTaskConstants;
+import org.apache.mesos.offer.TaskUtils;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+
+/**
+ * This rule ensures that the given Offer is colocated with the specified task 'type', whose
+ * retrieval from the TaskInfo is defined by the developer's implementation of a
+ * {@link TaskTypeConverter}.
+ *
+ * For example, this can be used to colocate 'data' nodes with 'index' nodes, or to ensure that the
+ * two are never colocated.
+ */
+public class TaskTypeGenerator implements PlacementRuleGenerator {
+
+    /**
+     * Given a {@link TaskInfo}, returns a type string for that task. This must be implemented by
+     * the developer, or see {@link TaskIDDashConverter} for a sample implementation which expects
+     * task ids of the form "tasktypehere-0__uuid".
+     */
+    public interface TaskTypeConverter {
+        public String getTaskType(TaskInfo taskInfo);
+    }
+
+    /**
+     * Implementation of {@link TaskTypeConverter} which expects TaskIDs of the form
+     * "tasktypehere-0__uuid" => "tasktypehere".
+     *
+     * @see TaskUtils#toTaskType(org.apache.mesos.Protos.TaskID)
+     */
+    public static class TaskIDDashConverter implements TaskTypeConverter {
+        @Override
+        public String getTaskType(TaskInfo taskInfo) {
+            return TaskUtils.toTaskType(taskInfo.getTaskId());
+        }
+    }
+
+    /**
+     * Implementation of {@link TaskTypeConverter} which expects an envvar providing the task type
+     * named {@link DcosTaskConstants.TASK_TYPE}.
+     *
+     * @throws IllegalArgumentException if the provided task doesn't have TASK_TYPE in its env
+     */
+    public static class TaskEnvMapConverter implements TaskTypeConverter {
+        @Override
+        public String getTaskType(TaskInfo taskInfo) {
+            Protos.CommandInfo commandInfo;
+            try {
+                commandInfo = Protos.CommandInfo.parseFrom(taskInfo.getData());
+            } catch (InvalidProtocolBufferException e) {
+                throw new IllegalArgumentException(String.format(
+                        "Unable to extract CommandInfo from provided TaskInfo: %s", taskInfo), e);
+            }
+            for (Protos.Environment.Variable var : commandInfo.getEnvironment().getVariablesList()) {
+                if (var.getName().equals(DcosTaskConstants.TASK_TYPE)) {
+                    return var.getValue();
+                }
+            }
+            throw new IllegalArgumentException(String.format(
+                    "Unable to find environment variable named '%s' in commandInfo: %s",
+                    DcosTaskConstants.TASK_TYPE, commandInfo));
+        }
+    }
+
+    /**
+     * Returns a PlacementRuleGenerator which enforces avoidance of tasks which have the provided
+     * type. For example, this could be used to ensure that 'data' nodes are never colocated with
+     * 'index' nodes, or that 'data' nodes are never colocated with other 'data' nodes
+     * (self-avoidance). Note that this rule is unidirectional; mutual avoidance requires
+     * creating separate colocate rules for each direction.
+     *
+     * Unlike with {@link #createColocate(String, TaskTypeConverter)}, this will NOT throw a
+     * {@link StuckDeploymentException} if the task to avoid is missing from the cluster, as this
+     * may be expected in certain situations (eg mutual avoidance).
+     */
+    public static PlacementRuleGenerator createAvoid(
+            String typeToColocateWith, TaskTypeConverter typeConverter) {
+        return new TaskTypeGenerator(typeToColocateWith, typeConverter, BehaviorType.AVOID);
+    }
+
+    /**
+     * Returns a PlacementRuleGenerator which enforces colocation with tasks which have the provided
+     * type. For example, this could be used to ensure that 'data' nodes are always colocated with
+     * 'index' nodes. Note that this rule is unidirectional; mutual colocation requires
+     * creating separate colocate rules for each direction.
+     *
+     * Note that if the colocated task does not already exist in the cluster, this will just pick a
+     * random node. This behavior is to support defining mutual colocation: A colocates with B, and
+     * B colocates with A. In this case one of the two directions won't see anything to colocate
+     * with.
+     */
+    public static PlacementRuleGenerator createColocate(
+            String typeToColocateWith, TaskTypeConverter typeConverter) {
+        return new TaskTypeGenerator(typeToColocateWith, typeConverter, BehaviorType.COLOCATE);
+    }
+
+    /**
+     * The behavior to be used.
+     */
+    private enum BehaviorType {
+        COLOCATE,
+        AVOID
+    }
+
+    private final String typeToFind;
+    private final TaskTypeConverter typeConverter;
+    private final BehaviorType behaviorType;
+
+    private TaskTypeGenerator(
+            String typeToFind, TaskTypeConverter typeConverter, BehaviorType behaviorType) {
+        this.typeToFind = typeToFind;
+        this.typeConverter = typeConverter;
+        this.behaviorType = behaviorType;
+    }
+
+    @Override
+    public PlacementRule generate(Collection<TaskInfo> tasks) {
+        Set<String> agentsWithMatchingType = new HashSet<>();
+        for (TaskInfo task : tasks) {
+            if (typeToFind.equals(typeConverter.getTaskType(task))) {
+                // Matching task type found. Colocate with it on this agent.
+                agentsWithMatchingType.add(task.getSlaveId().getValue());
+            }
+        }
+
+        List<PlacementRule> agentRules = new ArrayList<>();
+        for (String agent : agentsWithMatchingType) {
+            agentRules.add(new AgentRule(agent));
+        }
+        switch (behaviorType) {
+        case COLOCATE:
+            if (agentRules.isEmpty()) {
+                // nothing to colocate with! fall back to picking whatever offer looks good.
+                // this is expected when the developer has configured bidirectional rules
+                // (A colocates with B + B colocates with A)
+                return new PassthroughRule();
+            } else {
+                return new OrRule(agentRules);
+            }
+        case AVOID:
+            if (agentRules.isEmpty()) {
+                // nothing to avoid, but this is expected when avoiding nodes of the same type
+                // (self-avoidance), or when the developer has configured bidirectional rules
+                // (A avoids B + B avoids A)
+                return new PassthroughRule();
+            } else {
+                return new NotRule(new OrRule(agentRules));
+            }
+        default:
+            throw new IllegalStateException("Unsupported behavior type: " + behaviorType);
+        }
+    }
+}

--- a/src/main/java/org/apache/mesos/offer/constrain/TaskTypeGenerator.java
+++ b/src/main/java/org/apache/mesos/offer/constrain/TaskTypeGenerator.java
@@ -75,6 +75,13 @@ public class TaskTypeGenerator implements PlacementRuleGenerator {
     }
 
     /**
+     * Calls {@link #createAvoid(String, TaskTypeConverter) with a {@link TaskEnvMapConverter}.
+     */
+    public static PlacementRuleGenerator createAvoid(String typeToColocateWith) {
+        return createAvoid(typeToColocateWith, new TaskEnvMapConverter());
+    }
+
+    /**
      * Returns a PlacementRuleGenerator which enforces colocation with tasks which have the provided
      * type. For example, this could be used to ensure that 'data' nodes are always colocated with
      * 'index' nodes. Note that this rule is unidirectional; mutual colocation requires
@@ -88,6 +95,13 @@ public class TaskTypeGenerator implements PlacementRuleGenerator {
     public static PlacementRuleGenerator createColocate(
             String typeToColocateWith, TaskTypeConverter typeConverter) {
         return new TaskTypeGenerator(typeToColocateWith, typeConverter, BehaviorType.COLOCATE);
+    }
+
+    /**
+     * Calls {@link #createColocate(String, TaskTypeConverter) with a {@link TaskEnvMapConverter}.
+     */
+    public static PlacementRuleGenerator createColocate(String typeToColocateWith) {
+        return createColocate(typeToColocateWith, new TaskEnvMapConverter());
     }
 
     /**

--- a/src/main/java/org/apache/mesos/offer/constrain/TaskTypeGenerator.java
+++ b/src/main/java/org/apache/mesos/offer/constrain/TaskTypeGenerator.java
@@ -9,7 +9,6 @@ import java.util.Set;
 import org.apache.mesos.Protos;
 import org.apache.mesos.Protos.TaskInfo;
 import org.apache.mesos.executor.DcosTaskConstants;
-import org.apache.mesos.offer.TaskUtils;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 
@@ -30,19 +29,6 @@ public class TaskTypeGenerator implements PlacementRuleGenerator {
      */
     public interface TaskTypeConverter {
         public String getTaskType(TaskInfo taskInfo);
-    }
-
-    /**
-     * Implementation of {@link TaskTypeConverter} which expects TaskIDs of the form
-     * "tasktypehere-0__uuid" => "tasktypehere".
-     *
-     * @see TaskUtils#toTaskType(org.apache.mesos.Protos.TaskID)
-     */
-    public static class TaskIDDashConverter implements TaskTypeConverter {
-        @Override
-        public String getTaskType(TaskInfo taskInfo) {
-            return TaskUtils.toTaskType(taskInfo.getTaskId());
-        }
     }
 
     /**

--- a/src/main/java/org/apache/mesos/offer/constrain/TaskTypeGenerator.java
+++ b/src/main/java/org/apache/mesos/offer/constrain/TaskTypeGenerator.java
@@ -143,7 +143,8 @@ public class TaskTypeGenerator implements PlacementRuleGenerator {
                 // nothing to colocate with! fall back to picking whatever offer looks good.
                 // this is expected when the developer has configured bidirectional rules
                 // (A colocates with B + B colocates with A)
-                return new PassthroughRule();
+                return new PassthroughRule(
+                        String.format("no tasks of type '%s' to colocate with", typeToFind));
             } else {
                 return new OrRule(agentRules);
             }
@@ -152,7 +153,8 @@ public class TaskTypeGenerator implements PlacementRuleGenerator {
                 // nothing to avoid, but this is expected when avoiding nodes of the same type
                 // (self-avoidance), or when the developer has configured bidirectional rules
                 // (A avoids B + B avoids A)
-                return new PassthroughRule();
+                return new PassthroughRule(
+                        String.format("no tasks of type '%s' to avoid", typeToFind));
             } else {
                 return new NotRule(new OrRule(agentRules));
             }

--- a/src/main/java/org/apache/mesos/scheduler/DefaultScheduler.java
+++ b/src/main/java/org/apache/mesos/scheduler/DefaultScheduler.java
@@ -121,7 +121,8 @@ public class DefaultScheduler implements Scheduler {
 
     private void initializeDeploymentPlan() {
         logger.info("Initializing deployment plan");
-        planScheduler = new DefaultPlanScheduler(offerAccepter, taskKiller);
+        planScheduler = new DefaultPlanScheduler(
+                offerAccepter, new OfferEvaluator(stateStore), taskKiller);
         PlanSpecification planSpecification =
                 new DefaultPlanSpecificationFactory().getPlanSpecification(serviceSpecification);
 

--- a/src/main/java/org/apache/mesos/scheduler/plan/DefaultPlanScheduler.java
+++ b/src/main/java/org/apache/mesos/scheduler/plan/DefaultPlanScheduler.java
@@ -22,10 +22,6 @@ public class DefaultPlanScheduler implements PlanScheduler {
     private final TaskKiller taskKiller;
 
     @Inject
-    public DefaultPlanScheduler(OfferAccepter offerAccepter, TaskKiller taskKiller) {
-        this(offerAccepter, new OfferEvaluator(), taskKiller);
-    }
-
     public DefaultPlanScheduler(OfferAccepter offerAccepter, OfferEvaluator offerEvaluator, TaskKiller taskKiller) {
         this.offerAccepter = offerAccepter;
         this.offerEvaluator = offerEvaluator;

--- a/src/main/java/org/apache/mesos/scheduler/recovery/DefaultRecoveryScheduler.java
+++ b/src/main/java/org/apache/mesos/scheduler/recovery/DefaultRecoveryScheduler.java
@@ -100,7 +100,7 @@ public class DefaultRecoveryScheduler {
 
         if (recoveryRequirement.isPresent() && launchConstrainer.canLaunch(recoveryRequirement.get())) {
             log.info("Preparing to launch task");
-            OfferEvaluator offerEvaluator = new OfferEvaluator();
+            OfferEvaluator offerEvaluator = new OfferEvaluator(stateStore);
             List<OfferRecommendation> recommendations =
                     offerEvaluator.evaluate(recoveryRequirement.get().getOfferRequirement(), offers);
             List<Operation> launchOperations = recommendations.stream()

--- a/src/main/java/org/apache/mesos/specification/DefaultTaskSpecification.java
+++ b/src/main/java/org/apache/mesos/specification/DefaultTaskSpecification.java
@@ -2,6 +2,7 @@ package org.apache.mesos.specification;
 
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import org.apache.mesos.Protos;
+import org.apache.mesos.offer.TaskUtils;
 import org.apache.mesos.offer.ValueUtils;
 import org.apache.mesos.protobuf.DefaultVolumeSpecification;
 import org.slf4j.Logger;
@@ -30,7 +31,7 @@ public class DefaultTaskSpecification implements TaskSpecification {
 
     public static DefaultTaskSpecification create(TaskTypeSpecification taskTypeSpecification, int index) {
         return new DefaultTaskSpecification(
-                taskTypeSpecification.getName() + "-" + index,
+                TaskUtils.toTaskName(taskTypeSpecification.getName(), index),
                 taskTypeSpecification.getCommand(index),
                 taskTypeSpecification.getResources(),
                 taskTypeSpecification.getVolumes());

--- a/src/main/java/org/apache/mesos/specification/DefaultTaskTypeSpecification.java
+++ b/src/main/java/org/apache/mesos/specification/DefaultTaskTypeSpecification.java
@@ -2,8 +2,10 @@ package org.apache.mesos.specification;
 
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import org.apache.mesos.Protos;
+import org.apache.mesos.offer.constrain.PlacementRuleGenerator;
 
 import java.util.Collection;
+import java.util.Optional;
 
 /**
  * This class provides a default implementation of the TaskTypeSpecification interface.
@@ -14,18 +16,21 @@ public class DefaultTaskTypeSpecification implements TaskTypeSpecification {
     private final Protos.CommandInfo command;
     private final Collection<ResourceSpecification> resources;
     private final Collection<VolumeSpecification> volumes;
+    private final Optional<PlacementRuleGenerator> placementOptional;
 
     public DefaultTaskTypeSpecification(
             int count,
             String name,
             Protos.CommandInfo command,
             Collection<ResourceSpecification> resources,
-            Collection<VolumeSpecification> volumes) {
+            Collection<VolumeSpecification> volumes,
+            Optional<PlacementRuleGenerator> placementOptional) {
         this.count = count;
         this.name = name;
         this.command = command;
         this.resources = resources;
         this.volumes = volumes;
+        this.placementOptional = placementOptional;
     }
 
     @Override
@@ -51,6 +56,11 @@ public class DefaultTaskTypeSpecification implements TaskTypeSpecification {
     @Override
     public Collection<VolumeSpecification> getVolumes() {
         return volumes;
+    }
+
+    @Override
+    public Optional<PlacementRuleGenerator> getPlacement() {
+        return placementOptional;
     }
 
     @Override

--- a/src/main/java/org/apache/mesos/specification/TaskSpecification.java
+++ b/src/main/java/org/apache/mesos/specification/TaskSpecification.java
@@ -1,15 +1,50 @@
 package org.apache.mesos.specification;
 
 import org.apache.mesos.Protos;
+import org.apache.mesos.offer.constrain.PlacementRuleGenerator;
 
 import java.util.Collection;
+import java.util.Optional;
 
 /**
  * A TaskSpecification is a simplified description of a Mesos Task.
  */
 public interface TaskSpecification {
+
+    /**
+     * Returns the name of this task. Eg "index-3" for the fourth index node or "data-0" for the
+     * first data node.
+     */
     String getName();
+
+    /**
+     * Returns the Mesos {@code CommandInfo} to be used for the starting task.
+     */
     Protos.CommandInfo getCommand();
+
+    /**
+     * Returns the contanier resources required by tasks of this type, or an empty list if no
+     * container resources are necessary. In practice you probably want something here.
+     *
+     * See the documentation for {@link ResourceSpecification} for more information.
+     */
     Collection<ResourceSpecification> getResources();
+
+    /**
+     * Returns the persistent volumes required for this task, or an empty list if no persistent
+     * volumes are necessary, eg when not using persistent volumes.
+     *
+     * See the documentation for {@link VolumeSpecification} for more information.
+     */
     Collection<VolumeSpecification> getVolumes();
+
+    /**
+     * Returns the placement constraint for this task type. This can be anything from "colocate with
+     * another type", "ensure instances are only launched on nodes with attribute X", etc. This may
+     * return an empty {@code Optional} if no specific placement rules are applicable.
+     *
+     * See the documentation for {@link PlacementRuleGenerator} and {@link PlacementRule} for more
+     * information.
+     */
+    Optional<PlacementRuleGenerator> getPlacement();
 }

--- a/src/main/java/org/apache/mesos/specification/TaskTypeSpecification.java
+++ b/src/main/java/org/apache/mesos/specification/TaskTypeSpecification.java
@@ -1,16 +1,57 @@
 package org.apache.mesos.specification;
 
 import org.apache.mesos.Protos;
+import org.apache.mesos.offer.constrain.PlacementRuleGenerator;
 
 import java.util.Collection;
+import java.util.Optional;
 
 /**
  * A TaskTypeSpecification describes a Type of Task and how many should be launched.
  */
 public interface TaskTypeSpecification {
+
+    /**
+     * Returns the number of tasks of this type to be deployed.
+     */
     int getCount();
+
+    /**
+     * Returns the name of this task type. Eg "index" for an index node type or "data" for a data
+     * node type.
+     */
     String getName();
+
+    /**
+     * Returns the Mesos {@code CommandInfo} to be used for starting the task with index {@code id}.
+     * The {@code id} parameter allows slightly different commands for different tasks of the same
+     * type.
+     */
     Protos.CommandInfo getCommand(int id);
+
+    /**
+     * Returns the contanier resources required by tasks of this type, or an empty list if no
+     * container resources are necessary. But you probably want something here.
+     *
+     * See the documentation for {@link ResourceSpecification} for more information.
+     */
     Collection<ResourceSpecification> getResources();
+
+    /**
+     * Returns the persistent volumes required by tasks of this type, or an empty list if no
+     * persistent volumes are necessary, eg when not using persistent volumes.
+     *
+     * See the documentation for {@link VolumeSpecification} for more information.
+     */
     Collection<VolumeSpecification> getVolumes();
+
+    /**
+     * Returns the placement constraint for this task type. This can be anything from "colocate with
+     * another type", "ensure instances are only launched on nodes with attribute X", etc. This may
+     * return an empty {@code Optional} if no specific placement rules are applicable.
+     *
+     * See the documentation for {@link PlacementRuleGenerator} and {@link PlacementRule} for more
+     * information.
+     */
+    Optional<PlacementRuleGenerator> getPlacement();
 }

--- a/src/test/java/org/apache/mesos/offer/AttributeStringUtilsTest.java
+++ b/src/test/java/org/apache/mesos/offer/AttributeStringUtilsTest.java
@@ -1,0 +1,195 @@
+package org.apache.mesos.offer;
+
+import org.apache.mesos.Protos.Attribute;
+import org.apache.mesos.Protos.Value.Type;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for {@link AttributeStringUtils}.
+ *
+ * Samples:
+ * --resources='cpus:24;gpus:2;mem:24576;disk:409600;ports:[21000-24000,30000-34000];bugs(debug_role):{a,b,c}'
+ * --attributes='rack:abc;zone:west;os:centos5;level:10;keys:[1000-1500]'
+ */
+public class AttributeStringUtilsTest {
+
+    @Test
+    public void testRangeAttributeString() {
+        Attribute.Builder attr = Attribute.newBuilder().setType(Type.RANGES).setName("ram");
+        attr.getRangesBuilder().addRangeBuilder().setBegin(1).setEnd(2);
+        assertEquals("ram:[1-2]", AttributeStringUtils.toString(attr.build()));
+
+        attr = Attribute.newBuilder().setType(Type.RANGES).setName("ports");
+        attr.getRangesBuilder().addRangeBuilder().setBegin(1).setEnd(2);
+        attr.getRangesBuilder().addRangeBuilder().setBegin(-321).setEnd(-123);
+        attr.getRangesBuilder().addRangeBuilder().setBegin(21000).setEnd(24000);
+        attr.getRangesBuilder().addRangeBuilder().setBegin(0).setEnd(0);
+        attr.getRangesBuilder().addRangeBuilder().setBegin(30000).setEnd(34000);
+        attr.getRangesBuilder().addRangeBuilder().setBegin(321).setEnd(123);
+        assertEquals("ports:[1-2,-321--123,21000-24000,0-0,30000-34000,321-123]",
+                AttributeStringUtils.toString(attr.build()));
+
+        attr = Attribute.newBuilder().setType(Type.RANGES).setName("ram");
+        attr.getRangesBuilder().addRangeBuilder().setBegin(0).setEnd(0);
+        assertEquals("ram:[0-0]", AttributeStringUtils.toString(attr.build()));
+
+        attr = Attribute.newBuilder().setType(Type.RANGES).setName("disk");
+        attr.getRangesBuilder().addRangeBuilder().setBegin(-321).setEnd(-123);
+        assertEquals("disk:[-321--123]", AttributeStringUtils.toString(attr.build()));
+
+        attr = Attribute.newBuilder().setType(Type.RANGES).setName("");
+        attr.getRangesBuilder().addRangeBuilder().setBegin(-321).setEnd(-123);
+        assertEquals(":[-321--123]", AttributeStringUtils.toString(attr.build()));
+
+        attr = Attribute.newBuilder().setType(Type.RANGES).setName("empty");
+        assertEquals("empty:[]", AttributeStringUtils.toString(attr.build()));
+
+        attr = Attribute.newBuilder().setType(Type.RANGES).setName("");
+        assertEquals(":[]", AttributeStringUtils.toString(attr.build()));
+    }
+
+    @Test
+    public void testScalarAttributeString() {
+        Attribute.Builder attr = Attribute.newBuilder().setType(Type.SCALAR).setName("ram");
+        attr.getScalarBuilder().setValue(0);
+        assertEquals("ram:0.000", AttributeStringUtils.toString(attr.build()));
+
+        attr = Attribute.newBuilder().setType(Type.SCALAR).setName("ports");
+        attr.getScalarBuilder().setValue(0.000);
+        assertEquals("ports:0.000", AttributeStringUtils.toString(attr.build()));
+
+        attr = Attribute.newBuilder().setType(Type.SCALAR).setName("ports");
+        attr.getScalarBuilder().setValue(0.0001);
+        assertEquals("ports:0.000", AttributeStringUtils.toString(attr.build()));
+
+        attr = Attribute.newBuilder().setType(Type.SCALAR).setName("ports");
+        attr.getScalarBuilder().setValue(0.0005);
+        assertEquals("ports:0.001", AttributeStringUtils.toString(attr.build()));
+
+        attr = Attribute.newBuilder().setType(Type.SCALAR).setName("rounddown");
+        attr.getScalarBuilder().setValue(-1.99999);
+        assertEquals("rounddown:-2.000", AttributeStringUtils.toString(attr.build()));
+
+        attr = Attribute.newBuilder().setType(Type.SCALAR).setName("roundup1");
+        attr.getScalarBuilder().setValue(1.99999);
+        assertEquals("roundup1:2.000", AttributeStringUtils.toString(attr.build()));
+
+        attr = Attribute.newBuilder().setType(Type.SCALAR).setName("");
+        attr.getScalarBuilder().setValue(1.99999);
+        assertEquals(":2.000", AttributeStringUtils.toString(attr.build()));
+
+        attr = Attribute.newBuilder().setType(Type.SCALAR).setName("roundup2");
+        attr.getScalarBuilder().setValue(999999.99999);
+        assertEquals("roundup2:1000000.000", AttributeStringUtils.toString(attr.build()));
+
+        attr = Attribute.newBuilder().setType(Type.SCALAR).setName("empty");
+        assertEquals("empty:0.000", AttributeStringUtils.toString(attr.build()));
+
+        attr = Attribute.newBuilder().setType(Type.SCALAR).setName("");
+        assertEquals(":0.000", AttributeStringUtils.toString(attr.build()));
+    }
+
+    @Test
+    public void testSetAttributeString() {
+        Attribute.Builder attr = Attribute.newBuilder().setType(Type.SET).setName("ram");
+        attr.getSetBuilder().addItem("");
+        assertEquals("ram:{}", AttributeStringUtils.toString(attr.build()));
+
+        attr = Attribute.newBuilder().setType(Type.SET).setName("ports");
+        attr.getSetBuilder().addItem("a").addItem("b").addItem("c");
+        assertEquals("ports:{a,b,c}", AttributeStringUtils.toString(attr.build()));
+
+        attr = Attribute.newBuilder().setType(Type.SET).setName("disk");
+        attr.getSetBuilder().addItem("-1").addItem("-2");
+        assertEquals("disk:{-1,-2}", AttributeStringUtils.toString(attr.build()));
+
+        attr = Attribute.newBuilder().setType(Type.SET).setName("");
+        attr.getSetBuilder().addItem("-1").addItem("-2");
+        assertEquals(":{-1,-2}", AttributeStringUtils.toString(attr.build()));
+
+        attr = Attribute.newBuilder().setType(Type.SET).setName("empty");
+        assertEquals("empty:{}", AttributeStringUtils.toString(attr.build()));
+
+        attr = Attribute.newBuilder().setType(Type.SET).setName("");
+        assertEquals(":{}", AttributeStringUtils.toString(attr.build()));
+    }
+
+    @Test
+    public void testTextAttributeString() {
+        Attribute.Builder attr = Attribute.newBuilder().setType(Type.TEXT).setName("ram");
+        attr.getTextBuilder().setValue(":::");
+        assertEquals("ram::::", AttributeStringUtils.toString(attr.build()));
+
+        attr = Attribute.newBuilder().setType(Type.TEXT).setName("ram");
+        attr.getTextBuilder().setValue("abc");
+        assertEquals("ram:abc", AttributeStringUtils.toString(attr.build()));
+
+        attr = Attribute.newBuilder().setType(Type.TEXT).setName("");
+        attr.getTextBuilder().setValue("123");
+        assertEquals(":" + "123", AttributeStringUtils.toString(attr.build()));
+
+        attr = Attribute.newBuilder().setType(Type.TEXT).setName("empty");
+        assertEquals("empty:", AttributeStringUtils.toString(attr.build()));
+
+        attr = Attribute.newBuilder().setType(Type.TEXT).setName("");
+        assertEquals(":", AttributeStringUtils.toString(attr.build()));
+    }
+
+    @Test
+    public void testMixedAttributeStrings() {
+        List<Attribute> attrs = new ArrayList<>();
+        assertEquals("", AttributeStringUtils.toString(attrs));
+
+        Attribute.Builder attr = Attribute.newBuilder().setType(Type.TEXT).setName("ram");
+        attr.getTextBuilder().setValue("");
+        attrs.add(attr.build());
+        assertEquals("ram:", AttributeStringUtils.toString(attrs));
+
+        attr = Attribute.newBuilder().setType(Type.SET).setName("ports");
+        attr.getSetBuilder().addItem("a").addItem("b").addItem("c");
+        attrs.add(attr.build());
+        assertEquals("ram:;ports:{a,b,c}", AttributeStringUtils.toString(attrs));
+
+        attr = Attribute.newBuilder().setType(Type.SCALAR).setName("roundup1");
+        attr.getScalarBuilder().setValue(1.99999);
+        attrs.add(attr.build());
+        assertEquals("ram:;ports:{a,b,c};roundup1:2.000", AttributeStringUtils.toString(attrs));
+
+        attr = Attribute.newBuilder().setType(Type.RANGES).setName("disk");
+        attr.getRangesBuilder().addRangeBuilder().setBegin(-321).setEnd(-123);
+        attrs.add(attr.build());
+        assertEquals("ram:;ports:{a,b,c};roundup1:2.000;disk:[-321--123]", AttributeStringUtils.toString(attrs));
+    }
+
+    @Test
+    public void testSplitAttributeString() {
+        assertTrue(AttributeStringUtils.toStringList("").isEmpty());
+
+        List<String> strs = AttributeStringUtils.toStringList(
+                "cpus:24;gpus:2;mem:24576;disk:409600;ports:[21000-24000,30000-34000];bugs(debug_role):{a,b,c}");
+        List<String> expect = new ArrayList<>();
+        expect.add("cpus:24");
+        expect.add("gpus:2");
+        expect.add("mem:24576");
+        expect.add("disk:409600");
+        expect.add("ports:[21000-24000,30000-34000]");
+        expect.add("bugs(debug_role):{a,b,c}");
+        assertEquals(expect, strs);
+
+        strs = AttributeStringUtils.toStringList(
+                "rack:abc;zone:west;os:centos5;level:10;keys:[1000-1500]");
+        expect.clear();
+        expect.add("rack:abc");
+        expect.add("zone:west");
+        expect.add("os:centos5");
+        expect.add("level:10");
+        expect.add("keys:[1000-1500]");
+        assertEquals(expect, strs);
+    }
+}

--- a/src/test/java/org/apache/mesos/offer/OfferRequirementTest.java
+++ b/src/test/java/org/apache/mesos/offer/OfferRequirementTest.java
@@ -92,8 +92,7 @@ public class OfferRequirementTest {
         TaskInfo taskInfo = TaskTestUtils.getTaskInfo(cpu);
         ExecutorInfo execInfo = TaskTestUtils.getExecutorInfo(cpu);
         OfferRequirement offerRequirement = new OfferRequirement(Arrays.asList(taskInfo), Optional.of(execInfo));
-        Resource executorResource = offerRequirement
-                .getExecutorRequirement()
+        Resource executorResource = offerRequirement.getExecutorRequirement().get()
                 .getExecutorInfo()
                 .getResourcesList()
                 .get(0);

--- a/src/test/java/org/apache/mesos/offer/constrain/AgentRuleTest.java
+++ b/src/test/java/org/apache/mesos/offer/constrain/AgentRuleTest.java
@@ -1,0 +1,103 @@
+package org.apache.mesos.offer.constrain;
+
+import org.apache.mesos.Protos.Offer;
+import org.apache.mesos.testutils.OfferTestUtils;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Collections;
+
+/**
+ * Tests for {@link AgentRule}.
+ */
+public class AgentRuleTest {
+    private static final String AGENT_1 = "agent-1-uuid";
+    private static final String AGENT_2 = "agent-2-uuid";
+    private static final String AGENT_3 = "agent-3-uuid";
+
+    @Test
+    public void testColocateAgent() {
+        PlacementRule rule = new AgentRule.ColocateAgentGenerator(AGENT_1).generate(Collections.emptyList());
+        Offer filtered = rule.filter(offerWithAgent(AGENT_1));
+        assertEquals(3, filtered.getResourcesCount());
+        filtered = rule.filter(offerWithAgent(AGENT_2));
+        assertEquals(0, filtered.getResourcesCount());
+        filtered = rule.filter(offerWithAgent(AGENT_3));
+        assertEquals(0, filtered.getResourcesCount());
+
+        rule = new AgentRule.ColocateAgentGenerator(AGENT_2).generate(Collections.emptyList());
+        filtered = rule.filter(offerWithAgent(AGENT_1));
+        assertEquals(0, filtered.getResourcesCount());
+        filtered = rule.filter(offerWithAgent(AGENT_2));
+        assertEquals(3, filtered.getResourcesCount());
+        filtered = rule.filter(offerWithAgent(AGENT_3));
+        assertEquals(0, filtered.getResourcesCount());
+    }
+
+    @Test
+    public void testAvoidAgent() {
+        PlacementRule rule = new AgentRule.AvoidAgentGenerator(AGENT_1).generate(Collections.emptyList());
+        Offer filtered = rule.filter(offerWithAgent(AGENT_1));
+        assertEquals(0, filtered.getResourcesCount());
+        filtered = rule.filter(offerWithAgent(AGENT_2));
+        assertEquals(3, filtered.getResourcesCount());
+        filtered = rule.filter(offerWithAgent(AGENT_3));
+        assertEquals(3, filtered.getResourcesCount());
+
+        rule = new AgentRule.AvoidAgentGenerator(AGENT_2).generate(Collections.emptyList());
+        filtered = rule.filter(offerWithAgent(AGENT_1));
+        assertEquals(3, filtered.getResourcesCount());
+        filtered = rule.filter(offerWithAgent(AGENT_2));
+        assertEquals(0, filtered.getResourcesCount());
+        filtered = rule.filter(offerWithAgent(AGENT_3));
+        assertEquals(3, filtered.getResourcesCount());
+    }
+
+    @Test
+    public void testColocateAgents() {
+        PlacementRule rule = new AgentRule.ColocateAgentsGenerator(AGENT_1, AGENT_3).generate(Collections.emptyList());
+        Offer filtered = rule.filter(offerWithAgent(AGENT_1));
+        assertEquals(3, filtered.getResourcesCount());
+        filtered = rule.filter(offerWithAgent(AGENT_2));
+        assertEquals(0, filtered.getResourcesCount());
+        filtered = rule.filter(offerWithAgent(AGENT_3));
+        assertEquals(3, filtered.getResourcesCount());
+
+        rule = new AgentRule.ColocateAgentsGenerator(AGENT_2, AGENT_3).generate(Collections.emptyList());
+        filtered = rule.filter(offerWithAgent(AGENT_1));
+        assertEquals(0, filtered.getResourcesCount());
+        filtered = rule.filter(offerWithAgent(AGENT_2));
+        assertEquals(3, filtered.getResourcesCount());
+        filtered = rule.filter(offerWithAgent(AGENT_3));
+        assertEquals(3, filtered.getResourcesCount());
+    }
+
+    @Test
+    public void testAvoidAgents() {
+        PlacementRule rule = new AgentRule.AvoidAgentsGenerator(AGENT_1, AGENT_3).generate(Collections.emptyList());
+        Offer filtered = rule.filter(offerWithAgent(AGENT_1));
+        assertEquals(0, filtered.getResourcesCount());
+        filtered = rule.filter(offerWithAgent(AGENT_2));
+        assertEquals(3, filtered.getResourcesCount());
+        filtered = rule.filter(offerWithAgent(AGENT_3));
+        assertEquals(0, filtered.getResourcesCount());
+
+        rule = new AgentRule.AvoidAgentsGenerator(AGENT_2, AGENT_3).generate(Collections.emptyList());
+        filtered = rule.filter(offerWithAgent(AGENT_1));
+        assertEquals(3, filtered.getResourcesCount());
+        filtered = rule.filter(offerWithAgent(AGENT_2));
+        assertEquals(0, filtered.getResourcesCount());
+        filtered = rule.filter(offerWithAgent(AGENT_3));
+        assertEquals(0, filtered.getResourcesCount());
+    }
+
+    private static Offer offerWithAgent(String agentId) {
+        Offer.Builder o = OfferTestUtils.getEmptyOfferBuilder();
+        o.getSlaveIdBuilder().setValue(agentId);
+        OfferTestUtils.addResource(o, "a");
+        OfferTestUtils.addResource(o, "b");
+        OfferTestUtils.addResource(o, "c");
+        return o.build();
+    }
+}

--- a/src/test/java/org/apache/mesos/offer/constrain/AndRuleTest.java
+++ b/src/test/java/org/apache/mesos/offer/constrain/AndRuleTest.java
@@ -1,0 +1,207 @@
+package org.apache.mesos.offer.constrain;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+import org.apache.mesos.Protos.Offer;
+import org.apache.mesos.Protos.Resource;
+import org.apache.mesos.Protos.Value;
+import org.apache.mesos.testutils.OfferTestUtils;
+
+/**
+ * Tests for {@link AndRule}.
+ */
+public class AndRuleTest {
+
+    private static final Resource RESOURCE_1;
+    private static final Resource RESOURCE_2;
+    private static final Resource RESOURCE_3;
+    private static final Resource RESOURCE_4;
+
+    private static final Collection<Resource> RESOURCES;
+
+    static {
+        Resource.Builder b = Resource.newBuilder().setName("1").setType(Value.Type.RANGES);
+        b.getRangesBuilder().addRangeBuilder().setBegin(5).setEnd(6);
+        b.getRangesBuilder().addRangeBuilder().setBegin(10).setEnd(12);
+        RESOURCE_1 = b.build();
+
+        b = Resource.newBuilder().setName("2").setType(Value.Type.SCALAR);
+        b.getScalarBuilder().setValue(123.456);
+        RESOURCE_2 = b.build();
+
+        b = Resource.newBuilder().setName("3").setType(Value.Type.SET);
+        b.getSetBuilder().addItem("foo").addItem("bar").addItem("baz");
+        RESOURCE_3 = b.build();
+
+        b = Resource.newBuilder().setName("4").setType(Value.Type.RANGES);
+        b.getRangesBuilder().addRangeBuilder().setBegin(7).setEnd(8);
+        b.getRangesBuilder().addRangeBuilder().setBegin(10).setEnd(12);
+        RESOURCE_4 = b.build();
+
+        RESOURCES = Arrays.asList(RESOURCE_1, RESOURCE_2, RESOURCE_3, RESOURCE_4);
+    }
+
+    private static final PlacementRule ALL = new PlacementRule() {
+        @Override
+        public Offer filter(Offer offer) {
+            return offer;
+        }
+    };
+    private static final PlacementRule NONE = new PlacementRule() {
+        @Override
+        public Offer filter(Offer offer) {
+            return offer.toBuilder().clearResources().build();
+        }
+    };
+    private static final PlacementRule REMOVE_FIRST = new PlacementRule() {
+        @Override
+        public Offer filter(Offer offer) {
+            if (offer.getResourcesCount() == 0) {
+                return offer;
+            }
+            return offer.toBuilder().removeResources(0).build();
+        }
+    };
+    private static final PlacementRule REMOVE_LAST = new PlacementRule() {
+        @Override
+        public Offer filter(Offer offer) {
+            int count = offer.getResourcesCount();
+            if (count == 0) {
+                return offer;
+            }
+            return offer.toBuilder().removeResources(count - 1).build();
+        }
+    };
+
+    @Test
+    public void testEmpty() {
+        Offer o = new AndRule().filter(offerWith(RESOURCES));
+        assertTrue(o.getResourcesList().isEmpty());
+    }
+
+    @Test
+    public void testAllPass() {
+        Offer o = new AndRule(ALL).filter(offerWith(RESOURCES));
+        assertEquals(offerWith(RESOURCES), o);
+
+        o = new AndRule(ALL, ALL, ALL).filter(offerWith(RESOURCES));
+        assertEquals(offerWith(RESOURCES), o);
+    }
+
+    @Test
+    public void testAllFail() {
+        Offer o = new AndRule(NONE).filter(offerWith(RESOURCES));
+        assertTrue(o.getResourcesList().isEmpty());
+
+        o = new AndRule(NONE, ALL).filter(offerWith(RESOURCES));
+        assertTrue(o.getResourcesList().isEmpty());
+
+        o = new AndRule(ALL, NONE).filter(offerWith(RESOURCES));
+        assertTrue(o.getResourcesList().isEmpty());
+
+        o = new AndRule(NONE, NONE).filter(offerWith(RESOURCES));
+        assertTrue(o.getResourcesList().isEmpty());
+
+        o = new AndRule(NONE, ALL, NONE).filter(offerWith(RESOURCES));
+        assertTrue(o.getResourcesList().isEmpty());
+
+        o = new AndRule(ALL, NONE, ALL).filter(offerWith(RESOURCES));
+        assertTrue(o.getResourcesList().isEmpty());
+
+        o = new AndRule(NONE, NONE, NONE).filter(offerWith(RESOURCES));
+        assertTrue(o.getResourcesList().isEmpty());
+    }
+
+    @Test
+    public void testFirstRemoved() {
+        Offer o = new AndRule(REMOVE_FIRST).filter(offerWith(RESOURCES));
+        assertEquals(offerWith(RESOURCE_2, RESOURCE_3, RESOURCE_4), o);
+
+        o = new AndRule(REMOVE_FIRST, ALL).filter(offerWith(RESOURCES));
+        assertEquals(offerWith(RESOURCE_2, RESOURCE_3, RESOURCE_4), o);
+
+        o = new AndRule(ALL, REMOVE_FIRST).filter(offerWith(RESOURCES));
+        assertEquals(offerWith(RESOURCE_2, RESOURCE_3, RESOURCE_4), o);
+
+        o = new AndRule(REMOVE_FIRST, REMOVE_FIRST).filter(offerWith(RESOURCES));
+        assertEquals(offerWith(RESOURCE_2, RESOURCE_3, RESOURCE_4), o);
+
+        o = new AndRule(REMOVE_FIRST, ALL, REMOVE_FIRST).filter(offerWith(RESOURCES));
+        assertEquals(offerWith(RESOURCE_2, RESOURCE_3, RESOURCE_4), o);
+
+        o = new AndRule(ALL, REMOVE_FIRST, ALL).filter(offerWith(RESOURCES));
+        assertEquals(offerWith(RESOURCE_2, RESOURCE_3, RESOURCE_4), o);
+
+        o = new AndRule(REMOVE_FIRST, REMOVE_FIRST, REMOVE_FIRST).filter(offerWith(RESOURCES));
+        assertEquals(offerWith(RESOURCE_2, RESOURCE_3, RESOURCE_4), o);
+    }
+
+    @Test
+    public void testLastRemoved() {
+        Offer o = new AndRule(REMOVE_LAST).filter(offerWith(RESOURCES));
+        assertEquals(offerWith(RESOURCE_1, RESOURCE_2, RESOURCE_3), o);
+
+        o = new AndRule(REMOVE_LAST, ALL).filter(offerWith(RESOURCES));
+        assertEquals(offerWith(RESOURCE_1, RESOURCE_2, RESOURCE_3), o);
+
+        o = new AndRule(ALL, REMOVE_LAST).filter(offerWith(RESOURCES));
+        assertEquals(offerWith(RESOURCE_1, RESOURCE_2, RESOURCE_3), o);
+
+        o = new AndRule(REMOVE_LAST, REMOVE_LAST).filter(offerWith(RESOURCES));
+        assertEquals(offerWith(RESOURCE_1, RESOURCE_2, RESOURCE_3), o);
+
+        o = new AndRule(REMOVE_LAST, ALL, REMOVE_LAST).filter(offerWith(RESOURCES));
+        assertEquals(offerWith(RESOURCE_1, RESOURCE_2, RESOURCE_3), o);
+
+        o = new AndRule(ALL, REMOVE_LAST, ALL).filter(offerWith(RESOURCES));
+        assertEquals(offerWith(RESOURCE_1, RESOURCE_2, RESOURCE_3), o);
+
+        o = new AndRule(REMOVE_LAST, REMOVE_LAST, REMOVE_LAST).filter(offerWith(RESOURCES));
+        assertEquals(offerWith(RESOURCE_1, RESOURCE_2, RESOURCE_3), o);
+    }
+
+    @Test
+    public void testFirstLastRemoved() {
+        Offer o = new AndRule(REMOVE_LAST, REMOVE_FIRST, ALL).filter(offerWith(RESOURCES));
+        assertEquals(offerWith(RESOURCE_2, RESOURCE_3), o);
+
+        o = new AndRule(REMOVE_FIRST, ALL, REMOVE_LAST).filter(offerWith(RESOURCES));
+        assertEquals(offerWith(RESOURCE_2, RESOURCE_3), o);
+
+        o = new AndRule(REMOVE_LAST, REMOVE_FIRST).filter(offerWith(RESOURCES));
+        assertEquals(offerWith(RESOURCE_2, RESOURCE_3), o);
+
+        o = new AndRule(REMOVE_FIRST, REMOVE_LAST, REMOVE_FIRST, REMOVE_LAST).filter(offerWith(RESOURCES));
+        assertEquals(offerWith(RESOURCE_2, RESOURCE_3), o);
+    }
+
+    @Test
+    public void testGenerator() {
+        PlacementRule r = new AndRule.Generator(
+                new PassthroughGenerator(REMOVE_LAST),
+                new PassthroughGenerator(REMOVE_FIRST),
+                new PassthroughGenerator(ALL))
+                .generate(Collections.emptyList());
+        Offer o = r.filter(offerWith(RESOURCES));
+        assertEquals(r.toString(), offerWith(RESOURCE_2, RESOURCE_3), o);
+    }
+
+    private static Offer offerWith(Collection<Resource> resources) {
+        Offer.Builder o = OfferTestUtils.getEmptyOfferBuilder();
+        for (Resource r : resources) {
+            o.addResources(r);
+        }
+        return o.build();
+    }
+
+    private static Offer offerWith(Resource... resources) {
+        return offerWith(Arrays.asList(resources));
+    }
+}

--- a/src/test/java/org/apache/mesos/offer/constrain/AttributeRuleTest.java
+++ b/src/test/java/org/apache/mesos/offer/constrain/AttributeRuleTest.java
@@ -1,0 +1,198 @@
+package org.apache.mesos.offer.constrain;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Collections;
+
+import org.apache.mesos.Protos.Attribute;
+import org.apache.mesos.Protos.Offer;
+import org.apache.mesos.Protos.Value;
+import org.apache.mesos.offer.AttributeStringUtils;
+import org.apache.mesos.testutils.OfferTestUtils;
+
+/**
+ * Tests for {@link AttributeRule}.
+ */
+public class AttributeRuleTest {
+
+    private static final Attribute ATTR_TEXT;
+    private static final Attribute ATTR_SCALAR;
+    private static final Attribute ATTR_RANGES;
+    private static final Attribute ATTR_SET;
+    static {
+        Attribute.Builder a = Attribute.newBuilder()
+                .setType(Value.Type.TEXT)
+                .setName("footext");
+        a.getTextBuilder().setValue("bar");
+        ATTR_TEXT = a.build();
+        a = Attribute.newBuilder()
+                .setType(Value.Type.SCALAR)
+                .setName("fooscalar");
+        a.getScalarBuilder().setValue(123.456);
+        ATTR_SCALAR = a.build();
+        a = Attribute.newBuilder()
+                .setType(Value.Type.RANGES)
+                .setName("fooranges");
+        a.getRangesBuilder().addRangeBuilder().setBegin(234).setEnd(345);
+        a.getRangesBuilder().addRangeBuilder().setBegin(456).setEnd(567);
+        ATTR_RANGES = a.build();
+        a = Attribute.newBuilder()
+                .setType(Value.Type.SET)
+                .setName("fooset");
+        a.getSetBuilder().addItem("bar").addItem("baz");
+        ATTR_SET = a.build();
+    }
+    private static final String ATTR_TEXT_REGEX = "footext:...";
+    private static final String ATTR_SCALAR_REGEX = ".*:[0-9.]+";
+    private static final String ATTR_RANGES_REGEX = ".*ranges:.+";
+    private static final String ATTR_SET_REGEX = ".*:\\{bar,baz\\}";
+
+    @Test
+    public void testExactMatchesString() {
+        Offer.Builder o = getOfferWithResources()
+                .addAttributes(ATTR_TEXT);
+        assertEquals(o.build(), new AttributeRule(AttributeSelector.createStringSelector(
+                AttributeStringUtils.toString(ATTR_TEXT))).filter(o.build()));
+
+        o = getOfferWithResources()
+                .addAttributes(ATTR_SCALAR);
+        assertEquals(o.build(), new AttributeRule(AttributeSelector.createStringSelector(
+                AttributeStringUtils.toString(ATTR_SCALAR))).filter(o.build()));
+
+        o = getOfferWithResources()
+                .addAttributes(ATTR_RANGES);
+        assertEquals(o.build(), new AttributeRule(AttributeSelector.createStringSelector(
+                AttributeStringUtils.toString(ATTR_RANGES))).filter(o.build()));
+
+        o = getOfferWithResources()
+                .addAttributes(ATTR_SET);
+        assertEquals(o.build(), new AttributeRule(AttributeSelector.createStringSelector(
+                AttributeStringUtils.toString(ATTR_SET))).filter(o.build()));
+    }
+
+    @Test
+    public void testAnyMatchesString() {
+        Offer o = getOfferWithResources()
+                .addAttributes(ATTR_TEXT)
+                .addAttributes(ATTR_SCALAR)
+                .addAttributes(ATTR_RANGES)
+                .addAttributes(ATTR_SET)
+                .build();
+        assertEquals(o, new AttributeRule.Generator(AttributeSelector.createStringSelector(
+                AttributeStringUtils.toString(ATTR_TEXT))).generate(Collections.emptyList()).filter(o));
+        assertEquals(o, new AttributeRule(AttributeSelector.createStringSelector(
+                AttributeStringUtils.toString(ATTR_SCALAR))).filter(o));
+        assertEquals(o, new AttributeRule(AttributeSelector.createStringSelector(
+                AttributeStringUtils.toString(ATTR_RANGES))).filter(o));
+        assertEquals(o, new AttributeRule(AttributeSelector.createStringSelector(
+                AttributeStringUtils.toString(ATTR_SET))).filter(o));
+    }
+
+    @Test
+    public void testMismatchesString() {
+        Offer o = getOfferWithResources()
+                .addAttributes(ATTR_SCALAR)
+                .addAttributes(ATTR_SET)
+                .build();
+        assertEquals(0, new AttributeRule(AttributeSelector.createStringSelector(
+                AttributeStringUtils.toString(ATTR_TEXT))).filter(o).getResourcesCount());
+        assertEquals(o, new AttributeRule(AttributeSelector.createStringSelector(
+                AttributeStringUtils.toString(ATTR_SCALAR))).filter(o));
+        assertEquals(0, new AttributeRule(AttributeSelector.createStringSelector(
+                AttributeStringUtils.toString(ATTR_RANGES))).filter(o).getResourcesCount());
+        assertEquals(o, new AttributeRule(AttributeSelector.createStringSelector(
+                AttributeStringUtils.toString(ATTR_SET))).filter(o));
+
+        o = getOfferWithResources()
+                .addAttributes(ATTR_RANGES)
+                .addAttributes(ATTR_TEXT)
+                .build();
+        assertEquals(o, new AttributeRule(AttributeSelector.createStringSelector(
+                AttributeStringUtils.toString(ATTR_TEXT))).filter(o));
+        assertEquals(0, new AttributeRule(AttributeSelector.createStringSelector(
+                AttributeStringUtils.toString(ATTR_SCALAR))).filter(o).getResourcesCount());
+        assertEquals(o, new AttributeRule(AttributeSelector.createStringSelector(
+                AttributeStringUtils.toString(ATTR_RANGES))).filter(o));
+        assertEquals(0, new AttributeRule(AttributeSelector.createStringSelector(
+                AttributeStringUtils.toString(ATTR_SET))).filter(o).getResourcesCount());
+    }
+
+    @Test
+    public void testExactMatchesRegex() {
+        Offer.Builder o = getOfferWithResources()
+                .addAttributes(ATTR_TEXT);
+        assertEquals(o.build(), new AttributeRule(AttributeSelector.createRegexSelector(
+                ATTR_TEXT_REGEX)).filter(o.build()));
+
+        o = getOfferWithResources()
+                .addAttributes(ATTR_SCALAR);
+        assertEquals(o.build(), new AttributeRule(AttributeSelector.createRegexSelector(
+                ATTR_SCALAR_REGEX)).filter(o.build()));
+
+        o = getOfferWithResources()
+                .addAttributes(ATTR_RANGES);
+        assertEquals(o.build(), new AttributeRule(AttributeSelector.createRegexSelector(
+                ATTR_RANGES_REGEX)).filter(o.build()));
+
+        o = getOfferWithResources()
+                .addAttributes(ATTR_SET);
+        assertEquals(o.build(), new AttributeRule(AttributeSelector.createRegexSelector(
+                ATTR_SET_REGEX)).filter(o.build()));
+    }
+
+    @Test
+    public void testAnyMatchesRegex() {
+        Offer o = getOfferWithResources()
+                .addAttributes(ATTR_TEXT)
+                .addAttributes(ATTR_SCALAR)
+                .addAttributes(ATTR_RANGES)
+                .addAttributes(ATTR_SET)
+                .build();
+        assertEquals(o, new AttributeRule(AttributeSelector.createRegexSelector(
+                ATTR_TEXT_REGEX)).filter(o));
+        assertEquals(o, new AttributeRule(AttributeSelector.createRegexSelector(
+                ATTR_SCALAR_REGEX)).filter(o));
+        assertEquals(o, new AttributeRule(AttributeSelector.createRegexSelector(
+                ATTR_RANGES_REGEX)).filter(o));
+        assertEquals(o, new AttributeRule(AttributeSelector.createRegexSelector(
+                ATTR_SET_REGEX)).filter(o));
+    }
+
+    @Test
+    public void testMismatchesRegex() {
+        Offer o = getOfferWithResources()
+                .addAttributes(ATTR_SCALAR)
+                .addAttributes(ATTR_SET)
+                .build();
+        assertEquals(0, new AttributeRule(AttributeSelector.createRegexSelector(
+                ATTR_TEXT_REGEX)).filter(o).getResourcesCount());
+        assertEquals(o, new AttributeRule(AttributeSelector.createRegexSelector(
+                ATTR_SCALAR_REGEX)).filter(o));
+        assertEquals(0, new AttributeRule(AttributeSelector.createRegexSelector(
+                ATTR_RANGES_REGEX)).filter(o).getResourcesCount());
+        assertEquals(o, new AttributeRule(AttributeSelector.createRegexSelector(
+                ATTR_SET_REGEX)).filter(o));
+
+        o = getOfferWithResources()
+                .addAttributes(ATTR_RANGES)
+                .addAttributes(ATTR_TEXT)
+                .build();
+        assertEquals(o, new AttributeRule(AttributeSelector.createRegexSelector(
+                ATTR_TEXT_REGEX)).filter(o));
+        assertEquals(0, new AttributeRule(AttributeSelector.createRegexSelector(
+                ATTR_SCALAR_REGEX)).filter(o).getResourcesCount());
+        assertEquals(o, new AttributeRule(AttributeSelector.createRegexSelector(
+                ATTR_RANGES_REGEX)).filter(o));
+        assertEquals(0, new AttributeRule(AttributeSelector.createRegexSelector(
+                ATTR_SET_REGEX)).filter(o).getResourcesCount());
+    }
+
+    private static Offer.Builder getOfferWithResources() {
+        Offer.Builder o = OfferTestUtils.getEmptyOfferBuilder();
+        OfferTestUtils.addResource(o, "a");
+        OfferTestUtils.addResource(o, "b");
+        return o;
+    }
+}

--- a/src/test/java/org/apache/mesos/offer/constrain/MaxPerAttributeGeneratorTest.java
+++ b/src/test/java/org/apache/mesos/offer/constrain/MaxPerAttributeGeneratorTest.java
@@ -1,0 +1,155 @@
+package org.apache.mesos.offer.constrain;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.apache.mesos.Protos.Attribute;
+import org.apache.mesos.Protos.Offer;
+import org.apache.mesos.Protos.TaskInfo;
+import org.apache.mesos.Protos.Value;
+import org.apache.mesos.offer.TaskUtils;
+import org.apache.mesos.testutils.OfferTestUtils;
+import org.apache.mesos.testutils.TaskTestUtils;
+
+/**
+ * Tests for {@link MaxPerAttributeGenerator}.
+ */
+public class MaxPerAttributeGeneratorTest {
+
+    private static final String ATTR_PATTERN = "^footext:.*$";
+    private static final AttributeSelector ATTR_SELECTOR = AttributeSelector.createRegexSelector(ATTR_PATTERN);
+
+    private static final Offer OFFER_NO_ATTRS = getOfferWithResources();
+    private static final Offer OFFER_ATTR_MATCH_1;
+    private static final Offer OFFER_ATTR_MATCH_2;
+    private static final Offer OFFER_ATTR_MISMATCH;
+    static {
+        Attribute.Builder a = Attribute.newBuilder()
+                .setType(Value.Type.TEXT)
+                .setName("footext");
+        a.getTextBuilder().setValue("123");
+        OFFER_ATTR_MATCH_1 = OFFER_NO_ATTRS.toBuilder().addAttributes(a.build()).build();
+
+        a = Attribute.newBuilder()
+                .setType(Value.Type.TEXT)
+                .setName("footext");
+        a.getTextBuilder().setValue("456");
+        OFFER_ATTR_MATCH_2 = OFFER_NO_ATTRS.toBuilder().addAttributes(a.build()).build();
+
+        a = Attribute.newBuilder()
+                .setType(Value.Type.TEXT)
+                .setName("other");
+        a.getTextBuilder().setValue("123");
+        OFFER_ATTR_MISMATCH = OFFER_NO_ATTRS.toBuilder().addAttributes(a.build()).build();
+    }
+
+    private static final TaskInfo TASK_NO_ATTRS = TaskTestUtils.getTaskInfo(Collections.emptyList());
+    private static final TaskInfo TASK_ATTR_MATCH_1;
+    private static final TaskInfo TASK_ATTR_MATCH_2;
+    private static final TaskInfo TASK_ATTR_MISMATCH;
+    static {
+        TASK_ATTR_MATCH_1 = TaskUtils.setOfferAttributes(TASK_NO_ATTRS.toBuilder(), OFFER_ATTR_MATCH_1).build();
+        TASK_ATTR_MATCH_2 = TaskUtils.setOfferAttributes(TASK_NO_ATTRS.toBuilder(), OFFER_ATTR_MATCH_2).build();
+        TASK_ATTR_MISMATCH = TaskUtils.setOfferAttributes(TASK_NO_ATTRS.toBuilder(), OFFER_ATTR_MISMATCH).build();
+    }
+
+    @Test
+    public void testZeroLimit() {
+        PlacementRuleGenerator generator = new MaxPerAttributeGenerator(0, ATTR_SELECTOR);
+
+        PlacementRule rule = generator.generate(Arrays.asList(
+                TASK_NO_ATTRS, TASK_ATTR_MATCH_1, TASK_ATTR_MATCH_2, TASK_ATTR_MISMATCH));
+        assertEquals(rule.toString(), 2, rule.filter(OFFER_NO_ATTRS).getResourcesCount());
+        assertEquals(rule.toString(), 0, rule.filter(OFFER_ATTR_MATCH_1).getResourcesCount());
+        assertEquals(rule.toString(), 0, rule.filter(OFFER_ATTR_MATCH_2).getResourcesCount());
+        assertEquals(rule.toString(), 2, rule.filter(OFFER_ATTR_MISMATCH).getResourcesCount());
+
+        rule = generator.generate(Arrays.asList());
+        assertEquals(rule.toString(), 2, rule.filter(OFFER_NO_ATTRS).getResourcesCount());
+        assertEquals(rule.toString(), 2, rule.filter(OFFER_ATTR_MATCH_1).getResourcesCount());
+        assertEquals(rule.toString(), 2, rule.filter(OFFER_ATTR_MATCH_2).getResourcesCount());
+        assertEquals(rule.toString(), 2, rule.filter(OFFER_ATTR_MISMATCH).getResourcesCount());
+    }
+
+    @Test
+    public void testOneLimit() {
+        PlacementRuleGenerator generator = new MaxPerAttributeGenerator(1, ATTR_SELECTOR);
+
+        PlacementRule rule = generator.generate(Arrays.asList(
+                TASK_NO_ATTRS, TASK_ATTR_MATCH_1, TASK_ATTR_MATCH_2, TASK_ATTR_MISMATCH));
+        assertEquals(rule.toString(), 2, rule.filter(OFFER_NO_ATTRS).getResourcesCount());
+        assertEquals(rule.toString(), 0, rule.filter(OFFER_ATTR_MATCH_1).getResourcesCount());
+        assertEquals(rule.toString(), 0, rule.filter(OFFER_ATTR_MATCH_2).getResourcesCount());
+        assertEquals(rule.toString(), 2, rule.filter(OFFER_ATTR_MISMATCH).getResourcesCount());
+
+        rule = generator.generate(Arrays.asList());
+        assertEquals(rule.toString(), 2, rule.filter(OFFER_NO_ATTRS).getResourcesCount());
+        assertEquals(rule.toString(), 2, rule.filter(OFFER_ATTR_MATCH_1).getResourcesCount());
+        assertEquals(rule.toString(), 2, rule.filter(OFFER_ATTR_MATCH_2).getResourcesCount());
+        assertEquals(rule.toString(), 2, rule.filter(OFFER_ATTR_MISMATCH).getResourcesCount());
+    }
+
+    @Test
+    public void testTwoLimit() {
+        PlacementRuleGenerator generator = new MaxPerAttributeGenerator(2, ATTR_SELECTOR);
+
+        PlacementRule rule = generator.generate(Arrays.asList(
+                TASK_NO_ATTRS, TASK_ATTR_MATCH_1, TASK_ATTR_MATCH_2, TASK_ATTR_MISMATCH));
+        assertEquals(rule.toString(), 2, rule.filter(OFFER_NO_ATTRS).getResourcesCount());
+        assertEquals(rule.toString(), 2, rule.filter(OFFER_ATTR_MATCH_1).getResourcesCount());
+        assertEquals(rule.toString(), 2, rule.filter(OFFER_ATTR_MATCH_2).getResourcesCount());
+        assertEquals(rule.toString(), 2, rule.filter(OFFER_ATTR_MISMATCH).getResourcesCount());
+
+        rule = generator.generate(Arrays.asList());
+        assertEquals(rule.toString(), 2, rule.filter(OFFER_NO_ATTRS).getResourcesCount());
+        assertEquals(rule.toString(), 2, rule.filter(OFFER_ATTR_MATCH_1).getResourcesCount());
+        assertEquals(rule.toString(), 2, rule.filter(OFFER_ATTR_MATCH_2).getResourcesCount());
+        assertEquals(rule.toString(), 2, rule.filter(OFFER_ATTR_MISMATCH).getResourcesCount());
+    }
+
+    @Test
+    public void testTwoLimitDuplicates() {
+        PlacementRuleGenerator generator = new MaxPerAttributeGenerator(2, ATTR_SELECTOR);
+
+        PlacementRule rule = generator.generate(Arrays.asList(
+                TASK_NO_ATTRS,
+                TASK_ATTR_MATCH_1, TASK_ATTR_MATCH_1,
+                TASK_ATTR_MATCH_2,
+                TASK_ATTR_MISMATCH));
+        assertEquals(rule.toString(), 2, rule.filter(OFFER_NO_ATTRS).getResourcesCount());
+        assertEquals(rule.toString(), 0, rule.filter(OFFER_ATTR_MATCH_1).getResourcesCount());
+        assertEquals(rule.toString(), 2, rule.filter(OFFER_ATTR_MATCH_2).getResourcesCount());
+        assertEquals(rule.toString(), 2, rule.filter(OFFER_ATTR_MISMATCH).getResourcesCount());
+
+        rule = generator.generate(Arrays.asList(
+                TASK_NO_ATTRS, TASK_NO_ATTRS, TASK_NO_ATTRS,
+                TASK_ATTR_MATCH_1,
+                TASK_ATTR_MATCH_2, TASK_ATTR_MATCH_2,
+                TASK_ATTR_MISMATCH));
+        assertEquals(rule.toString(), 2, rule.filter(OFFER_NO_ATTRS).getResourcesCount());
+        assertEquals(rule.toString(), 2, rule.filter(OFFER_ATTR_MATCH_1).getResourcesCount());
+        assertEquals(rule.toString(), 0, rule.filter(OFFER_ATTR_MATCH_2).getResourcesCount());
+        assertEquals(rule.toString(), 2, rule.filter(OFFER_ATTR_MISMATCH).getResourcesCount());
+
+        rule = generator.generate(Arrays.asList(
+                TASK_NO_ATTRS,
+                TASK_ATTR_MATCH_1, TASK_ATTR_MATCH_1,
+                TASK_ATTR_MATCH_2, TASK_ATTR_MATCH_2,
+                TASK_ATTR_MISMATCH, TASK_ATTR_MISMATCH, TASK_ATTR_MISMATCH));
+        assertEquals(rule.toString(), 2, rule.filter(OFFER_NO_ATTRS).getResourcesCount());
+        assertEquals(rule.toString(), 0, rule.filter(OFFER_ATTR_MATCH_1).getResourcesCount());
+        assertEquals(rule.toString(), 0, rule.filter(OFFER_ATTR_MATCH_2).getResourcesCount());
+        assertEquals(rule.toString(), 2, rule.filter(OFFER_ATTR_MISMATCH).getResourcesCount());
+    }
+
+    private static Offer getOfferWithResources() {
+        Offer.Builder o = OfferTestUtils.getEmptyOfferBuilder();
+        OfferTestUtils.addResource(o, "a");
+        OfferTestUtils.addResource(o, "b");
+        return o.build();
+    }
+}

--- a/src/test/java/org/apache/mesos/offer/constrain/NotRuleTest.java
+++ b/src/test/java/org/apache/mesos/offer/constrain/NotRuleTest.java
@@ -1,0 +1,126 @@
+package org.apache.mesos.offer.constrain;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+import org.apache.mesos.Protos.Offer;
+import org.apache.mesos.Protos.Resource;
+import org.apache.mesos.Protos.Value;
+import org.apache.mesos.testutils.OfferTestUtils;
+
+/**
+ * Tests for {@link NotRule}.
+ */
+public class NotRuleTest {
+
+    private static final Resource RESOURCE_1;
+    private static final Resource RESOURCE_2;
+    private static final Resource RESOURCE_3;
+    private static final Resource RESOURCE_4;
+
+    private static final Collection<Resource> RESOURCES;
+
+    static {
+        Resource.Builder b = Resource.newBuilder().setName("1").setType(Value.Type.RANGES);
+        b.getRangesBuilder().addRangeBuilder().setBegin(5).setEnd(6);
+        b.getRangesBuilder().addRangeBuilder().setBegin(10).setEnd(12);
+        RESOURCE_1 = b.build();
+
+        b = Resource.newBuilder().setName("2").setType(Value.Type.SCALAR);
+        b.getScalarBuilder().setValue(123.456);
+        RESOURCE_2 = b.build();
+
+        b = Resource.newBuilder().setName("3").setType(Value.Type.SET);
+        b.getSetBuilder().addItem("foo").addItem("bar").addItem("baz");
+        RESOURCE_3 = b.build();
+
+        b = Resource.newBuilder().setName("4").setType(Value.Type.RANGES);
+        b.getRangesBuilder().addRangeBuilder().setBegin(7).setEnd(8);
+        b.getRangesBuilder().addRangeBuilder().setBegin(10).setEnd(12);
+        RESOURCE_4 = b.build();
+
+        RESOURCES = Arrays.asList(RESOURCE_1, RESOURCE_2, RESOURCE_3, RESOURCE_4);
+    }
+
+    private static final PlacementRule ALL = new PlacementRule() {
+        @Override
+        public Offer filter(Offer offer) {
+            return offer;
+        }
+    };
+    private static final PlacementRule NONE = new PlacementRule() {
+        @Override
+        public Offer filter(Offer offer) {
+            return offer.toBuilder().clearResources().build();
+        }
+    };
+    private static final PlacementRule REMOVE_FIRST = new PlacementRule() {
+        @Override
+        public Offer filter(Offer offer) {
+            if (offer.getResourcesCount() == 0) {
+                return offer;
+            }
+            return offer.toBuilder().removeResources(0).build();
+        }
+    };
+    private static final PlacementRule REMOVE_LAST = new PlacementRule() {
+        @Override
+        public Offer filter(Offer offer) {
+            int count = offer.getResourcesCount();
+            if (count == 0) {
+                return offer;
+            }
+            return offer.toBuilder().removeResources(count - 1).build();
+        }
+    };
+
+    @Test
+    public void testNotAll() {
+        Offer o = new NotRule(ALL).filter(offerWith(RESOURCES));
+        assertTrue(o.getResourcesList().isEmpty());
+    }
+
+    @Test
+    public void testNotNone() {
+        Offer o = new NotRule(NONE).filter(offerWith(RESOURCES));
+        assertEquals(offerWith(RESOURCES), o);
+    }
+
+    @Test
+    public void testNotFirstRemoved() {
+        Offer o = new NotRule(REMOVE_FIRST).filter(offerWith(RESOURCES));
+        assertEquals(offerWith(RESOURCE_1), o);
+    }
+
+    @Test
+    public void testNotLastRemoved() {
+        Offer o = new NotRule(REMOVE_LAST).filter(offerWith(RESOURCES));
+        assertEquals(offerWith(RESOURCE_4), o);
+    }
+
+    @Test
+    public void testGenerator() {
+        Offer o = new NotRule.Generator(new PassthroughGenerator(REMOVE_LAST))
+                .generate(Collections.emptyList())
+                .filter(offerWith(RESOURCES));
+        assertEquals(offerWith(RESOURCE_4), o);
+    }
+
+    private static Offer offerWith(Collection<Resource> resources) {
+        Offer.Builder o = OfferTestUtils.getEmptyOfferBuilder();
+        for (Resource r : resources) {
+            o.addResources(r);
+        }
+        return o.build();
+    }
+
+    private static Offer offerWith(Resource... resources) {
+        return offerWith(Arrays.asList(resources));
+    }
+}

--- a/src/test/java/org/apache/mesos/offer/constrain/OrRuleTest.java
+++ b/src/test/java/org/apache/mesos/offer/constrain/OrRuleTest.java
@@ -1,0 +1,204 @@
+package org.apache.mesos.offer.constrain;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+import org.apache.mesos.Protos.Offer;
+import org.apache.mesos.Protos.Resource;
+import org.apache.mesos.Protos.Value;
+import org.apache.mesos.testutils.OfferTestUtils;
+
+/**
+ * Tests for {@link OrRule}.
+ */
+public class OrRuleTest {
+
+    private static final Resource RESOURCE_1;
+    private static final Resource RESOURCE_2;
+    private static final Resource RESOURCE_3;
+    private static final Resource RESOURCE_4;
+
+    private static final Collection<Resource> RESOURCES;
+
+    static {
+        Resource.Builder b = Resource.newBuilder().setName("1").setType(Value.Type.RANGES);
+        b.getRangesBuilder().addRangeBuilder().setBegin(5).setEnd(6);
+        b.getRangesBuilder().addRangeBuilder().setBegin(10).setEnd(12);
+        RESOURCE_1 = b.build();
+
+        b = Resource.newBuilder().setName("2").setType(Value.Type.SCALAR);
+        b.getScalarBuilder().setValue(123.456);
+        RESOURCE_2 = b.build();
+
+        b = Resource.newBuilder().setName("3").setType(Value.Type.SET);
+        b.getSetBuilder().addItem("foo").addItem("bar").addItem("baz");
+        RESOURCE_3 = b.build();
+
+        b = Resource.newBuilder().setName("4").setType(Value.Type.RANGES);
+        b.getRangesBuilder().addRangeBuilder().setBegin(7).setEnd(8);
+        b.getRangesBuilder().addRangeBuilder().setBegin(10).setEnd(12);
+        RESOURCE_4 = b.build();
+
+        RESOURCES = Arrays.asList(RESOURCE_1, RESOURCE_2, RESOURCE_3, RESOURCE_4);
+    }
+
+    private static final PlacementRule ALL = new PlacementRule() {
+        @Override
+        public Offer filter(Offer offer) {
+            return offer;
+        }
+    };
+    private static final PlacementRule NONE = new PlacementRule() {
+        @Override
+        public Offer filter(Offer offer) {
+            return offer.toBuilder().clearResources().build();
+        }
+    };
+    private static final PlacementRule REMOVE_FIRST = new PlacementRule() {
+        @Override
+        public Offer filter(Offer offer) {
+            if (offer.getResourcesCount() == 0) {
+                return offer;
+            }
+            return offer.toBuilder().removeResources(0).build();
+        }
+    };
+    private static final PlacementRule REMOVE_LAST = new PlacementRule() {
+        @Override
+        public Offer filter(Offer offer) {
+            int count = offer.getResourcesCount();
+            if (count == 0) {
+                return offer;
+            }
+            return offer.toBuilder().removeResources(count - 1).build();
+        }
+    };
+
+    @Test
+    public void testEmpty() {
+        Offer o = new OrRule().filter(offerWith(RESOURCES));
+        assertTrue(o.getResourcesList().isEmpty());
+    }
+
+    @Test
+    public void testAllPass() {
+        Offer o = new OrRule(ALL).filter(offerWith(RESOURCES));
+        assertEquals(offerWith(RESOURCES), o);
+
+        o = new OrRule(ALL, ALL, ALL).filter(offerWith(RESOURCES));
+        assertEquals(offerWith(RESOURCES), o);
+    }
+
+    @Test
+    public void testAllFail() {
+        Offer o = new OrRule(NONE).filter(offerWith(RESOURCES));
+        assertTrue(o.getResourcesList().isEmpty());
+
+        o = new OrRule(NONE, ALL).filter(offerWith(RESOURCES));
+        assertEquals(offerWith(RESOURCES), o);
+
+        o = new OrRule(ALL, NONE).filter(offerWith(RESOURCES));
+        assertEquals(offerWith(RESOURCES), o);
+
+        o = new OrRule(NONE, NONE).filter(offerWith(RESOURCES));
+        assertTrue(o.getResourcesList().isEmpty());
+
+        o = new OrRule(NONE, ALL, NONE).filter(offerWith(RESOURCES));
+        assertEquals(offerWith(RESOURCES), o);
+
+        o = new OrRule(ALL, NONE, ALL).filter(offerWith(RESOURCES));
+        assertEquals(offerWith(RESOURCES), o);
+
+        o = new OrRule(NONE, NONE, NONE).filter(offerWith(RESOURCES));
+        assertTrue(o.getResourcesList().isEmpty());
+    }
+
+    @Test
+    public void testFirstRemoved() {
+        Offer o = new OrRule(REMOVE_FIRST).filter(offerWith(RESOURCES));
+        assertEquals(offerWith(RESOURCE_2, RESOURCE_3, RESOURCE_4), o);
+
+        o = new OrRule(REMOVE_FIRST, ALL).filter(offerWith(RESOURCES));
+        assertEquals(offerWith(RESOURCE_1, RESOURCE_2, RESOURCE_3, RESOURCE_4), o);
+
+        o = new OrRule(ALL, REMOVE_FIRST).filter(offerWith(RESOURCES));
+        assertEquals(offerWith(RESOURCE_1, RESOURCE_2, RESOURCE_3, RESOURCE_4), o);
+
+        o = new OrRule(REMOVE_FIRST, REMOVE_FIRST).filter(offerWith(RESOURCES));
+        assertEquals(offerWith(RESOURCE_2, RESOURCE_3, RESOURCE_4), o);
+
+        o = new OrRule(REMOVE_FIRST, ALL, REMOVE_FIRST).filter(offerWith(RESOURCES));
+        assertEquals(offerWith(RESOURCE_1, RESOURCE_2, RESOURCE_3, RESOURCE_4), o);
+
+        o = new OrRule(ALL, REMOVE_FIRST, ALL).filter(offerWith(RESOURCES));
+        assertEquals(offerWith(RESOURCE_1, RESOURCE_2, RESOURCE_3, RESOURCE_4), o);
+
+        o = new OrRule(REMOVE_FIRST, REMOVE_FIRST, REMOVE_FIRST).filter(offerWith(RESOURCES));
+        assertEquals(offerWith(RESOURCE_2, RESOURCE_3, RESOURCE_4), o);
+    }
+
+    @Test
+    public void testLastRemoved() {
+        Offer o = new OrRule(REMOVE_LAST).filter(offerWith(RESOURCES));
+        assertEquals(offerWith(RESOURCE_1, RESOURCE_2, RESOURCE_3), o);
+
+        o = new OrRule(REMOVE_LAST, ALL).filter(offerWith(RESOURCES));
+        assertEquals(offerWith(RESOURCE_1, RESOURCE_2, RESOURCE_3, RESOURCE_4), o);
+
+        o = new OrRule(ALL, REMOVE_LAST).filter(offerWith(RESOURCES));
+        assertEquals(offerWith(RESOURCE_1, RESOURCE_2, RESOURCE_3, RESOURCE_4), o);
+
+        o = new OrRule(REMOVE_LAST, REMOVE_LAST).filter(offerWith(RESOURCES));
+        assertEquals(offerWith(RESOURCE_1, RESOURCE_2, RESOURCE_3), o);
+
+        o = new OrRule(REMOVE_LAST, ALL, REMOVE_LAST).filter(offerWith(RESOURCES));
+        assertEquals(offerWith(RESOURCE_1, RESOURCE_2, RESOURCE_3, RESOURCE_4), o);
+
+        o = new OrRule(ALL, REMOVE_LAST, ALL).filter(offerWith(RESOURCES));
+        assertEquals(offerWith(RESOURCE_1, RESOURCE_2, RESOURCE_3, RESOURCE_4), o);
+
+        o = new OrRule(REMOVE_LAST, REMOVE_LAST, REMOVE_LAST).filter(offerWith(RESOURCES));
+        assertEquals(offerWith(RESOURCE_1, RESOURCE_2, RESOURCE_3), o);
+    }
+
+    @Test
+    public void testFirstLastRemoved() {
+        Offer o = new OrRule(REMOVE_LAST, REMOVE_FIRST, ALL).filter(offerWith(RESOURCES));
+        assertEquals(offerWith(RESOURCE_1, RESOURCE_2, RESOURCE_3, RESOURCE_4), o);
+
+        o = new OrRule(REMOVE_FIRST, ALL, REMOVE_LAST).filter(offerWith(RESOURCES));
+        assertEquals(offerWith(RESOURCE_1, RESOURCE_2, RESOURCE_3, RESOURCE_4), o);
+
+        o = new OrRule(REMOVE_LAST, REMOVE_FIRST).filter(offerWith(RESOURCES));
+        assertEquals(offerWith(RESOURCE_1, RESOURCE_2, RESOURCE_3, RESOURCE_4), o);
+
+        o = new OrRule(REMOVE_FIRST, REMOVE_LAST, REMOVE_FIRST, REMOVE_LAST).filter(offerWith(RESOURCES));
+        assertEquals(offerWith(RESOURCE_1, RESOURCE_2, RESOURCE_3, RESOURCE_4), o);
+    }
+
+    @Test
+    public void testGenerator() {
+        Offer o = new OrRule.Generator(new PassthroughGenerator(REMOVE_LAST))
+                .generate(Collections.emptyList())
+                .filter(offerWith(RESOURCES));
+        assertEquals(offerWith(RESOURCE_1, RESOURCE_2, RESOURCE_3), o);
+    }
+
+    private static Offer offerWith(Collection<Resource> resources) {
+        Offer.Builder o = OfferTestUtils.getEmptyOfferBuilder();
+        for (Resource r : resources) {
+            o.addResources(r);
+        }
+        return o.build();
+    }
+
+    private static Offer offerWith(Resource... resources) {
+        return offerWith(Arrays.asList(resources));
+    }
+}

--- a/src/test/java/org/apache/mesos/offer/constrain/RoleRuleTest.java
+++ b/src/test/java/org/apache/mesos/offer/constrain/RoleRuleTest.java
@@ -1,0 +1,93 @@
+package org.apache.mesos.offer.constrain;
+
+import org.apache.mesos.Protos.Offer;
+import org.apache.mesos.testutils.OfferTestUtils;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+
+/**
+ * Tests for {@link RoleRule}.
+ */
+public class RoleRuleTest {
+
+    private static final String ROLE = "some_role";
+    private static final String DEFAULT_ROLE = "*";
+
+    @Test
+    public void testAllMatch() {
+        Offer.Builder o = OfferTestUtils.getEmptyOfferBuilder();
+        OfferTestUtils.addResource(o, "a", ROLE);
+        OfferTestUtils.addResource(o, "b", ROLE);
+        OfferTestUtils.addResource(o, "c", ROLE);
+        Offer offer = new RoleRule(ROLE).filter(o.build());
+        assertEquals(3, offer.getResourcesCount());
+        assertEquals("a", offer.getResources(0).getName());
+        assertEquals("b", offer.getResources(1).getName());
+        assertEquals("c", offer.getResources(2).getName());
+    }
+
+    @Test
+    public void testSomeMatch() {
+        Offer.Builder o = OfferTestUtils.getEmptyOfferBuilder();
+        OfferTestUtils.addResource(o, "a", ROLE);
+        OfferTestUtils.addResource(o, "b", ROLE.toUpperCase());
+        OfferTestUtils.addResource(o, "c", DEFAULT_ROLE);
+        OfferTestUtils.addResource(o, "d", ROLE);
+        OfferTestUtils.addResource(o, "e", ROLE.substring(1));
+        OfferTestUtils.addResource(o, "f");
+        Offer offer = new RoleRule(ROLE).filter(o.build());
+        assertEquals(2, offer.getResourcesCount());
+        assertEquals("a", offer.getResources(0).getName());
+        assertEquals("d", offer.getResources(1).getName());
+    }
+
+    @Test
+    public void testGeneratorSomeMatch() {
+        Offer.Builder o = OfferTestUtils.getEmptyOfferBuilder();
+        OfferTestUtils.addResource(o, "a", ROLE);
+        OfferTestUtils.addResource(o, "b", ROLE.toUpperCase());
+        OfferTestUtils.addResource(o, "c", DEFAULT_ROLE);
+        OfferTestUtils.addResource(o, "d", ROLE);
+        OfferTestUtils.addResource(o, "e", ROLE.substring(1));
+        OfferTestUtils.addResource(o, "f");
+        Offer offer = new RoleRule.Generator(ROLE).generate(new ArrayList<>()).filter(o.build());
+        assertEquals(2, offer.getResourcesCount());
+        assertEquals("a", offer.getResources(0).getName());
+        assertEquals("d", offer.getResources(1).getName());
+    }
+
+    @Test
+    public void testAsteriskRole() {
+        Offer.Builder o = OfferTestUtils.getEmptyOfferBuilder();
+        OfferTestUtils.addResource(o, "a", ROLE);
+        OfferTestUtils.addResource(o, "b", ROLE.toUpperCase());
+        OfferTestUtils.addResource(o, "c", DEFAULT_ROLE);
+        OfferTestUtils.addResource(o, "d", ROLE);
+        OfferTestUtils.addResource(o, "e", ROLE.substring(1));
+        OfferTestUtils.addResource(o, "f");
+        Offer offer = new RoleRule(DEFAULT_ROLE).filter(o.build());
+        assertEquals(2, offer.getResourcesCount());
+        assertEquals("c", offer.getResources(0).getName());
+        assertEquals("f", offer.getResources(1).getName());
+    }
+
+    @Test
+    public void testNoneMatch() {
+        Offer.Builder o = OfferTestUtils.getEmptyOfferBuilder();
+        OfferTestUtils.addResource(o, "a", ROLE.toUpperCase());
+        OfferTestUtils.addResource(o, "b", DEFAULT_ROLE);
+        OfferTestUtils.addResource(o, "c", ROLE.substring(1));
+        OfferTestUtils.addResource(o, "d");
+        Offer offer = new RoleRule(ROLE).filter(o.build());
+        assertEquals(0, offer.getResourcesCount());
+    }
+
+    @Test
+    public void testEmptyOffer() {
+        Offer offer = new RoleRule(ROLE).filter(OfferTestUtils.getEmptyOfferBuilder().build());
+        assertEquals(0, offer.getResourcesCount());
+    }
+}

--- a/src/test/java/org/apache/mesos/offer/constrain/TaskTypeRuleGeneratorTest.java
+++ b/src/test/java/org/apache/mesos/offer/constrain/TaskTypeRuleGeneratorTest.java
@@ -2,19 +2,20 @@ package org.apache.mesos.offer.constrain;
 
 import org.junit.Test;
 
+import com.google.protobuf.ByteString;
+
 import static org.junit.Assert.assertEquals;
 
 import java.util.Arrays;
 import java.util.Collections;
 
+import org.apache.mesos.Protos;
 import org.apache.mesos.Protos.CommandInfo;
 import org.apache.mesos.Protos.Offer;
 import org.apache.mesos.Protos.SlaveID;
-import org.apache.mesos.Protos.TaskID;
 import org.apache.mesos.Protos.TaskInfo;
 import org.apache.mesos.executor.DcosTaskConstants;
 import org.apache.mesos.offer.constrain.TaskTypeGenerator.TaskEnvMapConverter;
-import org.apache.mesos.offer.constrain.TaskTypeGenerator.TaskIDDashConverter;
 import org.apache.mesos.testutils.OfferTestUtils;
 import org.apache.mesos.testutils.TaskTestUtils;
 
@@ -27,37 +28,33 @@ public class TaskTypeRuleGeneratorTest {
     private static final Offer OFFER_2 = getOffer("agent2");
     private static final Offer OFFER_3 = getOffer("agent3");
 
-    private static final TaskInfo TASK_MATCH_1 = getTask("match-0__uuid", "agent1");
-    private static final TaskInfo TASK_MATCH_3 = getTask("match-2__uuid", "agent3");
-    private static final TaskInfo TASK_MISMATCH_1 = getTask("mismatch-0__uuid", "agent1");
-    private static final TaskInfo TASK_MISMATCH_2 = getTask("mismatch-1__uuid", "agent2");
-    private static final TaskInfo TASK_MISMATCH_3 = getTask("mismatch-2__uuid", "agent3");
-
-    @Test
-    public void testDashConverter() {
-        assertEquals("hello", new TaskIDDashConverter().getTaskType(getTask("hello-1234__uuid", "agent")));
-    }
-
-    @Test(expected=IllegalArgumentException.class)
-    public void testDashConverterFails() {
-        new TaskIDDashConverter().getTaskType(getTask("hello1234__uuid", "agent"));
-    }
+    private static final TaskInfo TASK_MATCH_1 = getTask("match", "matchtask-0__uuid", "agent1");
+    private static final TaskInfo TASK_MATCH_3 = getTask("match", "matchtask-2__uuid", "agent3");
+    private static final TaskInfo TASK_MISMATCH_1 = getTask("mismatch", "othertask-0__uuid", "agent1");
+    private static final TaskInfo TASK_MISMATCH_2 = getTask("mismatch", "othertask-1__uuid", "agent2");
+    private static final TaskInfo TASK_MISMATCH_3 = getTask("mismatch", "othertask-2__uuid", "agent3");
 
     @Test
     public void testEnvConverter() {
-        CommandInfo.Builder cb = CommandInfo.newBuilder();
-        cb.getEnvironmentBuilder().addVariablesBuilder()
-                .setName(DcosTaskConstants.TASK_TYPE)
-                .setValue("hey");
-        TaskInfo task = getTask("hello-1234__uuid", "agent").toBuilder()
-                .setData(cb.build().toByteString())
-                .build();
+        TaskInfo task = getTask("hey", "hello-1234__uuid", "agent");
         assertEquals("hey", new TaskEnvMapConverter().getTaskType(task));
     }
 
     @Test(expected=IllegalArgumentException.class)
-    public void testEnvConverterNoCommandinfo() {
-        new TaskEnvMapConverter().getTaskType(getTask("hello-1234__uuid", "agent"));
+    public void testEnvConverterNoData() {
+        TaskInfo task = getTask("hey", "hello-1234__uuid", "agent").toBuilder()
+                .clearData()
+                .build();
+        new TaskEnvMapConverter().getTaskType(task);
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void testEnvConverterBadData() {
+        ByteString corrupt = ByteString.copyFromUtf8("Hello");
+        TaskInfo task = getTask("hey", "hello-1234__uuid", "agent").toBuilder()
+                .setData(corrupt)
+                .build();
+        new TaskEnvMapConverter().getTaskType(task);
     }
 
     @Test(expected=IllegalArgumentException.class)
@@ -66,7 +63,7 @@ public class TaskTypeRuleGeneratorTest {
         cb.getEnvironmentBuilder().addVariablesBuilder()
                 .setName("hi")
                 .setValue("hey");
-        TaskInfo task = getTask("hello-1234__uuid", "agent").toBuilder()
+        TaskInfo task = getTask("DELETEME", "hello-1234__uuid", "agent").toBuilder()
                 .setData(cb.build().toByteString())
                 .build();
         new TaskEnvMapConverter().getTaskType(task);
@@ -74,7 +71,7 @@ public class TaskTypeRuleGeneratorTest {
 
     @Test
     public void testColocate() {
-        PlacementRule rule = TaskTypeGenerator.createColocate("match", new TaskIDDashConverter())
+        PlacementRule rule = TaskTypeGenerator.createColocate("match", new TaskEnvMapConverter())
                 .generate(Arrays.asList(
                         TASK_MISMATCH_1, TASK_MATCH_1,
                         TASK_MISMATCH_2,
@@ -86,7 +83,7 @@ public class TaskTypeRuleGeneratorTest {
 
     @Test
     public void testAvoid() {
-        PlacementRule rule = TaskTypeGenerator.createAvoid("match", new TaskIDDashConverter())
+        PlacementRule rule = TaskTypeGenerator.createAvoid("match", new TaskEnvMapConverter())
                 .generate(Arrays.asList(
                         TASK_MISMATCH_1, TASK_MATCH_1,
                         TASK_MISMATCH_2,
@@ -98,7 +95,7 @@ public class TaskTypeRuleGeneratorTest {
 
     @Test
     public void testColocateNotFound() {
-        PlacementRule rule = TaskTypeGenerator.createColocate("match", new TaskIDDashConverter())
+        PlacementRule rule = TaskTypeGenerator.createColocate("match", new TaskEnvMapConverter())
                 .generate(Arrays.asList(TASK_MISMATCH_1, TASK_MISMATCH_2, TASK_MISMATCH_3));
         assertEquals(rule.toString(), 2, rule.filter(OFFER_1).getResourcesCount());
         assertEquals(rule.toString(), 2, rule.filter(OFFER_2).getResourcesCount());
@@ -107,18 +104,23 @@ public class TaskTypeRuleGeneratorTest {
 
     @Test
     public void testAvoidNotFound() {
-        PlacementRule rule = TaskTypeGenerator.createAvoid("match", new TaskIDDashConverter())
+        PlacementRule rule = TaskTypeGenerator.createAvoid("match", new TaskEnvMapConverter())
                 .generate(Arrays.asList(TASK_MISMATCH_1, TASK_MISMATCH_2, TASK_MISMATCH_3));
         assertEquals(rule.toString(), 2, rule.filter(OFFER_1).getResourcesCount());
         assertEquals(rule.toString(), 2, rule.filter(OFFER_2).getResourcesCount());
         assertEquals(rule.toString(), 2, rule.filter(OFFER_3).getResourcesCount());
     }
 
-    private static TaskInfo getTask(String id, String agent) {
-        return TaskTestUtils.getTaskInfo(Collections.emptyList()).toBuilder()
-                .setTaskId(TaskID.newBuilder().setValue(id))
-                .setSlaveId(SlaveID.newBuilder().setValue(agent))
-                .build();
+    private static TaskInfo getTask(String type, String id, String agent) {
+        Protos.CommandInfo.Builder cmdInfoBuilder = Protos.CommandInfo.newBuilder();
+        cmdInfoBuilder.getEnvironmentBuilder().addVariablesBuilder()
+                .setName(DcosTaskConstants.TASK_TYPE)
+                .setValue(type);
+        TaskInfo.Builder taskBuilder = TaskTestUtils.getTaskInfo(Collections.emptyList()).toBuilder()
+                .setData(cmdInfoBuilder.build().toByteString());
+        taskBuilder.getTaskIdBuilder().setValue(id);
+        taskBuilder.getSlaveIdBuilder().setValue(agent);
+        return taskBuilder.build();
     }
 
     private static Offer getOffer(String agent) {

--- a/src/test/java/org/apache/mesos/offer/constrain/TaskTypeRuleGeneratorTest.java
+++ b/src/test/java/org/apache/mesos/offer/constrain/TaskTypeRuleGeneratorTest.java
@@ -71,7 +71,7 @@ public class TaskTypeRuleGeneratorTest {
 
     @Test
     public void testColocate() {
-        PlacementRule rule = TaskTypeGenerator.createColocate("match", new TaskEnvMapConverter())
+        PlacementRule rule = TaskTypeGenerator.createColocate("match")
                 .generate(Arrays.asList(
                         TASK_MISMATCH_1, TASK_MATCH_1,
                         TASK_MISMATCH_2,
@@ -83,7 +83,7 @@ public class TaskTypeRuleGeneratorTest {
 
     @Test
     public void testAvoid() {
-        PlacementRule rule = TaskTypeGenerator.createAvoid("match", new TaskEnvMapConverter())
+        PlacementRule rule = TaskTypeGenerator.createAvoid("match")
                 .generate(Arrays.asList(
                         TASK_MISMATCH_1, TASK_MATCH_1,
                         TASK_MISMATCH_2,
@@ -95,7 +95,7 @@ public class TaskTypeRuleGeneratorTest {
 
     @Test
     public void testColocateNotFound() {
-        PlacementRule rule = TaskTypeGenerator.createColocate("match", new TaskEnvMapConverter())
+        PlacementRule rule = TaskTypeGenerator.createColocate("match")
                 .generate(Arrays.asList(TASK_MISMATCH_1, TASK_MISMATCH_2, TASK_MISMATCH_3));
         assertEquals(rule.toString(), 2, rule.filter(OFFER_1).getResourcesCount());
         assertEquals(rule.toString(), 2, rule.filter(OFFER_2).getResourcesCount());
@@ -104,7 +104,7 @@ public class TaskTypeRuleGeneratorTest {
 
     @Test
     public void testAvoidNotFound() {
-        PlacementRule rule = TaskTypeGenerator.createAvoid("match", new TaskEnvMapConverter())
+        PlacementRule rule = TaskTypeGenerator.createAvoid("match")
                 .generate(Arrays.asList(TASK_MISMATCH_1, TASK_MISMATCH_2, TASK_MISMATCH_3));
         assertEquals(rule.toString(), 2, rule.filter(OFFER_1).getResourcesCount());
         assertEquals(rule.toString(), 2, rule.filter(OFFER_2).getResourcesCount());

--- a/src/test/java/org/apache/mesos/offer/constrain/TaskTypeRuleGeneratorTest.java
+++ b/src/test/java/org/apache/mesos/offer/constrain/TaskTypeRuleGeneratorTest.java
@@ -1,0 +1,131 @@
+package org.apache.mesos.offer.constrain;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.apache.mesos.Protos.CommandInfo;
+import org.apache.mesos.Protos.Offer;
+import org.apache.mesos.Protos.SlaveID;
+import org.apache.mesos.Protos.TaskID;
+import org.apache.mesos.Protos.TaskInfo;
+import org.apache.mesos.executor.DcosTaskConstants;
+import org.apache.mesos.offer.constrain.TaskTypeGenerator.TaskEnvMapConverter;
+import org.apache.mesos.offer.constrain.TaskTypeGenerator.TaskIDDashConverter;
+import org.apache.mesos.testutils.OfferTestUtils;
+import org.apache.mesos.testutils.TaskTestUtils;
+
+/**
+ * Tests for {@link TaskTypeGenerator}.
+ */
+public class TaskTypeRuleGeneratorTest {
+
+    private static final Offer OFFER_1 = getOffer("agent1");
+    private static final Offer OFFER_2 = getOffer("agent2");
+    private static final Offer OFFER_3 = getOffer("agent3");
+
+    private static final TaskInfo TASK_MATCH_1 = getTask("match-0__uuid", "agent1");
+    private static final TaskInfo TASK_MATCH_3 = getTask("match-2__uuid", "agent3");
+    private static final TaskInfo TASK_MISMATCH_1 = getTask("mismatch-0__uuid", "agent1");
+    private static final TaskInfo TASK_MISMATCH_2 = getTask("mismatch-1__uuid", "agent2");
+    private static final TaskInfo TASK_MISMATCH_3 = getTask("mismatch-2__uuid", "agent3");
+
+    @Test
+    public void testDashConverter() {
+        assertEquals("hello", new TaskIDDashConverter().getTaskType(getTask("hello-1234__uuid", "agent")));
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void testDashConverterFails() {
+        new TaskIDDashConverter().getTaskType(getTask("hello1234__uuid", "agent"));
+    }
+
+    @Test
+    public void testEnvConverter() {
+        CommandInfo.Builder cb = CommandInfo.newBuilder();
+        cb.getEnvironmentBuilder().addVariablesBuilder()
+                .setName(DcosTaskConstants.TASK_TYPE)
+                .setValue("hey");
+        TaskInfo task = getTask("hello-1234__uuid", "agent").toBuilder()
+                .setData(cb.build().toByteString())
+                .build();
+        assertEquals("hey", new TaskEnvMapConverter().getTaskType(task));
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void testEnvConverterNoCommandinfo() {
+        new TaskEnvMapConverter().getTaskType(getTask("hello-1234__uuid", "agent"));
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void testEnvConverterMissingEnvvar() {
+        CommandInfo.Builder cb = CommandInfo.newBuilder();
+        cb.getEnvironmentBuilder().addVariablesBuilder()
+                .setName("hi")
+                .setValue("hey");
+        TaskInfo task = getTask("hello-1234__uuid", "agent").toBuilder()
+                .setData(cb.build().toByteString())
+                .build();
+        new TaskEnvMapConverter().getTaskType(task);
+    }
+
+    @Test
+    public void testColocate() {
+        PlacementRule rule = TaskTypeGenerator.createColocate("match", new TaskIDDashConverter())
+                .generate(Arrays.asList(
+                        TASK_MISMATCH_1, TASK_MATCH_1,
+                        TASK_MISMATCH_2,
+                        TASK_MISMATCH_3, TASK_MATCH_3));
+        assertEquals(rule.toString(), 2, rule.filter(OFFER_1).getResourcesCount());
+        assertEquals(rule.toString(), 0, rule.filter(OFFER_2).getResourcesCount());
+        assertEquals(rule.toString(), 2, rule.filter(OFFER_3).getResourcesCount());
+    }
+
+    @Test
+    public void testAvoid() {
+        PlacementRule rule = TaskTypeGenerator.createAvoid("match", new TaskIDDashConverter())
+                .generate(Arrays.asList(
+                        TASK_MISMATCH_1, TASK_MATCH_1,
+                        TASK_MISMATCH_2,
+                        TASK_MISMATCH_3, TASK_MATCH_3));
+        assertEquals(rule.toString(), 0, rule.filter(OFFER_1).getResourcesCount());
+        assertEquals(rule.toString(), 2, rule.filter(OFFER_2).getResourcesCount());
+        assertEquals(rule.toString(), 0, rule.filter(OFFER_3).getResourcesCount());
+    }
+
+    @Test
+    public void testColocateNotFound() {
+        PlacementRule rule = TaskTypeGenerator.createColocate("match", new TaskIDDashConverter())
+                .generate(Arrays.asList(TASK_MISMATCH_1, TASK_MISMATCH_2, TASK_MISMATCH_3));
+        assertEquals(rule.toString(), 2, rule.filter(OFFER_1).getResourcesCount());
+        assertEquals(rule.toString(), 2, rule.filter(OFFER_2).getResourcesCount());
+        assertEquals(rule.toString(), 2, rule.filter(OFFER_3).getResourcesCount());
+    }
+
+    @Test
+    public void testAvoidNotFound() {
+        PlacementRule rule = TaskTypeGenerator.createAvoid("match", new TaskIDDashConverter())
+                .generate(Arrays.asList(TASK_MISMATCH_1, TASK_MISMATCH_2, TASK_MISMATCH_3));
+        assertEquals(rule.toString(), 2, rule.filter(OFFER_1).getResourcesCount());
+        assertEquals(rule.toString(), 2, rule.filter(OFFER_2).getResourcesCount());
+        assertEquals(rule.toString(), 2, rule.filter(OFFER_3).getResourcesCount());
+    }
+
+    private static TaskInfo getTask(String id, String agent) {
+        return TaskTestUtils.getTaskInfo(Collections.emptyList()).toBuilder()
+                .setTaskId(TaskID.newBuilder().setValue(id))
+                .setSlaveId(SlaveID.newBuilder().setValue(agent))
+                .build();
+    }
+
+    private static Offer getOffer(String agent) {
+        Offer.Builder o = OfferTestUtils.getEmptyOfferBuilder()
+                .setSlaveId(SlaveID.newBuilder().setValue(agent));
+        OfferTestUtils.addResource(o, "a");
+        OfferTestUtils.addResource(o, "b");
+        return o.build();
+    }
+}

--- a/src/test/java/org/apache/mesos/scheduler/recovery/RecoverySchedulerTest.java
+++ b/src/test/java/org/apache/mesos/scheduler/recovery/RecoverySchedulerTest.java
@@ -98,8 +98,7 @@ public class RecoverySchedulerTest {
         Resource cpus = ResourceTestUtils.getDesiredCpu(1.0);
         Resource mem = ResourceTestUtils.getDesiredMem(1.0);
         List<TaskInfo> infos = Collections.singletonList(TaskTestUtils.getTaskInfo(Arrays.asList(cpus, mem)));
-        RecoveryRequirement recoveryRequirement = getRecoveryRequirement(
-                new OfferRequirement(infos, Optional.empty(), Collections.EMPTY_LIST, Collections.EMPTY_LIST));
+        RecoveryRequirement recoveryRequirement = getRecoveryRequirement(new OfferRequirement(infos));
         when(stateStore.fetchTerminatedTasks()).thenReturn(infos);
         when(recoveryRequirementProvider.getTransientRecoveryRequirements(any())).thenReturn(Arrays.asList(recoveryRequirement));
         launchConstrainer.setCanLaunch(false);
@@ -126,7 +125,7 @@ public class RecoverySchedulerTest {
         Resource mem = ResourceTestUtils.getDesiredMem(1.0);
         List<Offer> offers = getOffers(1.0, 1.0);
         List<TaskInfo> infos = Collections.singletonList(TaskTestUtils.getTaskInfo(Arrays.asList(cpus, mem)));
-        RecoveryRequirement recoveryRequirement = getRecoveryRequirement(new OfferRequirement(infos, Optional.empty(), Collections.EMPTY_LIST, Collections.EMPTY_LIST));
+        RecoveryRequirement recoveryRequirement = getRecoveryRequirement(new OfferRequirement(infos));
         when(stateStore.fetchTerminatedTasks()).thenReturn(infos);
         when(recoveryRequirementProvider.getTransientRecoveryRequirements(any())).thenReturn(Arrays.asList(recoveryRequirement));
         when(offerAccepter.accept(any(), any())).thenReturn(Arrays.asList(offers.get(0).getId()));
@@ -169,7 +168,7 @@ public class RecoverySchedulerTest {
         Resource mem = ResourceTestUtils.getDesiredMem(1.0);
         List<Offer> offers = getOffers(1.0, 1.0);
         List<TaskInfo> infos = Collections.singletonList(TaskTestUtils.getTaskInfo(Arrays.asList(cpus, mem)));
-        RecoveryRequirement recoveryRequirement = getRecoveryRequirement(new OfferRequirement(infos, Optional.empty(), Collections.EMPTY_LIST, Collections.EMPTY_LIST));
+        RecoveryRequirement recoveryRequirement = getRecoveryRequirement(new OfferRequirement(infos));
         launchConstrainer.setCanLaunch(true);
 
         when(recoveryRequirementProvider.getTransientRecoveryRequirements(any())).thenReturn(Arrays.asList(recoveryRequirement));
@@ -214,7 +213,7 @@ public class RecoverySchedulerTest {
         List<TaskInfo> infos = Collections.singletonList(TaskTestUtils.getTaskInfo(Arrays.asList(cpus, mem)));
         when(stateStore.fetchTerminatedTasks()).thenReturn(infos);
         List<Offer> offers = getOffers(1.0, 1.0);
-        RecoveryRequirement recoveryRequirement = getRecoveryRequirement(new OfferRequirement(infos, Optional.empty(), Collections.EMPTY_LIST, Collections.EMPTY_LIST));
+        RecoveryRequirement recoveryRequirement = getRecoveryRequirement(new OfferRequirement(infos));
 
         when(stateStore.fetchTerminatedTasks()).thenReturn(infos);
         when(recoveryRequirementProvider.getPermanentRecoveryRequirements(any())).thenReturn(Arrays.asList(recoveryRequirement));
@@ -249,7 +248,7 @@ public class RecoverySchedulerTest {
         Resource cpus = ResourceTestUtils.getDesiredCpu(desiredCpu);
         Resource mem = ResourceTestUtils.getDesiredMem(desiredMem);
         List<TaskInfo> infos = Collections.singletonList(TaskTestUtils.getTaskInfo(Arrays.asList(cpus, mem)));
-        RecoveryRequirement recoveryRequirement = getRecoveryRequirement(new OfferRequirement(infos, Optional.empty(), Collections.EMPTY_LIST, Collections.EMPTY_LIST));
+        RecoveryRequirement recoveryRequirement = getRecoveryRequirement(new OfferRequirement(infos));
 
         List<Offer> insufficientOffers = getOffers(insufficientCpu, insufficientMem);
 

--- a/src/test/java/org/apache/mesos/specification/CustomTaskTypeSpecificationTest.java
+++ b/src/test/java/org/apache/mesos/specification/CustomTaskTypeSpecificationTest.java
@@ -17,6 +17,9 @@ public class CustomTaskTypeSpecificationTest {
     public void testCustomCommand() {
         Random random = new Random();
         int taskCount = random.nextInt(Integer.SIZE - 1); // Random positive integer
+        if (taskCount < 0) {
+            taskCount *= -1; // The above can return negative values (twos compliment bit still set?)
+        }
         TaskTypeSpecification taskTypeSpecification = new CustomTaskTypeSpecification(
                 taskCount,
                 "custom",

--- a/src/test/java/org/apache/mesos/specification/CustomTaskTypeSpecificationTest.java
+++ b/src/test/java/org/apache/mesos/specification/CustomTaskTypeSpecificationTest.java
@@ -1,11 +1,13 @@
 package org.apache.mesos.specification;
 
 import org.apache.mesos.Protos;
+import org.apache.mesos.offer.constrain.PlacementRuleGenerator;
 import org.junit.Test;
 import org.testng.Assert;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Optional;
 import java.util.Random;
 
 /**
@@ -25,7 +27,8 @@ public class CustomTaskTypeSpecificationTest {
                 "custom",
                 null,
                 Collections.emptyList(),
-                Collections.emptyList());
+                Collections.emptyList(),
+                Optional.empty());
 
         int id = random.nextInt(taskCount);
         Assert.assertEquals("custom " + id, taskTypeSpecification.getCommand(id).getValue());
@@ -38,8 +41,9 @@ public class CustomTaskTypeSpecificationTest {
                 String name,
                 Protos.CommandInfo command,
                 Collection<ResourceSpecification> resources,
-                Collection<VolumeSpecification> volumes) {
-            super(count, name, command, resources, volumes);
+                Collection<VolumeSpecification> volumes,
+                Optional<PlacementRuleGenerator> placementOptional) {
+            super(count, name, command, resources, volumes, placementOptional);
         }
 
         @Override

--- a/src/test/java/org/apache/mesos/specification/TestTaskSpecification.java
+++ b/src/test/java/org/apache/mesos/specification/TestTaskSpecification.java
@@ -1,49 +1,32 @@
 package org.apache.mesos.specification;
 
-import org.apache.mesos.Protos;
-
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 
 /**
  * This implementation of the TaskSpecification is for test purposes.  It allows what would otherwise be bad practices
  * like changing the ResourceSpecifications encapsulated by the TaskSpecification after construction.
  */
-public class TestTaskSpecification implements TaskSpecification {
-    private final String name;
-    private final Protos.CommandInfo command;
-    private final Collection<VolumeSpecification> volumes;
-    private Collection<ResourceSpecification> resources;
+public class TestTaskSpecification extends DefaultTaskSpecification {
+    private Collection<ResourceSpecification> mutableResources;
 
     public TestTaskSpecification(TaskSpecification taskSpecification) {
-        this.name = taskSpecification.getName();
-        this.command = taskSpecification.getCommand();
-        this.resources = taskSpecification.getResources();
-        this.volumes = taskSpecification.getVolumes();
-    }
-
-    @Override
-    public String getName() {
-        return name;
-    }
-
-    @Override
-    public Protos.CommandInfo getCommand() {
-        return command;
+        super(taskSpecification.getName(),
+                taskSpecification.getCommand(),
+                Collections.emptyList(),
+                taskSpecification.getVolumes(),
+                taskSpecification.getPlacement());
+        this.mutableResources = taskSpecification.getResources();
     }
 
     @Override
     public Collection<ResourceSpecification> getResources() {
-        return resources;
-    }
-
-    @Override
-    public Collection<VolumeSpecification> getVolumes() {
-        return volumes;
+        return mutableResources;
     }
 
     public void addResource(ResourceSpecification resourceSpecification) {
-        resources = new ArrayList<>(resources);
-        resources.add(resourceSpecification);
+        mutableResources = new ArrayList<>(mutableResources);
+        mutableResources.add(resourceSpecification);
     }
 }

--- a/src/test/java/org/apache/mesos/specification/TestTaskSpecificationFactory.java
+++ b/src/test/java/org/apache/mesos/specification/TestTaskSpecificationFactory.java
@@ -6,6 +6,7 @@ import org.apache.mesos.testutils.TestConstants;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Optional;
 
 /**
  * This class provides TaskTypeSpecifications for testing purposes.
@@ -41,7 +42,8 @@ public class TestTaskSpecificationFactory {
                 name,
                 getCommand(cmd),
                 getResources(cpu, mem, TestConstants.role, TestConstants.principal),
-                getVolumes(disk, TestConstants.role, TestConstants.principal));
+                getVolumes(disk, TestConstants.role, TestConstants.principal),
+                Optional.empty());
     }
 
     public static TaskSpecification getTaskSpecification() {
@@ -64,7 +66,8 @@ public class TestTaskSpecificationFactory {
                 name,
                 getCommand(cmd),
                 getResources(cpu, mem, TestConstants.role, TestConstants.principal),
-                getVolumes(disk, TestConstants.role, TestConstants.principal));
+                getVolumes(disk, TestConstants.role, TestConstants.principal),
+                Optional.empty());
     }
 
 

--- a/src/test/java/org/apache/mesos/testutils/OfferRequirementTestUtils.java
+++ b/src/test/java/org/apache/mesos/testutils/OfferRequirementTestUtils.java
@@ -17,22 +17,4 @@ public class OfferRequirementTestUtils {
     public static OfferRequirement getOfferRequirement(List<Protos.Resource> resources) throws InvalidRequirementException {
         return new OfferRequirement(Arrays.asList(TaskTestUtils.getTaskInfo(resources)));
     }
-
-    public static OfferRequirement getOfferRequirement(
-            Protos.Resource resource, List<String> avoidAgents, List<String> collocateAgents)
-            throws InvalidRequirementException {
-        return new OfferRequirement(
-                Arrays.asList(TaskTestUtils.getTaskInfo(resource)),
-                Optional.empty(),
-                toSlaveIds(avoidAgents),
-                toSlaveIds(collocateAgents));
-    }
-
-    private static Collection<Protos.SlaveID> toSlaveIds(List<String> ids) {
-        List<Protos.SlaveID> slaveIds = new ArrayList<>();
-        for (String id : ids) {
-            slaveIds.add(Protos.SlaveID.newBuilder().setValue(id).build());
-        }
-        return slaveIds;
-    }
 }

--- a/src/test/java/org/apache/mesos/testutils/OfferTestUtils.java
+++ b/src/test/java/org/apache/mesos/testutils/OfferTestUtils.java
@@ -1,6 +1,9 @@
 package org.apache.mesos.testutils;
 
 import org.apache.mesos.Protos;
+import org.apache.mesos.Protos.Offer;
+import org.apache.mesos.Protos.Resource;
+import org.apache.mesos.Protos.Value;
 
 import java.util.Arrays;
 import java.util.List;
@@ -18,7 +21,7 @@ public class OfferTestUtils {
     }
 
     public static Protos.Offer getOffer(List<Protos.Resource> resources) {
-        return getBuilder().addAllResources(resources).build();
+        return getEmptyOfferBuilder().addAllResources(resources).build();
     }
 
     public static List<Protos.Offer> getOffers(Protos.Resource resource) {
@@ -26,7 +29,7 @@ public class OfferTestUtils {
     }
 
     public static Protos.Offer getOffer(Protos.ExecutorID executorId, List<Protos.Resource> resources) {
-        Protos.Offer.Builder builder = getBuilder();
+        Protos.Offer.Builder builder = getEmptyOfferBuilder();
         builder.addAllResources(resources);
 
         if (executorId != null) {
@@ -36,11 +39,31 @@ public class OfferTestUtils {
         return builder.build();
     }
 
-    private static Protos.Offer.Builder getBuilder() {
+    /**
+     * Minimum to keep required field errors away.
+     */
+    public static Protos.Offer.Builder getEmptyOfferBuilder() {
         return Protos.Offer.newBuilder()
                 .setId(TestConstants.offerId)
                 .setFrameworkId(TestConstants.frameworkId)
                 .setSlaveId(TestConstants.agentId)
                 .setHostname(TestConstants.hostname);
+    }
+
+    /**
+     * Minimum to keep required field errors away.
+     */
+    public static void addResource(Offer.Builder o, String name, String role) {
+        Resource.Builder b = o.addResourcesBuilder().setType(Value.Type.RANGES).setName(name);
+        if (role != null) {
+            b.setRole(role);
+        }
+    }
+
+    /**
+     * Minimum to keep required field errors away.
+     */
+    public static void addResource(Offer.Builder o, String name) {
+        addResource(o, name, null);
     }
 }


### PR DESCRIPTION
New concepts:
- PlacementRule: A static rule which accepts/declines Offers for the
  purpose of launching a single task.
- PlacementRuleGenerator: A dynamic rule generator which creates a
  PlacementRule for the next task to be launched, based on current
  task deployment.

Note that PlacementRules may internally be composites of other PlacementRules, via AndRule/OrRule/NotRule (which contrary to their names are actually performing set logic on returned Offer Resources).

The provided PlacementRuleGenerator implementations support things like 'avoid (or colocate with) any tasks with this type', and 'don't launch more than N tasks of this type on agents with this attribute'.

Summary of changes to existing dcos-commons:
- Store a string representation of the offer attributes, if any, as
  a label in the TaskInfo. The string representation matches the spec
  provided by Mesos for attribute strings.
- Replace existing avoidAgents/colocateAgents logic with a rules-based
  implementation.
- Replace "taskType + '-' + index" in DefaultTaskSpecification with a
  a new 'toTaskName()' utility function in TaskUtils.