### PR TITLE
Serialize and deserialize TaskInfos with custom Executors and data fields

### DIFF
--- a/src/main/java/org/apache/mesos/executor/CustomExecutor.java
+++ b/src/main/java/org/apache/mesos/executor/CustomExecutor.java
@@ -63,12 +63,13 @@ public class CustomExecutor implements Executor {
         LOGGER.info("Launching task: {}", task);
 
         try {
-            final ExecutorTask taskToExecute = executorTaskFactory.createTask(task, driver);
+            Protos.TaskInfo deserializedTask = TaskUtils.deserializeTaskInfo(task);
+            final ExecutorTask taskToExecute = executorTaskFactory.createTask(deserializedTask, driver);
 
             Future<?> future = executorService.submit(taskToExecute);
             LaunchedTask launchedTask = new LaunchedTask(taskToExecute, future);
-            launchedTasks.put(task.getTaskId(), launchedTask);
-            scheduleHealthCheck(task, launchedTask);
+            launchedTasks.put(deserializedTask.getTaskId(), launchedTask);
+            scheduleHealthCheck(deserializedTask, launchedTask);
         } catch (Throwable t) {
             LOGGER.error("Error launching task = {}. Reason: {}", task, t);
 

--- a/src/main/java/org/apache/mesos/executor/CustomExecutor.java
+++ b/src/main/java/org/apache/mesos/executor/CustomExecutor.java
@@ -63,13 +63,13 @@ public class CustomExecutor implements Executor {
         LOGGER.info("Launching task: {}", task);
 
         try {
-            Protos.TaskInfo deserializedTask = TaskUtils.deserializeTaskInfo(task);
-            final ExecutorTask taskToExecute = executorTaskFactory.createTask(deserializedTask, driver);
+            Protos.TaskInfo unpackedTaskInfo = TaskUtils.unpackTaskInfo(task);
+            final ExecutorTask taskToExecute = executorTaskFactory.createTask(unpackedTaskInfo, driver);
 
             Future<?> future = executorService.submit(taskToExecute);
             LaunchedTask launchedTask = new LaunchedTask(taskToExecute, future);
-            launchedTasks.put(deserializedTask.getTaskId(), launchedTask);
-            scheduleHealthCheck(deserializedTask, launchedTask);
+            launchedTasks.put(unpackedTaskInfo.getTaskId(), launchedTask);
+            scheduleHealthCheck(unpackedTaskInfo, launchedTask);
         } catch (Throwable t) {
             LOGGER.error("Error launching task = {}. Reason: {}", task, t);
 

--- a/src/main/java/org/apache/mesos/offer/OfferEvaluator.java
+++ b/src/main/java/org/apache/mesos/offer/OfferEvaluator.java
@@ -385,9 +385,8 @@ public class OfferEvaluator {
 
             taskBuilder.setExecutor(execBuilder.build());
         }
-        taskBuilder = ResourceUtils.serializeCommandInfo(
-                ResourceUtils.updateEnvironment(taskBuilder, fulfilledTaskResources));
 
-        return taskBuilder.build();
+        return TaskUtils.serializeTaskInfo(
+                ResourceUtils.updateEnvironment(taskBuilder, fulfilledTaskResources).build());
     }
 }

--- a/src/main/java/org/apache/mesos/offer/OfferEvaluator.java
+++ b/src/main/java/org/apache/mesos/offer/OfferEvaluator.java
@@ -386,7 +386,7 @@ public class OfferEvaluator {
             taskBuilder.setExecutor(execBuilder.build());
         }
 
-        return TaskUtils.serializeTaskInfo(
+        return TaskUtils.packTaskInfo(
                 ResourceUtils.updateEnvironment(taskBuilder, fulfilledTaskResources).build());
     }
 }

--- a/src/main/java/org/apache/mesos/offer/ResourceUtils.java
+++ b/src/main/java/org/apache/mesos/offer/ResourceUtils.java
@@ -203,17 +203,6 @@ public class ResourceUtils {
         return resBuilder.build();
     }
 
-    public static TaskInfo.Builder serializeCommandInfo(Protos.TaskInfo.Builder builder) {
-        Protos.CommandInfo command = builder.getCommand();
-
-        if (builder.hasExecutor()) {
-            builder.clearCommand();
-            builder.setData(command.toByteString());
-        }
-
-        return builder;
-    }
-
     public static Resource setDynamicPortName(Resource resource, String name) {
         Labels labels = setDynamicPortName(resource.getReservation().getLabels(), name);
 

--- a/src/main/java/org/apache/mesos/offer/TaskUtils.java
+++ b/src/main/java/org/apache/mesos/offer/TaskUtils.java
@@ -310,7 +310,14 @@ public class TaskUtils {
         }
     }
 
-    public static TaskInfo serializeTaskInfo(TaskInfo taskInfo) {
+    /**
+     * Mesos protobuf requirements do not allow a TaskInfo to simultaneously have a Command and Executor.  In order to
+     * workaround this we encapsulate a TaskInfo's Command and Data fields in an ExecutorInfo and store it in the
+     * data field of the TaskInfo.
+     * @param taskInfo
+     * @return
+     */
+    public static TaskInfo packTaskInfo(TaskInfo taskInfo) {
         if (!taskInfo.hasExecutor()) {
             return taskInfo;
         } else {
@@ -319,6 +326,8 @@ public class TaskUtils {
 
             if (taskInfo.hasCommand()) {
                 executorInfoBuilder.setCommand(taskInfo.getCommand());
+            } else {
+                executorInfoBuilder.setCommand(CommandInfo.getDefaultInstance());
             }
 
             if (taskInfo.hasData()) {
@@ -332,7 +341,13 @@ public class TaskUtils {
         }
     }
 
-    public static TaskInfo deserializeTaskInfo(TaskInfo taskInfo) throws InvalidProtocolBufferException {
+    /**
+     * This method reverses the work done in packTaskInfo such that the original TaskInfo is regenerated.
+     * @param taskInfo
+     * @return
+     * @throws InvalidProtocolBufferException
+     */
+    public static TaskInfo unpackTaskInfo(TaskInfo taskInfo) throws InvalidProtocolBufferException {
         if (!taskInfo.hasExecutor()) {
             return taskInfo;
         } else {

--- a/src/test/java/org/apache/mesos/executor/ProcessTaskTest.java
+++ b/src/test/java/org/apache/mesos/executor/ProcessTaskTest.java
@@ -51,7 +51,7 @@ public class ProcessTaskTest {
 
         final ProcessTask processTask = ProcessTask.create(
                 mockExecutorDriver,
-                TaskUtils.deserializeTaskInfo(taskInfo),
+                TaskUtils.unpackTaskInfo(taskInfo),
                 false);
 
         Assert.assertFalse(processTask.isAlive());

--- a/src/test/java/org/apache/mesos/executor/ProcessTaskTest.java
+++ b/src/test/java/org/apache/mesos/executor/ProcessTaskTest.java
@@ -19,6 +19,18 @@ public class ProcessTaskTest {
     private static final String EXECUTOR_NAME = "TEST_EXECUTOR";
     private static final String TASK_NAME = "TEST_TASK";
 
+    private static final Protos.ExecutorInfo cmdPkgExecutorInfo = Protos.ExecutorInfo
+            .newBuilder()
+            .setExecutorId(Protos.ExecutorID.newBuilder().setValue("dummy_value_unused"))
+            .setCommand(Protos.CommandInfo.newBuilder()
+                    .setValue("sleep 5")
+                    .setEnvironment(Protos.Environment
+                            .newBuilder()
+                            .addVariables(
+                                    TaskTestUtils.createEnvironmentVariable(DcosTaskConstants.TASK_TYPE, "TEST")))
+                    .build())
+            .build();
+
     @Test
     public void testSimple() throws Exception {
         final ExecutorDriver mockExecutorDriver = Mockito.mock(ExecutorDriver.class);
@@ -27,23 +39,20 @@ public class ProcessTaskTest {
                 .setName(EXECUTOR_NAME)
                 .setExecutorId(ExecutorUtils.toExecutorId(EXECUTOR_NAME))
                 .setCommand(Protos.CommandInfo.newBuilder().setValue("ls")).build();
+
         final Protos.TaskInfo taskInfo = Protos.TaskInfo
                 .newBuilder()
                 .setName(TASK_NAME)
                 .setTaskId(TaskUtils.toTaskId(TASK_NAME))
                 .setSlaveId(SlaveID.newBuilder().setValue("ignored"))
                 .setExecutor(executorInfo)
-                .setData(Protos.CommandInfo
-                        .newBuilder()
-                        .setValue("sleep 5")
-                        .setEnvironment(Protos.Environment
-                                .newBuilder()
-                                .addVariables(
-                                        TaskTestUtils.createEnvironmentVariable(DcosTaskConstants.TASK_TYPE, "TEST")))
-                        .build()
-                        .toByteString())
+                .setData(cmdPkgExecutorInfo.toByteString())
                 .build();
-        final ProcessTask processTask = ProcessTask.create(mockExecutorDriver, taskInfo, false);
+
+        final ProcessTask processTask = ProcessTask.create(
+                mockExecutorDriver,
+                TaskUtils.deserializeTaskInfo(taskInfo),
+                false);
 
         Assert.assertFalse(processTask.isAlive());
         final ExecutorService executorService = Executors.newCachedThreadPool();
@@ -55,6 +64,36 @@ public class ProcessTaskTest {
         Assert.assertTrue(processTask.isAlive());
         processTask.stop(null);
         Assert.assertFalse(processTask.isAlive());
+    }
+
+    @Test
+    public void testFailingTask() throws Exception {
+        final ExecutorDriver mockExecutorDriver = Mockito.mock(ExecutorDriver.class);
+
+        final Protos.ExecutorInfo executorInfo = Protos.ExecutorInfo
+                .newBuilder()
+                .setName(EXECUTOR_NAME)
+                .setExecutorId(ExecutorUtils.toExecutorId(EXECUTOR_NAME))
+                .setCommand(Protos.CommandInfo.newBuilder().setValue("ls")).build();
+
+        final Protos.TaskInfo taskInfo = Protos.TaskInfo
+                .newBuilder()
+                .setName(TASK_NAME)
+                .setTaskId(TaskUtils.toTaskId(TASK_NAME))
+                .setSlaveId(SlaveID.newBuilder().setValue("ignored"))
+                .setExecutor(executorInfo)
+                .setData(cmdPkgExecutorInfo.toByteString())
+                .build();
+
+        final FailingProcessTask failingProcessTask = new FailingProcessTask(
+                mockExecutorDriver,
+                taskInfo,
+                TaskUtils.getProcess(taskInfo),
+                false);
+        final ExecutorService executorService = Executors.newCachedThreadPool();
+        executorService.submit(failingProcessTask);
+
+        Mockito.verify(mockExecutorDriver, timeout(1000)).sendStatusUpdate(Mockito.any());
     }
 
     public static class FailingProcessTask extends ProcessTask {
@@ -72,39 +111,4 @@ public class ProcessTaskTest {
         }
     }
 
-    @Test
-    public void testFailingTask() throws Exception {
-        final ExecutorDriver mockExecutorDriver = Mockito.mock(ExecutorDriver.class);
-
-        final Protos.ExecutorInfo executorInfo = Protos.ExecutorInfo
-                .newBuilder()
-                .setName(EXECUTOR_NAME)
-                .setExecutorId(ExecutorUtils.toExecutorId(EXECUTOR_NAME))
-                .setCommand(Protos.CommandInfo.newBuilder().setValue("ls")).build();
-        final Protos.TaskInfo taskInfo = Protos.TaskInfo
-                .newBuilder()
-                .setName(TASK_NAME)
-                .setTaskId(TaskUtils.toTaskId(TASK_NAME))
-                .setSlaveId(SlaveID.newBuilder().setValue("ignored"))
-                .setExecutor(executorInfo)
-                .setData(Protos.CommandInfo
-                        .newBuilder()
-                        .setValue("sleep 5")
-                        .setEnvironment(Protos.Environment
-                                .newBuilder()
-                                .addVariables(
-                                        TaskTestUtils.createEnvironmentVariable(DcosTaskConstants.TASK_TYPE, "TEST")))
-                        .build()
-                        .toByteString())
-                .build();
-        final FailingProcessTask failingProcessTask = new FailingProcessTask(
-                mockExecutorDriver,
-                taskInfo,
-                TaskUtils.getProcess(taskInfo),
-                false);
-        final ExecutorService executorService = Executors.newCachedThreadPool();
-        executorService.submit(failingProcessTask);
-
-        Mockito.verify(mockExecutorDriver, timeout(1000)).sendStatusUpdate(Mockito.any());
-    }
 }

--- a/src/test/java/org/apache/mesos/offer/OfferEvaluatorTest.java
+++ b/src/test/java/org/apache/mesos/offer/OfferEvaluatorTest.java
@@ -163,7 +163,7 @@ public class OfferEvaluatorTest {
         resourceIdLabel = fulfilledExecutorPortResource.getReservation().getLabels().getLabels(0);
         Assert.assertEquals("resource_id", resourceIdLabel.getKey());
 
-        CommandInfo command = TaskUtils.deserializeTaskInfo(taskInfo).getCommand();
+        CommandInfo command = TaskUtils.unpackTaskInfo(taskInfo).getCommand();
         Assert.assertEquals(0, taskInfo.getCommand().getEnvironment().getVariablesCount());
         Assert.assertEquals(1, command.getEnvironment().getVariablesCount());
 

--- a/src/test/java/org/apache/mesos/offer/OfferEvaluatorTest.java
+++ b/src/test/java/org/apache/mesos/offer/OfferEvaluatorTest.java
@@ -163,7 +163,7 @@ public class OfferEvaluatorTest {
         resourceIdLabel = fulfilledExecutorPortResource.getReservation().getLabels().getLabels(0);
         Assert.assertEquals("resource_id", resourceIdLabel.getKey());
 
-        CommandInfo command = CommandInfo.parseFrom(taskInfo.getData());
+        CommandInfo command = TaskUtils.deserializeTaskInfo(taskInfo).getCommand();
         Assert.assertEquals(0, taskInfo.getCommand().getEnvironment().getVariablesCount());
         Assert.assertEquals(1, command.getEnvironment().getVariablesCount());
 

--- a/src/test/java/org/apache/mesos/testutils/TaskTestUtils.java
+++ b/src/test/java/org/apache/mesos/testutils/TaskTestUtils.java
@@ -17,7 +17,8 @@ public class TaskTestUtils {
         Protos.TaskInfo.Builder builder = Protos.TaskInfo.newBuilder()
                 .setTaskId(TestConstants.TASK_ID)
                 .setName(TestConstants.TASK_NAME)
-                .setSlaveId(TestConstants.AGENT_ID);
+                .setSlaveId(TestConstants.AGENT_ID)
+                .setCommand(TestConstants.COMMAND_INFO);
 
         return builder.addAllResources(resources).build();
     }

--- a/src/test/java/org/apache/mesos/testutils/TestConstants.java
+++ b/src/test/java/org/apache/mesos/testutils/TestConstants.java
@@ -34,4 +34,9 @@ public class TestConstants {
             Protos.FrameworkID.newBuilder()
                     .setValue("test-framework-id")
                     .build();
+
+    public static final Protos.CommandInfo COMMAND_INFO =
+            Protos.CommandInfo.newBuilder()
+            .setValue("echo test")
+            .build();
 }


### PR DESCRIPTION
TaskInfos may not simultaneously have CommandInfo and ExecutorInfo fields.  That doesn't make sense and there is [a ticket with a shepherd to fix it on the Mesos side](https://issues.apache.org/jira/browse/MESOS-6294).

In the mean time we had been serializing the CommandInfo when a custom Executor is used and putting it in the data field.  However, this overwrites anything that was in the data field.  So one more level of encapsulation is needed.  I am reusing the ExecutorInfo protobuf for this as it's the smallest protobuf with both CommandInfo and data fields.

So, when a TaskInfo with both CommandInfo and ExecutorInfo is encountered, the necessary information is serialized and encapsulated in an ExecutorInfo (in the data field) on the Scheduler side.  The deserialization operation is performed on our CustomExecutor's launchTask side.