### PR TITLE
Use a pre-built/uploaded VM image, instead of requiring DIY builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,10 @@ target/
 
 # dcos-docker artifacts
 dcos-docker/
+ignore/
+genconf/
+.vagrant/
+*.box
 
 # leftovers from running tools directly
 tools/env/

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@
 [DC/OS](https://dcos.io) is a datacenter operating system for running distributed services, such as databases. Like most operating systems, DC/OS has a package manager and package repository, so services can be installed with 1-click.
 
 The __DC/OS SDK__ is a collection of tools, libraries, and documentation for packaging services for DC/OS. With the SDK, you can easily integrate stateful services developed in any programing language.
- 
+
 ### Benefits
 
-* __Simple and Flexible__: The SDK provides the simplicity of a declarative YAML API as well as the flexibility to use the full Java programming language. 
+* __Simple and Flexible__: The SDK provides the simplicity of a declarative YAML API as well as the flexibility to use the full Java programming language.
 
 * __Automate Maintenance__: Some services, such as databases, need to be maintained. With the SDK, you can automate maintenance routines to simplify operations.
 
@@ -33,10 +33,10 @@ From a workstation with 8G Memory, [Git](https://git-scm.com/book/en/v2/Getting-
   ```
   git clone https://github.com/mesosphere/dcos-commons.git
   ```
-  
+
 2. Create your local development environment.
   ```
-  cd dcos-commons/ && ./build-dcos-docker.sh
+  cd dcos-commons/ && ./get-dcos-docker.sh
   ```
   * Visit the DC/OS cluster [dashboard](http://172.17.0.2/) to verify your development environment is running.
 
@@ -44,17 +44,17 @@ From a workstation with 8G Memory, [Git](https://git-scm.com/book/en/v2/Getting-
   ```
   cd dcos-docker/ && vagrant ssh
   ```
-  
+
 4. Build your hello-world example project.
   ```
   cd /dcos-commons/frameworks/helloworld/ && ./build.sh local
   ```
-  
+
 5. Start your hello-world DC/OS service.
   ```
   dcos package install hello-world
   ```
-  
+
 6. Explore your hello-world service.
   * Visit the [dashboard](http://172.17.0.2/#/services/%2Fhello-world/) to see your hello-world service running.
   * Click through to one of your tasks (e.g. `world-server-1-<uuid>`), select the __Files__ tab, select __world-container-path__, and finally select the __output__ file.

--- a/get-dcos-docker.sh
+++ b/get-dcos-docker.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+# Launches a DC/OS dev environment based containing a running 3-agent cluster and dev tools.
+#
+# Prerequisites:
+# - 8GB RAM
+# - Vagrant
+# - Virtualbox
+#
+# Arguments:
+# - BOX_PATH: Local path to use for .box image (useful if installing from USB stick)
+
+# capture anonymous metrics for reporting
+curl --fail https://mesosphere.com/wp-content/themes/mesosphere/library/images/assets/sdk/create-dev-env-start.png >/dev/null 2>&1
+
+# abort script at first error:
+set -e
+
+BOX_NAME=mesosphere/dcos-docker-sdk
+
+error_msg() {
+    echo "---"
+    echo "Failed to build the cluster: Exited early at $0:L$1"
+    echo "To try again, re-run this script."
+    echo "---"
+}
+trap 'error_msg ${LINENO}' ERR
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd $SCRIPT_DIR
+
+cd tools/vagrant/
+VAGRANT_DIR=$(pwd)
+
+# Image-on-USB-stick scenario: Manually add the provided .box file directly
+if [ $(vagrant box list | grep $BOX_NAME | wc -l) -eq 0 ]; then
+    if [ -n "$BOX_PATH" ]; then
+        echo "### Installing provided local box image as $BOX_NAME: $BOX_PATH"
+        vagrant box add --name $BOX_NAME ${BOX_PATH}
+    fi
+elif [ -n "$BOX_PATH" ]; then
+    echo "### NOTICE: Local box image was provided, but vagrant already has a box named $BOX_NAME. Ignoring provided image: $BOX_PATH"
+fi
+
+echo "### Destroying pre-existing VM, if any"
+vagrant destroy # intentionally allowing confirmation prompt in case the user didn't actually want to do this
+
+echo "### Bringing up VM"
+vagrant up
+
+echo "### Starting DC/OS environment within VM"
+vagrant ssh -c "/home/vagrant/start-dcos.sh"
+
+echo "### Waiting for cluster to finish coming up"
+vagrant ssh -c "docker exec -i dcos-docker-master1 dcos-postflight"
+
+${SCRIPT_DIR}/node-route.sh
+
+echo "----"
+echo "Dashboard URL:  http://172.17.0.2"
+echo ""
+echo "Log into VM:    pushd ${VAGRANT_DIR} && vagrant ssh && popd"
+echo "Build example:  Log into VM, then: cd /dcos-commons/frameworks/helloworld && ./build.sh local"
+echo ""
+echo "Repair routes:  ${SCRIPT_DIR}/node-route.sh # (use this if VM connectivity is lost)"
+echo "Delete VM:      pushd ${VAGRANT_DIR} && vagrant destroy && popd"
+echo "Delete data:    rm -rf ${VAGRANT_DIR}/*.box && vagrant box remove $BOX_NAME"
+echo "---"
+
+# capture anonymous metrics for reporting
+curl --fail https://mesosphere.com/wp-content/themes/mesosphere/library/images/assets/sdk/create-dev-env-finish.png >/dev/null 2>&1

--- a/tools/publish_http.py
+++ b/tools/publish_http.py
@@ -228,8 +228,8 @@ Artifacts:       {}
         logger.info('Install your package using the following command:')
     else:
         logger.info('Install your package using the following commands:')
-        logger.info('dcos package repo add --index=0 {}-aws {}'.format(self._pkg_name, universe_url))
-    logger.info('dcos package install {}'.format(self._pkg_name))
+        logger.info('dcos package repo add --index=0 {}-aws {}'.format(package_name, universe_url))
+    logger.info('dcos package install {}'.format(package_name))
     return 0
 
 

--- a/tools/vagrant/.gitignore
+++ b/tools/vagrant/.gitignore
@@ -1,3 +1,0 @@
-ignore/
-genconf/
-*.box

--- a/tools/vagrant/Vagrantfile
+++ b/tools/vagrant/Vagrantfile
@@ -1,9 +1,8 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-$dcos_box = ENV.fetch('DCOS_BOX', 'dcos-docker-sdk')
-$dcos_box_url = ENV.fetch('DCOS_BOX_URL', 'http://example.com/dcos-docker-sdk.box')
-$dcos_box_version = ENV.fetch('DCOS_BOX_VERSION', '')
+$dcos_box = ENV.fetch('DCOS_BOX', 'mesosphere/dcos-docker-sdk')
+$dcos_box_url = ENV.fetch('DCOS_BOX_URL', 'http://downloads.mesosphere.com/dcos-docker-sdk/metadata.json')
 
 $dcos_cpus = ENV.fetch('DCOS_CPUS', 2)
 $dcos_mem = ENV.fetch('DCOS_MEM', 6144) # 6GB
@@ -20,14 +19,11 @@ Vagrant.configure(2) do |config|
   config.vm.define 'dcos-docker-sdk' do |vm_cfg|
     vm_cfg.vm.box = $dcos_box
     vm_cfg.vm.box_url = $dcos_box_url
-    vm_cfg.vm.box_version = $dcos_box_version
-
-    config.ssh.username = "vagrant"
-    config.ssh.password = "vagrant"
 
     vm_cfg.vm.hostname = 'dcos-docker-sdk'
     vm_cfg.vm.network :private_network, ip: '192.168.65.50'
     config.vm.synced_folder '.', '/vagrant', type: :virtualbox
+    config.vm.synced_folder '../../', '/dcos-commons', type: :virtualbox
 
     vm_cfg.vm.provider :virtualbox do |v|
       v.name = vm_cfg.vm.hostname

--- a/tools/vagrant/build-dcos-docker.sh
+++ b/tools/vagrant/build-dcos-docker.sh
@@ -1,5 +1,14 @@
 #!/bin/bash
 
+# Creates a Vagrant/Virtualbox VM containing:
+# - A 3-node DC/OS cluster
+# - All the development tools needed to build the SDK from within the image (if desired)
+# ===
+# Syntax:
+#   build-dcos-docker.sh [package]
+#
+# If the 'package' argument is specified, the resulting image is halted and packaged into a .box file.
+
 # capture anonymous metrics for reporting
 curl --fail https://mesosphere.com/wp-content/themes/mesosphere/library/images/assets/sdk/create-dev-env-start.png >/dev/null 2>&1
 
@@ -37,7 +46,7 @@ DCOS_DOCKER_DIR=$(pwd)
 
 # Manually fetch/install base box: Allow on-disk caching of box file (usb stick scenario)
 if [ $(vagrant box list | grep mesosphere/dcos-centos-virtualbox | wc -l) -eq 0 ]; then
-    echo "### Downloading base box image"
+    echo "### Downloading/adding base box image"
     if [ ! -f ${ARTIFACT_BOX_BASE} ]; then
         curl -O https://downloads.dcos.io/dcos-vagrant/${ARTIFACT_BOX_BASE}
     fi
@@ -50,10 +59,11 @@ if [ ! -f ${ARTIFACT_DCOS_INSTALLER} ]; then
 fi
 
 echo "### Destroying pre-existing VM, if any"
-vagrant destroy
+vagrant destroy # intentionally allowing confirmation prompt in case the user didn't actually want to do this
+vagrant box remove mesosphere/dcos-docker-sdk
 
 echo "### Building VM"
-DCOS_BOX_URL="file:/$(pwd)/${ARTIFACT_BOX_BASE}" vagrant/resize-disk.sh ${VM_DISK_SIZE:=20480}
+DCOS_BOX_URL="file://$(pwd)/${ARTIFACT_BOX_BASE}" vagrant/resize-disk.sh ${VM_DISK_SIZE:=20480}
 
 echo "### Launching cluster and installing tools in VM"
 # Note: every variable that isn't escaped with a backslash is injected from THIS script.
@@ -127,6 +137,11 @@ chmod 700 /home/vagrant/.ssh &&
 cp /vagrant/genconf/ssh_key /home/vagrant/.ssh/id_rsa &&
 chmod 600 /home/vagrant/.ssh/id_rsa &&
 
+echo '### Clean up some unnecessary files' &&
+sudo rm -rf /usr/src/ &&
+sudo rm -rf /root/.cache &&
+sudo rm -f /home/vagrant/VBoxGuestAdditions_*.iso &&
+
 echo '### Wait for cluster to finish coming up' &&
 make postflight
 EOF
@@ -137,45 +152,33 @@ echo "### Copying start-dcos.sh into image"
 cat > start-dcos.sh <<EOF
 #!/bin/bash
 
-STOPPED_MASTERS=\$(docker ps -a -f status=exited | awk '{print \$NF}' | grep dcos-docker-master | sort)
-STOPPED_PUB_AGENTS=\$(docker ps -a -f status=exited | awk '{print \$NF}' | grep dcos-docker-pubagent | sort)
-STOPPED_PRIV_AGENTS=\$(docker ps -a -f status=exited | awk '{print \$NF}' | grep dcos-docker-agent | sort)
-
-restart_nodes() {
-    for node in \$1; do
-        docker start \$node
-        sleep 2
-    done
+restart_if_needed() {
+    STOPPED_NODES=\$(docker ps -a -f status=exited | awk '{print \$NF}' | grep dcos-docker-\${1} | sort)
+    NUM_STOPPED_NODES=\$(echo \$STOPPED_NODES | wc -w)
+    if [ \$NUM_STOPPED_NODES -eq 0 ]; then
+        echo "- No \${1}s to launch"
+    else
+        echo "- Launching \$NUM_STOPPED_NODES \$1(s)"
+        for node in \$STOPPED_NODES; do
+            docker start \$node
+            sleep 2
+        done
+    fi
 }
 
-echo "Launching \$(echo \$STOPPED_MASTERS | wc -w) master(s)"
-restart_nodes "\$STOPPED_MASTERS"
+restart_if_needed master
 
-# mystery: need to kick 'make' before starting agents, or else this happens:
+# The following step must be completed before restarting agents, or else this happens:
 # dcos-docker-agent1 mesos-agent[3545]:   3546 systemd.cpp:325] Started systemd slice 'mesos_executors.slice'
 # dcos-docker-agent1 mesos-agent[3545]: Failed to initialize systemd: Failed to locate systemd cgroups hierarchy: does not exist
+echo "- Setting up agent prerequisites"
+sudo systemctl start mesos_executors.slice
 
-NUM_STOPPED_PUB_AGENTS=\$(echo \$STOPPED_PUB_AGENTS | wc -w)
-if [ \$NUM_STOPPED_PUB_AGENTS -eq 0 ]; then
-    echo "No public agents to launch"
-else
-    echo "Launching \$NUM_STOPPED_PUB_AGENTS public agents"
-    PUBLIC_AGENTS=\$NUM_STOPPED_PUB_AGENTS make -C dcos-docker/ public_agent
-    restart_nodes "\$STOPPED_PUB_AGENTS"
-fi
-
-NUM_STOPPED_PRIV_AGENTS=\$(echo \$STOPPED_PRIV_AGENTS | wc -w)
-if [ \$NUM_STOPPED_PRIV_AGENTS -eq 0 ]; then
-    echo "No private agents to launch"
-else
-    echo "Launching \$NUM_STOPPED_PRIV_AGENTS private agents"
-    AGENTS=\$NUM_STOPPED_PRIV_AGENTS make -C dcos-docker/ agent
-    restart_nodes "\$STOPPED_PRIV_AGENTS"
-fi
+restart_if_needed pubagent
+restart_if_needed agent
 EOF
 chmod +x start-dcos.sh
-# copy makefile (+ file dependency) from dcos-docker repo for 'kick':
-vagrant ssh -c "cp /vagrant/start-dcos.sh /vagrant/Makefile /vagrant/common.mk ~"
+vagrant ssh -c "cp /vagrant/start-dcos.sh ~"
 
 ${SCRIPT_DIR}/node-route.sh
 
@@ -185,11 +188,18 @@ echo ""
 echo "Log into VM:    pushd ${DCOS_DOCKER_DIR} && vagrant ssh && popd"
 echo "Build example:  Log into VM, then: cd /dcos-commons/frameworks/helloworld && ./build.sh local"
 echo ""
-echo "Rebuild routes: ${SCRIPT_DIR}/node-route.sh"
+echo "Repair routes:  ${SCRIPT_DIR}/node-route.sh # (use this if VM connectivity is lost)"
 echo "Delete VM:      pushd ${DCOS_DOCKER_DIR} && vagrant destroy && popd"
 echo "Delete data:    rm -rf ${DCOS_DOCKER_DIR}"
 echo "---"
 
+if [ "$1" = "package" ]; then
+    echo "Packaging built image into .box file."
+    vagrant package --output dcos-docker-sdk-$(date -u +%Y%m%d-%H%M%S).box dcos-docker
+    echo "Package created. Removing installed images."
+    vagrant destroy -f
+    vagrant box remove mesosphere/dcos-centos-virtualbox
+fi
+
 # capture anonymous metrics for reporting
 curl --fail https://mesosphere.com/wp-content/themes/mesosphere/library/images/assets/sdk/create-dev-env-finish.png >/dev/null 2>&1
-

--- a/tools/vagrant/metadata.json
+++ b/tools/vagrant/metadata.json
@@ -1,0 +1,19 @@
+{
+  "name": "mesosphere/dcos-docker-sdk",
+  "description": "DC/OS framework development environment, containing a cluster and dev tools",
+  "versions": [
+    {
+      "version": "20161121-213020",
+      "status": "active",
+      "description_markdown": "initial release, needs size optimizations and auto-start",
+      "providers": [
+        {
+          "name": "virtualbox",
+          "url": "https://downloads.mesosphere.com/dcos-docker-sdk/dcos-docker-sdk-20161121-213020.box",
+          "checksum_type": "sha1",
+          "checksum": "e44aca7e80c29870403da7de621842ebe727011a"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Upside(s):
- Environment creation is much simpler, mainly consisting of convenince logic surrounding a plain ol' `vagrant up` command.

Downside:
- Current up-front image download approaches 5GB (many easy optimizations left to be made by DC/OS). This is ameliorated somewhat by the USB-stick option.

Main changes:
- Adds new `get-dcos-docker.sh` and updates quickstart to use it. This replacement for `build-dcos-docker.sh` just grabs the latest version of the uploaded package. Supports passing a local path to the package using a `BOX_PATH` envvar (USB stick support).
- Moves `build-dcos-docker.sh` into `tools/vagrant/` while adding some automation around creating box packages. This tool should now only be needed when the box package needs an update.