### PR TITLE
Added package upgrade test.

### DIFF
--- a/examples/reference/integration/tests/test_sanity.py
+++ b/examples/reference/integration/tests/test_sanity.py
@@ -1,6 +1,4 @@
 import dcos.http
-import inspect
-import os
 import pytest
 import shakedown
 
@@ -10,6 +8,7 @@ from tests.test_utils import (
     check_health,
     get_marathon_config,
     get_deployment_plan,
+    install,
     marathon_api_url,
     request,
     uninstall,
@@ -17,20 +16,10 @@ from tests.test_utils import (
 )
 
 
-strict_mode = os.getenv('SECURITY', 'permissive')
-
-
 def setup_module(module):
     uninstall()
 
-    if strict_mode == 'strict':
-        shakedown.install_package_and_wait(
-            package_name=PACKAGE_NAME,
-            options_file=os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe()))) + "/strict.json")
-    else:
-        shakedown.install_package_and_wait(
-            package_name=PACKAGE_NAME,
-            options_file=None)
+    install()
 
     check_health()
 

--- a/examples/reference/integration/tests/test_upgrade.py
+++ b/examples/reference/integration/tests/test_upgrade.py
@@ -1,0 +1,89 @@
+import dcos.http
+import pytest
+import re
+import shakedown
+
+from tests.test_utils import (
+    PACKAGE_NAME,
+    check_health,
+    install,
+    marathon_api_url_with_param,
+    request,
+    run_dcos_cli_cmd,
+    spin,
+    uninstall,
+)
+
+
+MASTER_CUSTOM_NAME='Master Custom'
+# TODO: replace this URL once we have a stock version from which to upgrade
+MASTER_CUSTOM_URL='https://infinity-artifacts.s3.amazonaws.com/reference-latest/stub-universe-reference.zip'
+
+
+def setup_module(module):
+    uninstall()
+
+
+def teardown_module(module):
+    uninstall()
+
+
+@pytest.mark.upgrade
+def test_upgrade():
+    test_version = get_pkg_version()
+    print('Found test version: {}'.format(test_version))
+    add_repo(test_version)
+    master_version = get_pkg_version()
+    print('Found master version: {}'.format(master_version))
+    print('Installing master version')
+    install(master_version)
+    check_health()
+    print('Upgrading to test version')
+    destroy_service()
+    install(test_version)
+    check_health()
+    # clean up
+    remove_repo(master_version)
+
+
+def get_pkg_version():
+    cmd = 'dcos package describe {}'.format(PACKAGE_NAME)
+    pkg_description = run_dcos_cli_cmd(cmd)
+    regex = r'"version": "(\S+)"'
+    match = re.search(regex, pkg_description)
+    return match.group(1)
+
+
+def add_repo(prev_version):
+    assert shakedown.add_package_repo(
+        MASTER_CUSTOM_NAME,
+        MASTER_CUSTOM_URL,
+        0)
+    # Make sure the new repo packages are available
+    new_default_version_available(prev_version)
+
+
+def new_default_version_available(prev_version):
+    def fn():
+        get_pkg_version()
+    def success_predicate(pkg_version):
+        return (pkg_version != prev_version, 'Package version has not changed')
+    spin(fn, success_predicate)
+
+
+def destroy_service():
+    destroy_endpoint = marathon_api_url_with_param('apps', PACKAGE_NAME)
+    request(dcos.http.delete, destroy_endpoint)
+    # Make sure the scheduler has been destroyed
+    def fn():
+        shakedown.get_service(PACKAGE_NAME)
+
+    def success_predicate(service):
+        return (service == None, 'Service not destroyed')
+
+    spin(fn, success_predicate)
+
+
+def remove_repo(prev_version):
+    assert shakedown.remove_package_repo(MASTER_CUSTOM_NAME)
+    new_default_version_available(prev_version)

--- a/examples/reference/integration/tests/test_utils.py
+++ b/examples/reference/integration/tests/test_utils.py
@@ -1,7 +1,10 @@
 import time
 
 import dcos
+import inspect
+import os
 import shakedown
+import subprocess
 
 
 PACKAGE_NAME = 'data-store'
@@ -9,6 +12,9 @@ WAIT_TIME_IN_SECONDS = 15 * 60
 
 TASK_RUNNING_STATE = 'TASK_RUNNING'
 DEFAULT_TASK_COUNT = 5 # 2 metadata nodes, 3 data nodes
+
+
+strict_mode = os.getenv('SECURITY', 'permissive')
 
 
 def check_health(expected_tasks = DEFAULT_TASK_COUNT):
@@ -49,6 +55,19 @@ def get_deployment_plan():
         )
 
     return spin(fn, success_predicate)
+
+
+def install(package_version=None):
+    if strict_mode == 'strict':
+        shakedown.install_package_and_wait(
+            package_name=PACKAGE_NAME,
+            package_version=package_version,
+            options_file=os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe()))) + "/strict.json")
+    else:
+        shakedown.install_package_and_wait(
+            package_name=PACKAGE_NAME,
+            package_version=package_version,
+            options_file=None)
 
 
 def uninstall():
@@ -110,6 +129,10 @@ def marathon_api_url(basename):
     return '{}/v2/{}'.format(shakedown.dcos_service_url('marathon'), basename)
 
 
+def marathon_api_url_with_param(basename, path_param):
+    return '{}/{}'.format(marathon_api_url(basename), path_param)
+
+
 def request(request_fn, *args, **kwargs):
     def success_predicate(response):
         return (
@@ -118,3 +141,10 @@ def request(request_fn, *args, **kwargs):
         )
 
     return spin(request_fn, success_predicate, *args, **kwargs)
+
+
+def run_dcos_cli_cmd(cmd):
+    print('Running {}'.format(cmd))
+    stdout = subprocess.check_output(cmd, shell=True).decode('utf-8')
+    print(stdout)
+    return stdout

--- a/examples/reference/integration/tests/test_utils.py
+++ b/examples/reference/integration/tests/test_utils.py
@@ -14,9 +14,6 @@ TASK_RUNNING_STATE = 'TASK_RUNNING'
 DEFAULT_TASK_COUNT = 5 # 2 metadata nodes, 3 data nodes
 
 
-strict_mode = os.getenv('SECURITY', 'permissive')
-
-
 def check_health(expected_tasks = DEFAULT_TASK_COUNT):
     def fn():
         try:
@@ -58,6 +55,7 @@ def get_deployment_plan():
 
 
 def install(package_version=None):
+    strict_mode = os.getenv('SECURITY', 'permissive')
     if strict_mode == 'strict':
         shakedown.install_package_and_wait(
             package_name=PACKAGE_NAME,


### PR DESCRIPTION
0. - (After normal test tools have already automatically added the infinity-artifacts stub universe...)
1. - Add the master custom universe at index 0
2. - Install data-store master build
4. - Upgrade data-store to infinity-artifacts build
5. - Verify that rollout occurred as expected, and that upgraded data-store is healthy