### PR TITLE
Add static VIP support in task and executor requirements

### DIFF
--- a/examples/reference/integration/tests/test_utils.py
+++ b/examples/reference/integration/tests/test_utils.py
@@ -54,7 +54,7 @@ def get_deployment_plan():
 def uninstall():
     print('Uninstalling/janitoring {}'.format(PACKAGE_NAME))
     try:
-        shakedown.uninstall_package_and_wait(PACKAGE_NAME, app_id=PACKAGE_NAME)
+        shakedown.uninstall_package_and_wait(PACKAGE_NAME, service_name=PACKAGE_NAME)
     except (dcos.errors.DCOSException, ValueError) as e:
         print('Got exception when uninstalling package, continuing with janitor anyway: {}'.format(e))
 

--- a/frameworks/hdfs/integration/tests/test_utils.py
+++ b/frameworks/hdfs/integration/tests/test_utils.py
@@ -56,7 +56,7 @@ def install(additional_options = {}):
 def uninstall():
     print('Uninstalling/janitoring {}'.format(PACKAGE_NAME))
     try:
-        shakedown.uninstall_package_and_wait(PACKAGE_NAME, app_id=PACKAGE_NAME)
+        shakedown.uninstall_package_and_wait(PACKAGE_NAME, service_name=PACKAGE_NAME)
     except (dcos.errors.DCOSException, ValueError) as e:
         print('Got exception when uninstalling package, continuing with janitor anyway: {}'.format(e))
 

