### PR TITLE
Fix/bump image, use uncached metadata.json

### DIFF
--- a/tools/build_cli.sh
+++ b/tools/build_cli.sh
@@ -13,7 +13,7 @@ CLI_DIR=$2
 REPO_CLI_RELATIVE_PATH=$3 # eg 'frameworks/helloworld/cli/'
 
 TOOLS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-REPO_ROOT_DIR=$(realpath $TOOLS_DIR/..)
+REPO_ROOT_DIR=$(dirname $TOOLS_DIR) # note: need an absolute path for REPO_CLI_RELATIVE_PATH below
 
 if [ -z "$GOPATH" -o -z "$(which go)" ]; then
   echo "Missing GOPATH environment variable or 'go' executable. Please configure a Go build environment."

--- a/tools/vagrant/Vagrantfile
+++ b/tools/vagrant/Vagrantfile
@@ -2,7 +2,9 @@
 # vi: set ft=ruby :
 
 $dcos_box = ENV.fetch('DCOS_BOX', 'mesosphere/dcos-docker-sdk')
-$dcos_box_url = ENV.fetch('DCOS_BOX_URL', 'http://downloads.mesosphere.com/dcos-docker-sdk/metadata.json')
+# TODO: when box isn't being upgraded regularly, switch from the raw URL to the (commented-out) cached URL:
+#$dcos_box_url = ENV.fetch('DCOS_BOX_URL', 'https://downloads.mesosphere.com/dcos-docker-sdk/metadata.json')
+$dcos_box_url = ENV.fetch('DCOS_BOX_URL', 'https://s3.amazonaws.com/downloads.mesosphere.io/dcos-docker-sdk/metadata.json')
 
 $dcos_cpus = ENV.fetch('DCOS_CPUS', 2)
 $dcos_mem = ENV.fetch('DCOS_MEM', 6144) # 6GB

--- a/tools/vagrant/metadata.json
+++ b/tools/vagrant/metadata.json
@@ -3,15 +3,15 @@
   "description": "DC/OS framework development environment, containing a cluster and dev tools",
   "versions": [
     {
-      "version": "20161121-213020",
+      "version": "20161123-025803",
       "status": "active",
       "description_markdown": "initial release, needs size optimizations and auto-start",
       "providers": [
         {
           "name": "virtualbox",
-          "url": "https://downloads.mesosphere.com/dcos-docker-sdk/dcos-docker-sdk-20161121-213020.box",
+          "url": "https://downloads.mesosphere.com/dcos-docker-sdk/dcos-docker-sdk-20161123-025803.box",
           "checksum_type": "sha1",
-          "checksum": "e44aca7e80c29870403da7de621842ebe727011a"
+          "checksum": "16a6388b3b90c6509b0b8b2de181e2bc799e869c"
         }
       ]
     }


### PR DESCRIPTION
- Use uncached metadata.json as the .box is still moving quickly. Want changes to deploy sooner than ~24h
- Bump .box image: includes fixes in image builder (especially refraining from wiping `/usr/src` which is needed)
- Fix regressions in image builder and add steps to upload
- Path in build_cli.sh was still broken for OSX (no `realpath`)