### PR TITLE
Now detecting DC/OS version using on-disk file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ build/
 # OS X
 .DS_Store
 
+# Ignore keys
+*.pem

--- a/gradle/findbugs/excludeFilter.xml
+++ b/gradle/findbugs/excludeFilter.xml
@@ -21,4 +21,8 @@
         <Class name="org.apache.mesos.executor.ProcessTask" />
         <Bug pattern="DM_EXIT"/>
     </Match>
+    <Match>
+        <Class name="org.apache.mesos.dcos.DcosCluster" />
+        <Bug pattern="DMI_HARDCODED_ABSOLUTE_FILENAME"/>
+    </Match>
 </FindBugsFilter>

--- a/src/main/java/org/apache/mesos/dcos/Capabilities.java
+++ b/src/main/java/org/apache/mesos/dcos/Capabilities.java
@@ -2,6 +2,7 @@ package org.apache.mesos.dcos;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.util.Optional;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -19,17 +20,20 @@ public class Capabilities {
     }
 
     public boolean supportsNamedVips() throws IOException, URISyntaxException {
-        DcosVersion.Elements versionElements = dcosCluster.getDcosVersion().getElements();
-        try {
-            // Named Vips are supported by DC/OS 1.8 upwards.
-            if (versionElements.getFirstElement() == 1) {
-                return versionElements.getSecondElement() >= 8;
+        final Optional<DcosVersion> dcosVersion = dcosCluster.getDcosVersion();
+        if (dcosVersion.isPresent()) {
+            DcosVersion.Elements versionElements = dcosVersion.get().getElements();
+            try {
+                // Named Vips are supported by DC/OS 1.8 upwards.
+                if (versionElements.getFirstElement() == 1) {
+                    return versionElements.getSecondElement() >= 8;
+                }
+                return versionElements.getFirstElement() > 1;
+            } catch (NumberFormatException ex) {
+                // incorrect version string. Todo(joerg84): Consider throwing an exception here.
+                LOGGER.warn("Unable to parse version string for Named Vip", ex);
             }
-            return versionElements.getFirstElement() > 1;
-        } catch (NumberFormatException ex) {
-            // incorrect version string. Todo(joerg84): Consider throwing an exception here.
-            LOGGER.warn("Unable to parse version string for Named Vip", ex);
-            return false;
         }
+        return false;
     }
 }

--- a/src/main/java/org/apache/mesos/dcos/DcosCluster.java
+++ b/src/main/java/org/apache/mesos/dcos/DcosCluster.java
@@ -1,19 +1,28 @@
 package org.apache.mesos.dcos;
 
-import org.apache.http.client.fluent.Content;
-import org.apache.http.client.fluent.Request;
+import org.apache.commons.io.Charsets;
 import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Optional;
 
 /**
  * Instances of this class represent DC/OS clusters.
  */
 public class DcosCluster {
-    private static final String DCOS_VERSION_PATH = "/dcos-metadata/dcos-version.json";
+    private static final Logger LOGGER = LoggerFactory.getLogger(DcosCluster.class);
+
+    /**
+     * Location of file on DC/OS cluster that can be used to extract version information.
+     */
+    public static final String DCOS_VERSION_PATH = "/opt/mesosphere/active/dcos-metadata/etc/dcos-version.json";
 
     private final URI dcosUri;
     private Optional<DcosVersion> dcosVersion = Optional.empty();
@@ -30,16 +39,29 @@ public class DcosCluster {
         return dcosUri;
     }
 
-    public DcosVersion getDcosVersion() throws IOException {
+    /**
+     * Gets the version of DC/OS.
+     *
+     * @return An {@link Optional} composing {@link DcosVersion} object.
+     * Can be empty if there was a failure reading the version file.
+     * @throws IOException
+     */
+    public Optional<DcosVersion> getDcosVersion() {
         if (!dcosVersion.isPresent()) {
-            URI versionUri = getUriUnchecked(dcosUri + DCOS_VERSION_PATH);
-            Content content = Request.Get(versionUri)
-                    .execute().returnContent();
-            JSONObject jsonObject = new JSONObject(content.toString());
-            dcosVersion = Optional.of(new DcosVersion(jsonObject));
+            try {
+                final Path dcosVersionFile = Paths.get(DCOS_VERSION_PATH);
+
+                if (Files.exists(dcosVersionFile)) {
+                    final byte[] bytes = Files.readAllBytes(dcosVersionFile);
+                    JSONObject jsonObject = new JSONObject(new String(bytes, Charsets.UTF_8));
+                    dcosVersion = Optional.of(new DcosVersion(jsonObject));
+                }
+            } catch (Exception e) {
+                LOGGER.error("Error determining the DC/OS version", e);
+            }
         }
 
-        return dcosVersion.get();
+        return dcosVersion;
     }
 
     /**

--- a/src/main/java/org/apache/mesos/dcos/DcosVersion.java
+++ b/src/main/java/org/apache/mesos/dcos/DcosVersion.java
@@ -3,23 +3,15 @@ package org.apache.mesos.dcos;
 import org.json.JSONObject;
 
 /**
- * This class encapsulates the response from a DC/OS cluster's dcos-metadata/dcos-version.json endpoint.
- * Example response:
- *     HTTP/1.1 200 OK
- *     Accept-Ranges: bytes
- *     Connection: keep-alive
- *     Content-Length: 154
- *     Content-Type: application/json
- *     Date: Thu, 28 Jul 2016 17:57:48 GMT
- *     ETag: "5797a2e7-9a"
- *     Last-Modified: Tue, 26 Jul 2016 17:50:31 GMT
- *     Server: openresty/1.7.10.2
-
- *     {
- *         "bootstrap-id": "27f0ee12ec563574dd9a6fa93faba1a1be38bde5",
- *         "dcos-image-commit": "3fe4305af8ab9b4c2c3606569f3c0cb5c5437aa3",
- *         "version": "1.7.3"
- *     }
+ * This class encapsulates the response from a DC/OS cluster's /dcos-metadata/dcos-version.json endpoint OR
+ * the contents of /opt/mesosphere/active/dcos-metadata/etc/dcos-version.json file on any DC/OS host.
+ * <p>
+ * {
+ * "bootstrap-id": "27f0ee12ec563574dd9a6fa93faba1a1be38bde5",
+ * "dcos-image-commit": "3fe4305af8ab9b4c2c3606569f3c0cb5c5437aa3",
+ * "version": "1.7.3"
+ * }
+ * </p>
  */
 public class DcosVersion {
 
@@ -69,8 +61,8 @@ public class DcosVersion {
 
     DcosVersion(JSONObject jsonObject) {
         this((String) jsonObject.get(DcosVersion.BOOTSTRAP_ID_KEY),
-             (String) jsonObject.get(DcosVersion.DCOS_IMAGE_COMMIT),
-             (String) jsonObject.get(DcosVersion.VERSION_KEY));
+                (String) jsonObject.get(DcosVersion.DCOS_IMAGE_COMMIT),
+                (String) jsonObject.get(DcosVersion.VERSION_KEY));
     }
 
     public String getBootstrapId() {

--- a/src/main/java/org/apache/mesos/specification/DefaultTaskSpecification.java
+++ b/src/main/java/org/apache/mesos/specification/DefaultTaskSpecification.java
@@ -60,7 +60,9 @@ public class DefaultTaskSpecification implements TaskSpecification {
     }
 
     @Override
-    public Optional<Protos.HealthCheck> getHealthCheck() { return healthCheck; }
+    public Optional<Protos.HealthCheck> getHealthCheck() {
+        return healthCheck;
+    }
 
     @Override
     public String getName() {

--- a/src/test/java/org/apache/mesos/dcos/CapabilitiesTest.java
+++ b/src/test/java/org/apache/mesos/dcos/CapabilitiesTest.java
@@ -1,85 +1,97 @@
 package org.apache.mesos.dcos;
 
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.util.Optional;
 
 /**
  * This class tests the Capabilities class.
  */
 public class CapabilitiesTest {
-    private MockDcosCluster mockDcosCluster;
-
-    @After
-    public void afterEach() {
-        if (mockDcosCluster != null) {
-            mockDcosCluster.stop();
-        }
-    }
+    private DcosCluster mockDcosCluster;
 
     @Test
     public void testHasNamedVipsFails_0_9() throws URISyntaxException, IOException {
-        mockDcosCluster = MockDcosCluster.create("0.9.0");
-        Capabilities capabilities = new Capabilities(mockDcosCluster.getDcosCluster());
+        mockDcosCluster = Mockito.mock(DcosCluster.class);
+        Mockito.when(mockDcosCluster.getDcosVersion()).thenReturn(Optional.of(
+                new DcosVersion(MockDcosCluster.TEST_BOOTSTRAP_ID, MockDcosCluster.TEST_DCOS_IMAGE_COMMIT, "0.9.0")));
+        Capabilities capabilities = new Capabilities(mockDcosCluster);
         Assert.assertFalse(capabilities.supportsNamedVips());
     }
 
     @Test
     public void testHasNamedVipsFails_1_7() throws URISyntaxException, IOException {
-        mockDcosCluster = MockDcosCluster.create("1.7.0");
-        Capabilities capabilities = new Capabilities(mockDcosCluster.getDcosCluster());
+        mockDcosCluster = Mockito.mock(DcosCluster.class);
+        Mockito.when(mockDcosCluster.getDcosVersion()).thenReturn(Optional.of(
+                new DcosVersion(MockDcosCluster.TEST_BOOTSTRAP_ID, MockDcosCluster.TEST_DCOS_IMAGE_COMMIT, "1.7.0")));
+        Capabilities capabilities = new Capabilities(mockDcosCluster);
         Assert.assertFalse(capabilities.supportsNamedVips());
     }
 
     @Test
     public void testHasNamedVipsFails_1_7dev() throws URISyntaxException, IOException {
-        mockDcosCluster = MockDcosCluster.create("1.7-dev");
-        Capabilities capabilities = new Capabilities(mockDcosCluster.getDcosCluster());
+        mockDcosCluster = Mockito.mock(DcosCluster.class);
+        Mockito.when(mockDcosCluster.getDcosVersion()).thenReturn(Optional.of(
+                new DcosVersion(MockDcosCluster.TEST_BOOTSTRAP_ID, MockDcosCluster.TEST_DCOS_IMAGE_COMMIT, "1.7-dev")));
+        Capabilities capabilities = new Capabilities(mockDcosCluster);
         Assert.assertFalse(capabilities.supportsNamedVips());
     }
 
     @Test
     public void testHasNamedVipsSucceeds_1_8() throws URISyntaxException, IOException {
-        mockDcosCluster = MockDcosCluster.create("1.8.0");
-        Capabilities capabilities = new Capabilities(mockDcosCluster.getDcosCluster());
+        mockDcosCluster = Mockito.mock(DcosCluster.class);
+        Mockito.when(mockDcosCluster.getDcosVersion()).thenReturn(Optional.of(
+                new DcosVersion(MockDcosCluster.TEST_BOOTSTRAP_ID, MockDcosCluster.TEST_DCOS_IMAGE_COMMIT, "1.8.0")));
+        Capabilities capabilities = new Capabilities(mockDcosCluster);
         Assert.assertTrue(capabilities.supportsNamedVips());
     }
 
     @Test
     public void testHasNamedVipsSucceeds_1_8dev() throws URISyntaxException, IOException {
-        mockDcosCluster = MockDcosCluster.create("1.8-dev");
-        Capabilities capabilities = new Capabilities(mockDcosCluster.getDcosCluster());
+        mockDcosCluster = Mockito.mock(DcosCluster.class);
+        Mockito.when(mockDcosCluster.getDcosVersion()).thenReturn(Optional.of(
+                new DcosVersion(MockDcosCluster.TEST_BOOTSTRAP_ID, MockDcosCluster.TEST_DCOS_IMAGE_COMMIT, "1.8-dev")));
+        Capabilities capabilities = new Capabilities(mockDcosCluster);
         Assert.assertTrue(capabilities.supportsNamedVips());
     }
 
     @Test
     public void testHasNamedVipsSucceeds_1_9() throws URISyntaxException, IOException {
-        mockDcosCluster = MockDcosCluster.create("1.9.0");
-        Capabilities capabilities = new Capabilities(mockDcosCluster.getDcosCluster());
+        mockDcosCluster = Mockito.mock(DcosCluster.class);
+        Mockito.when(mockDcosCluster.getDcosVersion()).thenReturn(Optional.of(
+                new DcosVersion(MockDcosCluster.TEST_BOOTSTRAP_ID, MockDcosCluster.TEST_DCOS_IMAGE_COMMIT, "1.9.0")));
+        Capabilities capabilities = new Capabilities(mockDcosCluster);
         Assert.assertTrue(capabilities.supportsNamedVips());
     }
 
     @Test
     public void testHasNamedVipsSucceeds_1_9dev() throws URISyntaxException, IOException {
-        mockDcosCluster = MockDcosCluster.create("1.9-dev");
-        Capabilities capabilities = new Capabilities(mockDcosCluster.getDcosCluster());
+        mockDcosCluster = Mockito.mock(DcosCluster.class);
+        Mockito.when(mockDcosCluster.getDcosVersion()).thenReturn(Optional.of(
+                new DcosVersion(MockDcosCluster.TEST_BOOTSTRAP_ID, MockDcosCluster.TEST_DCOS_IMAGE_COMMIT, "1.9-dev")));
+        Capabilities capabilities = new Capabilities(mockDcosCluster);
         Assert.assertTrue(capabilities.supportsNamedVips());
     }
 
     @Test
     public void testHasNamedVipsSucceeds_2_0() throws URISyntaxException, IOException {
-        mockDcosCluster = MockDcosCluster.create("2.0.0");
-        Capabilities capabilities = new Capabilities(mockDcosCluster.getDcosCluster());
+        mockDcosCluster = Mockito.mock(DcosCluster.class);
+        Mockito.when(mockDcosCluster.getDcosVersion()).thenReturn(Optional.of(
+                new DcosVersion(MockDcosCluster.TEST_BOOTSTRAP_ID, MockDcosCluster.TEST_DCOS_IMAGE_COMMIT, "2.0.0")));
+        Capabilities capabilities = new Capabilities(mockDcosCluster);
         Assert.assertTrue(capabilities.supportsNamedVips());
     }
 
     @Test
     public void testHasNamedVipsSucceeds_2_0dev() throws URISyntaxException, IOException {
-        mockDcosCluster =  MockDcosCluster.create("2.0-dev");
-        Capabilities capabilities = new Capabilities(mockDcosCluster.getDcosCluster());
+        mockDcosCluster = Mockito.mock(DcosCluster.class);
+        Mockito.when(mockDcosCluster.getDcosVersion()).thenReturn(Optional.of(
+                new DcosVersion(MockDcosCluster.TEST_BOOTSTRAP_ID, MockDcosCluster.TEST_DCOS_IMAGE_COMMIT, "2.0-dev")));
+        Capabilities capabilities = new Capabilities(mockDcosCluster);
         Assert.assertTrue(capabilities.supportsNamedVips());
     }
 }

--- a/src/test/java/org/apache/mesos/dcos/DcosClusterTest.java
+++ b/src/test/java/org/apache/mesos/dcos/DcosClusterTest.java
@@ -4,9 +4,11 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.util.Optional;
 
 /**
  * This class tests the DcosCluster class.
@@ -30,70 +32,84 @@ public class DcosClusterTest {
 
     @Test
     public void testGetImageInfo() throws IOException, URISyntaxException {
-        mockDcosCluster = MockDcosCluster.create(TEST_VERSION);
-        DcosVersion dcosVersion = mockDcosCluster.getDcosCluster().getDcosVersion();
-        Assert.assertNotNull(dcosVersion);
-        Assert.assertEquals(MockDcosCluster.TEST_BOOTSTRAP_ID, dcosVersion.getBootstrapId());
-        Assert.assertEquals(MockDcosCluster.TEST_DCOS_IMAGE_COMMIT, dcosVersion.getDcosImageCommit());
+        DcosCluster mockDcosCluster = Mockito.mock(DcosCluster.class);
+        Mockito.when(mockDcosCluster.getDcosVersion()).thenReturn(Optional.of(
+                new DcosVersion(MockDcosCluster.TEST_BOOTSTRAP_ID, MockDcosCluster.TEST_DCOS_IMAGE_COMMIT, TEST_VERSION)));
+        Optional<DcosVersion> dcosVersion = mockDcosCluster.getDcosVersion();
+        Assert.assertTrue(dcosVersion.isPresent());
+        Assert.assertEquals(MockDcosCluster.TEST_BOOTSTRAP_ID, dcosVersion.get().getBootstrapId());
+        Assert.assertEquals(MockDcosCluster.TEST_DCOS_IMAGE_COMMIT, dcosVersion.get().getDcosImageCommit());
     }
 
     @Test
     public void testGetVersion() throws IOException, URISyntaxException {
-        mockDcosCluster = MockDcosCluster.create(TEST_VERSION);
-        DcosVersion dcosVersion = mockDcosCluster.getDcosCluster().getDcosVersion();
-        Assert.assertNotNull(dcosVersion);
-        Assert.assertEquals(TEST_VERSION, dcosVersion.getVersion());
-        Assert.assertEquals(1, dcosVersion.getElements().getFirstElement());
-        Assert.assertEquals(8, dcosVersion.getElements().getSecondElement());
+        DcosCluster mockDcosCluster = Mockito.mock(DcosCluster.class);
+        Mockito.when(mockDcosCluster.getDcosVersion()).thenReturn(Optional.of(
+                new DcosVersion(MockDcosCluster.TEST_BOOTSTRAP_ID, MockDcosCluster.TEST_DCOS_IMAGE_COMMIT, TEST_VERSION)));
+        Optional<DcosVersion> dcosVersion = mockDcosCluster.getDcosVersion();
+        Assert.assertTrue(dcosVersion.isPresent());
+        Assert.assertEquals(TEST_VERSION, dcosVersion.get().getVersion());
+        Assert.assertEquals(1, dcosVersion.get().getElements().getFirstElement());
+        Assert.assertEquals(8, dcosVersion.get().getElements().getSecondElement());
     }
 
     @Test(expected = NumberFormatException.class)
     public void testGetBadVersionInt() throws IOException, URISyntaxException {
-        mockDcosCluster = MockDcosCluster.create("5");
-        DcosVersion dcosVersion = mockDcosCluster.getDcosCluster().getDcosVersion();
-        Assert.assertNotNull(dcosVersion);
-        Assert.assertEquals("5", dcosVersion.getVersion());
-        Assert.assertEquals(5, dcosVersion.getElements().getFirstElement());
-        dcosVersion.getElements().getSecondElement();
+        DcosCluster mockDcosCluster = Mockito.mock(DcosCluster.class);
+        Mockito.when(mockDcosCluster.getDcosVersion()).thenReturn(Optional.of(
+                new DcosVersion(MockDcosCluster.TEST_BOOTSTRAP_ID, MockDcosCluster.TEST_DCOS_IMAGE_COMMIT, "5")));
+        Optional<DcosVersion> dcosVersion = mockDcosCluster.getDcosVersion();
+        Assert.assertTrue(dcosVersion.isPresent());
+        Assert.assertEquals("5", dcosVersion.get().getVersion());
+        Assert.assertEquals(5, dcosVersion.get().getElements().getFirstElement());
+        dcosVersion.get().getElements().getSecondElement();
     }
 
     @Test(expected = NumberFormatException.class)
     public void testGetBadVersionIntDot() throws IOException, URISyntaxException {
-        mockDcosCluster = MockDcosCluster.create("0.");
-        DcosVersion dcosVersion = mockDcosCluster.getDcosCluster().getDcosVersion();
-        Assert.assertNotNull(dcosVersion);
-        Assert.assertEquals("0.", dcosVersion.getVersion());
-        Assert.assertEquals(0, dcosVersion.getElements().getFirstElement());
-        dcosVersion.getElements().getSecondElement();
+        DcosCluster mockDcosCluster = Mockito.mock(DcosCluster.class);
+        Mockito.when(mockDcosCluster.getDcosVersion()).thenReturn(Optional.of(
+                new DcosVersion(MockDcosCluster.TEST_BOOTSTRAP_ID, MockDcosCluster.TEST_DCOS_IMAGE_COMMIT, "0.")));
+        Optional<DcosVersion> dcosVersion = mockDcosCluster.getDcosVersion();
+        Assert.assertTrue(dcosVersion.isPresent());
+        Assert.assertEquals("0.", dcosVersion.get().getVersion());
+        Assert.assertEquals(0, dcosVersion.get().getElements().getFirstElement());
+        dcosVersion.get().getElements().getSecondElement();
     }
 
     @Test(expected = NumberFormatException.class)
     public void testGetBadVersionDot() throws IOException, URISyntaxException {
-        mockDcosCluster = MockDcosCluster.create(".");
-        DcosVersion dcosVersion = mockDcosCluster.getDcosCluster().getDcosVersion();
-        Assert.assertNotNull(dcosVersion);
-        Assert.assertEquals(".", dcosVersion.getVersion());
-        dcosVersion.getElements().getFirstElement();
+        DcosCluster mockDcosCluster = Mockito.mock(DcosCluster.class);
+        Mockito.when(mockDcosCluster.getDcosVersion()).thenReturn(Optional.of(
+                new DcosVersion(MockDcosCluster.TEST_BOOTSTRAP_ID, MockDcosCluster.TEST_DCOS_IMAGE_COMMIT, ".")));
+        Optional<DcosVersion> dcosVersion = mockDcosCluster.getDcosVersion();
+        Assert.assertTrue(dcosVersion.isPresent());
+        Assert.assertEquals(".", dcosVersion.get().getVersion());
+        dcosVersion.get().getElements().getFirstElement();
     }
 
     @Test(expected = NumberFormatException.class)
     public void testGetBadVersionString() throws IOException, URISyntaxException {
-        mockDcosCluster = MockDcosCluster.create("0.hello");
-        DcosVersion dcosVersion = mockDcosCluster.getDcosCluster().getDcosVersion();
-        Assert.assertNotNull(dcosVersion);
-        Assert.assertEquals("0.hello", dcosVersion.getVersion());
-        Assert.assertEquals(0, dcosVersion.getElements().getFirstElement());
-        dcosVersion.getElements().getSecondElement();
+        DcosCluster mockDcosCluster = Mockito.mock(DcosCluster.class);
+        Mockito.when(mockDcosCluster.getDcosVersion()).thenReturn(Optional.of(
+                new DcosVersion(MockDcosCluster.TEST_BOOTSTRAP_ID, MockDcosCluster.TEST_DCOS_IMAGE_COMMIT, "0.hello")));
+        Optional<DcosVersion> dcosVersion = mockDcosCluster.getDcosVersion();
+        Assert.assertTrue(dcosVersion.isPresent());
+        Assert.assertEquals("0.hello", dcosVersion.get().getVersion());
+        Assert.assertEquals(0, dcosVersion.get().getElements().getFirstElement());
+        dcosVersion.get().getElements().getSecondElement();
     }
 
     @Test(expected = NumberFormatException.class)
     public void testGetBadVersionSuffix() throws IOException, URISyntaxException {
-        mockDcosCluster = MockDcosCluster.create("0.5-hey");
-        DcosVersion dcosVersion = mockDcosCluster.getDcosCluster().getDcosVersion();
-        Assert.assertNotNull(dcosVersion);
-        Assert.assertEquals("0.5-hey", dcosVersion.getVersion());
-        Assert.assertEquals(0, dcosVersion.getElements().getFirstElement());
-        dcosVersion.getElements().getSecondElement();
+        DcosCluster mockDcosCluster = Mockito.mock(DcosCluster.class);
+        Mockito.when(mockDcosCluster.getDcosVersion()).thenReturn(Optional.of(
+                new DcosVersion(MockDcosCluster.TEST_BOOTSTRAP_ID, MockDcosCluster.TEST_DCOS_IMAGE_COMMIT, "0.5-hey")));
+        Optional<DcosVersion> dcosVersion = mockDcosCluster.getDcosVersion();
+        Assert.assertTrue(dcosVersion.isPresent());
+        Assert.assertEquals("0.5-hey", dcosVersion.get().getVersion());
+        Assert.assertEquals(0, dcosVersion.get().getElements().getFirstElement());
+        dcosVersion.get().getElements().getSecondElement();
     }
 
     @Test


### PR DESCRIPTION
Each DC/OS node has a file at location: `/opt/mesosphere/active/dcos-metadata/etc/dcos-version.json`. Use this file to determine DC/OS version, and do so in best-effort fashion.