### PR TITLE
Allow custom RecoveryRequirementProvider

### DIFF
--- a/sdk/scheduler/src/main/java/org/apache/mesos/scheduler/recovery/DefaultRecoveryPlanManager.java
+++ b/sdk/scheduler/src/main/java/org/apache/mesos/scheduler/recovery/DefaultRecoveryPlanManager.java
@@ -133,7 +133,6 @@ public class DefaultRecoveryPlanManager extends ChainedObserver implements PlanM
 
     private Step createStep(Protos.TaskInfo taskInfo)
             throws InvalidTaskSpecificationException, TaskException, InvalidRequirementException {
-        final OfferRequirementProvider offerRequirementProvider = new DefaultOfferRequirementProvider();
         final TaskSpecification taskSpec = DefaultTaskSpecification.create(taskInfo);
         final List<RecoveryRequirement> recoveryRequirements;
 
@@ -143,12 +142,16 @@ public class DefaultRecoveryPlanManager extends ChainedObserver implements PlanM
             recoveryRequirements = recoveryReqProvider.getTransientRecoveryRequirements(Arrays.asList(taskInfo));
         }
 
-        return new DefaultRecoveryStep(
-                taskSpec.getName(),
-                offerRequirementProvider.getExistingOfferRequirement(taskInfo, taskSpec),
-                Status.PENDING,
-                recoveryRequirements.get(0),
-                launchConstrainer);
+        if (recoveryRequirements.size() == 1) {
+            return new DefaultRecoveryStep(
+                    taskSpec.getName(),
+                    Status.PENDING,
+                    recoveryRequirements.get(0),
+                    launchConstrainer);
+        } else {
+            throw new InvalidRequirementException(
+                    "Failed to generate the expected RecoveryRequirement: " + recoveryRequirements);
+        }
     }
 
     @Override

--- a/sdk/scheduler/src/main/java/org/apache/mesos/scheduler/recovery/DefaultRecoveryStep.java
+++ b/sdk/scheduler/src/main/java/org/apache/mesos/scheduler/recovery/DefaultRecoveryStep.java
@@ -24,11 +24,10 @@ public class DefaultRecoveryStep extends DefaultStep {
 
     public DefaultRecoveryStep(
             String name,
-            OfferRequirement offerRequirement,
             Status status,
             RecoveryRequirement recoveryRequirement,
             LaunchConstrainer launchConstrainer) {
-        super(name, Optional.of(offerRequirement), status, Collections.emptyList());
+        super(name, Optional.of(recoveryRequirement.getOfferRequirement()), status, Collections.emptyList());
         this.launchConstrainer = launchConstrainer;
         this.recoveryRequirement = recoveryRequirement;
     }

--- a/sdk/scheduler/src/main/java/org/apache/mesos/scheduler/recovery/DefaultRecoveryStep.java
+++ b/sdk/scheduler/src/main/java/org/apache/mesos/scheduler/recovery/DefaultRecoveryStep.java
@@ -2,7 +2,6 @@ package org.apache.mesos.scheduler.recovery;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.mesos.Protos;
-import org.apache.mesos.offer.OfferRequirement;
 import org.apache.mesos.scheduler.plan.DefaultStep;
 import org.apache.mesos.scheduler.plan.Status;
 import org.apache.mesos.scheduler.recovery.constrain.LaunchConstrainer;


### PR DESCRIPTION
* Allow children of the DefaultScheduler to specify custom RecoveryRequirementProvider (Allows Kafka to start using the the DefaultScheduler)
* Fixed bug where the DefaultOfferRequirementProvider was being used as the RecoveryRequirementProvider.
* Reorganized member variables so they're grouped together a little sanely.