### PR TITLE
make github update optional

### DIFF
--- a/tools/github_update.py
+++ b/tools/github_update.py
@@ -172,6 +172,10 @@ class GithubStatusUpdater(object):
         if os.environ.get('GITHUB_DISABLE', ''):
             # environment has notifications disabled. skip actually sending anything to GitHub
             return True
+        if not (os.environ.get('GITHUB_COMMIT_STATUS_URL') or os.environ.get('BUILD_URL')):
+            # CI job did not come from GITHUB
+            return True
+
 
         request = self._build_request(state, message, details_url)
         response = self._send_request(request)


### PR DESCRIPTION
cc @nickbp 

explicitly adding GITHUB_DISABLE shouldn't be necessary.  The update script should be smart enough to know when it can and can't update.