### PR TITLE
Add default config validators (and associated tests)

### DIFF
--- a/sdk/scheduler/src/main/java/org/apache/mesos/config/validate/TaskSetsCannotShrink.java
+++ b/sdk/scheduler/src/main/java/org/apache/mesos/config/validate/TaskSetsCannotShrink.java
@@ -1,0 +1,61 @@
+package org.apache.mesos.config.validate;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.mesos.specification.ServiceSpecification;
+import org.apache.mesos.specification.TaskSet;
+
+/**
+ * Sample configuration validator which validates that a ServiceSpecification's number of TaskSets
+ * and number of tasks within those TaskSets never go down.
+ */
+public class TaskSetsCannotShrink implements ConfigurationValidator<ServiceSpecification> {
+
+    @Override
+    public Collection<ConfigurationValidationError> validate(
+            ServiceSpecification nullableConfig, ServiceSpecification newConfig) {
+        List<ConfigurationValidationError> errors = new ArrayList<>();
+        Map<String, Integer> newTaskTypeCounts = new HashMap<>();
+        for (TaskSet taskSet : newConfig.getTaskSets()) {
+            Integer prevValue = newTaskTypeCounts.put(
+                    taskSet.getName(), taskSet.getTaskSpecifications().size());
+            if (prevValue != null) {
+                errors.add(ConfigurationValidationError.valueError(
+                        "TaskSets", taskSet.getName(),
+                        String.format("Duplicate TaskSets named '%s' in Service '%s'",
+                                taskSet.getName(), newConfig.getName())));
+            }
+        }
+        if (nullableConfig == null) {
+            // No sizes to compare.
+            return errors;
+        }
+        // Check for TaskSets in the old config which are missing or smaller in the new config.
+        // Adding new TaskSets or increasing the size of tasksets are allowed.
+        for (TaskSet oldTaskSet : nullableConfig.getTaskSets()) {
+            final String typeName = oldTaskSet.getName();
+            int oldValue = oldTaskSet.getTaskSpecifications().size();
+            Integer newValue = newTaskTypeCounts.get(typeName);
+            if (newValue == null) {
+                errors.add(ConfigurationValidationError.transitionError(
+                        String.format("TaskSet[name:%s]", typeName),
+                        String.valueOf(oldValue),
+                        "null",
+                        String.format("New config is missing TaskSet named '%s' (expected present with >= %d tasks)",
+                                typeName, oldValue)));
+            } else if (newValue < oldValue) {
+                errors.add(ConfigurationValidationError.transitionError(
+                        String.format("TaskSet[setname:%s]", typeName),
+                        String.valueOf(oldValue),
+                        String.valueOf(newValue),
+                        String.format("New config's TaskSet named '%s' has %d tasks, expected >=%d tasks",
+                                typeName, newValue, oldValue)));
+            }
+        }
+        return errors;
+    }
+}

