### PR TITLE
a quick fix for cli, update in README, and removal of 'health' command in cli 

### DIFF
--- a/cli/commands.go
+++ b/cli/commands.go
@@ -92,7 +92,6 @@ func HandleCommonSections(app *kingpin.Application, connectionTypes []string) {
 	HandleConnectionSection(app, connectionTypes)
 	HandlePlanSection(app)
 	HandleStateSection(app)
-	HandleHealthSection(app)
 }
 
 // Config section
@@ -261,20 +260,4 @@ func HandleStateSection(app *kingpin.Application) {
 	task.Arg("name", "Name of the task to display").Required().StringVar(&cmd.TaskName)
 
 	state.Command("tasks", "List names of all persisted tasks").Action(cmd.RunTasks)
-}
-
-// Health section
-
-type HealthHandler struct {
-}
-
-func (cmd *HealthHandler) RunHealthCheck(c *kingpin.ParseContext) error {
-	PrintJSON(HTTPGet("admin/healthcheck"))
-	return nil
-}
-
-func HandleHealthSection(app *kingpin.Application) {
-	// health
-	cmd := &HealthHandler{}
-	app.Command("health", fmt.Sprintf("View healthcheck information)")).Action(cmd.RunHealthCheck)
 }

--- a/frameworks/helloworld/README.md
+++ b/frameworks/helloworld/README.md
@@ -6,3 +6,32 @@ Three sample configuration files are given here (change the name of the input ym
        - svc_plan.yml (two pods, with healthcheck, with disk, with port, and with a plan structure)
 
 
+Framework API Port:
+
+	Please note that Marathon dynamically selects a port number, and passes this information to the framework ( PORT0 in our examples). We start the API service on that given port number. You can start the framework by giving a specific port number, if you are sure that the port is available to you. This is very unlikely, so api-port should be set to a variable as shown below:  
+   
+		api-port : {{PORT0}}
+
+See universe/marathon.json.mustache for more information:
+…
+…
+ "DCOS_MIGRATION_API_PATH": "/v1/plan",
+    "MARATHON_SINGLE_INSTANCE_APP":"true",
+    "DCOS_SERVICE_NAME": "{{service.name}}",
+    "DCOS_SERVICE_PORT_INDEX": "0",
+    "DCOS_SERVICE_SCHEME": "http”
+…
+…
+…
+  "portDefinitions": [
+    {
+      "port": 0,
+      "protocol": "tcp",
+      "name": "api",
+…
+…
+…
+
+
+
+

--- a/frameworks/helloworld/src/main/dist/svc.yml
+++ b/frameworks/helloworld/src/main/dist/svc.yml
@@ -1,7 +1,7 @@
 name: "hello-world"
 principal: "hello-world-principal"
 zookeeper: master.mesos:2181
-api-port: 8080
+api-port: {{PORT0}}
 pods:
   hello:
     count: {{HELLO_COUNT}}


### PR DESCRIPTION
 * removing 'health' command from cli.  no admin/healthcheck  in com.mesosphere.sdk.api
 
     ./dcos-hello-world-darwin hello-world health
    HTTP GET Query for http://35.164.209.100/service/hello-world/admin/healthcheck failed: 404 Not Found

 *   updated README.md, added a note about api-port

  *  api-port is dynamically set by Marathon.  In yml file, it should be “api-port: {{PORT0}}”
    
    Marathon dynamically selects a port, and pass this info to the framework, so framework can start the service on that selected port.

