### PR TITLE
YAML: Add 'colocate-types'/'avoid-types' for devs, make 'placement' Marathon-formatted for ops

### DIFF
--- a/frameworks/helloworld/src/main/dist/svc_plan.yml
+++ b/frameworks/helloworld/src/main/dist/svc_plan.yml
@@ -5,6 +5,9 @@ api-port: {{PORT0}}
 pods:
   hello:
     count: {{HELLO_COUNT}}
+    avoid-types:
+      - hello
+      - world
     tasks:
       server:
         goal: RUNNING
@@ -23,6 +26,9 @@ pods:
 
   world:
     count: {{WORLD_COUNT}}
+    avoid-types:
+      - hello
+      - world
     resource-sets:
       world-resource:
         cpus: {{WORLD_CPUS}}

--- a/frameworks/helloworld/src/test/java/com/mesosphere/sdk/helloworld/scheduler/HelloWorldServiceSpecTest.java
+++ b/frameworks/helloworld/src/test/java/com/mesosphere/sdk/helloworld/scheduler/HelloWorldServiceSpecTest.java
@@ -59,35 +59,35 @@ public class HelloWorldServiceSpecTest {
 
     @Test
     public void test_yml_base() throws Exception{
-        ServiceSpecDeserialization("svc.yml");
+        serviceSpecDeserialization("svc.yml");
     }
 
     @Test
     public void test_yml_simple() throws Exception{
-        ServiceSpecDeserialization("svc_simple.yml");
+        serviceSpecDeserialization("svc_simple.yml");
     }
 
     @Test
     public void test_yml_withPlan() throws Exception{
-        ServiceSpecDeserialization("svc_plan.yml");
+        serviceSpecDeserialization("svc_plan.yml");
     }
 
     @Test
     public void test_validate_yml_base() throws Exception{
-        ServiceSpecValidation("svc.yml");
+        serviceSpecValidation("svc.yml");
     }
 
     @Test
     public void test_validate_yml_simple() throws Exception{
-        ServiceSpecValidation("svc_simple.yml");
+        serviceSpecValidation("svc_simple.yml");
     }
 
     @Test
     public void test_validate_yml_withPlan() throws Exception{
-        ServiceSpecValidation("svc_plan.yml");
+        serviceSpecValidation("svc_plan.yml");
     }
 
-    private void ServiceSpecDeserialization(String fileName) throws Exception {
+    private void serviceSpecDeserialization(String fileName) throws Exception {
         ClassLoader classLoader = getClass().getClassLoader();
         File file = new File(classLoader.getResource(fileName).getFile());
         DefaultServiceSpec serviceSpec = YAMLServiceSpecFactory
@@ -97,7 +97,7 @@ public class HelloWorldServiceSpecTest {
         DefaultServiceSpec.getFactory(serviceSpec, Collections.emptyList());
     }
 
-    private void ServiceSpecValidation(String fileName) throws Exception {
+    private void serviceSpecValidation(String fileName) throws Exception {
         ClassLoader classLoader = getClass().getClassLoader();
         File file = new File(classLoader.getResource(fileName).getFile());
         DefaultServiceSpec serviceSpec = YAMLServiceSpecFactory
@@ -134,5 +134,6 @@ public class HelloWorldServiceSpecTest {
         DefaultScheduler defaultScheduler = DefaultScheduler
                 .create(serviceSpec, stateStore, configStore, offerRequirementProvider);
         defaultScheduler.registered(mockSchedulerDriver, FRAMEWORK_ID, MASTER_INFO);
+        testingServer.close();
     }
 }

--- a/sdk/common/src/test/resources/valid-exhaustive.yml
+++ b/sdk/common/src/test/resources/valid-exhaustive.yml
@@ -7,7 +7,8 @@ replacement-failure-policy:
   min-replace-delay-ms: 10
 pods:
   meta-data:
-    placement: "avoid-type: meta-data"
+    avoid-types:
+      - meta-data
     count: 2
     resource-sets:
       meta-data-resources:
@@ -38,7 +39,8 @@ pods:
             delay: 0
             timeout: 10
   data-store:
-    placement: "avoid-type: data-store"
+    avoid-types:
+      - data-store
     count: 3
     resource-sets:
       data-store-resources:

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/constrain/AgentRule.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/constrain/AgentRule.java
@@ -37,7 +37,14 @@ public class AgentRule implements PlacementRule {
      * @param agentIds mesos ID of the agents to require
      */
     public static PlacementRule require(Collection<String> agentIds) {
-        return new OrRule(toAgentRules(agentIds));
+        switch (agentIds.size()) {
+        case 0:
+            return new PassthroughRule();
+        case 1:
+            return require(agentIds.iterator().next());
+        default:
+            return new OrRule(toAgentRules(agentIds));
+        }
     }
 
     /**
@@ -117,7 +124,7 @@ public class AgentRule implements PlacementRule {
     private static Collection<PlacementRule> toAgentRules(Collection<String> agentIds) {
         List<PlacementRule> rules = new ArrayList<>();
         for (String agentId : agentIds) {
-            rules.add(new AgentRule(agentId));
+            rules.add(require(agentId));
         }
         return rules;
     }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/constrain/TaskTypeRule.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/constrain/TaskTypeRule.java
@@ -45,6 +45,25 @@ public class TaskTypeRule implements PlacementRule {
     }
 
     /**
+     * Requires avoidance of any of the provided types. Effectively an AND wrapper around
+     * {@link #avoid(String)}.
+     */
+    public static PlacementRule avoid(Collection<String> typesToAvoid) {
+        switch (typesToAvoid.size()) {
+        case 0:
+            return new PassthroughRule();
+        case 1:
+            return avoid(typesToAvoid.iterator().next());
+        default:
+            List<PlacementRule> avoidRules = new ArrayList<>();
+            for (String type : typesToAvoid) {
+                avoidRules.add(avoid(type));
+            }
+            return new AndRule(avoidRules);
+        }
+    }
+
+    /**
      * Returns a {@link PlacementRule} which enforces colocation with tasks which have the provided
      * type. For example, this could be used to ensure that 'data' nodes are always colocated with
      * 'index' nodes. Note that this rule is unidirectional; mutual colocation requires
@@ -64,6 +83,25 @@ public class TaskTypeRule implements PlacementRule {
      */
     public static PlacementRule colocateWith(String typeToColocateWith) {
         return colocateWith(typeToColocateWith, null);
+    }
+
+    /**
+     * Requires colocation with one of the provided types. Effectively an OR wrapper around
+     * {@link #colocateWith(String)}.
+     */
+    public static PlacementRule colocateWith(Collection<String> typesToColocateWith) {
+        switch (typesToColocateWith.size()) {
+        case 0:
+            return new PassthroughRule();
+        case 1:
+            return colocateWith(typesToColocateWith.iterator().next());
+        default:
+            List<PlacementRule> colocateRules = new ArrayList<>();
+            for (String type : typesToColocateWith) {
+                colocateRules.add(colocateWith(type));
+            }
+            return new OrRule(colocateRules);
+        }
     }
 
     /**

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultPodSpec.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultPodSpec.java
@@ -38,6 +38,10 @@ public class DefaultPodSpec implements PodSpec {
     @UniqueTaskName(message = "Task names must be unique")
     private List<TaskSpec> tasks;
     @Valid
+    private Collection<String> colocateTypes;
+    @Valid
+    private Collection<String> avoidTypes;
+    @Valid
     private PlacementRule placementRule;
     @Valid
     @UniqueResourceSet
@@ -50,6 +54,8 @@ public class DefaultPodSpec implements PodSpec {
             @JsonProperty("count") Integer count,
             @JsonProperty("container") ContainerSpec container,
             @JsonProperty("task_specs") List<TaskSpec> tasks,
+            @JsonProperty("colocate_types") Collection<String> colocateTypes,
+            @JsonProperty("avoid_types") Collection<String> avoidTypes,
             @JsonProperty("placement_rule") PlacementRule placementRule,
             @JsonProperty("resource_sets") Collection<ResourceSet> resources) {
         this.type = type;
@@ -57,13 +63,15 @@ public class DefaultPodSpec implements PodSpec {
         this.count = count;
         this.container = container;
         this.tasks = tasks;
+        this.colocateTypes = colocateTypes;
+        this.avoidTypes = avoidTypes;
         this.placementRule = placementRule;
         this.resources = resources;
     }
 
     private DefaultPodSpec(Builder builder) {
-        this(builder.type, builder.user, builder.count, builder.container,
-                builder.tasks, builder.placementRule, builder.resources);
+        this(builder.type, builder.user, builder.count, builder.container, builder.tasks,
+                builder.colocateTypes, builder.avoidTypes, builder.placementRule, builder.resources);
     }
 
     public static Builder newBuilder() {
@@ -76,12 +84,11 @@ public class DefaultPodSpec implements PodSpec {
         builder.user = copy.getUser().isPresent() ? copy.getUser().get() : null;
         builder.count = copy.getCount();
         builder.container = copy.getContainer().isPresent() ? copy.getContainer().get() : null;
-        builder.tasks = new ArrayList<>();
-        builder.tasks.addAll(copy.getTasks());
-        builder.placementRule = copy.getPlacementRule().isPresent() ? copy.getPlacementRule().get() : null;
-        ArrayList<ResourceSet> resourcesCopy = new ArrayList<>();
-        resourcesCopy.addAll(copy.getResources());
-        builder.resources = resourcesCopy;
+        builder.tasks = new ArrayList<>(copy.getTasks());
+        builder.colocateTypes = new ArrayList<>(copy.getColocateTypes());
+        builder.avoidTypes = new ArrayList<>(copy.getAvoidTypes());
+        builder.placementRule = copy.getPlacementRule().orElse(null);
+        builder.resources = new ArrayList<>(copy.getResources());
         return builder;
     }
 
@@ -116,6 +123,16 @@ public class DefaultPodSpec implements PodSpec {
     }
 
     @Override
+    public Collection<String> getAvoidTypes() {
+        return avoidTypes;
+    }
+
+    @Override
+    public Collection<String> getColocateTypes() {
+        return colocateTypes;
+    }
+
+    @Override
     public Optional<PlacementRule> getPlacementRule() {
         return Optional.ofNullable(placementRule);
     }
@@ -140,6 +157,8 @@ public class DefaultPodSpec implements PodSpec {
         private Integer count;
         private ContainerSpec container;
         private List<TaskSpec> tasks = new ArrayList<>();
+        private Collection<String> colocateTypes = new ArrayList<>();
+        private Collection<String> avoidTypes = new ArrayList<>();
         private PlacementRule placementRule;
         private Collection<ResourceSet> resources;
 
@@ -214,6 +233,54 @@ public class DefaultPodSpec implements PodSpec {
         }
 
         /**
+         * Sets the task types to colocate with and returns a reference to this Builder so that the methods can be
+         * chained together.
+         *
+         * @param colocateTypes the task types to colocate with
+         * @return a reference to this Builder
+         */
+        public Builder colocateTypes(Collection<String> colocateTypes) {
+            this.colocateTypes = colocateTypes;
+            return this;
+        }
+
+        /**
+         * Adds a task type to colocate with and returns a reference to this Builder so that the methods can be chained
+         * together.
+         *
+         * @param colocateType the task type to colocate with
+         * @return a reference to this Builder
+         */
+        public Builder addColocateType(String colocateType) {
+            this.colocateTypes.add(colocateType);
+            return this;
+        }
+
+        /**
+         * Sets the task types to avoid and returns a reference to this Builder so that the methods can be chained
+         * together.
+         *
+         * @param avoidTypes the task types to avoid
+         * @return a reference to this Builder
+         */
+        public Builder avoidTypes(Collection<String> avoidTypes) {
+            this.avoidTypes = avoidTypes;
+            return this;
+        }
+
+        /**
+         * Adds a task type to avoid and returns a reference to this Builder so that the methods can be chained
+         * together.
+         *
+         * @param avoidType the task type to avoid
+         * @return a reference to this Builder
+         */
+        public Builder addAvoidType(String avoidType) {
+            this.avoidTypes.add(avoidType);
+            return this;
+        }
+
+        /**
          * Sets the {@code placementRule} and returns a reference to this Builder so that the methods can be chained
          * together.
          *
@@ -225,6 +292,13 @@ public class DefaultPodSpec implements PodSpec {
             return this;
         }
 
+        /**
+         * Sets the {@code resources} and returns a reference to this Builder so that the methods can be chained
+         * together.
+         *
+         * @param resources the {@code resources} to set
+         * @return a reference to this Builder
+         */
         public Builder resources(Collection<ResourceSet> resources) {
             this.resources = resources;
             return this;

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/PodSpec.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/PodSpec.java
@@ -32,6 +32,12 @@ public interface PodSpec {
     @JsonProperty("resource_sets")
     Collection<ResourceSet> getResources();
 
+    @JsonProperty("colocate_types")
+    Collection<String> getColocateTypes();
+
+    @JsonProperty("avoid_types")
+    Collection<String> getAvoidTypes();
+
     @JsonProperty("placement_rule")
     Optional<PlacementRule> getPlacementRule();
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/RawPod.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/RawPod.java
@@ -2,6 +2,8 @@ package com.mesosphere.sdk.specification.yaml;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 
 /**
@@ -9,13 +11,14 @@ import java.util.LinkedHashMap;
  */
 public class RawPod {
     private String name;
-    private String placement;
     private Integer count;
     private RawContainer container;
     private String strategy;
     private String user;
     private WriteOnceLinkedHashMap<String, RawTask> tasks;
     private WriteOnceLinkedHashMap<String, RawResourceSet> resourceSets;
+    private Collection<String> avoidTypes = Collections.emptyList();
+    private Collection<String> colocateTypes = Collections.emptyList();
 
     public String getName() {
         return name;
@@ -24,24 +27,6 @@ public class RawPod {
     @JsonProperty("name")
     public void setName(String name) {
         this.name = name;
-    }
-
-    public WriteOnceLinkedHashMap<String, RawResourceSet> getResourceSets() {
-        return resourceSets;
-    }
-
-    @JsonProperty("resource-sets")
-    public void setResourceSets(WriteOnceLinkedHashMap<String, RawResourceSet> resourceSets) {
-        this.resourceSets = resourceSets;
-    }
-
-    public String getPlacement() {
-        return placement;
-    }
-
-    @JsonProperty("placement")
-    public void setPlacement(String placement) {
-        this.placement = placement;
     }
 
     public Integer getCount() {
@@ -71,6 +56,15 @@ public class RawPod {
         this.strategy = strategy;
     }
 
+    public String getUser() {
+        return user;
+    }
+
+    @JsonProperty("user")
+    public void setUser(String user) {
+        this.user = user;
+    }
+
     public LinkedHashMap<String, RawTask> getTasks() {
         return tasks;
     }
@@ -80,12 +74,30 @@ public class RawPod {
         this.tasks = tasks;
     }
 
-    public String getUser() {
-        return user;
+    public WriteOnceLinkedHashMap<String, RawResourceSet> getResourceSets() {
+        return resourceSets;
     }
 
-    @JsonProperty("user")
-    public void setUser(String user) {
-        this.user = user;
+    @JsonProperty("resource-sets")
+    public void setResourceSets(WriteOnceLinkedHashMap<String, RawResourceSet> resourceSets) {
+        this.resourceSets = resourceSets;
+    }
+
+    public Collection<String> getAvoidTypes() {
+        return avoidTypes;
+    }
+
+    @JsonProperty("avoid-types")
+    public void setAvoidTypes(Collection<String> avoidTypes) {
+        this.avoidTypes = avoidTypes;
+    }
+
+    public Collection<String> getColocateTypes() {
+        return colocateTypes;
+    }
+
+    @JsonProperty("colocate-types")
+    public void setColocateTypes(Collection<String> colocateTypes) {
+        this.colocateTypes = colocateTypes;
     }
 }

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/OfferEvaluatorTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/OfferEvaluatorTest.java
@@ -1031,7 +1031,8 @@ public class OfferEvaluatorTest {
     private static OfferRequirement getOfferRequirement(
             Protos.Resource resource, List<String> avoidAgents, List<String> collocateAgents)
                     throws InvalidRequirementException {
-        Optional<PlacementRule> placement = PlacementUtils.getAgentPlacementRule(avoidAgents, collocateAgents);
+        Optional<PlacementRule> placement =
+                PlacementUtils.getAgentPlacementRule(avoidAgents, collocateAgents);
         return OfferRequirement.create(
                 TestConstants.TASK_TYPE,
                 0,

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/constrain/PlacementUtilsTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/constrain/PlacementUtilsTest.java
@@ -28,16 +28,120 @@ public class PlacementUtilsTest {
         rule = PlacementUtils.getAgentPlacementRule(
                 Arrays.asList("avoidme", "avoidme2"),
                 Collections.emptyList());
-        assertEquals("NotRule{rule=OrRule{rules=[AgentRule{agentId=avoidme}, AgentRule{agentId=avoidme2}]}}", rule.get().toString());
+        assertEquals("NotRule{rule=OrRule{rules=[" +
+                "AgentRule{agentId=avoidme}, " +
+                "AgentRule{agentId=avoidme2}" +
+                "]}}", rule.get().toString());
         rule = PlacementUtils.getAgentPlacementRule(
                 Collections.emptyList(),
                 Arrays.asList("colocateme", "colocateme2"));
-        assertEquals("OrRule{rules=[AgentRule{agentId=colocateme}, AgentRule{agentId=colocateme2}]}", rule.get().toString());
+        assertEquals("OrRule{rules=[" +
+                "AgentRule{agentId=colocateme}, " +
+                "AgentRule{agentId=colocateme2}" +
+                "]}", rule.get().toString());
         rule = PlacementUtils.getAgentPlacementRule(
                 Arrays.asList("avoidme", "avoidme2"),
                 Arrays.asList("colocateme", "colocateme2"));
-        assertEquals("AndRule{rules=[NotRule{rule=OrRule{rules=[AgentRule{agentId=avoidme}, AgentRule{agentId=avoidme2}]}}, " +
-                "OrRule{rules=[AgentRule{agentId=colocateme}, AgentRule{agentId=colocateme2}]}]}", rule.get().toString());
+        assertEquals("AndRule{rules=[" +
+                "NotRule{rule=OrRule{rules=[" +
+                "AgentRule{agentId=avoidme}, " +
+                "AgentRule{agentId=avoidme2}" +
+                "]}}, " +
+                "OrRule{rules=[" +
+                "AgentRule{agentId=colocateme}, " +
+                "AgentRule{agentId=colocateme2}" +
+                "]}" +
+                "]}", rule.get().toString());
+        rule = PlacementUtils.getAgentPlacementRule(
+                Arrays.asList("avoidme"),
+                Arrays.asList("colocateme"));
+        assertEquals("AndRule{rules=[" +
+                "NotRule{rule=AgentRule{agentId=avoidme}}, " +
+                "AgentRule{agentId=colocateme}" +
+                "]}", rule.get().toString());
+    }
+
+    @Test
+    public void testGetTaskTypePlacementRule() {
+        // all empty/missing:
+        Optional<PlacementRule> rule = PlacementUtils.getTaskTypePlacementRule(
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Optional.empty());
+        assertFalse(rule.isPresent());
+
+        // agents provided, no custom:
+        rule = PlacementUtils.getTaskTypePlacementRule(
+                Arrays.asList("avoidme", "avoidme2"),
+                Collections.emptyList(),
+                Optional.empty());
+        assertEquals("AndRule{rules=[" +
+                "TaskTypeRule{type=avoidme, converter=TaskTypeLabelConverter{}, behavior=AVOID}, " +
+                "TaskTypeRule{type=avoidme2, converter=TaskTypeLabelConverter{}, behavior=AVOID}]}", rule.get().toString());
+        rule = PlacementUtils.getTaskTypePlacementRule(
+                Collections.emptyList(),
+                Arrays.asList("colocateme", "colocateme2"),
+                Optional.empty());
+        assertEquals("OrRule{rules=[" +
+                "TaskTypeRule{type=colocateme, converter=TaskTypeLabelConverter{}, behavior=COLOCATE}, " +
+                "TaskTypeRule{type=colocateme2, converter=TaskTypeLabelConverter{}, behavior=COLOCATE}]}", rule.get().toString());
+        rule = PlacementUtils.getTaskTypePlacementRule(
+                Arrays.asList("avoidme", "avoidme2"),
+                Arrays.asList("colocateme", "colocateme2"),
+                Optional.empty());
+        assertEquals("AndRule{rules=[" +
+                "AndRule{rules=[" +
+                "TaskTypeRule{type=avoidme, converter=TaskTypeLabelConverter{}, behavior=AVOID}, " +
+                "TaskTypeRule{type=avoidme2, converter=TaskTypeLabelConverter{}, behavior=AVOID}]}, " +
+                "OrRule{rules=[" +
+                "TaskTypeRule{type=colocateme, converter=TaskTypeLabelConverter{}, behavior=COLOCATE}, " +
+                "TaskTypeRule{type=colocateme2, converter=TaskTypeLabelConverter{}, behavior=COLOCATE}]}]}", rule.get().toString());
+
+        // custom provided, no agents:
+        rule = PlacementUtils.getTaskTypePlacementRule(
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Optional.of(new PassthroughRule()));
+        assertEquals("PassthroughRule{}", rule.get().toString());
+
+        // agents provided with custom:
+        rule = PlacementUtils.getTaskTypePlacementRule(
+                Arrays.asList("avoidme", "avoidme2"),
+                Collections.emptyList(),
+                Optional.of(new PassthroughRule()));
+        assertEquals("AndRule{rules=[" +
+                "AndRule{rules=[" +
+                "TaskTypeRule{type=avoidme, converter=TaskTypeLabelConverter{}, behavior=AVOID}, " +
+                "TaskTypeRule{type=avoidme2, converter=TaskTypeLabelConverter{}, behavior=AVOID}" +
+                "]}, " +
+                "PassthroughRule{}" +
+                "]}", rule.get().toString());
+        rule = PlacementUtils.getTaskTypePlacementRule(
+                Collections.emptyList(),
+                Arrays.asList("colocateme", "colocateme2"),
+                Optional.of(new PassthroughRule()));
+        assertEquals("AndRule{rules=[" +
+                "OrRule{rules=[" +
+                "TaskTypeRule{type=colocateme, converter=TaskTypeLabelConverter{}, behavior=COLOCATE}, " +
+                "TaskTypeRule{type=colocateme2, converter=TaskTypeLabelConverter{}, behavior=COLOCATE}" +
+                "]}, " +
+                "PassthroughRule{}" +
+                "]}", rule.get().toString());
+        rule = PlacementUtils.getTaskTypePlacementRule(
+                Arrays.asList("avoidme", "avoidme2"),
+                Arrays.asList("colocateme", "colocateme2"),
+                Optional.of(new PassthroughRule()));
+        assertEquals("AndRule{rules=[" +
+                "AndRule{rules=[" +
+                "TaskTypeRule{type=avoidme, converter=TaskTypeLabelConverter{}, behavior=AVOID}, " +
+                "TaskTypeRule{type=avoidme2, converter=TaskTypeLabelConverter{}, behavior=AVOID}" +
+                "]}, " +
+                "OrRule{rules=[" +
+                "TaskTypeRule{type=colocateme, converter=TaskTypeLabelConverter{}, behavior=COLOCATE}, " +
+                "TaskTypeRule{type=colocateme2, converter=TaskTypeLabelConverter{}, behavior=COLOCATE}" +
+                "]}, " +
+                "PassthroughRule{}" +
+                "]}", rule.get().toString());
     }
 
     @Test

--- a/sdk/scheduler/src/test/resources/invalid-pod-name.yml
+++ b/sdk/scheduler/src/test/resources/invalid-pod-name.yml
@@ -7,7 +7,8 @@ replacement-failure-policy:
   min-replace-delay-ms: -1
 pods:
   meta-data:
-    placement: "avoid-type: meta-data"
+    avoid-types:
+      - meta-data
     count: 2
     resource-sets:
       - id: meta-data-resources
@@ -40,7 +41,8 @@ pods:
             delay: 0
             timeout: 10
   meta-data:
-    placement: "avoid-type: data-store"
+    avoid-types:
+      - data-store
     count: 3
     resource-sets:
       - id: data-store-resources

--- a/sdk/scheduler/src/test/resources/invalid-replacement-failure-policy.yml
+++ b/sdk/scheduler/src/test/resources/invalid-replacement-failure-policy.yml
@@ -7,7 +7,8 @@ replacement-failure-policy:
   min-replace-delay-ms: -1
 pods:
   meta-data:
-    placement: "avoid-type: meta-data"
+    avoid-types:
+      - meta-data
     count: 2
     resource-sets:
       meta-data-resources:
@@ -38,7 +39,8 @@ pods:
             delay: 0
             timeout: 10
   data-store:
-    placement: "avoid-type: data-store"
+    avoid-types:
+      - data-store
     count: 3
     resource-sets:
       data-store-resources:

--- a/sdk/scheduler/src/test/resources/invalid-resource-set-name.yml
+++ b/sdk/scheduler/src/test/resources/invalid-resource-set-name.yml
@@ -7,7 +7,8 @@ replacement-failure-policy:
   min-replace-delay-ms: -1
 pods:
   meta-data:
-    placement: "avoid-type: data-store"
+    avoid-types:
+      - data-store
     count: 3
     resource-sets:
       data-store-resources:

--- a/sdk/scheduler/src/test/resources/invalid-task-name.yml
+++ b/sdk/scheduler/src/test/resources/invalid-task-name.yml
@@ -7,7 +7,8 @@ replacement-failure-policy:
   min-replace-delay-ms: -1
 pods:
   meta-data:
-    placement: "avoid-type: meta-data"
+    avoid-types:
+      - meta-data
     count: 2
     resource-sets:
       - id: meta-data-resources
@@ -56,7 +57,8 @@ pods:
             delay: 0
             timeout: 10
   data-store:
-    placement: "avoid-type: data-store"
+    avoid-types:
+      - data-store
     count: 3
     resource-sets:
       - id: data-store-resources

--- a/sdk/scheduler/src/test/resources/invalid-task-resources.yml
+++ b/sdk/scheduler/src/test/resources/invalid-task-resources.yml
@@ -7,7 +7,8 @@ replacement-failure-policy:
   min-replace-delay-ms: 10
 pods:
   meta-data:
-    placement: "avoid-type: meta-data"
+    avoid-types:
+      - meta-data
     count: 2
     resource-sets:
       meta-data-resources:

--- a/sdk/scheduler/src/test/resources/invalid.yml.mustache
+++ b/sdk/scheduler/src/test/resources/invalid.yml.mustache
@@ -7,7 +7,8 @@ replacement-failure-policy:
   min-replace-delay-ms: -1
 pods:
   meta-data:
-    placement: "avoid-type: meta-data"
+    avoid-types:
+      - meta-data
     count: 2
     resource-sets:
       - id: meta-data-resources
@@ -40,7 +41,8 @@ pods:
             delay: 0
             timeout: 10
   data-store:
-    placement: "avoid-type: data-store"
+    avoid-types:
+      - data-store
     count: 3
     resource-sets:
       - id: data-store-resources

--- a/sdk/scheduler/src/test/resources/valid-exhaustive.yml
+++ b/sdk/scheduler/src/test/resources/valid-exhaustive.yml
@@ -7,7 +7,8 @@ replacement-failure-policy:
   min-replace-delay-ms: 10
 pods:
   meta-data:
-    placement: "avoid-type: meta-data"
+    avoid-types:
+      - meta-data
     count: 2
     resource-sets:
       meta-data-resources:
@@ -38,7 +39,8 @@ pods:
             delay: 0
             timeout: 10
   data-store:
-    placement: "avoid-type: data-store"
+    avoid-types:
+      - data-store
     count: 3
     resource-sets:
       data-store-resources:


### PR DESCRIPTION
In practice, type colocate/avoid is the main thing used in the yaml specs, so this optimizes for that common case. Devs may still implement their own fully custom placement rule trees, but that now requires using the Java API to do. Requiring the Java API for custom placement rules may be useful in its own right as authoring placement rule trees in yaml, particularly from scratch, is tricky/error-prone.

YAML:
- `avoid-tasks`/`colocate-tasks` are added to pod spec in yaml as shortcut for common placement use-case
- fully custom `placement` option is removed. devs who need custom placement logic are likely to be using java anyway, and writing the string form correctly is difficult.

Java:
- `getAvoidTasks()`/`getColocateTasks()` are added to pod spec to map from the yaml shortcut (or may also be used as a shortcut when building `PodSpec`s).
- fully custom placement setting is retained in the Java API, allowing devs to implement their own placement logic, and/or implement and use their own custom PlacementRule classes.