--- a/sdk/scheduler/src/main/java/org/apache/mesos/config/validate/TaskVolumesCannotChange.java
+++ b/sdk/scheduler/src/main/java/org/apache/mesos/config/validate/TaskVolumesCannotChange.java
@@ -1,0 +1,62 @@
+package org.apache.mesos.config.validate;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.mesos.offer.TaskUtils;
+import org.apache.mesos.specification.ServiceSpecification;
+import org.apache.mesos.specification.TaskSet;
+import org.apache.mesos.specification.TaskSpecification;
+
+/**
+ * Validates that each TaskSpecification's volumes have not been modified.
+ */
+public class TaskVolumesCannotChange implements ConfigurationValidator<ServiceSpecification> {
+
+    @Override
+    public Collection<ConfigurationValidationError> validate(
+            ServiceSpecification nullableOldConfig, ServiceSpecification newConfig) {
+        List<ConfigurationValidationError> errors = new ArrayList<>();
+        Map<String, TaskSpecification> oldTasks =
+                (nullableOldConfig == null) ? new HashMap<>() : getAllTasksByName(nullableOldConfig, errors);
+        Map<String, TaskSpecification> newTasks =
+                getAllTasksByName(newConfig, errors);
+        // Note: We're itentionally just comparing cases where the tasks in both TaskSpecs.
+        // Enforcement of new/removed tasks should be performed in a separate Validator.
+        for (Map.Entry<String, TaskSpecification> oldEntry : oldTasks.entrySet()) {
+            TaskSpecification newTask = newTasks.get(oldEntry.getKey());
+            if (newTask == null) {
+                // Task removed: Don't worry about it. We're just verifying that volumes don't change.
+                continue;
+            }
+            if (!TaskUtils.volumesEqual(oldEntry.getValue(), newTask)) {
+                errors.add(ConfigurationValidationError.transitionError(
+                        String.format("TaskVolumes[taskname:%s]", newTask.getName()),
+                        oldEntry.getValue().getVolumes().toString(),
+                        newTask.getVolumes().toString(),
+                        "Volumes must be equal."));
+            }
+        }
+        return errors;
+    }
+
+    private static Map<String, TaskSpecification> getAllTasksByName(
+            ServiceSpecification service, List<ConfigurationValidationError> errors) {
+        Map<String, TaskSpecification> tasks = new HashMap<>();
+        for (TaskSet taskSet : service.getTaskSets()) {
+            for (TaskSpecification taskSpecification : taskSet.getTaskSpecifications()) {
+                TaskSpecification priorTask = tasks.put(taskSpecification.getName(), taskSpecification);
+                if (priorTask != null) {
+                    errors.add(ConfigurationValidationError.valueError(
+                            "TaskSpecifications", taskSpecification.getName(),
+                            String.format("Duplicate TaskSpecifications named '%s' in Service '%s': %s %s",
+                                    taskSpecification.getName(), service.getName(), priorTask, taskSpecification)));
+                }
+            }
+        }
+        return tasks;
+    }
+}

