### PR TITLE
(nitpicks) Fix ConfigStore typing for callers that only need the target ID

### DIFF
--- a/sdk/scheduler/src/main/java/org/apache/mesos/config/ConfigStore.java
+++ b/sdk/scheduler/src/main/java/org/apache/mesos/config/ConfigStore.java
@@ -15,7 +15,7 @@ import java.util.UUID;
  * @param <T> The {@code Configuration} object to be serialized and deserialized in the
  *            implementation of this interface
  */
-public interface ConfigStore<T extends Configuration> {
+public interface ConfigStore<T extends Configuration> extends ConfigTargetStore {
 
     /**
      * Serializes the provided {@link Configuration} using its {@link Configuration#getBytes()}
@@ -51,21 +51,4 @@ public interface ConfigStore<T extends Configuration> {
      * @throws ConfigStoreException if list retrieval fails
      */
     Collection<UUID> list() throws ConfigStoreException;
-
-    /**
-     * Stores the ID of the active target configuration, replacing any current value.
-     *
-     * @see #getTargetConfig()
-     * @throws ConfigStoreException if writing the ID fails
-     */
-    void setTargetConfig(UUID id) throws ConfigStoreException;
-
-    /**
-     * Returns the current ID of the active target configuration, or throws an exception if none is
-     * set.
-     *
-     * @see #setTargetConfig(UUID)
-     * @throws ConfigStoreException if reading or deserializing the ID fails, or no value is set
-     */
-    UUID getTargetConfig() throws ConfigStoreException;
 }

--- a/sdk/scheduler/src/main/java/org/apache/mesos/config/ConfigTargetStore.java
+++ b/sdk/scheduler/src/main/java/org/apache/mesos/config/ConfigTargetStore.java
@@ -1,0 +1,30 @@
+package org.apache.mesos.config;
+
+import java.util.UUID;
+
+/**
+ * This interface defines the subset of {@link ConfigStore} operations which are applicable to
+ * setting and retrieving the {@link UUID} of the current target configuration.
+ *
+ * This interface is broken out from {@link ConfigStore} to allow users to ignore the the generic
+ * typing of the config objects themselves.
+ */
+public interface ConfigTargetStore {
+
+    /**
+     * Stores the ID of the active target configuration, replacing any current value.
+     *
+     * @see #getTargetConfig()
+     * @throws ConfigStoreException if writing the ID fails
+     */
+    void setTargetConfig(UUID id) throws ConfigStoreException;
+
+    /**
+     * Returns the current ID of the active target configuration, or throws an exception if none is
+     * set.
+     *
+     * @see #setTargetConfig(UUID)
+     * @throws ConfigStoreException if reading or deserializing the ID fails, or no value is set
+     */
+    UUID getTargetConfig() throws ConfigStoreException;
+}

--- a/sdk/scheduler/src/main/java/org/apache/mesos/scheduler/plan/DefaultPlanFactory.java
+++ b/sdk/scheduler/src/main/java/org/apache/mesos/scheduler/plan/DefaultPlanFactory.java
@@ -1,6 +1,6 @@
 package org.apache.mesos.scheduler.plan;
 
-import org.apache.mesos.config.ConfigStore;
+import org.apache.mesos.config.ConfigTargetStore;
 import org.apache.mesos.offer.OfferRequirementProvider;
 import org.apache.mesos.scheduler.plan.strategy.SerialStrategy;
 import org.apache.mesos.scheduler.plan.strategy.Strategy;
@@ -21,13 +21,13 @@ public class DefaultPlanFactory implements PlanFactory {
     private final PhaseFactory phaseFactory;
 
     public DefaultPlanFactory(
-            ConfigStore configStore,
+            ConfigTargetStore configTargetStore,
             StateStore stateStore,
             OfferRequirementProvider offerRequirementProvider,
             TaskSpecificationProvider taskSpecificationProvider,
             StrategyGenerator<Phase> strategyGenerator) {
         this(new DefaultPhaseFactory(
-                new DefaultStepFactory(configStore, stateStore, offerRequirementProvider, taskSpecificationProvider)),
+                new DefaultStepFactory(configTargetStore, stateStore, offerRequirementProvider)),
                 strategyGenerator);
     }
 

--- a/sdk/scheduler/src/main/java/org/apache/mesos/scheduler/plan/DefaultStepFactory.java
+++ b/sdk/scheduler/src/main/java/org/apache/mesos/scheduler/plan/DefaultStepFactory.java
@@ -1,14 +1,13 @@
 package org.apache.mesos.scheduler.plan;
 
 import org.apache.mesos.Protos;
-import org.apache.mesos.config.ConfigStore;
 import org.apache.mesos.config.ConfigStoreException;
+import org.apache.mesos.config.ConfigTargetStore;
 import org.apache.mesos.offer.InvalidRequirementException;
 import org.apache.mesos.offer.OfferRequirementProvider;
 import org.apache.mesos.offer.TaskException;
 import org.apache.mesos.offer.TaskUtils;
 import org.apache.mesos.specification.TaskSpecification;
-import org.apache.mesos.specification.TaskSpecificationProvider;
 import org.apache.mesos.state.StateStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,20 +22,17 @@ import java.util.UUID;
 public class DefaultStepFactory implements StepFactory {
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultStepFactory.class);
 
-    private final ConfigStore configStore;
+    private final ConfigTargetStore configTargetStore;
     private final StateStore stateStore;
     private final OfferRequirementProvider offerRequirementProvider;
-    private final TaskSpecificationProvider taskSpecificationProvider;
 
     public DefaultStepFactory(
-            ConfigStore configStore,
+            ConfigTargetStore configTargetStore,
             StateStore stateStore,
-            OfferRequirementProvider offerRequirementProvider,
-            TaskSpecificationProvider taskSpecificationProvider) {
-        this.configStore = configStore;
+            OfferRequirementProvider offerRequirementProvider) {
+        this.configTargetStore = configTargetStore;
         this.stateStore = stateStore;
         this.offerRequirementProvider = offerRequirementProvider;
-        this.taskSpecificationProvider = taskSpecificationProvider;
     }
 
     @Override
@@ -81,7 +77,7 @@ public class DefaultStepFactory implements StepFactory {
     }
 
     private boolean isOnTarget(Protos.TaskInfo taskInfo) throws ConfigStoreException, TaskException {
-        UUID targetConfigId = configStore.getTargetConfig();
+        UUID targetConfigId = configTargetStore.getTargetConfig();
         UUID taskConfigId = TaskUtils.getTargetConfiguration(taskInfo);
         return targetConfigId.equals(taskConfigId);
     }

--- a/sdk/scheduler/src/test/java/org/apache/mesos/scheduler/plan/DefaultPlanCoordinatorTest.java
+++ b/sdk/scheduler/src/test/java/org/apache/mesos/scheduler/plan/DefaultPlanCoordinatorTest.java
@@ -14,7 +14,6 @@ import org.apache.mesos.scheduler.TaskKiller;
 import org.apache.mesos.scheduler.recovery.TaskFailureListener;
 import org.apache.mesos.specification.DefaultServiceSpecification;
 import org.apache.mesos.specification.TaskSet;
-import org.apache.mesos.specification.TaskSpecificationProvider;
 import org.apache.mesos.specification.TestTaskSetFactory;
 import org.apache.mesos.state.StateStore;
 import org.apache.mesos.testing.CuratorTestUtils;
@@ -55,7 +54,6 @@ public class DefaultPlanCoordinatorTest {
     private DefaultPlanScheduler planScheduler;
     private TaskFailureListener taskFailureListener;
     private SchedulerDriver schedulerDriver;
-    private TaskSpecificationProvider taskSpecificationProvider;
     private StepFactory stepFactory;
     private PhaseFactory phaseFactory;
     private EnvironmentVariables environmentVariables;
@@ -72,7 +70,6 @@ public class DefaultPlanCoordinatorTest {
         offerAccepter = spy(new OfferAccepter(Arrays.asList()));
         taskFailureListener = mock(TaskFailureListener.class);
         schedulerDriver = mock(SchedulerDriver.class);
-        taskSpecificationProvider = mock(TaskSpecificationProvider.class);
         taskSets = Arrays.asList(TestTaskSetFactory.getTaskSet());
         taskSetsB = Arrays.asList(TestTaskSetFactory.getTaskSet(
                 TestConstants.TASK_TYPE + "-B",
@@ -90,8 +87,7 @@ public class DefaultPlanCoordinatorTest {
         stepFactory = new DefaultStepFactory(
                 mock(ConfigStore.class),
                 stateStore,
-                new DefaultOfferRequirementProvider(new DefaultTaskConfigRouter(new HashMap<>()), UUID.randomUUID()),
-                taskSpecificationProvider);
+                new DefaultOfferRequirementProvider(new DefaultTaskConfigRouter(new HashMap<>()), UUID.randomUUID()));
         phaseFactory = new DefaultPhaseFactory(stepFactory);
         taskKiller = new DefaultTaskKiller(stateStore, taskFailureListener, schedulerDriver);
         planScheduler = new DefaultPlanScheduler(offerAccepter, new OfferEvaluator(stateStore), taskKiller);

--- a/sdk/scheduler/src/test/java/org/apache/mesos/scheduler/plan/strategy/CustomPlanTest.java
+++ b/sdk/scheduler/src/test/java/org/apache/mesos/scheduler/plan/strategy/CustomPlanTest.java
@@ -1,6 +1,6 @@
 package org.apache.mesos.scheduler.plan.strategy;
 
-import org.apache.mesos.config.ConfigStore;
+import org.apache.mesos.config.ConfigTargetStore;
 import org.apache.mesos.offer.InvalidRequirementException;
 import org.apache.mesos.offer.OfferRequirement;
 import org.apache.mesos.offer.OfferRequirementProvider;
@@ -42,7 +42,7 @@ public class CustomPlanTest {
     private Collection<Step> steps;
     private ServiceSpecification serviceSpecification;
 
-    @Mock private ConfigStore mockConfigStore;
+    @Mock private ConfigTargetStore mockConfigTargetStore;
     @Mock private StateStore mockStateStore;
     @Mock private OfferRequirementProvider mockOfferRequirementProvider;
     @Mock private OfferRequirement mockOfferRequirement;
@@ -117,7 +117,7 @@ public class CustomPlanTest {
     public void testCustomPlanFromServiceSpecDoesntThrow()
             throws Step.InvalidStepException, InvalidRequirementException {
         StepFactory stepFactory = new DefaultStepFactory(
-                mockConfigStore, mockStateStore, mockOfferRequirementProvider, mockTaskSpecificationProvider);
+                mockConfigTargetStore, mockStateStore, mockOfferRequirementProvider);
         when(mockStateStore.fetchTask(anyString())).thenReturn(Optional.empty());
         when(mockOfferRequirementProvider.getNewOfferRequirement(any(TaskSpecification.class))).thenReturn(mockOfferRequirement);
         DefaultPhaseFactory phaseFactory = new DefaultPhaseFactory(stepFactory);


### PR DESCRIPTION
Breaks out setting/getting the target UUID into a separate untemplated interface.

Also removes unused TaskSpecificationProvider from DefaultStepFactory.