### PR TITLE
Add 'endpoints' endpoint

### DIFF
--- a/frameworks/helloworld/cli/dcos-hello-world/main.go
+++ b/frameworks/helloworld/cli/dcos-hello-world/main.go
@@ -14,7 +14,11 @@ func main() {
 		log.Fatalf(err.Error())
 	}
 
-	cli.HandleCommonArgs(app, "hello-world", "Example DC/OS CLI Module", []string{"foo", "bar"})
+	cli.HandleCommonFlags(app, "hello-world", "Example DC/OS CLI Module")
+	cli.HandleConfigSection(app)
+	cli.HandleEndpointsSection(app)
+	cli.HandlePlanSection(app)
+	cli.HandleStateSection(app)
 	handleExampleSection(app)
 
 	// Omit modname:

--- a/frameworks/kafka/cli/dcos-kafka/main.go
+++ b/frameworks/kafka/cli/dcos-kafka/main.go
@@ -14,7 +14,11 @@ func main() {
 		log.Fatalf(err.Error())
 	}
 
-	cli.HandleCommonArgs(app, "hello-world", "Example DC/OS CLI Module", []string{"foo", "bar"})
+	cli.HandleCommonFlags(app, "kafka", "Kafka CLI")
+	cli.HandleConfigSection(app)
+	cli.HandleEndpointsSection(app)
+	cli.HandlePlanSection(app)
+	cli.HandleStateSection(app)
 	handleExampleSection(app)
 
 	// Omit modname:

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/api/EndpointsResource.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/api/EndpointsResource.java
@@ -35,6 +35,7 @@ public class EndpointsResource {
     private static final String RESPONSE_KEY_DIRECT = "direct";
     private static final String RESPONSE_KEY_VIP = "vip";
     private static final String VIP_LABEL_PREFIX = "VIP_";
+    private static final String VIP_HOST_TLD = "l4lb.thisdcos.directory";
 
     private final StateStore stateStore;
     // We intentionally grab this value during initialization to ensure that we fail fast.
@@ -62,8 +63,10 @@ public class EndpointsResource {
      * should provide that information via {@link DiscoveryInfo} in your {@link TaskInfo} and they
      * will appear automatically.
      *
+     * @param name the name of the custom endpoint. custom endpoints take precedence over default
+     *     endpoints of the same name
      * @param valueProducer the endpoint producer, which will be invoked whenever a user queries the
-     *      list of endpoints
+     *     list of endpoints
      * @returns this
      */
     public EndpointsResource setCustomEndpoint(String name, EndpointProducer valueProducer) {
@@ -222,8 +225,8 @@ public class EndpointsResource {
             // append entry to 'direct' array for this task:
             vipEndpoint.append(RESPONSE_KEY_DIRECT, directHostPort);
             // populate 'vip' field if not yet populated (due to another task with the same vip):
-            vipEndpoint.put(RESPONSE_KEY_VIP, String.format("%s.%s.l4lb.thisdcos.directory:%d",
-                    vipInfo.name, serviceName, vipInfo.port));
+            vipEndpoint.put(RESPONSE_KEY_VIP, String.format("%s.%s.%s:%d",
+                    vipInfo.name, serviceName, VIP_HOST_TLD, vipInfo.port));
         }
 
         if (!foundAnyVips) {

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/api/EndpointsResource.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/api/EndpointsResource.java
@@ -1,0 +1,276 @@
+package com.mesosphere.sdk.api;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import com.google.common.base.Splitter;
+import com.mesosphere.sdk.api.types.EndpointProducer;
+import com.mesosphere.sdk.offer.CommonTaskUtils;
+import com.mesosphere.sdk.offer.TaskException;
+import com.mesosphere.sdk.state.StateStore;
+
+import org.apache.mesos.Protos.DiscoveryInfo;
+import org.apache.mesos.Protos.Environment;
+import org.apache.mesos.Protos.Label;
+import org.apache.mesos.Protos.Port;
+import org.apache.mesos.Protos.TaskInfo;
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A read-only API for accessing information about how to connect to the service.
+ */
+@Path("/v1/endpoints")
+public class EndpointsResource {
+    private static final Logger LOGGER = LoggerFactory.getLogger(EndpointsResource.class);
+
+    private static final String RESPONSE_KEY_DIRECT = "direct";
+    private static final String RESPONSE_KEY_VIP = "vip";
+    private static final String VIP_LABEL_PREFIX = "VIP_";
+
+    private final StateStore stateStore;
+    private final Map<String, EndpointProducer> customEndpoints = new HashMap<>();
+
+    /**
+     * Creates a new instance which retrieves task/pod state from the provided {@code stateStore}.
+     */
+    public EndpointsResource(StateStore stateStore) {
+        this.stateStore = stateStore;
+    }
+
+    /**
+     * Adds the provided custom endpoint key/value entry to this instance.
+     *
+     * This may be used to expose additional endpoint types independently of what's listed in
+     * {@link DiscoveryInfo}, such as a Kafka service exposing a Zookeeper path that's separate from
+     * the default broker host/port listing.
+     *
+     * This only supports simple string values in order to ensure that the 'endpoints' endpoint
+     * remains relatively consistent across services. For a per-task listing of endpoints, you
+     * should provide that information via {@link DiscoveryInfo} in your {@link TaskInfo} and they
+     * will appear automatically.
+     *
+     * @param valueProducer the endpoint producer, which will be invoked whenever a user queries the
+     *      list of endpoints
+     * @returns this
+     */
+    public EndpointsResource setCustomEndpoint(String name, EndpointProducer valueProducer) {
+        this.customEndpoints.put(name, valueProducer);
+        return this;
+    }
+
+    /**
+     * Produces a listing of all endpoints, with an optional format argument.
+     *
+     * @param format the format option, which should either be empty or "ip"
+     */
+    @GET
+    public Response getEndpoints(@QueryParam("format") String format) {
+        try {
+            JSONObject endpoints = new JSONObject();
+            // Custom values take precedence:
+            for (Map.Entry<String, EndpointProducer> entry : customEndpoints.entrySet()) {
+                endpoints.put(entry.getKey(), entry.getValue().getEndpoint());
+            }
+            // Add default values (when they don't collide with custom values):
+            for (Map.Entry<String, JSONObject> endpointType :
+                    getDiscoveryEndpoints(stateStore.fetchTasks(), isNativeFormat(format)).entrySet()) {
+                if (!endpoints.has(endpointType.getKey())) {
+                    endpoints.put(endpointType.getKey(), endpointType.getValue());
+                }
+            }
+            return Response.ok(endpoints.toString(), MediaType.APPLICATION_JSON).build();
+        } catch (Exception ex) {
+            LOGGER.error(String.format("Failed to fetch list of endpoints with format %s", format), ex);
+            return Response.serverError().build();
+        }
+    }
+
+    /**
+     * Produces the content of the specified endpoint, with an optional format argument.
+     *
+     * @param name the name of the endpoint whose content should be included
+     * @param format the format option, which should either be {@code null}/empty or 'native'
+     */
+    @Path("/{name}")
+    @GET
+    public Response getEndpoint(
+            @PathParam("name") String name,
+            @QueryParam("format") String format) {
+        try {
+            // Check for custom value before emitting any default values:
+            EndpointProducer customValue = customEndpoints.get(name);
+            if (customValue != null) {
+                return Response.ok(customValue.getEndpoint(), MediaType.TEXT_PLAIN).build();
+            }
+            JSONObject endpoint = getDiscoveryEndpoints(stateStore.fetchTasks(), isNativeFormat(format)).get(name);
+            if (endpoint == null) {
+                return Response.status(Response.Status.NOT_FOUND).build();
+            }
+            return Response.ok(endpoint.toString(), MediaType.APPLICATION_JSON).build();
+        } catch (Exception ex) {
+            LOGGER.error(String.format("Failed to fetch endpoint %s with format %s", name, format), ex);
+            return Response.serverError().build();
+        }
+    }
+
+    /**
+     * Returns whether the provided {@code format} argument indicates that native hosts (instead of
+     * Mesos-DNS hosts) should be produced
+     *
+     * @param format the value of the 'format' option, or a {@code null}/empty string if none was provided
+     */
+    private static boolean isNativeFormat(String format) {
+        return format != null && format.equals("native");
+    }
+
+    /**
+     * Returns a mapping of endpoint type to host:port (or ip:port) endpoints, endpoint type.
+     */
+    private static Map<String, JSONObject> getDiscoveryEndpoints(
+            Collection<TaskInfo> taskInfos, boolean isNativeFormat) throws TaskException {
+        Map<String, JSONObject> endpointsByName = new HashMap<>();
+        for (TaskInfo taskInfo : taskInfos) {
+            if (!taskInfo.hasDiscovery()) {
+                LOGGER.info("Task lacks any discovery information, no endpoints to report: {}",
+                        taskInfo.getName());
+                continue;
+            }
+            DiscoveryInfo discoveryInfo = taskInfo.getDiscovery();
+            if (discoveryInfo.getVisibility() != DiscoveryInfo.Visibility.EXTERNAL) {
+                LOGGER.info("Task discovery information has {} visibility, EXTERNAL needed: {}",
+                        discoveryInfo.getVisibility(), taskInfo.getName());
+                continue;
+            }
+            final String directHost;
+            if (isNativeFormat) {
+                // Hostname of agent at offer time:
+                directHost = CommonTaskUtils.getHostname(taskInfo);
+            } else {
+                // Mesos DNS hostname:
+                directHost = String.format("%s.%s.mesos", taskInfo.getName(), getFrameworkName(taskInfo));
+            }
+
+            for (Port port : discoveryInfo.getPorts().getPortsList()) {
+                // host:port to include in 'direct' array(s):
+                final String directHostPort = String.format("%s:%d", directHost, port.getNumber());
+                addPortToEndpoints(endpointsByName, taskInfo, directHostPort, port.getLabels().getLabelsList());
+            }
+        }
+        return endpointsByName;
+    }
+
+    /**
+     * Adds information about a {@link Port} to the provided {@code endpointsByName}. Information
+     * will be added for any VIPs listed against the {@link Port}'s labels, or if no VIPs are found,
+     * the information will be added against the task type.
+     *
+     * @param endpointsByName the map to write to
+     * @param taskInfo the task which has the port
+     * @param directHostPort the host:port value to advertise for directly connecting to the task
+     * @param portLabels list of any {@link Label}s which were present in the {@link Port}
+     * @throws TaskException if no VIPs were found and the task type couldn't be extracted
+     */
+    private static void addPortToEndpoints(
+            Map<String, JSONObject> endpointsByName,
+            TaskInfo taskInfo,
+            String directHostPort,
+            List<Label> portLabels) throws TaskException {
+        // Search for any VIPs to add the above host:port against:
+        boolean foundAnyVips = false;
+        for (Label label : portLabels) {
+            VIPInfo vipInfo = VIPInfo.parse(taskInfo.getName(), label);
+            if (vipInfo == null) {
+                continue;
+            }
+            // VIP found. file host:port against the VIP name.
+            foundAnyVips = true;
+
+            JSONObject vipEndpoint = endpointsByName.get(vipInfo.name);
+            if (vipEndpoint == null) {
+                vipEndpoint = new JSONObject();
+                endpointsByName.put(vipInfo.name, vipEndpoint);
+            }
+
+            // append entry to 'direct' array for this task:
+            vipEndpoint.append(RESPONSE_KEY_DIRECT, directHostPort);
+            // populate 'vip' field if not yet populated (due to another task with the same vip):
+            vipEndpoint.put(RESPONSE_KEY_VIP, String.format("%s.%s.l4lb.thisdcos.directory:%d",
+                    vipInfo.name, getFrameworkName(taskInfo), vipInfo.port));
+        }
+
+        if (!foundAnyVips) {
+            // No VIPs found for this port. file direct host:port against task type.
+            final String taskType = CommonTaskUtils.getType(taskInfo);
+
+            JSONObject taskEndpoint = endpointsByName.get(taskType);
+            if (taskEndpoint == null) {
+                taskEndpoint = new JSONObject();
+                endpointsByName.put(taskType, taskEndpoint);
+            }
+
+            // append entry to 'direct' array for this task:
+            taskEndpoint.append(RESPONSE_KEY_DIRECT, directHostPort);
+        }
+
+    }
+
+    private static String getFrameworkName(TaskInfo taskInfo) {
+        // Get from scheduler env:
+        String name = System.getenv("SERVICE_NAME");
+        if (name != null) {
+            return name;
+        }
+        // Fall back to task env:
+        for (Environment.Variable envvar : taskInfo.getCommand().getEnvironment().getVariablesList()) {
+            if (envvar.getName().equals("FRAMEWORK_NAME")) {
+                return envvar.getValue();
+            }
+        }
+        return "UNKNOWN_FRAMEWORK_NAME";
+    }
+
+    /**
+     * Struct for VIP name + port, e.g. 'broker' and 9092.
+     */
+    private static class VIPInfo {
+        private final String name;
+        private final int port;
+
+        private VIPInfo(String name, int port) {
+            this.name = name;
+            this.port = port;
+        }
+
+        private static VIPInfo parse(String taskName, Label label) {
+            if (!label.getKey().startsWith(VIP_LABEL_PREFIX)) {
+                return null;
+            }
+            List<String> namePort = Splitter.on(':').splitToList(label.getValue());
+            if (namePort.size() != 2) {
+                LOGGER.error("Task {}'s VIP value for {} is invalid, expected 2 components but got {}: {}",
+                        taskName, label.getKey(), namePort.size(), label.getValue());
+                return null;
+            }
+            int vipPort;
+            try {
+                vipPort = Integer.parseInt(namePort.get(1));
+            } catch (NumberFormatException e) {
+                LOGGER.error(String.format(
+                        "Unable to Task %s's VIP port from %s as an int",
+                        taskName, label.getValue()), e);
+                return null;
+            }
+            return new VIPInfo(namePort.get(0), vipPort);
+        }
+    }
+}

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/api/types/EndpointProducer.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/api/types/EndpointProducer.java
@@ -1,0 +1,25 @@
+package com.mesosphere.sdk.api.types;
+
+/**
+ * Interface for an object which returns the String content of an endpoint when requested.
+ */
+public interface EndpointProducer {
+
+    /**
+     * Returns some endpoint content to be sent in response to an 'endpoints' lookup request. This
+     * could be a URL, or the content of a file, etc.
+     */
+    public String getEndpoint();
+
+    /**
+     * Creates and returns an {@link EndpointProducer} which only produces the provided constant value.
+     */
+    public static EndpointProducer constant(final String value) {
+        return new EndpointProducer() {
+            @Override
+            public String getEndpoint() {
+                return value;
+            }
+        };
+    }
+}

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/NamedVIPPortRequirement.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/NamedVIPPortRequirement.java
@@ -8,10 +8,8 @@ import java.util.Arrays;
  * This class describes port requirements that should be routed to with a named VIP (or "service address") in DC/OS.
  */
 public class NamedVIPPortRequirement extends ResourceRequirement {
-    private static final String VIP_LABEL_NAME_KEY = "vip_key";
-    private static final String VIP_LABEL_VALUE_KEY = "vip_value";
-    private String vipKey;
-    private String vipValue;
+    private final String vipKey;
+    private final String vipValue;
 
     public NamedVIPPortRequirement(Protos.Resource resource) throws NamedVIPPortException {
         super(resource);
@@ -21,11 +19,11 @@ public class NamedVIPPortRequirement extends ResourceRequirement {
     }
 
     public static String getVIPLabelKey(Protos.Resource resource) {
-        return getLabelValue(VIP_LABEL_NAME_KEY, resource);
+        return getLabelValue(MesosResource.VIP_LABEL_NAME_KEY, resource);
     }
 
     public static String getVIPLabelValue(Protos.Resource resource) {
-        return getLabelValue(VIP_LABEL_VALUE_KEY, resource);
+        return getLabelValue(MesosResource.VIP_LABEL_VALUE_KEY, resource);
     }
 
     private static String getLabelValue(String key, Protos.Resource resource) {

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/DefaultScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/DefaultScheduler.java
@@ -8,6 +8,7 @@ import org.apache.mesos.Scheduler;
 import org.apache.mesos.SchedulerDriver;
 
 import com.mesosphere.sdk.api.ConfigResource;
+import com.mesosphere.sdk.api.EndpointsResource;
 import com.mesosphere.sdk.api.PlansResource;
 import com.mesosphere.sdk.api.StateResource;
 import com.mesosphere.sdk.api.TaskResource;
@@ -442,12 +443,13 @@ public class DefaultScheduler implements Scheduler, Observer {
     private void initializeResources() throws InterruptedException {
         LOGGER.info("Initializing resources...");
         Collection<Object> resources = new ArrayList<>();
+        resources.add(new ConfigResource<ServiceSpec>(configStore));
+        resources.add(new EndpointsResource(stateStore));
         resources.add(new PlansResource(ImmutableMap.of(
                 "deploy", deploymentPlanManager,
                 "recovery", recoveryPlanManager)));
         resources.add(new StateResource(stateStore, new StringPropertyDeserializer()));
         resources.add(new TaskResource(stateStore, taskKiller, serviceSpec.getName()));
-        resources.add(new ConfigResource<ServiceSpec>(configStore));
         // use add() instead of put(): throw exception instead of waiting indefinitely
         resourcesQueue.add(resources);
     }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/DefaultScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/DefaultScheduler.java
@@ -444,7 +444,7 @@ public class DefaultScheduler implements Scheduler, Observer {
         LOGGER.info("Initializing resources...");
         Collection<Object> resources = new ArrayList<>();
         resources.add(new ConfigResource<ServiceSpec>(configStore));
-        resources.add(new EndpointsResource(stateStore));
+        resources.add(new EndpointsResource(stateStore, serviceSpec.getName()));
         resources.add(new PlansResource(ImmutableMap.of(
                 "deploy", deploymentPlanManager,
                 "recovery", recoveryPlanManager)));

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/api/EndpointsResourceTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/api/EndpointsResourceTest.java
@@ -37,7 +37,6 @@ public class EndpointsResourceTest {
     private static final TaskInfo TASK_WITH_VIPS_2;
     static {
         TaskInfo.Builder builder = TASK_EMPTY.toBuilder();
-        builder.getCommandBuilder().getEnvironmentBuilder().addVariablesBuilder().setName("FRAMEWORK_NAME").setValue("svc-name");
         CommonTaskUtils.setHostname(builder, OfferTestUtils.getOffer(Collections.emptyList()));
         CommonTaskUtils.setType(builder, "some-task-type");
         TASK_WITH_METADATA = builder.build();
@@ -137,7 +136,7 @@ public class EndpointsResourceTest {
     @Before
     public void beforeAll() {
         MockitoAnnotations.initMocks(this);
-        resource = new EndpointsResource(mockStateStore);
+        resource = new EndpointsResource(mockStateStore, "svc-name");
         resource.setCustomEndpoint("custom", EndpointProducer.constant(CUSTOM_VALUE));
     }
 
@@ -179,6 +178,7 @@ public class EndpointsResourceTest {
         assertEquals("with-vips-2.svc-name.mesos:3459", direct.get(5));
     }
 
+    @SuppressWarnings("PMD.AvoidUsingHardCodedIP")
     @Test
     public void testGetAllEndpointsNative() throws ConfigStoreException {
         when(mockStateStore.fetchTasks()).thenReturn(TASK_INFOS);
@@ -231,6 +231,7 @@ public class EndpointsResourceTest {
         assertEquals("with-vips-2.svc-name.mesos:3456", direct.get(1));
     }
 
+    @SuppressWarnings("PMD.AvoidUsingHardCodedIP")
     @Test
     public void testGetOneEndpointNative() throws ConfigStoreException {
         when(mockStateStore.fetchTasks()).thenReturn(TASK_INFOS);

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/api/EndpointsResourceTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/api/EndpointsResourceTest.java
@@ -1,0 +1,255 @@
+package com.mesosphere.sdk.api;
+
+import com.mesosphere.sdk.api.types.EndpointProducer;
+import com.mesosphere.sdk.config.ConfigStoreException;
+import com.mesosphere.sdk.offer.CommonTaskUtils;
+import com.mesosphere.sdk.state.StateStore;
+import com.mesosphere.sdk.testutils.OfferTestUtils;
+import com.mesosphere.sdk.testutils.TaskTestUtils;
+import com.mesosphere.sdk.testutils.TestConstants;
+
+import org.apache.mesos.Protos.DiscoveryInfo;
+import org.apache.mesos.Protos.Ports;
+import org.apache.mesos.Protos.TaskInfo;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import javax.ws.rs.core.Response;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
+public class EndpointsResourceTest {
+
+    private static final TaskInfo TASK_EMPTY = TaskTestUtils.getTaskInfo(Collections.emptyList());
+    private static final TaskInfo TASK_WITH_METADATA;
+    private static final TaskInfo TASK_WITH_PORTS_1;
+    private static final TaskInfo TASK_WITH_PORTS_2;
+    private static final TaskInfo TASK_WITH_HIDDEN_DISCOVERY;
+    private static final TaskInfo TASK_WITH_VIPS_1;
+    private static final TaskInfo TASK_WITH_VIPS_2;
+    static {
+        TaskInfo.Builder builder = TASK_EMPTY.toBuilder();
+        builder.getCommandBuilder().getEnvironmentBuilder().addVariablesBuilder().setName("FRAMEWORK_NAME").setValue("svc-name");
+        CommonTaskUtils.setHostname(builder, OfferTestUtils.getOffer(Collections.emptyList()));
+        CommonTaskUtils.setType(builder, "some-task-type");
+        TASK_WITH_METADATA = builder.build();
+
+        builder = TASK_WITH_METADATA.toBuilder().setName("with-ports-1");
+        Ports.Builder portsBuilder = builder.getDiscoveryBuilder()
+                .setVisibility(DiscoveryInfo.Visibility.EXTERNAL)
+                .setName("ports-1")
+                .getPortsBuilder();
+        portsBuilder.addPortsBuilder().setNumber(1234).setProtocol("tcp");
+        portsBuilder.addPortsBuilder().setNumber(1235).setProtocol("tcp");
+        TASK_WITH_PORTS_1 = builder.build();
+
+        builder = TASK_WITH_METADATA.toBuilder().setName("with-ports-2");
+        portsBuilder = builder.getDiscoveryBuilder()
+                .setVisibility(DiscoveryInfo.Visibility.EXTERNAL)
+                .setName("ports-2")
+                .getPortsBuilder();
+        portsBuilder.addPortsBuilder().setNumber(1243).setProtocol("tcp");
+        portsBuilder.addPortsBuilder().setNumber(1244).setProtocol("tcp");
+        TASK_WITH_PORTS_2 = builder.build();
+
+        builder = TASK_WITH_METADATA.toBuilder().setName("hidden-discovery");
+        portsBuilder = builder.getDiscoveryBuilder()
+                .setVisibility(DiscoveryInfo.Visibility.CLUSTER)
+                .setName("hidden")
+                .getPortsBuilder();
+        portsBuilder.addPortsBuilder().setNumber(1).setProtocol("tcp");
+        portsBuilder.addPortsBuilder().setNumber(2).setProtocol("tcp");
+        TASK_WITH_HIDDEN_DISCOVERY = builder.build();
+
+        builder = TASK_WITH_METADATA.toBuilder().setName("with-vips-1");
+        portsBuilder = builder.getDiscoveryBuilder()
+                .setVisibility(DiscoveryInfo.Visibility.EXTERNAL)
+                .setName("vips-1")
+                .getPortsBuilder();
+        portsBuilder.addPortsBuilder()
+                .setNumber(2345)
+                .setProtocol("tcp")
+                .getLabelsBuilder().addLabelsBuilder().setKey("VIP_abc").setValue("vip1:5432");
+        portsBuilder.addPortsBuilder()
+                .setNumber(2346)
+                .setProtocol("tcp")
+                .getLabelsBuilder().addLabelsBuilder().setKey("VIP_def").setValue("vip2:6432");
+        // overridden by 'custom' endpoint added below:
+        portsBuilder.addPortsBuilder()
+                .setNumber(2347)
+                .setProtocol("tcp")
+                .getLabelsBuilder().addLabelsBuilder().setKey("VIP_ghi").setValue("custom:6432");
+        // VIP ignored (filed against task type instead):
+        portsBuilder.addPortsBuilder()
+                .setNumber(2348)
+                .setProtocol("tcp")
+                .getLabelsBuilder().addLabelsBuilder().setKey("ignored_no_vip").setValue("ignored:6432");
+        TASK_WITH_VIPS_1 = builder.build();
+
+        builder = TASK_WITH_METADATA.toBuilder().setName("with-vips-2");
+        portsBuilder = builder.getDiscoveryBuilder()
+                .setVisibility(DiscoveryInfo.Visibility.EXTERNAL)
+                .setName("vips-2")
+                .getPortsBuilder();
+        portsBuilder.addPortsBuilder()
+                .setNumber(3456)
+                .setProtocol("tcp")
+                .getLabelsBuilder().addLabelsBuilder().setKey("VIP_abc").setValue("vip1:5432");
+        portsBuilder.addPortsBuilder()
+                .setNumber(3457)
+                .setProtocol("tcp")
+                .getLabelsBuilder().addLabelsBuilder().setKey("VIP_def").setValue("vip2:6432");
+        // overridden by 'custom' endpoint added below:
+        portsBuilder.addPortsBuilder()
+                .setNumber(3458)
+                .setProtocol("tcp")
+                .getLabelsBuilder().addLabelsBuilder().setKey("VIP_ghi").setValue("custom:6432");
+        // VIP ignored (filed against task type instead):
+        portsBuilder.addPortsBuilder()
+                .setNumber(3459)
+                .setProtocol("tcp")
+                .getLabelsBuilder().addLabelsBuilder().setKey("ignored_no_vip").setValue("ignored:6432");
+        TASK_WITH_VIPS_2 = builder.build();
+    }
+    private static final Collection<TaskInfo> TASK_INFOS = Arrays.asList(
+            TASK_EMPTY,
+            TASK_WITH_METADATA,
+            TASK_WITH_PORTS_1,
+            TASK_WITH_PORTS_2,
+            TASK_WITH_HIDDEN_DISCOVERY,
+            TASK_WITH_VIPS_1,
+            TASK_WITH_VIPS_2);
+    private static final String CUSTOM_VALUE = "hi\nhey\nhello";
+
+
+    @Mock private StateStore mockStateStore;
+
+    private EndpointsResource resource;
+
+    @Before
+    public void beforeAll() {
+        MockitoAnnotations.initMocks(this);
+        resource = new EndpointsResource(mockStateStore);
+        resource.setCustomEndpoint("custom", EndpointProducer.constant(CUSTOM_VALUE));
+    }
+
+    @Test
+    public void testGetAllEndpoints() throws ConfigStoreException {
+        when(mockStateStore.fetchTasks()).thenReturn(TASK_INFOS);
+        Response response = resource.getEndpoints(null);
+        assertEquals(200, response.getStatus());
+        JSONObject json = new JSONObject((String) response.getEntity());
+        assertEquals(json.toString(), 4, json.length());
+
+        assertEquals(CUSTOM_VALUE, json.get("custom"));
+
+        JSONObject vip1 = json.getJSONObject("vip1");
+        assertEquals(2, vip1.length());
+        assertEquals("vip1.svc-name.l4lb.thisdcos.directory:5432", vip1.get("vip"));
+        JSONArray direct = vip1.getJSONArray("direct");
+        assertEquals(2, direct.length());
+        assertEquals("with-vips-1.svc-name.mesos:2345", direct.get(0));
+        assertEquals("with-vips-2.svc-name.mesos:3456", direct.get(1));
+
+        JSONObject vip2 = json.getJSONObject("vip2");
+        assertEquals(2, vip2.length());
+        assertEquals("vip2.svc-name.l4lb.thisdcos.directory:6432", vip2.get("vip"));
+        direct = vip2.getJSONArray("direct");
+        assertEquals(2, direct.length());
+        assertEquals("with-vips-1.svc-name.mesos:2346", direct.get(0));
+        assertEquals("with-vips-2.svc-name.mesos:3457", direct.get(1));
+
+        JSONObject tasktype = json.getJSONObject("some-task-type");
+        assertEquals(1, tasktype.length());
+        direct = tasktype.getJSONArray("direct");
+        assertEquals(6, direct.length());
+        assertEquals("with-ports-1.svc-name.mesos:1234", direct.get(0));
+        assertEquals("with-ports-1.svc-name.mesos:1235", direct.get(1));
+        assertEquals("with-ports-2.svc-name.mesos:1243", direct.get(2));
+        assertEquals("with-ports-2.svc-name.mesos:1244", direct.get(3));
+        assertEquals("with-vips-1.svc-name.mesos:2348", direct.get(4));
+        assertEquals("with-vips-2.svc-name.mesos:3459", direct.get(5));
+    }
+
+    @Test
+    public void testGetAllEndpointsNative() throws ConfigStoreException {
+        when(mockStateStore.fetchTasks()).thenReturn(TASK_INFOS);
+        Response response = resource.getEndpoints("native");
+        assertEquals(200, response.getStatus());
+        JSONObject json = new JSONObject((String) response.getEntity());
+        assertEquals(json.toString(), 4, json.length());
+
+        assertEquals(CUSTOM_VALUE, json.get("custom"));
+
+        JSONObject vip1 = json.getJSONObject("vip1");
+        assertEquals(2, vip1.length());
+        assertEquals("vip1.svc-name.l4lb.thisdcos.directory:5432", vip1.get("vip"));
+        JSONArray direct = vip1.getJSONArray("direct");
+        assertEquals(2, direct.length());
+        assertEquals(TestConstants.HOSTNAME + ":2345", direct.get(0));
+        assertEquals(TestConstants.HOSTNAME + ":3456", direct.get(1));
+
+        JSONObject vip2 = json.getJSONObject("vip2");
+        assertEquals(2, vip2.length());
+        assertEquals("vip2.svc-name.l4lb.thisdcos.directory:6432", vip2.get("vip"));
+        direct = vip2.getJSONArray("direct");
+        assertEquals(2, direct.length());
+        assertEquals(TestConstants.HOSTNAME + ":2346", direct.get(0));
+        assertEquals(TestConstants.HOSTNAME + ":3457", direct.get(1));
+
+        JSONObject tasktype = json.getJSONObject("some-task-type");
+        assertEquals(1, tasktype.length());
+        direct = tasktype.getJSONArray("direct");
+        assertEquals(6, direct.length());
+        assertEquals(TestConstants.HOSTNAME + ":1234", direct.get(0));
+        assertEquals(TestConstants.HOSTNAME + ":1235", direct.get(1));
+        assertEquals(TestConstants.HOSTNAME + ":1243", direct.get(2));
+        assertEquals(TestConstants.HOSTNAME + ":1244", direct.get(3));
+        assertEquals(TestConstants.HOSTNAME + ":2348", direct.get(4));
+        assertEquals(TestConstants.HOSTNAME + ":3459", direct.get(5));
+    }
+
+    @Test
+    public void testGetOneEndpoint() throws ConfigStoreException {
+        when(mockStateStore.fetchTasks()).thenReturn(TASK_INFOS);
+        Response response = resource.getEndpoint("vip1", null);
+        assertEquals(200, response.getStatus());
+        JSONObject json = new JSONObject((String) response.getEntity());
+        assertEquals(json.toString(), 2, json.length());
+        assertEquals("vip1.svc-name.l4lb.thisdcos.directory:5432", json.get("vip"));
+        JSONArray direct = json.getJSONArray("direct");
+        assertEquals(2, direct.length());
+        assertEquals("with-vips-1.svc-name.mesos:2345", direct.get(0));
+        assertEquals("with-vips-2.svc-name.mesos:3456", direct.get(1));
+    }
+
+    @Test
+    public void testGetOneEndpointNative() throws ConfigStoreException {
+        when(mockStateStore.fetchTasks()).thenReturn(TASK_INFOS);
+        Response response = resource.getEndpoint("vip2", "native");
+        assertEquals(200, response.getStatus());
+        JSONObject json = new JSONObject((String) response.getEntity());
+        assertEquals(json.toString(), 2, json.length());
+        assertEquals("vip2.svc-name.l4lb.thisdcos.directory:6432", json.get("vip"));
+        JSONArray direct = json.getJSONArray("direct");
+        assertEquals(2, direct.length());
+        assertEquals(TestConstants.HOSTNAME + ":2346", direct.get(0));
+        assertEquals(TestConstants.HOSTNAME + ":3457", direct.get(1));
+    }
+
+    @Test
+    public void testGetOneCustomEndpoint() throws ConfigStoreException {
+        when(mockStateStore.fetchTasks()).thenReturn(TASK_INFOS);
+        Response response = resource.getEndpoint("custom", "native");
+        assertEquals(200, response.getStatus());
+        assertEquals(CUSTOM_VALUE, (String) response.getEntity());
+    }
+}


### PR DESCRIPTION
Common replacement for framework-specific `/connections` endpoints and CLI commands currently implemented by Cassandra/Kafka/HDFS.

The built-in `TaskInfo` search relies on the presence of `DiscoveryInfo`s containing the relevant port information (something that `hello-world` currently doesn't do -- as its tasks don't serve any requests). If the `DiscoveryInfo` has VIP label information, that is automatically included as well, otherwise the endpoints returned will just be based on the information in the base `DiscoveryInfo`.

In addition to the built-in `DiscoveryInfo` lookup, framework authors may also provide their own custom endpoint content (e.g. Kafka's zk path, or HDFS' xml files).