### PR TITLE
Provide better error when 'dcos' isn't in PATH

### DIFF
--- a/cli/runcli.go
+++ b/cli/runcli.go
@@ -15,8 +15,14 @@ func RunCLICommand(arg ...string) (string, error) {
 	}
 	outBytes, err := exec.Command("dcos", arg...).CombinedOutput()
 	if err != nil {
-		if Verbose {
-			log.Printf("CLI command returned error, PATH is: %s", os.Getenv("PATH"))
+		execErr, ok := err.(*exec.Error)
+		if ok && execErr.Err == exec.ErrNotFound {
+			// special case: 'dcos' not in PATH. provide special instructions
+			log.Printf("Unable to run DC/OS CLI command: dcos %s", strings.Join(arg, " "))
+			log.Printf("Please perform one of the following fixes, then try again:")
+			log.Printf("- Update your PATH environment to include the path to the 'dcos' executable, or...")
+			log.Printf("- Move the 'dcos' executable into a directory listed in your current PATH (see below).")
+			log.Fatalf("Current PATH is: %s", os.Getenv("PATH"))
 		}
 		return string(outBytes), err
 	}


### PR DESCRIPTION
The CLI modules need to call into 'dcos' to retrieve config settings.
To keep this straightforward, the modules assume that 'dcos' is
present in the PATH. This handling detects when that isn't the case,
and provides available options for solving it.

Fixes issue #176 