### PR TITLE
Fixed HDFS and common CLI pointing to incorrect endpoints.

### DIFF
--- a/cli/commands.go
+++ b/cli/commands.go
@@ -235,15 +235,15 @@ func (cmd *StateHandler) RunFrameworkId(c *kingpin.ParseContext) error {
 	return nil
 }
 func (cmd *StateHandler) RunStatus(c *kingpin.ParseContext) error {
-	PrintJSON(HTTPGet(fmt.Sprintf("v1/state/tasks/status/%s", cmd.TaskName)))
+	PrintJSON(HTTPGet(fmt.Sprintf("v1/tasks/status/%s", cmd.TaskName)))
 	return nil
 }
 func (cmd *StateHandler) RunTask(c *kingpin.ParseContext) error {
-	PrintJSON(HTTPGet(fmt.Sprintf("v1/state/tasks/info/%s", cmd.TaskName)))
+	PrintJSON(HTTPGet(fmt.Sprintf("v1/tasks/info/%s", cmd.TaskName)))
 	return nil
 }
 func (cmd *StateHandler) RunTasks(c *kingpin.ParseContext) error {
-	PrintJSON(HTTPGet("v1/state/tasks"))
+	PrintJSON(HTTPGet("v1/tasks"))
 	return nil
 }
 

--- a/frameworks/hdfs/cli/dcos-hdfs/main.go
+++ b/frameworks/hdfs/cli/dcos-hdfs/main.go
@@ -41,14 +41,14 @@ type NodeHandler struct {
 
 func (cmd *NodeHandler) runReplace(c *kingpin.ParseContext) error {
 	query := url.Values{}
-	query.Set("name", cmd.name)
-	cli.HTTPPutQuery("v1/nodes/replace", query.Encode())
+	query.Set("replace", "true")
+	cli.HTTPPostQuery(fmt.Sprintf("v1/tasks/restart/%s", cmd.name), query.Encode())
 	return nil
 }
 func (cmd *NodeHandler) runRestart(c *kingpin.ParseContext) error {
 	query := url.Values{}
-	query.Set("name", cmd.name)
-	cli.HTTPPutQuery("v1/nodes/restart", query.Encode())
+	query.Set("replace", "false")
+	cli.HTTPPostQuery(fmt.Sprintf("v1/tasks/restart/%s", cmd.name), query.Encode())
 	return nil
 }
 func handleNodeSection(app *kingpin.Application, modName string) {


### PR DESCRIPTION
Commands affected:

- hdfs node list
- hdfs state status datanode-0
- hdfs state task datanode-0
- hdfs node restart datanode-0 (affects only HDFS)
- hdfs node replace datanode-0 (affects only HDFS)