### PR TITLE
Ensure RandomRecoveryStrategy doesn't cause starvation

### DIFF
--- a/src/main/java/org/apache/mesos/scheduler/plan/RandomRecoveryStrategy.java
+++ b/src/main/java/org/apache/mesos/scheduler/plan/RandomRecoveryStrategy.java
@@ -1,10 +1,10 @@
 package org.apache.mesos.scheduler.plan;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.collections.CollectionUtils;
 
-import java.util.List;
-import java.util.Optional;
-import java.util.Random;
+import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * {@code RandomRecoveryStrategy} extends {@link DefaultInstallStrategy}, by providing a random block selection
@@ -17,11 +17,22 @@ public class RandomRecoveryStrategy extends DefaultInstallStrategy {
 
     @Override
     public Optional<Block> getCurrentBlock() {
-        final List<? extends Block> blocks = getPhase().getBlocks();
+        final List<? extends Block> blocks = filterOutCompletedBlocks(getPhase().getBlocks());
         if (isInterrupted() || CollectionUtils.isEmpty(blocks)) {
             return Optional.empty();
         } else {
             return Optional.of(blocks.get(new Random().nextInt(blocks.size())));
         }
+    }
+
+    /**
+     * Filters blocks that are already COMPLETE.
+     */
+    @VisibleForTesting
+    protected static List<Block> filterOutCompletedBlocks(List<? extends Block> blocks) {
+        if (blocks == null) {
+            return Arrays.asList();
+        }
+        return blocks.stream().filter(block -> !block.isComplete()).collect(Collectors.toList());
     }
 }

--- a/src/test/java/org/apache/mesos/scheduler/plan/RandomRecoveryStrategyTest.java
+++ b/src/test/java/org/apache/mesos/scheduler/plan/RandomRecoveryStrategyTest.java
@@ -24,12 +24,95 @@ public class RandomRecoveryStrategyTest {
 
     @Test
     @edu.umd.cs.findbugs.annotations.SuppressWarnings(value="RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT")
-    public void testGetCurrentBlockSingleBlock() {
+    public void testGetCurrentBlockSingleNonCompleteBlock() {
         Phase phase = mock(Phase.class);
-        final Block mock = mock(Block.class);
-        final List<? extends Block> blocks = Arrays.asList(mock);
+        final Block nonCompleteBlock = mock(Block.class);
+        final List<? extends Block> blocks = Arrays.asList(nonCompleteBlock);
         Mockito.doReturn(blocks).when(phase).getBlocks();
         final RandomRecoveryStrategy randomRecoveryStrategy = new RandomRecoveryStrategy(phase);
         Assert.assertTrue(randomRecoveryStrategy.getCurrentBlock().isPresent());
+    }
+
+    @Test
+    @edu.umd.cs.findbugs.annotations.SuppressWarnings(value="RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT")
+    public void testGetCurrentBlockSingleCompleteBlock() {
+        Phase phase = mock(Phase.class);
+        final Block completeBlock = mock(Block.class);
+        when(completeBlock.isComplete()).thenReturn(true);
+        final List<? extends Block> blocks = Arrays.asList(completeBlock);
+        Mockito.doReturn(blocks).when(phase).getBlocks();
+        final RandomRecoveryStrategy randomRecoveryStrategy = new RandomRecoveryStrategy(phase);
+        Assert.assertFalse(randomRecoveryStrategy.getCurrentBlock().isPresent());
+    }
+
+    @Test
+    @edu.umd.cs.findbugs.annotations.SuppressWarnings(value="RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT")
+    public void testGetCurrentBlockAllNonCompleteBlock() {
+        Phase phase = mock(Phase.class);
+        final Block notCompletedA = mock(Block.class);
+        final Block notCompletedB = mock(Block.class);
+        when(notCompletedA.isComplete()).thenReturn(false);
+        when(notCompletedB.isComplete()).thenReturn(false);
+        final List<Block> blocks = Arrays.asList(notCompletedA, notCompletedB);
+        Mockito.doReturn(blocks).when(phase).getBlocks();
+        final RandomRecoveryStrategy randomRecoveryStrategy = new RandomRecoveryStrategy(phase);
+        Assert.assertTrue(randomRecoveryStrategy.getCurrentBlock().isPresent());
+    }
+
+    @Test
+    @edu.umd.cs.findbugs.annotations.SuppressWarnings(value="RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT")
+    public void testGetCurrentBlockAllCompleteBlock() {
+        Phase phase = mock(Phase.class);
+        final Block notCompletedA = mock(Block.class);
+        final Block notCompletedB = mock(Block.class);
+        when(notCompletedA.isComplete()).thenReturn(true);
+        when(notCompletedB.isComplete()).thenReturn(true);
+        final List<Block> blocks = Arrays.asList(notCompletedA, notCompletedB);
+        Mockito.doReturn(blocks).when(phase).getBlocks();
+        final RandomRecoveryStrategy randomRecoveryStrategy = new RandomRecoveryStrategy(phase);
+        Assert.assertFalse(randomRecoveryStrategy.getCurrentBlock().isPresent());
+    }
+
+    @Test
+    public void testFilterOutCompletedBlocksOneCompleted() {
+        final Block completed = mock(Block.class);
+        final Block notCompleted = mock(Block.class);
+        when(completed.isComplete()).thenReturn(true);
+        when(notCompleted.isComplete()).thenReturn(false);
+        final List<Block> blocks = Arrays.asList(completed, notCompleted);
+        final List<Block> filtered = RandomRecoveryStrategy.filterOutCompletedBlocks(blocks);
+        Assert.assertNotNull(filtered);
+        Assert.assertEquals(1, filtered.size());
+    }
+
+    @Test
+    public void testFilterOutCompletedBlocksNoCompleted() {
+        final Block notCompletedA = mock(Block.class);
+        final Block notCompletedB = mock(Block.class);
+        when(notCompletedA.isComplete()).thenReturn(false);
+        when(notCompletedB.isComplete()).thenReturn(false);
+        final List<Block> blocks = Arrays.asList(notCompletedA, notCompletedB);
+        final List<Block> filtered = RandomRecoveryStrategy.filterOutCompletedBlocks(blocks);
+        Assert.assertNotNull(filtered);
+        Assert.assertEquals(2, filtered.size());
+    }
+
+    @Test
+    public void testFilterOutCompletedBlocksAllCompleted() {
+        final Block completedA = mock(Block.class);
+        final Block completedB = mock(Block.class);
+        when(completedA.isComplete()).thenReturn(true);
+        when(completedB.isComplete()).thenReturn(true);
+        final List<Block> blocks = Arrays.asList(completedA, completedB);
+        final List<Block> filtered = RandomRecoveryStrategy.filterOutCompletedBlocks(blocks);
+        Assert.assertNotNull(filtered);
+        Assert.assertEquals(0, filtered.size());
+    }
+
+    @Test
+    public void testFilterOutNull() {
+        final List<Block> filtered = RandomRecoveryStrategy.filterOutCompletedBlocks(null);
+        Assert.assertNotNull(filtered);
+        Assert.assertEquals(0, filtered.size());
     }
 }


### PR DESCRIPTION
Ensuring that `RandomRecoveryStrategy` works well with mostly and all `COMPLETED` blocks.