--- a/sdk/scheduler/src/test/java/org/apache/mesos/config/validate/TaskSetsCannotShrinkTest.java
+++ b/sdk/scheduler/src/test/java/org/apache/mesos/config/validate/TaskSetsCannotShrinkTest.java
@@ -1,0 +1,138 @@
+package org.apache.mesos.config.validate;
+
+import java.util.Arrays;
+
+import org.apache.mesos.offer.InvalidRequirementException;
+import org.apache.mesos.specification.DefaultServiceSpecification;
+import org.apache.mesos.specification.DefaultTaskSet;
+import org.apache.mesos.specification.ServiceSpecification;
+import org.apache.mesos.specification.TaskSpecification;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class TaskSetsCannotShrinkTest {
+    private static final ConfigurationValidator<ServiceSpecification> VALIDATOR = new TaskSetsCannotShrink();
+
+    @Mock
+    private TaskSpecification mockTaskSpec;
+
+    @Before
+    public void beforeEach() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void testMatchingSize() throws InvalidRequirementException {
+        ServiceSpecification serviceSpec1 = new DefaultServiceSpecification(
+                "svc1",
+                Arrays.asList(
+                        DefaultTaskSet.create("set1", Arrays.asList(mockTaskSpec)),
+                        DefaultTaskSet.create("set2", Arrays.asList(mockTaskSpec, mockTaskSpec))));
+        ServiceSpecification serviceSpec2 = new DefaultServiceSpecification(
+                "svc2",
+                Arrays.asList(
+                        DefaultTaskSet.create("set1", Arrays.asList(mockTaskSpec)),
+                        DefaultTaskSet.create("set2", Arrays.asList(mockTaskSpec, mockTaskSpec))));
+
+        Assert.assertEquals(0, VALIDATOR.validate(serviceSpec1, serviceSpec2).size());
+        Assert.assertEquals(0, VALIDATOR.validate(serviceSpec2, serviceSpec1).size());
+        Assert.assertEquals(0, VALIDATOR.validate(serviceSpec1, serviceSpec1).size());
+        Assert.assertEquals(0, VALIDATOR.validate(serviceSpec2, serviceSpec2).size());
+    }
+
+    @Test
+    public void testSetGrowth() throws InvalidRequirementException {
+        ServiceSpecification serviceSpec1 = new DefaultServiceSpecification(
+                "svc1",
+                Arrays.asList(
+                        DefaultTaskSet.create("set1", Arrays.asList(mockTaskSpec))));
+        ServiceSpecification serviceSpec2 = new DefaultServiceSpecification(
+                "svc2",
+                Arrays.asList(
+                        DefaultTaskSet.create("set1", Arrays.asList(mockTaskSpec)),
+                        DefaultTaskSet.create("set2", Arrays.asList(mockTaskSpec, mockTaskSpec))));
+
+        Assert.assertEquals(0, VALIDATOR.validate(serviceSpec1, serviceSpec2).size());
+        Assert.assertEquals(1, VALIDATOR.validate(serviceSpec2, serviceSpec1).size());
+        Assert.assertEquals(0, VALIDATOR.validate(serviceSpec1, serviceSpec1).size());
+        Assert.assertEquals(0, VALIDATOR.validate(serviceSpec2, serviceSpec2).size());
+    }
+
+    @Test
+    public void testTaskGrowth() throws InvalidRequirementException {
+        ServiceSpecification serviceSpec1 = new DefaultServiceSpecification(
+                "svc1",
+                Arrays.asList(
+                        DefaultTaskSet.create("set1", Arrays.asList(mockTaskSpec)),
+                        DefaultTaskSet.create("set2", Arrays.asList(mockTaskSpec))));
+        ServiceSpecification serviceSpec2 = new DefaultServiceSpecification(
+                "svc2",
+                Arrays.asList(
+                        DefaultTaskSet.create("set1", Arrays.asList(mockTaskSpec)),
+                        DefaultTaskSet.create("set2", Arrays.asList(mockTaskSpec, mockTaskSpec))));
+
+        Assert.assertEquals(0, VALIDATOR.validate(serviceSpec1, serviceSpec2).size());
+        Assert.assertEquals(1, VALIDATOR.validate(serviceSpec2, serviceSpec1).size());
+        Assert.assertEquals(0, VALIDATOR.validate(serviceSpec1, serviceSpec1).size());
+        Assert.assertEquals(0, VALIDATOR.validate(serviceSpec2, serviceSpec2).size());
+    }
+
+    @Test
+    public void testSetRemove() throws InvalidRequirementException {
+        ServiceSpecification serviceSpec1 = new DefaultServiceSpecification(
+                "svc1",
+                Arrays.asList(
+                        DefaultTaskSet.create("set1", Arrays.asList(mockTaskSpec)),
+                        DefaultTaskSet.create("set2", Arrays.asList(mockTaskSpec, mockTaskSpec))));
+        ServiceSpecification serviceSpec2 = new DefaultServiceSpecification(
+                "svc2",
+                Arrays.asList(
+                        DefaultTaskSet.create("set1", Arrays.asList(mockTaskSpec))));
+
+        Assert.assertEquals(1, VALIDATOR.validate(serviceSpec1, serviceSpec2).size());
+        Assert.assertEquals(0, VALIDATOR.validate(serviceSpec2, serviceSpec1).size());
+        Assert.assertEquals(0, VALIDATOR.validate(serviceSpec1, serviceSpec1).size());
+        Assert.assertEquals(0, VALIDATOR.validate(serviceSpec2, serviceSpec2).size());
+    }
+
+    @Test
+    public void testSetRename() throws InvalidRequirementException {
+        ServiceSpecification serviceSpec1 = new DefaultServiceSpecification(
+                "svc1",
+                Arrays.asList(
+                        DefaultTaskSet.create("set1", Arrays.asList(mockTaskSpec)),
+                        DefaultTaskSet.create("set2", Arrays.asList(mockTaskSpec, mockTaskSpec))));
+        ServiceSpecification serviceSpec2 = new DefaultServiceSpecification(
+                "svc2",
+                Arrays.asList(
+                        DefaultTaskSet.create("set1", Arrays.asList(mockTaskSpec)),
+                        DefaultTaskSet.create("set3", Arrays.asList(mockTaskSpec, mockTaskSpec))));
+
+        Assert.assertEquals(1, VALIDATOR.validate(serviceSpec1, serviceSpec2).size());
+        Assert.assertEquals(1, VALIDATOR.validate(serviceSpec2, serviceSpec1).size());
+        Assert.assertEquals(0, VALIDATOR.validate(serviceSpec1, serviceSpec1).size());
+        Assert.assertEquals(0, VALIDATOR.validate(serviceSpec2, serviceSpec2).size());
+    }
+
+    @Test
+    public void testDuplicateSet() throws InvalidRequirementException {
+        ServiceSpecification serviceSpec1 = new DefaultServiceSpecification(
+                "svc1",
+                Arrays.asList(
+                        DefaultTaskSet.create("set1", Arrays.asList(mockTaskSpec)),
+                        DefaultTaskSet.create("set1", Arrays.asList(mockTaskSpec))));
+        ServiceSpecification serviceSpec2 = new DefaultServiceSpecification(
+                "svc2",
+                Arrays.asList(
+                        DefaultTaskSet.create("set1", Arrays.asList(mockTaskSpec)),
+                        DefaultTaskSet.create("set2", Arrays.asList(mockTaskSpec))));
+
+        Assert.assertEquals(0, VALIDATOR.validate(serviceSpec1, serviceSpec2).size()); // only checked against new config
+        Assert.assertEquals(2, VALIDATOR.validate(serviceSpec2, serviceSpec1).size());
+        Assert.assertEquals(1, VALIDATOR.validate(serviceSpec1, serviceSpec1).size());
+        Assert.assertEquals(0, VALIDATOR.validate(serviceSpec2, serviceSpec2).size());
+    }
+}

