### PR TITLE
Ensure that TaskInfo has command in data field when executor has command set

### DIFF
--- a/src/main/java/org/apache/mesos/offer/MesosResourcePool.java
+++ b/src/main/java/org/apache/mesos/offer/MesosResourcePool.java
@@ -87,7 +87,7 @@ public class MesosResourcePool {
                                       .setEnd(range.getBegin())))
                       .build());
 
-      return new MesosResource(resource);
+      return consumeUnreservedMerged(new ResourceRequirement(resource));
     }
 
     return null;

--- a/src/main/java/org/apache/mesos/offer/OfferEvaluator.java
+++ b/src/main/java/org/apache/mesos/offer/OfferEvaluator.java
@@ -137,7 +137,7 @@ public class OfferEvaluator {
                                     fulfilledExecutorRequirement)));
         }
 
-        List<OfferRecommendation> recommendations = new ArrayList<OfferRecommendation>();
+        List<OfferRecommendation> recommendations = new ArrayList<>();
         recommendations.addAll(unreserves);
         recommendations.addAll(reserves);
         recommendations.addAll(creates);
@@ -369,8 +369,6 @@ public class OfferEvaluator {
                         .clearResources()
                         .addAllResources(fulfilledTaskResources);
 
-        taskBuilder = ResourceUtils.updateEnvironment(taskBuilder, fulfilledTaskResources);
-
         if (execInfo != null) {
             ExecutorInfo.Builder execBuilder =
                     ExecutorInfo.newBuilder(execInfo)
@@ -387,6 +385,8 @@ public class OfferEvaluator {
 
             taskBuilder.setExecutor(execBuilder.build());
         }
+        taskBuilder = ResourceUtils.serializeCommandInfo(
+                ResourceUtils.updateEnvironment(taskBuilder, fulfilledTaskResources));
 
         return taskBuilder.build();
     }

--- a/src/main/java/org/apache/mesos/offer/ResourceUtils.java
+++ b/src/main/java/org/apache/mesos/offer/ResourceUtils.java
@@ -203,6 +203,17 @@ public class ResourceUtils {
         return resBuilder.build();
     }
 
+    public static TaskInfo.Builder serializeCommandInfo(Protos.TaskInfo.Builder builder) {
+        Protos.CommandInfo command = builder.getCommand();
+
+        if (builder.hasExecutor()) {
+            builder.clearCommand();
+            builder.setData(command.toByteString());
+        }
+
+        return builder;
+    }
+
     public static Resource setDynamicPortName(Resource resource, String name) {
         Labels labels = setDynamicPortName(resource.getReservation().getLabels(), name);
 


### PR DESCRIPTION
Mesos will not accept a `TaskInfo` that both has its own `CommandInfo` as well as an `ExecutorInfo` with a `CommandInfo`. We end up in violation of this when setting dynamic port requirements on both our tasks and our executors, since those ports are stored as in environment variables on `TaskInfo.CommandInfo` and `TaskInfo.ExecutorInfo.CommandInfo`, respectively. To work around this case generally, we already have the capability of supplying a serialized `CommandInfo` in the `TaskInfo`'s `data` field, so this change causes the `OfferEvaluator` to check for a `TaskInfo` that has both `CommandInfo` fields, and, if so, moves the task's `CommandInfo` to its `data` field.