### PR TITLE
Fix stale rename of Step to Block

### DIFF
--- a/sdk/scheduler/src/main/java/org/apache/mesos/scheduler/plan/DefaultStepFactory.java
+++ b/sdk/scheduler/src/main/java/org/apache/mesos/scheduler/plan/DefaultStepFactory.java
@@ -38,7 +38,7 @@ public class DefaultStepFactory implements StepFactory {
 
         try {
             if (!taskInfoOptional.isPresent()) {
-                LOGGER.info("Generating new block for: {}", taskSpecification.getName());
+                LOGGER.info("Generating new step for: {}", taskSpecification.getName());
                 return new DefaultStep(
                         taskSpecification.getName(),
                         Optional.of(offerRequirementProvider.getNewOfferRequirement(taskSpecification)),
@@ -48,7 +48,7 @@ public class DefaultStepFactory implements StepFactory {
                 Protos.TaskInfo taskInfo = TaskUtils.unpackTaskInfo(taskInfoOptional.get());
                 TaskSpecification oldTaskSpecification = DefaultTaskSpecification.create(taskInfo);
                 Status status = getStatus(oldTaskSpecification, taskSpecification);
-                LOGGER.info("Generating existing block for: {} with status: {}", taskSpecification.getName(), status);
+                LOGGER.info("Generating existing step for: {} with status: {}", taskSpecification.getName(), status);
                 return new DefaultStep(
                         taskSpecification.getName(),
                         Optional.of(offerRequirementProvider

--- a/sdk/scheduler/src/test/java/org/apache/mesos/scheduler/recovery/DefaultRecoveryPlanManagerTest.java
+++ b/sdk/scheduler/src/test/java/org/apache/mesos/scheduler/recovery/DefaultRecoveryPlanManagerTest.java
@@ -199,7 +199,7 @@ public class DefaultRecoveryPlanManagerTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void blockWithSameNameNoLaunch() throws Exception {
+    public void stepWithSameNameNoLaunch() throws Exception {
         final RecoveryRequirement recoveryRequirement = getRecoveryRequirement(new OfferRequirement(TestConstants.TASK_TYPE, TASK_INFOS));
         final Step step = mock(Step.class);
         Protos.TaskStatus status = TaskTestUtils.generateStatus(TASK_INFO.getTaskId(), Protos.TaskState.TASK_FAILED);
@@ -229,7 +229,7 @@ public class DefaultRecoveryPlanManagerTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void blockWithDifferentNameLaunches() throws Exception {
+    public void stepWithDifferentNameLaunches() throws Exception {
         final List<Offer> offers = getOffers();
         final Protos.TaskStatus status = TaskTestUtils.generateStatus(TASK_INFO.getTaskId(), Protos.TaskState.TASK_FAILED);
         final RecoveryRequirement recoveryRequirement =


### PR DESCRIPTION
Looks like #256 had a few stale names that reverted the rename. This reverts the revert.