--- a/sdk/scheduler/src/test/java/org/apache/mesos/config/validate/TaskVolumesCannotChangeTest.java
+++ b/sdk/scheduler/src/test/java/org/apache/mesos/config/validate/TaskVolumesCannotChangeTest.java
@@ -1,0 +1,152 @@
+package org.apache.mesos.config.validate;
+
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collections;
+import org.apache.mesos.offer.InvalidRequirementException;
+import org.apache.mesos.specification.DefaultServiceSpecification;
+import org.apache.mesos.specification.DefaultTaskSet;
+import org.apache.mesos.specification.DefaultVolumeSpecification;
+import org.apache.mesos.specification.ServiceSpecification;
+import org.apache.mesos.specification.TaskSpecification;
+import org.apache.mesos.specification.VolumeSpecification;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class TaskVolumesCannotChangeTest {
+    private static final int DISK_SIZE_MB = 1000;
+
+    private static final ConfigurationValidator<ServiceSpecification> VALIDATOR = new TaskVolumesCannotChange();
+
+    // slight differences between volumes:
+    private static final VolumeSpecification VOLUME1 = new DefaultVolumeSpecification(
+            DISK_SIZE_MB, VolumeSpecification.Type.MOUNT, "/path/to/volume", "role", "principal");
+    private static final VolumeSpecification VOLUME2 = new DefaultVolumeSpecification(
+            DISK_SIZE_MB + 3, VolumeSpecification.Type.MOUNT, "/path/to/volume", "role", "principal");
+    private static final VolumeSpecification VOLUME3 = new DefaultVolumeSpecification(
+            DISK_SIZE_MB, VolumeSpecification.Type.ROOT, "/path/to/volume", "role", "principal");
+
+    @Mock
+    private TaskSpecification mockTaskSpec1;
+    @Mock
+    private TaskSpecification mockTaskSpec2;
+    @Mock
+    private TaskSpecification mockTaskSpec3;
+
+    @Before
+    public void beforeEach() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void testUnchangedVolumes() throws InvalidRequirementException {
+        ServiceSpecification serviceSpec1 = new DefaultServiceSpecification(
+                "svc1",
+                Arrays.asList(
+                        DefaultTaskSet.create("set1", Arrays.asList(mockTaskSpec1))));
+        ServiceSpecification serviceSpec2 = new DefaultServiceSpecification(
+                "svc2",
+                Arrays.asList(
+                        DefaultTaskSet.create("set1", Arrays.asList(mockTaskSpec1)),
+                        DefaultTaskSet.create("set2", Arrays.asList(mockTaskSpec2))));
+        ServiceSpecification serviceSpec3 = new DefaultServiceSpecification(
+                "svc3",
+                Arrays.asList(
+                        DefaultTaskSet.create("set1", Arrays.asList(mockTaskSpec1, mockTaskSpec2)),
+                        DefaultTaskSet.create("set2", Arrays.asList(mockTaskSpec3))));
+        ServiceSpecification serviceSpec4 = new DefaultServiceSpecification(
+                "svc4",
+                Arrays.asList(
+                        DefaultTaskSet.create("set1", Arrays.asList(mockTaskSpec1)),
+                        DefaultTaskSet.create("set2", Arrays.asList(mockTaskSpec2, mockTaskSpec3))));
+
+        when(mockTaskSpec1.getName()).thenReturn("task1");
+        when(mockTaskSpec2.getName()).thenReturn("task2");
+        when(mockTaskSpec3.getName()).thenReturn("task3");
+        when(mockTaskSpec1.getVolumes()).thenReturn(Arrays.asList(VOLUME1));
+        when(mockTaskSpec2.getVolumes()).thenReturn(Arrays.asList(VOLUME2, VOLUME3));
+        when(mockTaskSpec3.getVolumes()).thenReturn(Collections.emptyList());
+
+        Assert.assertTrue(VALIDATOR.validate(serviceSpec1, serviceSpec1).isEmpty());
+        Assert.assertTrue(VALIDATOR.validate(serviceSpec2, serviceSpec2).isEmpty());
+        Assert.assertTrue(VALIDATOR.validate(serviceSpec3, serviceSpec3).isEmpty());
+        Assert.assertTrue(VALIDATOR.validate(serviceSpec4, serviceSpec4).isEmpty());
+
+        // the tasks are reshuffled, but each task's volumes don't change!:
+        Assert.assertTrue(VALIDATOR.validate(serviceSpec1, serviceSpec2).isEmpty());
+        Assert.assertTrue(VALIDATOR.validate(serviceSpec1, serviceSpec3).isEmpty());
+        Assert.assertTrue(VALIDATOR.validate(serviceSpec1, serviceSpec4).isEmpty());
+        Assert.assertTrue(VALIDATOR.validate(serviceSpec2, serviceSpec1).isEmpty());
+        Assert.assertTrue(VALIDATOR.validate(serviceSpec2, serviceSpec3).isEmpty());
+        Assert.assertTrue(VALIDATOR.validate(serviceSpec2, serviceSpec4).isEmpty());
+        Assert.assertTrue(VALIDATOR.validate(serviceSpec3, serviceSpec1).isEmpty());
+        Assert.assertTrue(VALIDATOR.validate(serviceSpec3, serviceSpec2).isEmpty());
+        Assert.assertTrue(VALIDATOR.validate(serviceSpec3, serviceSpec4).isEmpty());
+        Assert.assertTrue(VALIDATOR.validate(serviceSpec4, serviceSpec1).isEmpty());
+        Assert.assertTrue(VALIDATOR.validate(serviceSpec4, serviceSpec2).isEmpty());
+        Assert.assertTrue(VALIDATOR.validate(serviceSpec4, serviceSpec3).isEmpty());
+    }
+
+    @Test
+    public void testChangedVolumes() throws InvalidRequirementException {
+
+        // "Change" only detected when mockTaskSpec1 AND mockTaskSpec2 are compared.
+
+        ServiceSpecification serviceSpec1 = new DefaultServiceSpecification(
+                "svc1",
+                Arrays.asList(
+                        DefaultTaskSet.create("set1", Arrays.asList(mockTaskSpec1))));
+        ServiceSpecification serviceSpec2 = new DefaultServiceSpecification(
+                "svc2",
+                Arrays.asList(
+                        DefaultTaskSet.create("set1", Arrays.asList(mockTaskSpec2))));
+        ServiceSpecification serviceSpec13 = new DefaultServiceSpecification(
+                "svc3",
+                Arrays.asList(
+                        DefaultTaskSet.create("set1", Arrays.asList(mockTaskSpec1)),
+                        DefaultTaskSet.create("set2", Arrays.asList(mockTaskSpec3))));
+        ServiceSpecification serviceSpec23 = new DefaultServiceSpecification(
+                "svc4",
+                Arrays.asList(
+                        DefaultTaskSet.create("set1", Arrays.asList(mockTaskSpec2)),
+                        DefaultTaskSet.create("set2", Arrays.asList(mockTaskSpec3))));
+
+        when(mockTaskSpec1.getName()).thenReturn("task1");
+        when(mockTaskSpec2.getName()).thenReturn("task1");
+        when(mockTaskSpec3.getName()).thenReturn("task2");
+        when(mockTaskSpec1.getVolumes()).thenReturn(Arrays.asList(VOLUME1));
+        when(mockTaskSpec2.getVolumes()).thenReturn(Arrays.asList(VOLUME2, VOLUME3));
+        when(mockTaskSpec3.getVolumes()).thenReturn(Collections.emptyList());
+
+        Assert.assertEquals(1, VALIDATOR.validate(serviceSpec1, serviceSpec2).size());
+        Assert.assertEquals(0, VALIDATOR.validate(serviceSpec1, serviceSpec13).size());
+        Assert.assertEquals(1, VALIDATOR.validate(serviceSpec1, serviceSpec23).size());
+        Assert.assertEquals(1, VALIDATOR.validate(serviceSpec2, serviceSpec1).size());
+        Assert.assertEquals(1, VALIDATOR.validate(serviceSpec2, serviceSpec13).size());
+        Assert.assertEquals(0, VALIDATOR.validate(serviceSpec2, serviceSpec23).size());
+        Assert.assertEquals(0, VALIDATOR.validate(serviceSpec13, serviceSpec1).size());
+        Assert.assertEquals(1, VALIDATOR.validate(serviceSpec13, serviceSpec2).size());
+        Assert.assertEquals(1, VALIDATOR.validate(serviceSpec13, serviceSpec23).size());
+        Assert.assertEquals(1, VALIDATOR.validate(serviceSpec23, serviceSpec1).size());
+        Assert.assertEquals(0, VALIDATOR.validate(serviceSpec23, serviceSpec2).size());
+        Assert.assertEquals(1, VALIDATOR.validate(serviceSpec23, serviceSpec13).size());
+    }
+
+    @Test
+    public void testDuplicateTasksInService() throws InvalidRequirementException {
+        ServiceSpecification serviceSpec1 = new DefaultServiceSpecification(
+                "svc1",
+                Arrays.asList(
+                        DefaultTaskSet.create("set1", Arrays.asList(mockTaskSpec1, mockTaskSpec2))));
+
+        when(mockTaskSpec1.getName()).thenReturn("task1");
+        when(mockTaskSpec2.getName()).thenReturn("task1");
+
+        // error hit twice, once in 'each' servicespec:
+        Assert.assertEquals(2, VALIDATOR.validate(serviceSpec1, serviceSpec1).size());
+    }
+}


### PR DESCRIPTION
- TaskSetsCannotShrink: disallows shrinking a deployment
- TaskVolumesCannotChange: disallows changes to VolumeSpecs