### PR TITLE
Include gradle call in reference scheduler's build.sh

### DIFF
--- a/examples/reference/build.sh
+++ b/examples/reference/build.sh
@@ -9,6 +9,11 @@ cd $REPO_ROOT_DIR
 # Grab dcos-commons build/release tools:
 rm -rf dcos-commons-tools/ && curl https://infinity-artifacts.s3.amazonaws.com/dcos-commons-tools.tgz | tar xz
 
+# GitHub notifier config
+_notify_github() {
+    $REPO_ROOT_DIR/tools/github_update.py $1 build $2
+}
+
 # Service (Java):
 ../../gradlew clean check distZip
 if [ $? -ne 0 ]; then

--- a/examples/reference/build.sh
+++ b/examples/reference/build.sh
@@ -9,6 +9,13 @@ cd $REPO_ROOT_DIR
 # Grab dcos-commons build/release tools:
 rm -rf dcos-commons-tools/ && curl https://infinity-artifacts.s3.amazonaws.com/dcos-commons-tools.tgz | tar xz
 
+# Service (Java):
+../../gradlew clean check distZip
+if [ $? -ne 0 ]; then
+  _notify_github failure "Gradle build failed"
+  exit 1
+fi
+
 # CLI (Go):
 ./cli/build-cli.sh
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
At the moment scheduler.zip isn't being built when running build.sh