### PR TITLE
Explicitly add TASK_LOST as non-terminal

### DIFF
--- a/src/main/java/org/apache/mesos/offer/TaskUtils.java
+++ b/src/main/java/org/apache/mesos/offer/TaskUtils.java
@@ -97,6 +97,7 @@ public class TaskUtils {
             case TASK_KILLED:
             case TASK_ERROR:
                 return true;
+            case TASK_LOST:
             case TASK_KILLING:
             case TASK_RUNNING:
             case TASK_STAGING:


### PR DESCRIPTION
No effective change to logic (I assume this is correct?), just makes the case more explicit