### PR TITLE
Fixes for mac builds

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
-# This script does a full build/upload of dcos-commons artifacts.
-# This script is invoked by Jenkins CI, but may also be run locally on a dev system.
+# This script does a full build/test of SDK artifacts. This does not upload the artifacts, instead
+# see test.sh. This script (and test.sh) are executed by CI upon pull requests to the repository, or
+# may be run locally by developers.
 
 # Prevent jenkins from immediately killing the script when a step fails, allowing us to notify github:
 set +e

--- a/test.sh
+++ b/test.sh
@@ -1,9 +1,8 @@
 #!/usr/bin/env bash
 
 # This file contains logic for integration tests which are executed by CI upon pull requests to
-# dcos-commons. As such this focuses on executing tests for the Hello World Scheduler.
-# Individual projects/examples within the repository may have their own test scripts for exercising
-# additional custom functionality.
+# dcos-commons. The script builds the Hello World framework, packages and uploads it, then runs its
+# integration tests against a newly-launched cluster.
 
 # Exit immediately on errors -- the helper scripts all emit github statuses internally
 set -e

--- a/tools/build_cli.sh
+++ b/tools/build_cli.sh
@@ -102,7 +102,9 @@ REPO_NAME=dcos-commons # CI dir does not match repo name
 GOPATH_MESOSPHERE=$GOPATH/src/github.com/mesosphere
 rm -rf $GOPATH_MESOSPHERE/$REPO_NAME
 mkdir -p $GOPATH_MESOSPHERE
-ln -T -s $REPO_ROOT_DIR $GOPATH_MESOSPHERE/$REPO_NAME
+pushd $GOPATH_MESOSPHERE
+ln -s $REPO_ROOT_DIR $REPO_NAME
+popd
 echo "Created symlink $GOPATH_MESOSPHERE/$REPO_NAME -> $REPO_ROOT_DIR"
 
 # run get/build from within GOPATH:

--- a/tools/build_framework.sh
+++ b/tools/build_framework.sh
@@ -18,8 +18,7 @@ UNIVERSE_DIR=${UNIVERSE_DIR:=${FRAMEWORK_DIR}/universe}
 CLI_EXE_NAME=${CLI_EXE_NAME:=dcos-${FRAMEWORK_NAME}}
 
 TOOLS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-# 'realpath' isn't available on macs. workaround: trim '/tools' (6 chars) off of string
-REPO_ROOT_DIR=${TOOLS_DIR::-6}
+REPO_ROOT_DIR=$(dirname $TOOLS_DIR) # note: need an absolute path for REPO_CLI_RELATIVE_PATH below
 
 # GitHub notifier config
 _notify_github() {

--- a/tools/build_framework.sh
+++ b/tools/build_framework.sh
@@ -18,7 +18,8 @@ UNIVERSE_DIR=${UNIVERSE_DIR:=${FRAMEWORK_DIR}/universe}
 CLI_EXE_NAME=${CLI_EXE_NAME:=dcos-${FRAMEWORK_NAME}}
 
 TOOLS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-REPO_ROOT_DIR=$(realpath ${TOOLS_DIR}/..)
+# 'realpath' isn't available on macs. workaround: trim '/tools' (6 chars) off of string
+REPO_ROOT_DIR=${TOOLS_DIR::-6}
 
 # GitHub notifier config
 _notify_github() {


### PR DESCRIPTION
By default OSX doesn't have:
- -T flag for `ln`
- `realpath`