--- a/gradle/quality.gradle
+++ b/gradle/quality.gradle
@@ -7,6 +7,10 @@ apply plugin: 'jacoco'
 tasks.withType(FindBugs) {
   excludeFilter = file("$rootProject.projectDir/gradle/findbugs/excludeFilter.xml")
   maxHeapSize = '1024m'
+  reports {
+    xml.enabled = false
+    html.enabled = true
+  }
 }
 
 checkstyle {

--- a/sdk/scheduler/src/main/java/org/apache/mesos/offer/ExecutorRequirement.java
+++ b/sdk/scheduler/src/main/java/org/apache/mesos/offer/ExecutorRequirement.java
@@ -14,6 +14,7 @@ import org.apache.mesos.executor.ExecutorUtils;
  */
 public class ExecutorRequirement {
     private final Collection<DynamicPortRequirement> dynamicPortRequirements;
+    private final Collection<NamedVIPPortRequirement> namedVIPPortRequirements;
     private ExecutorInfo executorInfo;
     private Collection<ResourceRequirement> resourceRequirements;
 
@@ -59,8 +60,8 @@ public class ExecutorRequirement {
         this.resourceRequirements =
                 RequirementUtils.getResourceRequirements(executorInfo.getResourcesList());
         // These are managed in a separate collection, since the actual ports can only be fulfilled at offer time.
-        this.dynamicPortRequirements =
-                RequirementUtils.getDynamicPortRequirements(executorInfo.getResourcesList());
+        this.dynamicPortRequirements = RequirementUtils.getDynamicPortRequirements(executorInfo.getResourcesList());
+        this.namedVIPPortRequirements = RequirementUtils.getNamedVIPPortRequirements(executorInfo.getResourcesList());
     }
 
     public ExecutorInfo getExecutorInfo() {
@@ -73,6 +74,10 @@ public class ExecutorRequirement {
 
     public Collection<DynamicPortRequirement> getDynamicPortRequirements() {
         return dynamicPortRequirements;
+    }
+
+    public Collection<NamedVIPPortRequirement> getNamedVIPPortRequirements() {
+        return namedVIPPortRequirements;
     }
 
     public Collection<String> getResourceIds() {

--- a/sdk/scheduler/src/main/java/org/apache/mesos/offer/MesosResource.java
+++ b/sdk/scheduler/src/main/java/org/apache/mesos/offer/MesosResource.java
@@ -12,6 +12,8 @@ import org.apache.mesos.Protos.Value;
 public class MesosResource {
     public static final String RESOURCE_ID_KEY = "resource_id";
     public static final String DYNAMIC_PORT_KEY = "dynamic_port";
+    public static final String VIP_LABEL_NAME_KEY = "vip_key";
+    public static final String VIP_LABEL_VALUE_KEY = "vip_value";
 
     private Resource resource;
     private String resourceId;

--- a/sdk/scheduler/src/main/java/org/apache/mesos/offer/NamedVIPPortRequirement.java
+++ b/sdk/scheduler/src/main/java/org/apache/mesos/offer/NamedVIPPortRequirement.java
@@ -4,6 +4,9 @@ import org.apache.mesos.Protos;
 
 import java.util.Arrays;
 
+/**
+ * This class describes port requirements that should be routed to with a named VIP (or "service address") in DC/OS.
+ */
 public class NamedVIPPortRequirement extends ResourceRequirement {
     private static final String VIP_LABEL_NAME_KEY = "vip_key";
     private static final String VIP_LABEL_VALUE_KEY = "vip_value";
@@ -43,7 +46,8 @@ public class NamedVIPPortRequirement extends ResourceRequirement {
         return null;
     }
 
-    public static Protos.Resource getDesiredNamedVIPPort(String key, String name, Long port, String role, String principal) {
+    public static Protos.Resource getDesiredNamedVIPPort(
+            String key, String name, Long port, String role, String principal) {
         return ResourceUtils.setVIPPortName(
                 ResourceUtils.getDesiredRanges(
                         role,
@@ -76,6 +80,9 @@ public class NamedVIPPortRequirement extends ResourceRequirement {
         }
     }
 
+    /**
+     * Exception thrown when attempting to create malformed NamedVIPPortRequirements.
+     */
     public static class NamedVIPPortException extends InvalidRequirementException {
 
         public NamedVIPPortException(String msg) {

--- a/sdk/scheduler/src/main/java/org/apache/mesos/offer/NamedVIPPortRequirement.java
+++ b/sdk/scheduler/src/main/java/org/apache/mesos/offer/NamedVIPPortRequirement.java
@@ -1,0 +1,85 @@
+package org.apache.mesos.offer;
+
+import org.apache.mesos.Protos;
+
+import java.util.Arrays;
+
+public class NamedVIPPortRequirement extends ResourceRequirement {
+    private static final String VIP_LABEL_NAME_KEY = "vip_key";
+    private static final String VIP_LABEL_VALUE_KEY = "vip_value";
+    private String vipKey;
+    private String vipValue;
+
+    public NamedVIPPortRequirement(Protos.Resource resource) throws NamedVIPPortException {
+        super(resource);
+        this.vipKey = getVIPLabelKey(resource);
+        this.vipValue = getVIPLabelValue(resource);
+        validate();
+    }
+
+    public static String getVIPLabelKey(Protos.Resource resource) {
+        return getLabelValue(VIP_LABEL_NAME_KEY, resource);
+    }
+
+    public static String getVIPLabelValue(Protos.Resource resource) {
+        return getLabelValue(VIP_LABEL_VALUE_KEY, resource);
+    }
+
+    private static String getLabelValue(String key, Protos.Resource resource) {
+        if (!resource.hasReservation()) {
+            return null;
+        }
+
+        if (!resource.getReservation().hasLabels()) {
+            return null;
+        }
+
+        for (Protos.Label label : resource.getReservation().getLabels().getLabelsList()) {
+            if (label.getKey().equals(key)) {
+                return label.getValue();
+            }
+        }
+
+        return null;
+    }
+
+    public static Protos.Resource getDesiredNamedVIPPort(String key, String name, Long port, String role, String principal) {
+        return ResourceUtils.setVIPPortName(
+                ResourceUtils.getDesiredRanges(
+                        role,
+                        principal,
+                        "ports",
+                        Arrays.asList(
+                                Protos.Value.Range.newBuilder()
+                                .setBegin(port)
+                                .setEnd(port)
+                                .build()
+                        )
+                ),
+                key,
+                name
+        );
+    }
+
+    private void validate() throws NamedVIPPortException {
+        if (vipKey == null) {
+            throw new NamedVIPPortException("VIP label key is null");
+        }
+
+        if (vipValue == null) {
+            throw new NamedVIPPortException("VIP service address is null");
+        }
+
+        if (!RequirementUtils.isPortRequirement(getResource())) {
+            throw new NamedVIPPortException(
+                    "Resource should be a port and a single valued range, is: " + getResource());
+        }
+    }
+
+    public static class NamedVIPPortException extends InvalidRequirementException {
+
+        public NamedVIPPortException(String msg) {
+            super(msg);
+        }
+    }
+}

--- a/sdk/scheduler/src/main/java/org/apache/mesos/offer/RequirementUtils.java
+++ b/sdk/scheduler/src/main/java/org/apache/mesos/offer/RequirementUtils.java
@@ -41,7 +41,7 @@ public class RequirementUtils {
         Collection<ResourceRequirement> resourceRequirements = new ArrayList<>();
 
         for (Resource resource : resources) {
-            if (!isDynamicPort(resource)) {
+            if (!isDynamicPort(resource) && !isNamedVIPPort(resource)) {
                 resourceRequirements.add(new ResourceRequirement(resource));
             }
         }
@@ -62,10 +62,41 @@ public class RequirementUtils {
         return portRequirements;
     }
 
+    public static Collection<NamedVIPPortRequirement> getNamedVIPPortRequirements(List<Resource> resources)
+            throws NamedVIPPortRequirement.NamedVIPPortException {
+        Collection<NamedVIPPortRequirement> portRequirements = new ArrayList<>();
+
+        for (Resource resource : resources) {
+            if (isNamedVIPPort(resource)) {
+                portRequirements.add(new NamedVIPPortRequirement(resource));
+            }
+        }
+
+        return portRequirements;
+    }
+
     static boolean isDynamicPort(Resource resource) {
         if (resource.getName().equals("ports")) {
             List<Protos.Value.Range> ranges = resource.getRanges().getRangeList();
             return ranges.size() == 1 && ranges.get(0).getBegin() == 0 && ranges.get(0).getEnd() == 0;
+        }
+
+        return false;
+    }
+
+    static boolean isNamedVIPPort(Resource resource) {
+        if (isPortRequirement(resource)) {
+            return NamedVIPPortRequirement.getVIPLabelKey(resource) != null &&
+                    NamedVIPPortRequirement.getVIPLabelValue(resource) != null;
+        }
+
+        return false;
+    }
+
+    static boolean isPortRequirement(Resource resource) {
+        if (resource.getName().equals("ports")) {
+            List<Protos.Value.Range> ranges = resource.getRanges().getRangeList();
+            return ranges.size() == 1;
         }
 
         return false;

--- a/sdk/scheduler/src/main/java/org/apache/mesos/offer/ResourceUtils.java
+++ b/sdk/scheduler/src/main/java/org/apache/mesos/offer/ResourceUtils.java
@@ -275,7 +275,8 @@ public class ResourceUtils {
      * Populates {@link DiscoveryInfo} with necessary information to create VIP if the provided {@link ExecutorInfo}
      * has a port associated with a named VIP.
      */
-    public static ExecutorInfo.Builder setDiscoveryInfo(ExecutorInfo.Builder execBuilder, Collection<Resource> resources) {
+    public static ExecutorInfo.Builder setDiscoveryInfo(
+            ExecutorInfo.Builder execBuilder, Collection<Resource> resources) {
         for (Resource r : resources) {
             if (RequirementUtils.isNamedVIPPort(r)) {
                 DiscoveryInfo.Builder discoveryBuilder = DiscoveryInfo.newBuilder()

--- a/sdk/scheduler/src/main/java/org/apache/mesos/offer/ResourceUtils.java
+++ b/sdk/scheduler/src/main/java/org/apache/mesos/offer/ResourceUtils.java
@@ -12,9 +12,7 @@ import org.apache.mesos.specification.ResourceSpecification;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
 
 /**
  * This class encapsulates common methods for manipulating Resources.
@@ -222,6 +220,89 @@ public class ResourceUtils {
                 .build();
 
         return labelBuilder.build();
+    }
+
+    public static Resource setVIPPortName(Resource resource, String key, String name) {
+        Labels labels = setVIPPortName(resource.getReservation().getLabels(), key, name);
+
+        return Resource.newBuilder(resource)
+                .setReservation(
+                        ReservationInfo.newBuilder(resource.getReservation())
+                                .clearLabels()
+                                .setLabels(labels))
+                .build();
+    }
+
+    private static Labels setVIPPortName(Labels labels, String key, String name) {
+        Labels.Builder labelsBuilder = Labels.newBuilder(labels);
+        labelsBuilder.addLabels(
+                        Label.newBuilder()
+                            .setKey(MesosResource.VIP_LABEL_NAME_KEY)
+                            .setValue(key))
+                .addLabels(
+                        Label.newBuilder()
+                            .setKey(MesosResource.VIP_LABEL_VALUE_KEY)
+                            .setValue(name))
+                .build();
+
+        return labelsBuilder.build();
+    }
+
+    /**
+     * Populates {@link DiscoveryInfo} with necessary information to create VIP if the provided {@link TaskInfo}
+     * has a port associated with a named VIP.
+     */
+    public static TaskInfo.Builder setDiscoveryInfo(TaskInfo.Builder taskBuilder, Collection<Resource> resources) {
+        for (Resource r : resources) {
+            if (RequirementUtils.isNamedVIPPort(r)) {
+                DiscoveryInfo.Builder discoveryBuilder = DiscoveryInfo.newBuilder()
+                        .setVisibility(DiscoveryInfo.Visibility.EXTERNAL)
+                        .setName(taskBuilder.getName())
+                        .setPorts(Ports.newBuilder()
+                                .addPorts(Port.newBuilder()
+                                        .setNumber((int) r.getRanges().getRange(0).getBegin())
+                                        .setProtocol("tcp")
+                                        .setLabels(getVIPPortLabel(r))));
+
+                taskBuilder.setDiscovery(discoveryBuilder);
+            }
+        }
+
+        return taskBuilder;
+    }
+
+    /**
+     * Populates {@link DiscoveryInfo} with necessary information to create VIP if the provided {@link ExecutorInfo}
+     * has a port associated with a named VIP.
+     */
+    public static ExecutorInfo.Builder setDiscoveryInfo(ExecutorInfo.Builder execBuilder, Collection<Resource> resources) {
+        for (Resource r : resources) {
+            if (RequirementUtils.isNamedVIPPort(r)) {
+                DiscoveryInfo.Builder discoveryBuilder = DiscoveryInfo.newBuilder()
+                        .setVisibility(DiscoveryInfo.Visibility.EXTERNAL)
+                        .setName(execBuilder.getName())
+                        .setPorts(Ports.newBuilder()
+                                .addPorts(Port.newBuilder()
+                                        .setNumber((int) r.getRanges().getRange(0).getBegin())
+                                        .setProtocol("tcp")
+                                        .setLabels(getVIPPortLabel(r))));
+
+                execBuilder.setDiscovery(discoveryBuilder);
+            }
+        }
+
+        return execBuilder;
+    }
+
+    private static Labels getVIPPortLabel(Resource r) {
+        return Labels.newBuilder()
+                .addLabels(Label.newBuilder()
+                        .setKey(NamedVIPPortRequirement.getVIPLabelKey(r))
+                        .setValue(
+                                NamedVIPPortRequirement.getVIPLabelValue(r) +
+                                        ":" +
+                                        r.getRanges().getRange(0).getBegin()))
+                .build();
     }
 
     public static Protos.Environment getEnvironment(List<Resource> resources) {

--- a/sdk/scheduler/src/main/java/org/apache/mesos/offer/ResourceUtils.java
+++ b/sdk/scheduler/src/main/java/org/apache/mesos/offer/ResourceUtils.java
@@ -12,7 +12,10 @@ import org.apache.mesos.specification.ResourceSpecification;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
 
 /**
  * This class encapsulates common methods for manipulating Resources.

--- a/sdk/scheduler/src/main/java/org/apache/mesos/offer/TaskRequirement.java
+++ b/sdk/scheduler/src/main/java/org/apache/mesos/offer/TaskRequirement.java
@@ -13,6 +13,7 @@ public class TaskRequirement {
     private final TaskInfo taskInfo;
     private final Collection<ResourceRequirement> resourceRequirements;
     private Collection<DynamicPortRequirement> dynamicPortRequirements;
+    private Collection<NamedVIPPortRequirement> namedVIPPortRequirements;
 
     public TaskRequirement(TaskInfo unverifiedTaskInfo) throws InvalidRequirementException {
         validateTaskInfo(unverifiedTaskInfo);
@@ -24,6 +25,8 @@ public class TaskRequirement {
                 RequirementUtils.getResourceRequirements(taskInfo.getResourcesList());
         this.dynamicPortRequirements =
                 RequirementUtils.getDynamicPortRequirements(taskInfo.getResourcesList());
+        this.namedVIPPortRequirements =
+                RequirementUtils.getNamedVIPPortRequirements(taskInfo.getResourcesList());
     }
 
     public TaskInfo getTaskInfo() {
@@ -36,6 +39,10 @@ public class TaskRequirement {
 
     public Collection<DynamicPortRequirement> getDynamicPortRequirements() {
         return dynamicPortRequirements;
+    }
+
+    public Collection<NamedVIPPortRequirement> getNamedVIPPortRequirements() {
+        return namedVIPPortRequirements;
     }
 
     public Collection<String> getResourceIds() {

--- a/sdk/scheduler/src/test/java/org/apache/mesos/offer/MesosResourcePoolTest.java
+++ b/sdk/scheduler/src/test/java/org/apache/mesos/offer/MesosResourcePoolTest.java
@@ -126,6 +126,27 @@ public class MesosResourcePoolTest {
     }
 
     @Test
+    public void testConsumeNamedVIPPort() throws NamedVIPPortRequirement.NamedVIPPortException {
+        Resource desiredNamedVIPPort = NamedVIPPortRequirement.getDesiredNamedVIPPort(
+                TestConstants.VIP_KEY,
+                TestConstants.VIP_NAME,
+                (long) 10002,
+                TestConstants.ROLE,
+                TestConstants.PRINCIPAL);
+
+        NamedVIPPortRequirement namedVIPPortRequirement = new NamedVIPPortRequirement(desiredNamedVIPPort);
+        Resource offeredPorts = ResourceTestUtils.getUnreservedPorts(10000, 10005);
+        Offer offer = OfferTestUtils.getOffer(offeredPorts);
+        MesosResourcePool pool = new MesosResourcePool(offer);
+
+        MesosResource mesosResource = pool.consume(namedVIPPortRequirement).get();
+        Assert.assertEquals(1, mesosResource.getResource().getRanges().getRangeCount());
+        Protos.Value.Range range = mesosResource.getResource().getRanges().getRange(0);
+        Assert.assertEquals(10002, range.getBegin());
+        Assert.assertEquals(10002, range.getEnd());
+    }
+
+    @Test
     public void testReleaseAtomicResource() {
         Resource offerResource = ResourceTestUtils.getUnreservedMountVolume(1000);
         Resource releaseResource = ResourceTestUtils.getExpectedMountVolume(1000);

--- a/sdk/scheduler/src/test/java/org/apache/mesos/offer/NamedVIPPortRequirementTest.java
+++ b/sdk/scheduler/src/test/java/org/apache/mesos/offer/NamedVIPPortRequirementTest.java
@@ -1,0 +1,22 @@
+package org.apache.mesos.offer;
+
+import org.apache.mesos.Protos;
+import org.apache.mesos.testutils.TestConstants;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class NamedVIPPortRequirementTest {
+
+    @Test
+    public void testNamedVIPPortRequirementConstruction() throws NamedVIPPortRequirement.NamedVIPPortException {
+        Protos.Resource vipPortResource = NamedVIPPortRequirement.getDesiredNamedVIPPort(
+                TestConstants.VIP_KEY,
+                TestConstants.VIP_NAME,
+                (long) 10000,
+                TestConstants.ROLE,
+                TestConstants.PRINCIPAL);
+
+        NamedVIPPortRequirement namedVIPPortRequirement = new NamedVIPPortRequirement(vipPortResource);
+        Assert.assertNotNull(namedVIPPortRequirement);
+    }
+}

--- a/sdk/scheduler/src/test/java/org/apache/mesos/offer/NamedVIPPortRequirementTest.java
+++ b/sdk/scheduler/src/test/java/org/apache/mesos/offer/NamedVIPPortRequirementTest.java
@@ -19,4 +19,61 @@ public class NamedVIPPortRequirementTest {
         NamedVIPPortRequirement namedVIPPortRequirement = new NamedVIPPortRequirement(vipPortResource);
         Assert.assertNotNull(namedVIPPortRequirement);
     }
+
+    @Test(expected=NamedVIPPortRequirement.NamedVIPPortException.class)
+    public void testNamedVIPPortRequirementCreationFailureOnNullVIPKey()
+            throws NamedVIPPortRequirement.NamedVIPPortException {
+        Protos.Resource vipPortResource = NamedVIPPortRequirement.getDesiredNamedVIPPort(
+                TestConstants.VIP_KEY,
+                TestConstants.VIP_NAME,
+                (long) 10000,
+                TestConstants.ROLE,
+                TestConstants.PRINCIPAL);
+
+        Protos.Resource resource = removeLabel(vipPortResource, "vip_key");
+
+        new NamedVIPPortRequirement(resource);
+    }
+
+    @Test(expected=NamedVIPPortRequirement.NamedVIPPortException.class)
+    public void testNamedVIPPortRequirementCreationFailureOnNullVIPValue()
+            throws NamedVIPPortRequirement.NamedVIPPortException {
+        Protos.Resource vipPortResource = NamedVIPPortRequirement.getDesiredNamedVIPPort(
+                TestConstants.VIP_KEY,
+                TestConstants.VIP_NAME,
+                (long) 10000,
+                TestConstants.ROLE,
+                TestConstants.PRINCIPAL);
+
+        Protos.Resource resource = removeLabel(vipPortResource, "vip_value");
+
+        new NamedVIPPortRequirement(resource);
+    }
+
+    @Test(expected=NamedVIPPortRequirement.NamedVIPPortException.class)
+    public void testNamedVIPPortRequirementCreationFailureOnBadResourceType()
+            throws NamedVIPPortRequirement.NamedVIPPortException {
+        Protos.Resource vipPortResource = NamedVIPPortRequirement.getDesiredNamedVIPPort(
+                TestConstants.VIP_KEY,
+                TestConstants.VIP_NAME,
+                (long) 10000,
+                TestConstants.ROLE,
+                TestConstants.PRINCIPAL);
+
+        Protos.Resource resource = Protos.Resource.newBuilder(vipPortResource).setName("not_a_resource").build();
+
+        new NamedVIPPortRequirement(resource);
+    }
+
+    private static Protos.Resource removeLabel(Protos.Resource resource, String label) {
+        Protos.Labels.Builder labelBuilder = Protos.Labels.newBuilder();
+        for (Protos.Label l : labelBuilder.getLabelsList()) {
+            if (!l.getKey().equals(label)) {
+                labelBuilder.addLabels(l);
+            }
+        }
+        return Protos.Resource.newBuilder(resource)
+                .setReservation(Protos.Resource.ReservationInfo.newBuilder(resource.getReservation())
+                        .setLabels(labelBuilder)).build();
+    }
 }

--- a/sdk/scheduler/src/test/java/org/apache/mesos/offer/OfferEvaluatorTest.java
+++ b/sdk/scheduler/src/test/java/org/apache/mesos/offer/OfferEvaluatorTest.java
@@ -244,7 +244,7 @@ public class OfferEvaluatorTest {
                 TestConstants.ROLE,
                 TestConstants.PRINCIPAL);
 
-        OfferRequirement offerReq = new OfferRequirement(
+        OfferRequirement offerReq = OfferRequirement.create(
                 TestConstants.TASK_TYPE,
                 Arrays.asList(TaskTestUtils.getTaskInfo(desiredCpu)),
                 Optional.of(TaskTestUtils.getExecutorInfo(desiredNamedVIPPort)));

--- a/sdk/scheduler/src/test/java/org/apache/mesos/offer/OfferEvaluatorTest.java
+++ b/sdk/scheduler/src/test/java/org/apache/mesos/offer/OfferEvaluatorTest.java
@@ -102,10 +102,10 @@ public class OfferEvaluatorTest {
         Assert.assertEquals(String.valueOf(10000), variable.getValue());
 
         TaskInfo taskInfo = launchOperation.getLaunch().getTaskInfos(0);
-        fulfilledPortResource = taskInfo.getResources(0);
-        Assert.assertEquals(1, fulfilledPortResource.getReservation().getLabels().getLabelsCount());
+        Resource fulfilledCpuResource = taskInfo.getResources(0);
+        Assert.assertEquals(1, fulfilledCpuResource.getReservation().getLabels().getLabelsCount());
 
-        resourceIdLabel = fulfilledPortResource.getReservation().getLabels().getLabels(0);
+        resourceIdLabel = fulfilledCpuResource.getReservation().getLabels().getLabels(0);
         Assert.assertEquals("resource_id", resourceIdLabel.getKey());
 
         Assert.assertEquals(0, taskInfo.getCommand().getEnvironment().getVariablesCount());
@@ -181,6 +181,115 @@ public class OfferEvaluatorTest {
         Environment.Variable taskVariable = command.getEnvironment().getVariables(0);
         Assert.assertEquals(taskPortName, taskVariable.getName());
         Assert.assertEquals(String.valueOf(11000), taskVariable.getValue());
+    }
+
+    @Test
+    public void testReserveTaskNamedVIPPort() throws InvalidRequirementException {
+        Resource offeredPorts = ResourceTestUtils.getUnreservedPorts(10000, 10000);
+        Resource desiredNamedVIPPort = NamedVIPPortRequirement.getDesiredNamedVIPPort(
+                TestConstants.VIP_KEY,
+                TestConstants.VIP_NAME,
+                (long) 10000,
+                TestConstants.ROLE,
+                TestConstants.PRINCIPAL);
+
+        OfferRequirement offerRequirement = OfferRequirementTestUtils.getOfferRequirement(desiredNamedVIPPort);
+
+        List<OfferRecommendation> recommendations = evaluator.evaluate(
+                offerRequirement,
+                Arrays.asList(OfferTestUtils.getOffer(offeredPorts)));
+
+        Assert.assertEquals(2, recommendations.size());
+
+        Operation launchOperation = recommendations.get(1).getOperation();
+        TaskInfo taskInfo = launchOperation.getLaunch().getTaskInfos(0);
+        Resource fulfilledPortResource = taskInfo.getResources(0);
+        Assert.assertEquals(3, fulfilledPortResource.getReservation().getLabels().getLabelsCount());
+
+        Assert.assertEquals(10000, fulfilledPortResource.getRanges().getRange(0).getBegin());
+
+        Label namedVIPPortKeyLabel = fulfilledPortResource.getReservation().getLabels().getLabels(0);
+        Assert.assertEquals("vip_key", namedVIPPortKeyLabel.getKey());
+        Assert.assertEquals(TestConstants.VIP_KEY, namedVIPPortKeyLabel.getValue());
+
+        Label namedVIPPortNameLabel = fulfilledPortResource.getReservation().getLabels().getLabels(1);
+        Assert.assertEquals("vip_value", namedVIPPortNameLabel.getKey());
+        Assert.assertEquals(TestConstants.VIP_NAME, namedVIPPortNameLabel.getValue());
+
+        Label resourceIdLabel = fulfilledPortResource.getReservation().getLabels().getLabels(2);
+        Assert.assertEquals("resource_id", resourceIdLabel.getKey());
+
+        DiscoveryInfo discoveryInfo = taskInfo.getDiscovery();
+        Assert.assertEquals(discoveryInfo.getName(), taskInfo.getName());
+        Assert.assertEquals(discoveryInfo.getVisibility(), DiscoveryInfo.Visibility.EXTERNAL);
+
+        Port discoveryPort = discoveryInfo.getPorts().getPorts(0);
+        Assert.assertEquals(discoveryPort.getProtocol(), "tcp");
+        Assert.assertEquals(discoveryPort.getNumber(), 10000);
+        Label vipLabel = discoveryPort.getLabels().getLabels(0);
+        Assert.assertEquals(vipLabel.getKey(), "VIP_TEST");
+        Assert.assertEquals(vipLabel.getValue(), TestConstants.VIP_NAME + ":10000");
+    }
+
+    @Test
+    public void testReserveExecutorNamedVIPPort() throws InvalidRequirementException {
+        Resource offeredCpu = ResourceTestUtils.getUnreservedCpu(1.0);
+        Resource offeredPorts = ResourceTestUtils.getUnreservedPorts(10000, 10000);
+
+        Resource desiredCpu = ResourceTestUtils.getDesiredCpu(1.0);
+        Resource desiredNamedVIPPort = NamedVIPPortRequirement.getDesiredNamedVIPPort(
+                TestConstants.VIP_KEY,
+                TestConstants.VIP_NAME,
+                (long) 10000,
+                TestConstants.ROLE,
+                TestConstants.PRINCIPAL);
+
+        OfferRequirement offerReq = new OfferRequirement(
+                TestConstants.TASK_TYPE,
+                Arrays.asList(TaskTestUtils.getTaskInfo(desiredCpu)),
+                Optional.of(TaskTestUtils.getExecutorInfo(desiredNamedVIPPort)));
+
+        List<OfferRecommendation> recommendations = evaluator.evaluate(
+                offerReq,
+                Arrays.asList(OfferTestUtils.getOffer(Arrays.asList(offeredCpu, offeredPorts))));
+
+        Assert.assertEquals(3, recommendations.size());
+
+        Operation launchOperation = recommendations.get(2).getOperation();
+        ExecutorInfo executorInfo = launchOperation.getLaunch().getTaskInfos(0).getExecutor();
+        Resource fulfilledPortResource = executorInfo.getResources(0);
+        Assert.assertEquals(3, fulfilledPortResource.getReservation().getLabels().getLabelsCount());
+
+        Assert.assertEquals(10000, fulfilledPortResource.getRanges().getRange(0).getBegin());
+
+        Label namedVIPPortKeyLabel = fulfilledPortResource.getReservation().getLabels().getLabels(0);
+        Assert.assertEquals("vip_key", namedVIPPortKeyLabel.getKey());
+        Assert.assertEquals(TestConstants.VIP_KEY, namedVIPPortKeyLabel.getValue());
+
+        Label namedVIPPortNameLabel = fulfilledPortResource.getReservation().getLabels().getLabels(1);
+        Assert.assertEquals("vip_value", namedVIPPortNameLabel.getKey());
+        Assert.assertEquals(TestConstants.VIP_NAME, namedVIPPortNameLabel.getValue());
+
+        Label resourceIdLabel = fulfilledPortResource.getReservation().getLabels().getLabels(2);
+        Assert.assertEquals("resource_id", resourceIdLabel.getKey());
+
+        TaskInfo taskInfo = launchOperation.getLaunch().getTaskInfos(0);
+        Resource fulfilledCpuResource = taskInfo.getResources(0);
+        Assert.assertEquals(1, fulfilledCpuResource.getReservation().getLabels().getLabelsCount());
+
+        resourceIdLabel = fulfilledCpuResource.getReservation().getLabels().getLabels(0);
+        Assert.assertEquals("resource_id", resourceIdLabel.getKey());
+
+        DiscoveryInfo discoveryInfo = executorInfo.getDiscovery();
+        Assert.assertEquals(discoveryInfo.getName(), executorInfo.getName());
+        Assert.assertEquals(discoveryInfo.getVisibility(), DiscoveryInfo.Visibility.EXTERNAL);
+
+        Port discoveryPort = discoveryInfo.getPorts().getPorts(0);
+        Assert.assertEquals(discoveryPort.getProtocol(), "tcp");
+        Assert.assertEquals(discoveryPort.getNumber(), 10000);
+        Label vipLabel = discoveryPort.getLabels().getLabels(0);
+        Assert.assertEquals(vipLabel.getKey(), "VIP_TEST");
+        Assert.assertEquals(vipLabel.getValue(), TestConstants.VIP_NAME + ":10000");
     }
 
     @Test

--- a/sdk/scheduler/src/test/java/org/apache/mesos/testutils/TestConstants.java
+++ b/sdk/scheduler/src/test/java/org/apache/mesos/testutils/TestConstants.java
@@ -23,6 +23,8 @@ public class TestConstants {
     public static final Protos.ExecutorID EXECUTOR_ID = ExecutorUtils.toExecutorId(EXECUTOR_NAME);
     public static final Protos.TaskID TASK_ID = TaskUtils.toTaskId(TASK_NAME);
     public static final String PORT_NAME = "test-port-name";
+    public static final String VIP_KEY = "VIP_TEST";
+    public static final String VIP_NAME = "testvip";
 
     public static final Protos.MasterInfo MASTER_INFO =
             Protos.MasterInfo.newBuilder()


### PR DESCRIPTION
Similar to the `DynamicPortRequirement` class, the solution for adding this functionality involves tracking named-VIP-ports as a separate type of resource from regular the `ResourceRequirement` list. Although this involves changing many method signatures, it's preferable to blending this logic in with regular resource accounting with excessive branching. Ultimately, this logic will be encapsulated by an upcoming change to the `OfferEvaluator` which will introduce a pipeline of resource requirement/`TaskInfo` modification stages. Note that the final consequence of this change from Mesos' perspective is that either the `TaskInfo` or the `ExecutorInfo` will have a `DiscoveryInfo` attached, with a hostname and `Port` resource labeled with the intended service address.