### PR TITLE
Semi-formally deprecate 'HandleCommonArgs'

### DIFF
--- a/cli/commands.go
+++ b/cli/commands.go
@@ -44,7 +44,8 @@ func NewApp(version string, author string, longDescription string) (*kingpin.App
 
 // Add all of the below arguments and commands
 
-// TODO remove this entirely in favor of callers just adding sections granularly
+// TODO remove this deprecated function on or after Feb 1 2017.
+// No longer invoked in any repo's 'master' branch as of Dec 22 2016.
 func HandleCommonArgs(
 	app *kingpin.Application,
 	defaultServiceName string,
@@ -52,8 +53,8 @@ func HandleCommonArgs(
 	connectionTypes []string) {
 	HandleCommonFlags(app, defaultServiceName, shortDescription)
 	HandleConfigSection(app)
-	HandleConnectionSection(app, connectionTypes) // TODO remove
-	HandleEndpointsSection(app)
+	HandleConnectionSection(app, connectionTypes)
+	//HandleEndpointsSection(app) omitted since callers likely don't have this
 	HandlePlanSection(app)
 	HandleStateSection(app)
 }
@@ -146,6 +147,7 @@ func (cmd *ConnectionHandler) RunConnection(c *kingpin.ParseContext) error {
 	return nil
 }
 
+// TODO remove this command once callers have migrated to HandleEndpointsSection().
 func HandleConnectionSection(app *kingpin.Application, connectionTypes []string) {
 	// connection [type]
 	cmd := &ConnectionHandler{}

--- a/frameworks/hdfs/cli/dcos-hdfs/main.go
+++ b/frameworks/hdfs/cli/dcos-hdfs/main.go
@@ -24,12 +24,12 @@ func main() {
 		log.Fatalf(err.Error())
 	}
 
+	cli.HandleCommonFlags(app, modName, fmt.Sprintf("%s DC/OS CLI Module", strings.Title(modName)))
+	cli.HandleConfigSection(app)
+	cli.HandleEndpointsSection(app)
+	cli.HandlePlanSection(app)
+	cli.HandleStateSection(app)
 	handleNodeSection(app, modName)
-	cli.HandleCommonArgs(
-		app,
-		modName,
-		fmt.Sprintf("%s DC/OS CLI Module", strings.Title(modName)),
-		[]string{"hdfs-site.xml", "core-site.xml"})
 
 	// Omit modname:
 	kingpin.MustParse(app.Parse(os.Args[2:]))

--- a/frameworks/helloworld/cli/dcos-hello-world/main.go
+++ b/frameworks/helloworld/cli/dcos-hello-world/main.go
@@ -9,12 +9,17 @@ import (
 )
 
 func main() {
+	modName, err := cli.GetModuleName()
+	if err != nil {
+		log.Fatalf(err.Error())
+	}
+
 	app, err := cli.NewApp("0.1.0", "Mesosphere", "Provides an example for DC/OS service developers")
 	if err != nil {
 		log.Fatalf(err.Error())
 	}
 
-	cli.HandleCommonFlags(app, "hello-world", "Example DC/OS CLI Module")
+	cli.HandleCommonFlags(app, modName, "Example DC/OS CLI Module")
 	cli.HandleConfigSection(app)
 	cli.HandleEndpointsSection(app)
 	cli.HandlePlanSection(app)
@@ -40,10 +45,10 @@ func (cmd *ExampleCommand) runEcho(c *kingpin.ParseContext) error {
 }
 
 func handleExampleSection(app *kingpin.Application) {
-	// example echo -n <text>, example ping <host/ip>
 	cmd := &ExampleCommand{}
 	example := app.Command("example", "Example custom commands")
 
+	// 'example echo -n <text>'
 	echo := example.Command("echo", "Echos some text").Action(cmd.runEcho)
 	echo.Arg("text", "What to echo").StringsVar(&cmd.echoText)
 	echo.Flag("no-newline", "Omit newline").Short('n').BoolVar(&cmd.echoOmitNewline)


### PR DESCRIPTION
Per-project repos no longer invoke it in master, so add a timeline for removal.

Its use can cause the addition of unsupported commans when a repo invokes it but hasn't started using the new 'endpoints' endpoint. To avoid situations like this in the future it's preferable that callers explicitly add the CLI sections they know they support.