### PR TITLE
Eliminate NullPointerException on processing offers

### DIFF
--- a/src/main/java/org/apache/mesos/offer/MesosResourcePool.java
+++ b/src/main/java/org/apache/mesos/offer/MesosResourcePool.java
@@ -183,7 +183,7 @@ public class MesosResourcePool {
             }
         }
 
-        return Optional.of(mesosResource);
+        return Optional.ofNullable(mesosResource);
     }
 
     private Optional<MesosResource> consumeAtomic(ResourceRequirement resourceRequirement) {


### PR DESCRIPTION
If the resource is `null`, Java complains since `Optional`'s `.of` can't encapsulate a `null` value.

```
INFO  [2016-10-05 02:18:34,282] org.apache.mesos.scheduler.recovery.DefaultRecoveryScheduler: Preparing to launch task
INFO  [2016-10-05 02:18:34,282] org.apache.mesos.offer.MesosResourcePool: Retrieving reserved resource
ERROR [2016-10-05 02:18:34,282] com.mesosphere.dcos.kafka.scheduler.KafkaScheduler: Unexpected exception encountered when processing offers
! java.lang.NullPointerException: null
! at java.util.Objects.requireNonNull(Objects.java:203) ~[na:1.8.0_91]
! at java.util.Optional.<init>(Optional.java:96) ~[na:1.8.0_91]
! at java.util.Optional.of(Optional.java:108) ~[na:1.8.0_91]
! at org.apache.mesos.offer.MesosResourcePool.consumeReserved(MesosResourcePool.java:186) ~[dcos-commons-0.7.10-SNAPSHOT.jar:na]
! at org.apache.mesos.offer.MesosResourcePool.consume(MesosResourcePool.java:75) ~[dcos-commons-0.7.10-SNAPSHOT.jar:na]
! at org.apache.mesos.offer.OfferEvaluator$FulfilledRequirement.fulfillRequirement(OfferEvaluator.java:168) ~[dcos-commons-0.7.10-SNAPSHOT.jar:na]
! at org.apache.mesos.offer.OfferEvaluator.evaluate(OfferEvaluator.java:69) ~[dcos-commons-0.7.10-SNAPSHOT.jar:na]
! at org.apache.mesos.offer.OfferEvaluator.evaluate(OfferEvaluator.java:34) ~[dcos-commons-0.7.10-SNAPSHOT.jar:na]
! at org.apache.mesos.scheduler.recovery.DefaultRecoveryScheduler.resourceOffers(DefaultRecoveryScheduler.java:105) ~[dcos-commons-0.7.10-SNAPSHOT.jar:na]
! at com.mesosphere.dcos.kafka.scheduler.KafkaScheduler.resourceOffers(KafkaScheduler.java:298) ~[kafka-scheduler.jar:na]
```

@nickbp 