### PR TITLE
Provide instructions in the common newbie case of leftover ZK/resources

### DIFF
--- a/src/main/java/org/apache/mesos/scheduler/DefaultScheduler.java
+++ b/src/main/java/org/apache/mesos/scheduler/DefaultScheduler.java
@@ -37,7 +37,7 @@ import java.util.concurrent.*;
 public class DefaultScheduler implements Scheduler {
     private static final String UNINSTALL_INCOMPLETE_ERROR_MESSAGE = "Framework has been removed";
     private static final String UNINSTALL_INSTRUCTIONS_URI =
-            "https://docs.mesosphere.com/1.8/usage/managing-services/uninstall/";
+            "https://docs.mesosphere.com/latest/usage/managing-services/uninstall/";
 
     private static final Integer DELAY_BETWEEN_DESTRUCTIVE_RECOVERIES_SEC = 10 * 60;
     private static final Integer PERMANENT_FAILURE_DELAY_SEC = 20 * 60;


### PR DESCRIPTION
"Framework has been removed" isn't exactly the most intuitive error for describing what's really going on. Bridge the gap.

Solves issue #177 