### PR TITLE
Add ContainerInfo for TaskSpecification

### DIFF
--- a/examples/reference/src/main/java/com/mesosphere/sdk/reference/scheduler/Main.java
+++ b/examples/reference/src/main/java/com/mesosphere/sdk/reference/scheduler/Main.java
@@ -54,6 +54,7 @@ public class Main {
                 return Arrays.asList(
                         DefaultTaskSet.create(TASK_METADATA_COUNT,
                                 TASK_METADATA_NAME,
+                                TASK_METADATA_NAME,
                                 getCommand(TASK_METADATA_NAME),
                                 getResources(TASK_METADATA_CPU, TASK_METADATA_MEM_MB),
                                 getVolumes(TASK_METADATA_DISK_MB, TASK_METADATA_NAME),
@@ -63,6 +64,7 @@ public class Main {
                                 Optional.of(TaskTypeGenerator.createAvoid(TASK_METADATA_NAME)),
                                 Optional.of(getHealthCheck(TASK_METADATA_NAME))),
                         DefaultTaskSet.create(TASK_DATA_COUNT,
+                                TASK_DATA_NAME,
                                 TASK_DATA_NAME,
                                 getCommand(TASK_DATA_NAME),
                                 getResources(TASK_DATA_CPU, TASK_DATA_MEM_MB),

--- a/sdk/core/src/main/java/org/apache/mesos/offer/DefaultOfferRequirementProvider.java
+++ b/sdk/core/src/main/java/org/apache/mesos/offer/DefaultOfferRequirementProvider.java
@@ -34,19 +34,26 @@ public class DefaultOfferRequirementProvider implements OfferRequirementProvider
     public OfferRequirement getNewOfferRequirement(TaskSpecification taskSpecification)
             throws InvalidRequirementException {
 
-        Protos.CommandInfo updatedCommand = taskConfigRouter.getConfig(taskSpecification.getType())
-                .updateEnvironment(taskSpecification.getCommand());
         Protos.TaskInfo.Builder taskInfoBuilder = Protos.TaskInfo.newBuilder()
                 .setName(taskSpecification.getName())
-                .setCommand(updatedCommand)
                 .setTaskId(TaskUtils.emptyTaskId())
                 .setSlaveId(TaskUtils.emptyAgentId())
                 .addAllResources(getNewResources(taskSpecification));
 
         TaskUtils.setConfigFiles(taskInfoBuilder, taskSpecification.getConfigFiles());
 
+        if (taskSpecification.getCommand().isPresent()) {
+            Protos.CommandInfo updatedCommand = taskConfigRouter.getConfig(taskSpecification.getType())
+                    .updateEnvironment(taskSpecification.getCommand().get());
+            taskInfoBuilder.setCommand(updatedCommand);
+        }
+
         if (taskSpecification.getHealthCheck().isPresent()) {
             taskInfoBuilder.setHealthCheck(taskSpecification.getHealthCheck().get());
+        }
+
+        if (taskSpecification.getContainer().isPresent()) {
+            taskInfoBuilder.setContainer(taskSpecification.getContainer().get());
         }
 
         return new OfferRequirement(
@@ -86,12 +93,10 @@ public class DefaultOfferRequirementProvider implements OfferRequirementProvider
         } catch (TaskException e) {
             throw new InvalidRequirementException(e);
         }
-        Protos.CommandInfo updatedCommand = taskConfigRouter.getConfig(taskType)
-                .updateEnvironment(taskSpecification.getCommand());
+
         Protos.TaskInfo.Builder taskInfoBuilder = Protos.TaskInfo.newBuilder(taskInfo)
                 .clearResources()
                 .clearExecutor()
-                .setCommand(updatedCommand)
                 .addAllResources(updatedResources)
                 .addAllResources(getVolumes(taskInfo.getResourcesList()))
                 .setTaskId(TaskUtils.emptyTaskId())
@@ -99,8 +104,18 @@ public class DefaultOfferRequirementProvider implements OfferRequirementProvider
 
         TaskUtils.setConfigFiles(taskInfoBuilder, taskSpecification.getConfigFiles());
 
+        if (taskSpecification.getCommand().isPresent()) {
+            Protos.CommandInfo updatedCommand = taskConfigRouter.getConfig(taskType)
+                    .updateEnvironment(taskSpecification.getCommand().get());
+            taskInfoBuilder.setCommand(updatedCommand);
+        }
+
         if (taskSpecification.getHealthCheck().isPresent()) {
             taskInfoBuilder.setHealthCheck(taskSpecification.getHealthCheck().get());
+        }
+
+        if (taskSpecification.getContainer().isPresent()) {
+            taskInfoBuilder.setContainer(taskSpecification.getContainer().get());
         }
 
         try {

--- a/sdk/core/src/main/java/org/apache/mesos/offer/DefaultOfferRequirementProvider.java
+++ b/sdk/core/src/main/java/org/apache/mesos/offer/DefaultOfferRequirementProvider.java
@@ -48,12 +48,12 @@ public class DefaultOfferRequirementProvider implements OfferRequirementProvider
             taskInfoBuilder.setCommand(updatedCommand);
         }
 
-        if (taskSpecification.getHealthCheck().isPresent()) {
-            taskInfoBuilder.setHealthCheck(taskSpecification.getHealthCheck().get());
-        }
-
         if (taskSpecification.getContainer().isPresent()) {
             taskInfoBuilder.setContainer(taskSpecification.getContainer().get());
+        }
+
+        if (taskSpecification.getHealthCheck().isPresent()) {
+            taskInfoBuilder.setHealthCheck(taskSpecification.getHealthCheck().get());
         }
 
         return new OfferRequirement(
@@ -110,12 +110,12 @@ public class DefaultOfferRequirementProvider implements OfferRequirementProvider
             taskInfoBuilder.setCommand(updatedCommand);
         }
 
-        if (taskSpecification.getHealthCheck().isPresent()) {
-            taskInfoBuilder.setHealthCheck(taskSpecification.getHealthCheck().get());
-        }
-
         if (taskSpecification.getContainer().isPresent()) {
             taskInfoBuilder.setContainer(taskSpecification.getContainer().get());
+        }
+
+        if (taskSpecification.getHealthCheck().isPresent()) {
+            taskInfoBuilder.setHealthCheck(taskSpecification.getHealthCheck().get());
         }
 
         try {

--- a/sdk/core/src/main/java/org/apache/mesos/offer/TaskUtils.java
+++ b/sdk/core/src/main/java/org/apache/mesos/offer/TaskUtils.java
@@ -349,11 +349,42 @@ public class TaskUtils {
             return true;
         }
 
-        CommandInfo oldCommand = oldTaskSpecification.getCommand();
-        CommandInfo newCommand = newTaskSpecification.getCommand();
-        if (!Objects.equals(oldCommand, newCommand)) {
-            LOGGER.info("Task commands '{}' and '{}' are different.", oldCommand, newCommand);
+        boolean oldCommandPresent = oldTaskSpecification.getCommand().isPresent();
+        boolean newCommandPresent = newTaskSpecification.getCommand().isPresent();
+
+        if (oldCommandPresent != newCommandPresent) {
+            LOGGER.info(String.format("Task commands '%s' and '%s' are different.",
+                    (oldCommandPresent ? oldTaskSpecification.getCommand().get() : "NULL"),
+                    (newCommandPresent ? newTaskSpecification.getCommand().get() : "NULL")));
             return true;
+        }
+
+        if (oldCommandPresent && newCommandPresent) {
+            CommandInfo oldCommand = oldTaskSpecification.getCommand().get();
+            CommandInfo newCommand = newTaskSpecification.getCommand().get();
+            if (!Objects.equals(oldCommand, newCommand)) {
+                LOGGER.info(String.format("Task commands '%s' and '%s' are different.", oldCommand, newCommand));
+                return true;
+            }
+        }
+
+        boolean oldContainerPresent = oldTaskSpecification.getContainer().isPresent();
+        boolean newContainerPresent = newTaskSpecification.getContainer().isPresent();
+
+        if (oldContainerPresent != newContainerPresent) {
+            LOGGER.info(String.format("Task containers '%s' and '%s' are different.",
+                    (oldContainerPresent ? oldTaskSpecification.getContainer().get() : "NULL"),
+                    (newContainerPresent ? newTaskSpecification.getContainer().get() : "NULL")));
+            return true;
+        }
+
+        if (oldContainerPresent && newContainerPresent) {
+            ContainerInfo oldContainer = oldTaskSpecification.getContainer().get();
+            ContainerInfo newContainer = newTaskSpecification.getContainer().get();
+            if (!Objects.equals(oldContainer, newContainer)) {
+                LOGGER.info(String.format("Task containers '%s' and '%s' are different.", oldContainer, newContainer));
+                return true;
+            }
         }
 
         Map<String, ResourceSpecification> oldResourceMap = getResourceSpecMap(oldTaskSpecification.getResources());

--- a/sdk/core/src/main/java/org/apache/mesos/scheduler/plan/DefaultBlockFactory.java
+++ b/sdk/core/src/main/java/org/apache/mesos/scheduler/plan/DefaultBlockFactory.java
@@ -45,15 +45,15 @@ public class DefaultBlockFactory implements BlockFactory {
                         Status.PENDING,
                         Collections.emptyList());
             } else {
-                TaskSpecification oldTaskSpecification =
-                        DefaultTaskSpecification.create(TaskUtils.unpackTaskInfo(taskInfoOptional.get()));
+                Protos.TaskInfo taskInfo = TaskUtils.unpackTaskInfo(taskInfoOptional.get());
+                TaskSpecification oldTaskSpecification = DefaultTaskSpecification.create(taskInfo);
                 Status status = getStatus(oldTaskSpecification, taskSpecification);
                 logger.info("Generating existing block for: " + taskSpecification.getName() +
                         " with status: " + status);
                 return new DefaultBlock(
                         taskSpecification.getName(),
                         Optional.of(offerRequirementProvider
-                                .getExistingOfferRequirement(taskInfoOptional.get(), taskSpecification)),
+                                .getExistingOfferRequirement(taskInfo, taskSpecification)),
                         status,
                         Collections.emptyList());
             }

--- a/sdk/core/src/main/java/org/apache/mesos/scheduler/recovery/DefaultRecoveryPlanManager.java
+++ b/sdk/core/src/main/java/org/apache/mesos/scheduler/recovery/DefaultRecoveryPlanManager.java
@@ -1,11 +1,9 @@
 package org.apache.mesos.scheduler.recovery;
 
+import com.google.protobuf.InvalidProtocolBufferException;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.mesos.Protos;
-import org.apache.mesos.offer.DefaultOfferRequirementProvider;
-import org.apache.mesos.offer.InvalidRequirementException;
-import org.apache.mesos.offer.OfferRequirementProvider;
-import org.apache.mesos.offer.TaskException;
+import org.apache.mesos.offer.*;
 import org.apache.mesos.scheduler.ChainedObserver;
 import org.apache.mesos.scheduler.plan.*;
 import org.apache.mesos.scheduler.plan.strategy.RandomStrategy;
@@ -120,8 +118,12 @@ public class DefaultRecoveryPlanManager extends ChainedObserver implements PlanM
         return stateStore.fetchTasksNeedingRecovery().stream()
                 .map(taskInfo -> {
                     try {
-                        return createBlock(taskInfo);
-                    } catch (TaskException | InvalidTaskSpecificationException | InvalidRequirementException e) {
+                        return createBlock(TaskUtils.unpackTaskInfo(taskInfo));
+                    } catch (
+                            TaskException |
+                            InvalidTaskSpecificationException |
+                            InvalidRequirementException |
+                            InvalidProtocolBufferException e) {
                         return new DefaultBlock(
                                 taskInfo.getName(),
                                 Optional.empty(),

--- a/sdk/core/src/main/java/org/apache/mesos/specification/DefaultService.java
+++ b/sdk/core/src/main/java/org/apache/mesos/specification/DefaultService.java
@@ -82,7 +82,7 @@ public class DefaultService implements Service {
     }
 
     private static void registerFramework(Scheduler sched, Protos.FrameworkInfo frameworkInfo, String masterUri) {
-        LOGGER.info(String.format("Registering framework: %s", frameworkInfo));
+        LOGGER.info("Registering framework: {}", frameworkInfo);
         SchedulerDriver driver = new SchedulerDriverFactory().create(sched, frameworkInfo, masterUri);
         driver.run();
     }

--- a/sdk/core/src/main/java/org/apache/mesos/specification/DefaultService.java
+++ b/sdk/core/src/main/java/org/apache/mesos/specification/DefaultService.java
@@ -82,7 +82,7 @@ public class DefaultService implements Service {
     }
 
     private static void registerFramework(Scheduler sched, Protos.FrameworkInfo frameworkInfo, String masterUri) {
-        LOGGER.info("Registering framework: {}", frameworkInfo);
+        LOGGER.info(String.format("Registering framework: %s", frameworkInfo));
         SchedulerDriver driver = new SchedulerDriverFactory().create(sched, frameworkInfo, masterUri);
         driver.run();
     }

--- a/sdk/core/src/main/java/org/apache/mesos/specification/DefaultTaskSet.java
+++ b/sdk/core/src/main/java/org/apache/mesos/specification/DefaultTaskSet.java
@@ -24,7 +24,8 @@ public class DefaultTaskSet implements TaskSet {
             Collection<ResourceSpecification> resources,
             Collection<VolumeSpecification> volumes) {
 
-        return create(count,
+        return create(
+                count,
                 name,
                 type,
                 Optional.empty(),
@@ -47,7 +48,8 @@ public class DefaultTaskSet implements TaskSet {
             Optional<PlacementRuleGenerator> placementOptional,
             Optional<Protos.HealthCheck> healthCheck) {
 
-        return create(count,
+        return create(
+                count,
                 name,
                 type,
                 Optional.empty(),
@@ -70,7 +72,8 @@ public class DefaultTaskSet implements TaskSet {
             Optional<PlacementRuleGenerator> placementOptional,
             Optional<Protos.HealthCheck> healthCheck) {
 
-        return create(count,
+        return create(
+                count,
                 name,
                 type,
                 Optional.of(container),
@@ -94,16 +97,17 @@ public class DefaultTaskSet implements TaskSet {
             Optional<PlacementRuleGenerator> placementOptional,
             Optional<Protos.HealthCheck> healthCheck) {
 
-        return create(count,
-            name,
-            type,
-            Optional.of(container),
-            Optional.of(command),
-            resources,
-            volumes,
-            configs,
-            placementOptional,
-            healthCheck);
+        return create(
+                count,
+                name,
+                type,
+                Optional.of(container),
+                Optional.of(command),
+                resources,
+                volumes,
+                configs,
+                placementOptional,
+                healthCheck);
     }
 
     private static DefaultTaskSet create(

--- a/sdk/core/src/main/java/org/apache/mesos/specification/DefaultTaskSet.java
+++ b/sdk/core/src/main/java/org/apache/mesos/specification/DefaultTaskSet.java
@@ -19,13 +19,16 @@ public class DefaultTaskSet implements TaskSet {
     public static DefaultTaskSet create(
             int count,
             String name,
+            String type,
             Protos.CommandInfo command,
             Collection<ResourceSpecification> resources,
             Collection<VolumeSpecification> volumes) {
-        return create(
-                count,
+
+        return create(count,
                 name,
-                command,
+                type,
+                Optional.empty(),
+                Optional.of(command),
                 resources,
                 volumes,
                 new ArrayList<>() /* configs */,
@@ -36,7 +39,79 @@ public class DefaultTaskSet implements TaskSet {
     public static DefaultTaskSet create(
             int count,
             String name,
+            String type,
             Protos.CommandInfo command,
+            Collection<ResourceSpecification> resources,
+            Collection<VolumeSpecification> volumes,
+            Collection<ConfigFileSpecification> configs,
+            Optional<PlacementRuleGenerator> placementOptional,
+            Optional<Protos.HealthCheck> healthCheck) {
+
+        return create(count,
+                name,
+                type,
+                Optional.empty(),
+                Optional.of(command),
+                resources,
+                volumes,
+                configs,
+                placementOptional,
+                healthCheck);
+    }
+
+    public static DefaultTaskSet create(
+            int count,
+            String name,
+            String type,
+            Protos.ContainerInfo container,
+            Collection<ResourceSpecification> resources,
+            Collection<VolumeSpecification> volumes,
+            Collection<ConfigFileSpecification> configs,
+            Optional<PlacementRuleGenerator> placementOptional,
+            Optional<Protos.HealthCheck> healthCheck) {
+
+        return create(count,
+                name,
+                type,
+                Optional.of(container),
+                Optional.empty(),
+                resources,
+                volumes,
+                configs,
+                placementOptional,
+                healthCheck);
+    }
+
+    public static DefaultTaskSet create(
+            int count,
+            String name,
+            String type,
+            Protos.ContainerInfo container,
+            Protos.CommandInfo command,
+            Collection<ResourceSpecification> resources,
+            Collection<VolumeSpecification> volumes,
+            Collection<ConfigFileSpecification> configs,
+            Optional<PlacementRuleGenerator> placementOptional,
+            Optional<Protos.HealthCheck> healthCheck) {
+
+        return create(count,
+            name,
+            type,
+            Optional.of(container),
+            Optional.of(command),
+            resources,
+            volumes,
+            configs,
+            placementOptional,
+            healthCheck);
+    }
+
+    private static DefaultTaskSet create(
+            int count,
+            String name,
+            String type,
+            Optional<Protos.ContainerInfo> container,
+            Optional<Protos.CommandInfo> command,
             Collection<ResourceSpecification> resources,
             Collection<VolumeSpecification> volumes,
             Collection<ConfigFileSpecification> configs,
@@ -47,7 +122,8 @@ public class DefaultTaskSet implements TaskSet {
         for (int i = 0; i < count; i++) {
             taskSpecifications.add(new DefaultTaskSpecification(
                     name + "-" + i,
-                    name,
+                    type,
+                    container,
                     command,
                     resources,
                     volumes,

--- a/sdk/core/src/main/java/org/apache/mesos/specification/TaskSpecification.java
+++ b/sdk/core/src/main/java/org/apache/mesos/specification/TaskSpecification.java
@@ -24,9 +24,14 @@ public interface TaskSpecification {
     String getType();
 
     /**
-     * Returns the Mesos {@link Protos.CommandInfo} to be used for the starting task.
+     * Returns the Mesos {@code ContainerInfo} to be used for the starting task.
      */
-    Protos.CommandInfo getCommand();
+    Optional<Protos.ContainerInfo> getContainer();
+
+    /**
+     * Returns the Mesos {@code CommandInfo} to be used for the starting task.
+     */
+    Optional<Protos.CommandInfo> getCommand();
 
     /**
      * Returns the health check operation to be performed against this task while it's running, or

--- a/sdk/core/src/test/java/org/apache/mesos/offer/DefaultOfferRequirementProviderTest.java
+++ b/sdk/core/src/test/java/org/apache/mesos/offer/DefaultOfferRequirementProviderTest.java
@@ -36,6 +36,15 @@ public class DefaultOfferRequirementProviderTest {
         environmentVariables.set("EXECUTOR_URI", "");
     }
 
+    @Test(expected=InvalidTaskSpecificationException.class)
+    public void testEmptyTaskInfo() throws InvalidTaskSpecificationException, TaskException {
+        Protos.TaskInfo.Builder taskInfoBuilder = Protos.TaskInfo.newBuilder()
+                .setTaskId(TestConstants.TASK_ID)
+                .setName(TestConstants.TASK_NAME)
+                .setSlaveId(TestConstants.AGENT_ID);
+        DefaultTaskSpecification.create(taskInfoBuilder.build());
+    }
+
     @Test
     public void testUnchangedVolumes()
             throws InvalidTaskSpecificationException, InvalidRequirementException, TaskException {

--- a/sdk/core/src/test/java/org/apache/mesos/offer/DefaultOfferRequirementProviderTest.java
+++ b/sdk/core/src/test/java/org/apache/mesos/offer/DefaultOfferRequirementProviderTest.java
@@ -74,19 +74,6 @@ public class DefaultOfferRequirementProviderTest {
         Assert.assertEquals(true, taskSpecification.getCommand().isPresent());
 
         Assert.assertEquals(TestConstants.TASK_TYPE, offerRequirement.getTaskType());
-
-        /*
-        for (TaskRequirement taskRequirement : offerRequirement.getTaskRequirements()) {
-            boolean validCpu = false;
-            boolean validMem = false;
-            for (ResourceRequirement resourceRequirement : taskRequirement.getResourceRequirements()) {
-                validCpu |= resourceRequirement.getResource().equals(cpu);
-                validMem |= resourceRequirement.getResource().equals(mem);
-            }
-            Assert.assertTrue(validCpu);
-            Assert.assertTrue(validMem);
-        }
-        */
     }
 
     @Test

--- a/sdk/core/src/test/java/org/apache/mesos/offer/DefaultOfferRequirementProviderTest.java
+++ b/sdk/core/src/test/java/org/apache/mesos/offer/DefaultOfferRequirementProviderTest.java
@@ -45,6 +45,91 @@ public class DefaultOfferRequirementProviderTest {
         DefaultTaskSpecification.create(taskInfoBuilder.build());
     }
 
+    @Test(expected=TaskException.class)
+    public void testEmptyLabel() throws InvalidTaskSpecificationException, TaskException {
+        Protos.TaskInfo.Builder taskInfoBuilder = Protos.TaskInfo.newBuilder()
+                .setTaskId(TestConstants.TASK_ID)
+                .setCommand(TestConstants.COMMAND_INFO)
+                .setName(TestConstants.TASK_NAME)
+                .setSlaveId(TestConstants.AGENT_ID);
+        DefaultTaskSpecification.create(taskInfoBuilder.build());
+    }
+
+    @Test
+    public void testCommandTaskInfo()
+            throws InvalidTaskSpecificationException, TaskException, InvalidRequirementException {
+        Protos.Resource cpu = ResourceTestUtils.getExpectedCpu(CPU);
+        Protos.Resource mem = ResourceTestUtils.getDesiredMem(MEM);
+        Protos.TaskInfo tempTaskInfo = TaskTestUtils.getTaskInfo(Arrays.asList(cpu));
+        Protos.TaskInfo taskInfo = Protos.TaskInfo.newBuilder(tempTaskInfo)
+                .clearContainer()
+                .addResources(mem)
+                .build();
+
+        TaskSpecification taskSpecification = DefaultTaskSpecification.create(taskInfo);
+        OfferRequirement offerRequirement = defaultOfferRequirementProvider.getNewOfferRequirement(taskSpecification);
+
+        Assert.assertEquals(TestConstants.TASK_TYPE, taskSpecification.getType());
+        Assert.assertEquals(false, taskSpecification.getContainer().isPresent());
+        Assert.assertEquals(true, taskSpecification.getCommand().isPresent());
+
+        Assert.assertEquals(TestConstants.TASK_TYPE, offerRequirement.getTaskType());
+
+        /*
+        for (TaskRequirement taskRequirement : offerRequirement.getTaskRequirements()) {
+            boolean validCpu = false;
+            boolean validMem = false;
+            for (ResourceRequirement resourceRequirement : taskRequirement.getResourceRequirements()) {
+                validCpu |= resourceRequirement.getResource().equals(cpu);
+                validMem |= resourceRequirement.getResource().equals(mem);
+            }
+            Assert.assertTrue(validCpu);
+            Assert.assertTrue(validMem);
+        }
+        */
+    }
+
+    @Test
+    public void testContainerTaskInfo()
+            throws InvalidTaskSpecificationException, TaskException, InvalidRequirementException {
+        Protos.Resource cpu = ResourceTestUtils.getExpectedCpu(CPU);
+        Protos.Resource mem = ResourceTestUtils.getDesiredMem(MEM);
+        Protos.TaskInfo tempTaskInfo = TaskTestUtils.getTaskInfo(Arrays.asList(cpu));
+        Protos.TaskInfo taskInfo = Protos.TaskInfo.newBuilder(tempTaskInfo)
+                .clearCommand()
+                .addResources(mem)
+                .build();
+
+        TaskSpecification taskSpecification = DefaultTaskSpecification.create(taskInfo);
+        OfferRequirement offerRequirement = defaultOfferRequirementProvider.getNewOfferRequirement(taskSpecification);
+
+        Assert.assertEquals(TestConstants.TASK_TYPE, taskSpecification.getType());
+        Assert.assertEquals(false, taskSpecification.getCommand().isPresent());
+        Assert.assertEquals(true, taskSpecification.getContainer().isPresent());
+
+        Assert.assertEquals(TestConstants.TASK_TYPE, offerRequirement.getTaskType());
+    }
+
+    @Test
+    public void testCommandContainerTaskInfo()
+            throws InvalidTaskSpecificationException, TaskException, InvalidRequirementException {
+        Protos.Resource cpu = ResourceTestUtils.getExpectedCpu(CPU);
+        Protos.Resource mem = ResourceTestUtils.getDesiredMem(MEM);
+        Protos.TaskInfo tempTaskInfo = TaskTestUtils.getTaskInfo(Arrays.asList(cpu));
+        Protos.TaskInfo taskInfo = Protos.TaskInfo.newBuilder(tempTaskInfo)
+                .addResources(mem)
+                .build();
+
+        TaskSpecification taskSpecification = DefaultTaskSpecification.create(taskInfo);
+        OfferRequirement offerRequirement = defaultOfferRequirementProvider.getNewOfferRequirement(taskSpecification);
+
+        Assert.assertEquals(TestConstants.TASK_TYPE, taskSpecification.getType());
+        Assert.assertEquals(true, taskSpecification.getCommand().isPresent());
+        Assert.assertEquals(true, taskSpecification.getContainer().isPresent());
+
+        Assert.assertEquals(TestConstants.TASK_TYPE, offerRequirement.getTaskType());
+    }
+
     @Test
     public void testUnchangedVolumes()
             throws InvalidTaskSpecificationException, InvalidRequirementException, TaskException {

--- a/sdk/core/src/test/java/org/apache/mesos/specification/CustomTaskSetTest.java
+++ b/sdk/core/src/test/java/org/apache/mesos/specification/CustomTaskSetTest.java
@@ -17,8 +17,8 @@ public class CustomTaskSetTest {
     @Test
     public void testCustomCommand() {
         TaskSet taskSet = CustomTaskSet.create("custom", 3);
-        Assert.assertEquals("custom 0", taskSet.getTaskSpecifications().get(0).getCommand().getValue());
-        Assert.assertEquals("custom 2", taskSet.getTaskSpecifications().get(2).getCommand().getValue());
+        Assert.assertEquals("custom 0", taskSet.getTaskSpecifications().get(0).getCommand().get().getValue());
+        Assert.assertEquals("custom 2", taskSet.getTaskSpecifications().get(2).getCommand().get().getValue());
 
         Assert.assertEquals("custom_0", taskSet.getTaskSpecifications().get(0).getName());
         Assert.assertEquals("custom_2", taskSet.getTaskSpecifications().get(2).getName());

--- a/sdk/core/src/test/java/org/apache/mesos/specification/CustomTaskSetTest.java
+++ b/sdk/core/src/test/java/org/apache/mesos/specification/CustomTaskSetTest.java
@@ -60,7 +60,7 @@ public class CustomTaskSetTest {
             for (int i = 0; i < count; i++) {
                 taskSpecifications.add(new DefaultTaskSpecification(
                         name + "_" + i,
-                        name,
+                        TestConstants.TASK_TYPE,
                         Protos.CommandInfo.newBuilder()
                                 .setValue(name + " " + i)
                                 .build(),
@@ -80,6 +80,7 @@ public class CustomTaskSetTest {
             for (int i = 0; i < count; i++) {
                 taskSpecifications.add(new DefaultTaskSpecification(
                         name + "_" + i,
+                        TestConstants.TASK_TYPE,
                         container,
                         Collections.emptyList(),
                         Collections.emptyList(),
@@ -97,6 +98,7 @@ public class CustomTaskSetTest {
             for (int i = 0; i < count; i++) {
                 taskSpecifications.add(new DefaultTaskSpecification(
                         name + "_" + i,
+                        TestConstants.TASK_TYPE,
                         container,
                         command,
                         Collections.emptyList(),

--- a/sdk/core/src/test/java/org/apache/mesos/specification/CustomTaskSetTest.java
+++ b/sdk/core/src/test/java/org/apache/mesos/specification/CustomTaskSetTest.java
@@ -23,6 +23,7 @@ public class CustomTaskSetTest {
         for (int i = taskCount; i < taskCount; ++i) {
             Assert.assertEquals(false, taskSet.getTaskSpecifications().get(i).getContainer().isPresent());
             Assert.assertEquals(true, taskSet.getTaskSpecifications().get(i).getCommand().isPresent());
+            Assert.assertEquals(TestConstants.TASK_TYPE, taskSet.getTaskSpecifications().get(i).getType());
             Assert.assertEquals(String.format("custom_%s", i), taskSet.getTaskSpecifications().get(i).getName());
             Assert.assertEquals(String.format("custom %s", i), taskSet.getTaskSpecifications().get(i).getCommand().get().getValue());
         }
@@ -34,8 +35,9 @@ public class CustomTaskSetTest {
         for (int i = taskCount; i < taskCount; ++i) {
             Assert.assertEquals(true, taskSet.getTaskSpecifications().get(i).getContainer().isPresent());
             Assert.assertEquals(false, taskSet.getTaskSpecifications().get(i).getCommand().isPresent());
+            Assert.assertEquals(TestConstants.TASK_TYPE, taskSet.getTaskSpecifications().get(i).getType());
             Assert.assertEquals(String.format("custom_%s", i), taskSet.getTaskSpecifications().get(i).getName());
-            Assert.assertEquals(TestConstants.CONTAINER_INFO.getDocker().getImage(), taskSet.getTaskSpecifications().get(i).getContainer().get().getDocker().getImage().toString());
+            Assert.assertEquals(TestConstants.CONTAINER_INFO.getDocker().getImage(), taskSet.getTaskSpecifications().get(i).getContainer().get().getDocker().getImage());
             Assert.assertEquals(TestConstants.CONTAINER_INFO.getDocker().getNetwork(), taskSet.getTaskSpecifications().get(i).getContainer().get().getDocker().getNetwork());
         }
     }
@@ -46,9 +48,10 @@ public class CustomTaskSetTest {
         for (int i = 0; i < taskCount; ++i) {
             Assert.assertEquals(true, taskSet.getTaskSpecifications().get(i).getContainer().isPresent());
             Assert.assertEquals(true, taskSet.getTaskSpecifications().get(i).getCommand().isPresent());
+            Assert.assertEquals(TestConstants.TASK_TYPE, taskSet.getTaskSpecifications().get(i).getType());
             Assert.assertEquals(String.format("custom_%s", i), taskSet.getTaskSpecifications().get(i).getName());
             Assert.assertEquals(TestConstants.COMMAND_INFO.getValue(), taskSet.getTaskSpecifications().get(i).getCommand().get().getValue());
-            Assert.assertEquals(TestConstants.CONTAINER_INFO.getDocker().getImage().toString(), taskSet.getTaskSpecifications().get(i).getContainer().get().getDocker().getImage().toString());
+            Assert.assertEquals(TestConstants.CONTAINER_INFO.getDocker().getImage(), taskSet.getTaskSpecifications().get(i).getContainer().get().getDocker().getImage());
             Assert.assertEquals(TestConstants.CONTAINER_INFO.getDocker().getNetwork(), taskSet.getTaskSpecifications().get(i).getContainer().get().getDocker().getNetwork());
         }
     }

--- a/sdk/core/src/test/java/org/apache/mesos/specification/CustomTaskSetTest.java
+++ b/sdk/core/src/test/java/org/apache/mesos/specification/CustomTaskSetTest.java
@@ -1,6 +1,7 @@
 package org.apache.mesos.specification;
 
 import org.apache.mesos.Protos;
+import org.apache.mesos.testutils.TestConstants;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -13,15 +14,43 @@ import java.util.Optional;
  * This class tests the ability to customize TaskTypeSpecifications.
  */
 public class CustomTaskSetTest {
+    private static final int taskCount = 3;
 
     @Test
     public void testCustomCommand() {
-        TaskSet taskSet = CustomTaskSet.create("custom", 3);
-        Assert.assertEquals("custom 0", taskSet.getTaskSpecifications().get(0).getCommand().get().getValue());
-        Assert.assertEquals("custom 2", taskSet.getTaskSpecifications().get(2).getCommand().get().getValue());
+        TaskSet taskSet = CustomTaskSet.create("custom", taskCount);
 
-        Assert.assertEquals("custom_0", taskSet.getTaskSpecifications().get(0).getName());
-        Assert.assertEquals("custom_2", taskSet.getTaskSpecifications().get(2).getName());
+        for (int i = taskCount; i < taskCount; ++i) {
+            Assert.assertEquals(false, taskSet.getTaskSpecifications().get(i).getContainer().isPresent());
+            Assert.assertEquals(true, taskSet.getTaskSpecifications().get(i).getCommand().isPresent());
+            Assert.assertEquals(String.format("custom_%s", i), taskSet.getTaskSpecifications().get(i).getName());
+            Assert.assertEquals(String.format("custom %s", i), taskSet.getTaskSpecifications().get(i).getCommand().get().getValue());
+        }
+    }
+
+    @Test
+    public void testCustomContainer() {
+        TaskSet taskSet = CustomTaskSet.create("custom", taskCount, TestConstants.CONTAINER_INFO);
+        for (int i = taskCount; i < taskCount; ++i) {
+            Assert.assertEquals(true, taskSet.getTaskSpecifications().get(i).getContainer().isPresent());
+            Assert.assertEquals(false, taskSet.getTaskSpecifications().get(i).getCommand().isPresent());
+            Assert.assertEquals(String.format("custom_%s", i), taskSet.getTaskSpecifications().get(i).getName());
+            Assert.assertEquals(TestConstants.CONTAINER_INFO.getDocker().getImage(), taskSet.getTaskSpecifications().get(i).getContainer().get().getDocker().getImage().toString());
+            Assert.assertEquals(TestConstants.CONTAINER_INFO.getDocker().getNetwork(), taskSet.getTaskSpecifications().get(i).getContainer().get().getDocker().getNetwork());
+        }
+    }
+
+    @Test
+    public void testCustomContainerCommand() {
+        TaskSet taskSet = CustomTaskSet.create("custom", taskCount, TestConstants.CONTAINER_INFO, TestConstants.COMMAND_INFO);
+        for (int i = 0; i < taskCount; ++i) {
+            Assert.assertEquals(true, taskSet.getTaskSpecifications().get(i).getContainer().isPresent());
+            Assert.assertEquals(true, taskSet.getTaskSpecifications().get(i).getCommand().isPresent());
+            Assert.assertEquals(String.format("custom_%s", i), taskSet.getTaskSpecifications().get(i).getName());
+            Assert.assertEquals(TestConstants.COMMAND_INFO.getValue(), taskSet.getTaskSpecifications().get(i).getCommand().get().getValue());
+            Assert.assertEquals(TestConstants.CONTAINER_INFO.getDocker().getImage().toString(), taskSet.getTaskSpecifications().get(i).getContainer().get().getDocker().getImage().toString());
+            Assert.assertEquals(TestConstants.CONTAINER_INFO.getDocker().getNetwork(), taskSet.getTaskSpecifications().get(i).getContainer().get().getDocker().getNetwork());
+        }
     }
 
     public static class CustomTaskSet extends DefaultTaskSet {
@@ -35,6 +64,41 @@ public class CustomTaskSetTest {
                         Protos.CommandInfo.newBuilder()
                                 .setValue(name + " " + i)
                                 .build(),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        Optional.empty(),
+                        Optional.empty()));
+            }
+
+            return new CustomTaskSet(name, taskSpecifications);
+        }
+
+        public static CustomTaskSet create(String name, int count, Protos.ContainerInfo container) {
+
+            List<TaskSpecification> taskSpecifications = new ArrayList<>();
+            for (int i = 0; i < count; i++) {
+                taskSpecifications.add(new DefaultTaskSpecification(
+                        name + "_" + i,
+                        container,
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        Optional.empty(),
+                        Optional.empty()));
+            }
+
+            return new CustomTaskSet(name, taskSpecifications);
+        }
+
+        public static CustomTaskSet create(String name, int count, Protos.ContainerInfo container, Protos.CommandInfo command) {
+
+            List<TaskSpecification> taskSpecifications = new ArrayList<>();
+            for (int i = 0; i < count; i++) {
+                taskSpecifications.add(new DefaultTaskSpecification(
+                        name + "_" + i,
+                        container,
+                        command,
                         Collections.emptyList(),
                         Collections.emptyList(),
                         Collections.emptyList(),

--- a/sdk/core/src/test/java/org/apache/mesos/specification/TestTaskSetFactory.java
+++ b/sdk/core/src/test/java/org/apache/mesos/specification/TestTaskSetFactory.java
@@ -41,6 +41,7 @@ public class TestTaskSetFactory {
         return DefaultTaskSet.create(
                 count,
                 name,
+                TestConstants.TASK_TYPE,
                 getCommand(cmd),
                 getResources(cpu, mem, TestConstants.ROLE, TestConstants.PRINCIPAL),
                 getVolumes(disk, TestConstants.ROLE, TestConstants.PRINCIPAL),

--- a/sdk/core/src/test/java/org/apache/mesos/specification/TestTaskSpecification.java
+++ b/sdk/core/src/test/java/org/apache/mesos/specification/TestTaskSpecification.java
@@ -14,7 +14,8 @@ import java.util.Optional;
 public class TestTaskSpecification implements TaskSpecification {
     private final String name;
     private final String type;
-    private final Protos.CommandInfo command;
+    private final Optional<Protos.CommandInfo> command;
+    private final Optional<Protos.ContainerInfo> container;
     private final Collection<VolumeSpecification> volumes;
     private Collection<ResourceSpecification> resources;
     private Collection<ConfigFileSpecification> configs;
@@ -25,6 +26,7 @@ public class TestTaskSpecification implements TaskSpecification {
         this.name = taskSpecification.getName();
         this.type = taskSpecification.getType();
         this.command = taskSpecification.getCommand();
+        this.container = taskSpecification.getContainer();
         this.resources = taskSpecification.getResources();
         this.volumes = taskSpecification.getVolumes();
         this.configs = taskSpecification.getConfigFiles();
@@ -43,8 +45,13 @@ public class TestTaskSpecification implements TaskSpecification {
     }
 
     @Override
-    public Protos.CommandInfo getCommand() {
+    public Optional<Protos.CommandInfo> getCommand() {
         return command;
+    }
+
+    @Override
+    public Optional<Protos.ContainerInfo> getContainer() {
+        return container;
     }
 
     @Override

--- a/sdk/core/src/test/java/org/apache/mesos/testutils/TaskTestUtils.java
+++ b/sdk/core/src/test/java/org/apache/mesos/testutils/TaskTestUtils.java
@@ -19,7 +19,8 @@ public class TaskTestUtils {
                 .setTaskId(TestConstants.TASK_ID)
                 .setName(TestConstants.TASK_NAME)
                 .setSlaveId(TestConstants.AGENT_ID)
-                .setCommand(TestConstants.COMMAND_INFO);
+                .setCommand(TestConstants.COMMAND_INFO)
+                .setContainer(TestConstants.CONTAINER_INFO);
         builder = TaskUtils.setTaskType(builder, TestConstants.TASK_TYPE);
         return builder.addAllResources(resources).build();
     }

--- a/sdk/core/src/test/java/org/apache/mesos/testutils/TestConstants.java
+++ b/sdk/core/src/test/java/org/apache/mesos/testutils/TestConstants.java
@@ -36,6 +36,17 @@ public class TestConstants {
                     .setValue("test-framework-id")
                     .build();
 
+    public static final Protos.ContainerInfo CONTAINER_INFO =
+            Protos.ContainerInfo.newBuilder()
+            .setType(Protos.ContainerInfo.Type.DOCKER)
+            .setDocker(
+                    Protos.ContainerInfo.DockerInfo.newBuilder()
+                    .setImage("bash")
+                    .setNetwork(Protos.ContainerInfo.DockerInfo.Network.HOST)
+                    .build()
+            )
+            .build();
+
     public static final Protos.CommandInfo COMMAND_INFO =
             Protos.CommandInfo.newBuilder()
             .setValue("echo test")


### PR DESCRIPTION
The existing `DefaultTaskSpecification` does not provide appropriate entry points for running containers as tasks. This PR proposes an updated `TaskSpecification` interface.

cc @gabrielhartmann 

