### PR TITLE
Move task config mgmt out of 'features' section

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -681,6 +681,13 @@ The DC/OS Stateful Services SDK includes deployment strategies supporting
 these different requirements.
 
 ## Configuration management
+For any framework, at least two components must be configured: the
+scheduler and the service.  Scheduler configuration includes things
+like node count, deployment strategies, and security parameters.
+Service configuration includes resource settings such memory, cpu,
+ports, etc., as well as any configuration passed on to the underlying
+service.
+
 The DC/OS Stateful Services SDK includes logic for reading
 configuration from an external source (default: environment
 variables), detecting changes to the configuration, and redeploying

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -382,14 +382,6 @@ While the above describes configuration of the scheduler itself via
 environment variables, there's also a need for configuration of the
 underlying service tasks themselves in a flexible way.
 
-The DC/OS Stateful Services SDK includes logic for reading
-configuration from an external source (default: environment
-variables), detecting changes to the configuration, and redeploying
-any affected tasks.  It also supports marking certain configuration
-parameters as "unmodifiable", so that the user can't change them after
-install time.  For example, the disk size of permanent volumes cannot
-be modified because volume size is static.
-
 (Note: As of this writing, the following is still a work in progress,
 but should be available in the next week or two.)
 
@@ -687,6 +679,15 @@ including for instance Apache Cassandra, require nodes to be added to
 the cluster one at at time.  Others may permit parallel deployment.
 The DC/OS Stateful Services SDK includes deployment strategies supporting
 these different requirements.
+
+## Configuration management
+The DC/OS Stateful Services SDK includes logic for reading
+configuration from an external source (default: environment
+variables), detecting changes to the configuration, and redeploying
+any affected tasks.  It also supports marking certain configuration
+parameters as "unmodifiable", so that the user can't change them after
+install time.  For example, the disk size of permanent volumes cannot
+be modified because volume size is static.
 
 ## Upgrade support
 From time to time, services must be upgraded from version N to version N+1.


### PR DESCRIPTION
Now moved adjacent to the scheduler reconfiguration tutorial