### PR TITLE
Fix filtering terminated tasks

### DIFF
--- a/src/main/java/org/apache/mesos/scheduler/recovery/DefaultRecoveryPlanManager.java
+++ b/src/main/java/org/apache/mesos/scheduler/recovery/DefaultRecoveryPlanManager.java
@@ -250,11 +250,9 @@ public class DefaultRecoveryPlanManager implements PlanManager {
                 return terminatedTasks;
             }
 
-            for (String assetToIgnore : dirtiedAssets) {
-                for (Protos.TaskInfo taskForRepair : terminatedTasks) {
-                    if (!Objects.equals(taskForRepair.getName(), assetToIgnore)) {
-                        filteredTerminatedTasks.add(taskForRepair);
-                    }
+            for (Protos.TaskInfo taskForRepair : terminatedTasks) {
+                if (!dirtiedAssets.contains(taskForRepair.getName())) {
+                    filteredTerminatedTasks.add(taskForRepair);
                 }
             }
         } catch (Exception ex) {

--- a/src/test/java/org/apache/mesos/scheduler/recovery/DefaultRecoveryPlanManagerTest.java
+++ b/src/test/java/org/apache/mesos/scheduler/recovery/DefaultRecoveryPlanManagerTest.java
@@ -421,11 +421,18 @@ public class DefaultRecoveryPlanManagerTest {
         TaskInfo taskInfoB = TaskInfo.newBuilder(TaskTestUtils.getTaskInfo(Arrays.asList(cpus)))
                 .setTaskId(TaskUtils.toTaskId(taskNameB))
                 .setName(taskNameB).build();
-        List<TaskInfo> infos = Arrays.asList(taskInfoA, taskInfoB);
+        final String taskNameC = TestConstants.TASK_NAME + "-C";
+        TaskInfo taskInfoC = TaskInfo.newBuilder(TaskTestUtils.getTaskInfo(Arrays.asList(cpus)))
+                .setTaskId(TaskUtils.toTaskId(taskNameC))
+                .setName(taskNameC).build();
+        List<TaskInfo> infos = Arrays.asList(taskInfoA, taskInfoB, taskInfoC);
         when(stateStore.fetchTasksNeedingRecovery()).thenReturn(infos);
-        Block block = mock(Block.class);
-        when(block.getName()).thenReturn(TestConstants.TASK_NAME);
-        final Collection<TaskInfo> terminatedTasks = recoveryManager.getTerminatedTasks(Arrays.asList(block.getName()));
+        Block blockA = mock(Block.class);
+        when(blockA.getName()).thenReturn(taskInfoA.getName());
+        Block blockC = mock(Block.class);
+        when(blockC.getName()).thenReturn(taskInfoC.getName());
+        final Collection<TaskInfo> terminatedTasks = recoveryManager.getTerminatedTasks(
+                Arrays.asList(blockA.getName(), blockC.getName()));
         assertEquals(1, terminatedTasks.size());
         assertEquals(taskNameB, terminatedTasks.iterator().next().getName());
     }


### PR DESCRIPTION
Original code does not filter dirtied assets correctly. Assuming there are tasks A, B and C, that need recovery, and dirtied assets are A and C, the original code returns tasks B, C, A, B, instead of expected task B only.

This issue appeared during cluster update (such as increasing cpus/mem requirements, or changing command) with custom scheduler based on DefaultScheduler. Cluster update seems broken in this version of dcos-commons, when DefaultScheduler is used, and more fixes could be required.