### PR TITLE
Sidecar Plans

### DIFF
--- a/frameworks/helloworld/integration/tests/test_sanity.py
+++ b/frameworks/helloworld/integration/tests/test_sanity.py
@@ -25,10 +25,6 @@ def setup_module(module):
     check_health()
 
 
-def teardown_module(module):
-    uninstall()
-
-
 @pytest.mark.sanity
 def test_no_colocation_in_podtypes():
     # check that no two 'hellos' and no two 'worlds' are colocated on the same agent

--- a/frameworks/helloworld/integration/tests/test_sidecar.py
+++ b/frameworks/helloworld/integration/tests/test_sidecar.py
@@ -34,9 +34,22 @@ def setup_module(module):
 
 @pytest.mark.sanity
 def test_deploy():
-    get_deployment_plan()
+    deployment_plan = get_deployment_plan().json()
+    print("deployment_plan: " + str(deployment_plan))
+
+    assert(len(deployment_plan['phases']) == 2)
+    assert(deployment_plan['phases'][0]['name'] == 'server-deploy')
+    assert(deployment_plan['phases'][1]['name'] == 'once-deploy')
+    assert(len(deployment_plan['phases'][0]['steps']) == 2)
+    assert(len(deployment_plan['phases'][1]['steps']) == 2)
+
 
 @pytest.mark.sanity
 def test_sidecar():
     start_sidecar_plan()
-    get_sidecar_plan()
+    sidecar_plan = get_sidecar_plan().json()
+    print("sidecar_plan: " + str(sidecar_plan))
+
+    assert(len(sidecar_plan['phases']) == 1)
+    assert(sidecar_plan['phases'][0]['name'] == 'sidecar-deploy')
+    assert(len(sidecar_plan['phases'][0]['steps']) == 2)

--- a/frameworks/helloworld/integration/tests/test_sidecar.py
+++ b/frameworks/helloworld/integration/tests/test_sidecar.py
@@ -1,0 +1,42 @@
+import dcos.http
+import json
+import pytest
+import re
+import shakedown
+
+from tests.test_utils import (
+    PACKAGE_NAME,
+    check_health,
+    get_marathon_config,
+    get_deployment_plan,
+    get_sidecar_plan,
+    get_task_count,
+    install,
+    marathon_api_url,
+    request,
+    run_dcos_cli_cmd,
+    uninstall,
+    spin,
+    start_sidecar_plan
+)
+
+
+def setup_module(module):
+    uninstall()
+    options = {
+        "service": {
+            "spec_file": "sidecar.yml"
+        }
+    }
+
+    install(None, PACKAGE_NAME, options)
+
+
+@pytest.mark.sanity
+def test_deploy():
+    get_deployment_plan()
+
+@pytest.mark.sanity
+def test_sidecar():
+    start_sidecar_plan()
+    get_sidecar_plan()

--- a/frameworks/helloworld/integration/tests/test_utils.py
+++ b/frameworks/helloworld/integration/tests/test_utils.py
@@ -56,9 +56,18 @@ def check_health():
     return spin(fn, success_predicate)
 
 def get_deployment_plan():
+    return _get_plan("deploy")
+
+def get_sidecar_plan():
+    return _get_plan("sidecar")
+
+def start_sidecar_plan():
+    return dcos.http.post(shakedown.dcos_service_url(PACKAGE_NAME) + "/v1/plans/sidecar/start")
+
+def _get_plan(plan):
     def fn():
         try:
-            return dcos.http.get(shakedown.dcos_service_url(PACKAGE_NAME) + "/v1/plans/deploy")
+            return dcos.http.get(shakedown.dcos_service_url(PACKAGE_NAME) + "/v1/plans/" + plan)
         except dcos.errors.DCOSHTTPException:
             return []
 

--- a/frameworks/helloworld/integration/tests/test_utils.py
+++ b/frameworks/helloworld/integration/tests/test_utils.py
@@ -55,19 +55,23 @@ def check_health():
 
     return spin(fn, success_predicate)
 
+
 def get_deployment_plan():
     return _get_plan("deploy")
+
 
 def get_sidecar_plan():
     return _get_plan("sidecar")
 
+
 def start_sidecar_plan():
     return dcos.http.post(shakedown.dcos_service_url(PACKAGE_NAME) + "/v1/plans/sidecar/start")
+
 
 def _get_plan(plan):
     def fn():
         try:
-            return dcos.http.get(shakedown.dcos_service_url(PACKAGE_NAME) + "/v1/plans/" + plan)
+            return dcos.http.get("{}/v1/plans/{}".format(shakedown.dcos_service_url(PACKAGE_NAME), plan))
         except dcos.errors.DCOSHTTPException:
             return []
 

--- a/frameworks/helloworld/src/main/dist/sidecar.yml
+++ b/frameworks/helloworld/src/main/dist/sidecar.yml
@@ -1,0 +1,61 @@
+name: "hello-world"
+principal: "hello-world-principal"
+zookeeper: master.mesos:2181
+api-port: {{PORT0}}
+pods:
+  hello:
+    count: 2
+    resource-sets:
+      hello-resources:
+        cpus: {{HELLO_CPUS}}
+        memory: 256
+        volumes:
+          - path: "hello-container-path"
+            type: ROOT
+            size: 1024
+      sidecar-resources:
+        cpus: 1
+        memory: 256
+    tasks:
+      server:
+        goal: RUNNING
+        cmd: "echo $TASK_NAME >> hello-container-path/output && sleep $SLEEP_DURATION"
+        resource-set: hello-resources
+        env:
+          SLEEP_DURATION: 1000
+        health-checks:
+          check-up:
+            cmd: "stat hello-container-path/output"
+            interval: 5
+            grace-period: 30
+            max-consecutive-failures: 3
+            delay: 0
+            timeout: 10
+      once:
+        goal: FINISHED
+        cmd: "echo 'I run only once' >> hello-container-path/output"
+        resource-set: sidecar-resources
+      sidecar:
+        goal: FINISHED
+        cmd: "echo 'sidecar' >> hello-container-path/output"
+        resource-set: sidecar-resources
+
+plans:
+  deploy:
+    strategy: serial
+    phases:
+      server-deploy:
+        strategy: parallel
+        pod: hello
+        tasks: [server]
+      once-deploy:
+        strategy: parallel
+        pod: hello
+        tasks: [once]
+  sidecar:
+    strategy: serial
+    phases:
+      sidecar-deploy:
+        strategy: parallel
+        pod: hello
+        tasks: [sidecar]

--- a/frameworks/helloworld/src/main/dist/sidecar.yml
+++ b/frameworks/helloworld/src/main/dist/sidecar.yml
@@ -23,14 +23,6 @@ pods:
         resource-set: hello-resources
         env:
           SLEEP_DURATION: 1000
-        health-checks:
-          check-up:
-            cmd: "stat hello-container-path/output"
-            interval: 5
-            grace-period: 30
-            max-consecutive-failures: 3
-            delay: 0
-            timeout: 10
       once:
         goal: FINISHED
         cmd: "echo 'I run only once' >> hello-container-path/output"

--- a/frameworks/helloworld/universe/config.json
+++ b/frameworks/helloworld/universe/config.json
@@ -14,6 +14,11 @@
             "description":"The sleep duration in seconds before tasks exit.",
             "type":"number",
             "default":1000
+          },
+          "spec_file" : {
+            "description":"The name of the service spec yaml file.",
+            "type":"string",
+            "default":"svc.yml"
           }
         }
       },

--- a/frameworks/helloworld/universe/marathon.json.mustache
+++ b/frameworks/helloworld/universe/marathon.json.mustache
@@ -3,7 +3,7 @@
   "cpus": 1.0,
   "mem": 1230,
   "instances": 1,
-  "cmd": "export LD_LIBRARY_PATH=$MESOS_SANDBOX/libmesos-bundle/lib && export MESOS_NATIVE_JAVA_LIBRARY=$(ls $MESOS_SANDBOX/libmesos-bundle/lib/libmesos-*.so) && export PATH=$(ls -d $MESOS_SANDBOX/jre*/bin):$PATH && ./hello-world-scheduler/bin/helloworld ./hello-world-scheduler/svc.yml",
+  "cmd": "export LD_LIBRARY_PATH=$MESOS_SANDBOX/libmesos-bundle/lib && export MESOS_NATIVE_JAVA_LIBRARY=$(ls $MESOS_SANDBOX/libmesos-bundle/lib/libmesos-*.so) && export PATH=$(ls -d $MESOS_SANDBOX/jre*/bin):$PATH && ./hello-world-scheduler/bin/helloworld ./hello-world-scheduler/{{service.spec_file}}",
   "labels": {
     "DCOS_PACKAGE_FRAMEWORK_NAME": "{{service.name}}",
     "DCOS_MIGRATION_API_VERSION": "v1",

--- a/sdk/common/src/main/java/com/mesosphere/sdk/offer/CommonTaskUtils.java
+++ b/sdk/common/src/main/java/com/mesosphere/sdk/offer/CommonTaskUtils.java
@@ -89,7 +89,7 @@ public class CommonTaskUtils {
     /**
      * Returns whether the provided {@link TaskStatus} shows that the task needs to recover.
      */
-    public static boolean needsRecovery(TaskStatus taskStatus) {
+    public static boolean isRecoveryNeeded(TaskStatus taskStatus) {
         switch (taskStatus.getState()) {
             case TASK_FINISHED:
             case TASK_FAILED:
@@ -108,10 +108,17 @@ public class CommonTaskUtils {
     }
 
     /**
-     * Returns whether the provided {@link TaskStatus} shows that the task has reached a terminal state.
+     * Returns whether the provided {@link TaskStatus} has reached a terminal state.
      */
     public static boolean isTerminal(TaskStatus taskStatus) {
-        switch (taskStatus.getState()) {
+        return isTerminal(taskStatus.getState());
+    }
+
+    /**
+     * Returns whether the provided {@link TaskState} has reached a terminal state.
+     */
+    public static boolean isTerminal(TaskState taskState) {
+        switch (taskState) {
             case TASK_FINISHED:
             case TASK_FAILED:
             case TASK_KILLED:
@@ -129,25 +136,22 @@ public class CommonTaskUtils {
     }
 
     /**
-     * Ensures that the provided {@link TaskInfo} contains a {@link Label} identifying it as a
-     * transient task.
+     * Ensures that the provided {@link org.apache.mesos.Protos.TaskInfo.Builder} contains a {@link Label} identifying
+     * it as a transient task.
      */
-    public static TaskInfo setTransient(TaskInfo taskInfo) {
-        return taskInfo.toBuilder()
+    public static TaskInfo.Builder setTransient(TaskInfo.Builder taskInfo) {
+        return taskInfo
                 .setLabels(withLabelSet(taskInfo.getLabels(),
                         TRANSIENT_FLAG_KEY,
-                        "true"))
-                .build();
+                        "true"));
     }
 
     /**
-     * Ensures that the provided {@link TaskInfo} does not contain a {@link Label} identifying it as
-     * a transient task.
+     * Ensures that the provided {@link org.apache.mesos.Protos.TaskInfo.Builder} does not contain a {@link Label}
+     * identifying it as a transient task.
      */
-    public static TaskInfo clearTransient(TaskInfo taskInfo) {
-        return taskInfo.toBuilder()
-                .setLabels(withLabelRemoved(taskInfo.getLabels(), TRANSIENT_FLAG_KEY))
-                .build();
+    public static TaskInfo.Builder clearTransient(TaskInfo.Builder builder) {
+        return builder.setLabels(withLabelRemoved(builder.getLabels(), TRANSIENT_FLAG_KEY));
     }
 
     /**

--- a/sdk/common/src/main/java/com/mesosphere/sdk/offer/Constants.java
+++ b/sdk/common/src/main/java/com/mesosphere/sdk/offer/Constants.java
@@ -20,4 +20,6 @@ public class Constants {
     public static final String LIBMESOS_URI = "LIBMESOS_URI";
     public static final String JAVA_URI = "JAVA_URI";
     public static final String DEFAULT_JAVA_URI = "https://downloads.mesosphere.com/java/jre-8u112-linux-x64.tar.gz";
+
+    public static final String DEPLOY_PLAN_NAME = "deploy";
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/DefaultOfferRequirementProvider.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/DefaultOfferRequirementProvider.java
@@ -331,22 +331,19 @@ public class DefaultOfferRequirementProvider implements OfferRequirementProvider
     private Protos.ExecutorInfo getExecutor(PodInstance podInstance) {
         List<Protos.TaskInfo> podTasks = TaskUtils.getPodTasks(podInstance, stateStore);
 
-        List<String> taskNames = podTasks.stream()
-                .map(taskInfo -> taskInfo.getName())
-                .collect(Collectors.toList());
-
-        LOGGER.info("For pod: {}, found tasks: {}", podInstance.getName(), taskNames);
-
         for (Protos.TaskInfo taskInfo : podTasks) {
             Optional<Protos.TaskStatus> taskStatusOptional = stateStore.fetchStatus(taskInfo.getName());
             if (taskStatusOptional.isPresent()
                     && taskStatusOptional.get().getState() == Protos.TaskState.TASK_RUNNING) {
-                LOGGER.info("Reusing executor: ", taskInfo.getExecutor());
+                LOGGER.info(
+                        "Reusing executor from task '{}': {}",
+                        taskInfo.getName(),
+                        TextFormat.shortDebugString(taskInfo.getExecutor()));
                 return taskInfo.getExecutor();
             }
         }
 
-        LOGGER.info("Getting new executor.");
+        LOGGER.info("Creating new executor for pod {}, as no RUNNING tasks were found", podInstance.getName());
         return getNewExecutorInfo(podInstance.getPod());
     }
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/DefaultScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/DefaultScheduler.java
@@ -1,7 +1,6 @@
 package com.mesosphere.sdk.scheduler;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableMap;
 import com.google.protobuf.TextFormat;
 import com.mesosphere.sdk.state.StateStoreUtils;
 import org.apache.mesos.Protos;
@@ -41,6 +40,9 @@ import org.slf4j.LoggerFactory;
 import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.*;
+import java.util.stream.Collectors;
+
+import static com.mesosphere.sdk.offer.Constants.DEPLOY_PLAN_NAME;
 
 /**
  * This scheduler when provided with a ServiceSpec will deploy the service and recover from encountered faults
@@ -402,14 +404,18 @@ public class DefaultScheduler implements Scheduler, Observer {
         initializeGlobals(driver);
         initializeDeploymentPlanManager();
         initializeRecoveryPlanManager();
+        initializePlanCoordinator();
         initializeResources();
         DcosCertInstaller.installCertificate(System.getenv("JAVA_HOME"));
-        final List<PlanManager> planManagers = Arrays.asList(
-                deploymentPlanManager,
-                recoveryPlanManager);
-        planCoordinator = new DefaultPlanCoordinator(planManagers, planScheduler);
         planCoordinator.subscribe(this);
         LOGGER.info("Done initializing.");
+    }
+
+    private Collection<PlanManager> getOtherPlanManagers() {
+        return plans.stream()
+                .filter(plan -> !plan.getName().equals(DEPLOY_PLAN_NAME))
+                .map(plan -> new DefaultPlanManager(plan))
+                .collect(Collectors.toList());
     }
 
     private void initializeGlobals(SchedulerDriver driver) {
@@ -428,7 +434,9 @@ public class DefaultScheduler implements Scheduler, Observer {
      */
     protected void initializeDeploymentPlanManager() {
         LOGGER.info("Initializing deployment plan...");
-        Optional<Plan> deploy = plans.stream().filter(plan -> Objects.equals(plan.getName(), "deploy")).findFirst();
+        Optional<Plan> deploy = plans.stream()
+                .filter(plan -> Objects.equals(plan.getName(), DEPLOY_PLAN_NAME))
+                .findFirst();
         Plan deployPlan;
         if (!deploy.isPresent()) {
             LOGGER.info("No deploy plan provided. Generating one");
@@ -439,6 +447,7 @@ public class DefaultScheduler implements Scheduler, Observer {
             deployPlan = deploy.get();
         }
         deploymentPlanManager = new DefaultPlanManager(deployPlan);
+        deploymentPlanManager.getPlan().getStrategy().proceed();
     }
 
     /**
@@ -455,14 +464,20 @@ public class DefaultScheduler implements Scheduler, Observer {
                         : new NeverFailureMonitor());
     }
 
+    protected void initializePlanCoordinator() {
+        final List<PlanManager> planManagers = new ArrayList<>();
+        planManagers.add(deploymentPlanManager);
+        planManagers.add(recoveryPlanManager);
+        planManagers.addAll(getOtherPlanManagers());
+        planCoordinator = new DefaultPlanCoordinator(planManagers, planScheduler);
+    }
+
     private void initializeResources() throws InterruptedException {
         LOGGER.info("Initializing resources...");
         Collection<Object> resources = new ArrayList<>();
         resources.add(new ConfigResource<ServiceSpec>(configStore));
         resources.add(new EndpointsResource(stateStore, serviceSpec.getName()));
-        resources.add(new PlansResource(ImmutableMap.of(
-                "deploy", deploymentPlanManager,
-                "recovery", recoveryPlanManager)));
+        resources.add(new PlansResource(planCoordinator));
         resources.add(new PodsResource(taskKiller, stateStore));
         resources.add(new StateResource(stateStore, new StringPropertyDeserializer()));
         resources.add(new TaskResource(stateStore, taskKiller, serviceSpec.getName()));
@@ -594,8 +609,9 @@ public class DefaultScheduler implements Scheduler, Observer {
                 // Store status, then pass status to PlanManager => Plan => Steps
                 try {
                     stateStore.storeStatus(status);
-                    deploymentPlanManager.update(status);
-                    recoveryPlanManager.update(status);
+                    planCoordinator.getPlanManagers().stream()
+                            .filter(planManager -> !planManager.getPlan().isWaiting())
+                            .forEach(planManager -> planManager.update(status));
                     reconciler.update(status);
 
                     if (stateStore.isSuppressed()

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/DefaultTaskKiller.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/DefaultTaskKiller.java
@@ -22,6 +22,10 @@ public class DefaultTaskKiller implements TaskKiller {
 
     @Override
     public void killTask(TaskID taskId, boolean destructive) {
+        if (taskId.getValue().isEmpty()) {
+            return;
+        }
+
         logger.info("Scheduling task {} to be killed {}",
                 taskId.getValue(), destructive ? "destructively" : "non-destructively");
         if (destructive) {

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/DefaultTaskKiller.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/DefaultTaskKiller.java
@@ -22,7 +22,11 @@ public class DefaultTaskKiller implements TaskKiller {
 
     @Override
     public void killTask(TaskID taskId, boolean destructive) {
+        // In order to update a podinstance its normal to kill all tasks in a pod.
+        // Sometimes a task hasn't been launched ever but it has been recorded for
+        // resource reservation footprint reasons, and therefore doesn't have a TaskID yet.
         if (taskId.getValue().isEmpty()) {
+            logger.warn("Attempted to kill empty TaskID.");
             return;
         }
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/DefaultPlanCoordinator.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/DefaultPlanCoordinator.java
@@ -19,8 +19,8 @@ import java.util.stream.Collectors;
 public class DefaultPlanCoordinator extends ChainedObserver implements PlanCoordinator {
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultPlanCoordinator.class);
 
-    private List<PlanManager> planManagers = new LinkedList<>();
-    private PlanScheduler planScheduler;
+    private final List<PlanManager> planManagers = new LinkedList<>();
+    private final PlanScheduler planScheduler;
 
     public DefaultPlanCoordinator(
             List<PlanManager> planManagers,
@@ -50,15 +50,21 @@ public class DefaultPlanCoordinator extends ChainedObserver implements PlanCoord
         // with offers first, does not accidentally schedule an asset that's actively being worked upon by another
         // PlanManager that is presented offers later.
         dirtiedAssets.addAll(planManagers.stream()
+                .filter(planManager -> !planManager.getPlan().isWaiting())
                 .flatMap(planManager -> planManager.getDirtyAssets().stream())
                 .collect(Collectors.toList()));
 
         LOGGER.info("Initial dirtied assets: {}", dirtiedAssets);
 
-        for (final PlanManager planManager : planManagers) {
+        for (final PlanManager planManager : getPlanManagers()) {
+            if (planManager.getPlan().isWaiting()) {
+                LOGGER.info("Skipping interrupted plan: {}", planManager.getPlan().getName());
+                continue;
+            }
+
             try {
                 Set<String> relevantDirtyAssets = getRelevantDirtyAssets(planManager, dirtiedAssets);
-                LOGGER.info("Processing offers for plan: {} with relevant dirtied assets: {}.",
+                LOGGER.info("Processing offers for plan: '{}' with relevant dirtied assets: {}.",
                         planManager.getPlan().getName(), relevantDirtyAssets, planManager.getPlan().getName());
 
                 // Get candidate steps to be scheduled
@@ -93,6 +99,11 @@ public class DefaultPlanCoordinator extends ChainedObserver implements PlanCoord
     @Override
     public boolean hasOperations() {
         return planManagers.stream().anyMatch(manager -> !manager.getPlan().isComplete());
+    }
+
+    @Override
+    public Collection<PlanManager> getPlanManagers() {
+        return planManagers;
     }
 
     private Set<String> getRelevantDirtyAssets(PlanManager planManager, Set<String> dirtiedAssets) {

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/DefaultPlanCoordinator.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/DefaultPlanCoordinator.java
@@ -65,7 +65,7 @@ public class DefaultPlanCoordinator extends ChainedObserver implements PlanCoord
             try {
                 Set<String> relevantDirtyAssets = getRelevantDirtyAssets(planManager, dirtiedAssets);
                 LOGGER.info("Processing offers for plan: '{}' with relevant dirtied assets: {}.",
-                        planManager.getPlan().getName(), relevantDirtyAssets, planManager.getPlan().getName());
+                        planManager.getPlan().getName(), relevantDirtyAssets);
 
                 // Get candidate steps to be scheduled
                 Collection<? extends Step> candidateSteps = planManager.getCandidates(relevantDirtyAssets);

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/DefaultPlanFactory.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/DefaultPlanFactory.java
@@ -9,6 +9,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static com.mesosphere.sdk.offer.Constants.DEPLOY_PLAN_NAME;
+
 /**
  * Given a StateStore and a PlanSpecification the DefaultPlanFactory can generate a Plan.
  */
@@ -36,7 +38,7 @@ public class DefaultPlanFactory implements PlanFactory {
     @Override
     public Plan getPlan(ServiceSpec serviceSpec) {
         return new DefaultPlan(
-                serviceSpec.getName(),
+                DEPLOY_PLAN_NAME,
                 getPhases(serviceSpec),
                 strategyGenerator.generate());
     }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/DefaultPlanManager.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/DefaultPlanManager.java
@@ -13,6 +13,7 @@ public class DefaultPlanManager extends ChainedObserver implements PlanManager {
     private final Plan plan;
 
     public DefaultPlanManager(final Plan plan) {
+        plan.getStrategy().interrupt();
         this.plan = plan;
         this.plan.subscribe(this);
     }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/DefaultPlanManager.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/DefaultPlanManager.java
@@ -13,6 +13,9 @@ public class DefaultPlanManager extends ChainedObserver implements PlanManager {
     private final Plan plan;
 
     public DefaultPlanManager(final Plan plan) {
+        // All plans begin in an interrupted state.  The deploy plan will
+        // be automatically proceeded when appropriate.  Other plans are
+        // sidecar plans and should be externally proceeded.
         plan.getStrategy().interrupt();
         this.plan = plan;
         this.plan.subscribe(this);

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/PlanCoordinator.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/PlanCoordinator.java
@@ -26,4 +26,9 @@ public interface PlanCoordinator extends Observable {
      * @return True if this {@link PlanCoordinator} has operations to perform.
      */
     boolean hasOperations();
+
+    /**
+     * @return The PlanManagers which the PlanCoordinator coordinates.
+     */
+    Collection<PlanManager> getPlanManagers();
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/PlanCoordinator.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/PlanCoordinator.java
@@ -28,7 +28,7 @@ public interface PlanCoordinator extends Observable {
     boolean hasOperations();
 
     /**
-     * @return The PlanManagers which the PlanCoordinator coordinates.
+     * @return The {@link PlanManager}s which the PlanCoordinator coordinates.
      */
     Collection<PlanManager> getPlanManagers();
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/PlanUtils.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/PlanUtils.java
@@ -17,6 +17,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static com.mesosphere.sdk.offer.Constants.DEPLOY_PLAN_NAME;
+
 /**
  * Common utility methods for {@link PlanManager}s.
  */
@@ -165,5 +167,9 @@ public class PlanUtils {
 
     public static List<Offer> filterAcceptedOffers(List<Offer> offers, Collection<OfferID> acceptedOfferIds) {
         return offers.stream().filter(offer -> !acceptedOfferIds.contains(offer.getId())).collect(Collectors.toList());
+    }
+
+    public static boolean isDeployPlan(Plan plan) {
+        return plan.getName().equals(DEPLOY_PLAN_NAME);
     }
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/strategy/StrategyFactory.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/strategy/StrategyFactory.java
@@ -9,10 +9,15 @@ import com.mesosphere.sdk.scheduler.plan.Step;
 public class StrategyFactory {
     public static Strategy<Phase> generateForPhase(String strategyType) {
         Strategy<Phase> strategy = null;
-        if ("serial".equals(strategyType)) {
-            strategy = new SerialStrategy.Generator<Phase>().generate();
-        } else if ("parallel".equals(strategyType)) {
-            strategy = new ParallelStrategy.Generator<Phase>().generate();
+        switch(strategyType) {
+            case "serial":
+                strategy = new SerialStrategy.Generator<Phase>().generate();
+                break;
+            case "parallel":
+                strategy = new ParallelStrategy.Generator<Phase>().generate();
+                break;
+            default:
+                strategy = new SerialStrategy.Generator<Phase>().generate();
         }
 
         return strategy;
@@ -20,10 +25,15 @@ public class StrategyFactory {
 
     public static Strategy<Step> generateForSteps(String strategyType) {
         Strategy<Step> strategy = null;
-        if ("serial".equals(strategyType)) {
-            strategy = new SerialStrategy.Generator<Step>().generate();
-        } else if ("parallel".equals(strategyType)) {
-            strategy = new ParallelStrategy.Generator<Step>().generate();
+        switch(strategyType) {
+            case "serial":
+                strategy = new SerialStrategy.Generator<Step>().generate();
+                break;
+            case "parallel":
+                strategy = new ParallelStrategy.Generator<Step>().generate();
+                break;
+            default:
+                strategy = new SerialStrategy.Generator<Step>().generate();
         }
 
         return strategy;

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultPlanGenerator.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultPlanGenerator.java
@@ -59,6 +59,11 @@ public class DefaultPlanGenerator implements PlanGenerator {
                 List<String> taskNames = taskSpecs.stream()
                         .map(taskSpec -> taskSpec.getName())
                         .collect(Collectors.toList());
+
+                if (!CollectionUtils.isEmpty(rawPhase.getTasks())) {
+                    taskNames = rawPhase.getTasks();
+                }
+
                 steps.add(from(podInstance, taskNames));
             }
         } else {

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultPlanGenerator.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultPlanGenerator.java
@@ -60,6 +60,8 @@ public class DefaultPlanGenerator implements PlanGenerator {
                         .map(taskSpec -> taskSpec.getName())
                         .collect(Collectors.toList());
 
+                // If the tasks to be launched have been explicitly indicated in the plan
+                // override the taskNames.
                 if (!CollectionUtils.isEmpty(rawPhase.getTasks())) {
                     taskNames = rawPhase.getTasks();
                 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/RawPhase.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/RawPhase.java
@@ -12,14 +12,21 @@ public class RawPhase {
     private final String strategy;
     private final String pod;
     private final List<RawStep> steps;
+    private final List<String> tasks;
 
     private RawPhase(
             @JsonProperty("strategy") String strategy,
             @JsonProperty("steps") List<RawStep> steps,
-            @JsonProperty("pod") String pod) {
+            @JsonProperty("pod") String pod,
+            @JsonProperty("tasks") List<String> tasks) {
+        if (strategy == null) {
+            strategy = "serial";
+        }
+
         this.strategy = strategy;
         this.steps = steps;
         this.pod = pod;
+        this.tasks = tasks;
     }
 
     public String getStrategy() {
@@ -32,6 +39,10 @@ public class RawPhase {
 
     public String getPod() {
         return pod;
+    }
+
+    public List<String> getTasks() {
+        return tasks;
     }
 }
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/RawPhase.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/RawPhase.java
@@ -19,10 +19,6 @@ public class RawPhase {
             @JsonProperty("steps") List<RawStep> steps,
             @JsonProperty("pod") String pod,
             @JsonProperty("tasks") List<String> tasks) {
-        if (strategy == null) {
-            strategy = "serial";
-        }
-
         this.strategy = strategy;
         this.steps = steps;
         this.pod = pod;

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/RawPlan.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/RawPlan.java
@@ -13,6 +13,10 @@ public class RawPlan {
     private RawPlan(
             @JsonProperty("strategy") String strategy,
             @JsonProperty("phases") WriteOnceLinkedHashMap<String, RawPhase> phases) {
+        if (strategy == null) {
+            strategy = "serial";
+        }
+
         this.strategy = strategy;
         this.phases = phases;
     }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/RawPlan.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/RawPlan.java
@@ -13,10 +13,6 @@ public class RawPlan {
     private RawPlan(
             @JsonProperty("strategy") String strategy,
             @JsonProperty("phases") WriteOnceLinkedHashMap<String, RawPhase> phases) {
-        if (strategy == null) {
-            strategy = "serial";
-        }
-
         this.strategy = strategy;
         this.phases = phases;
     }

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/OfferAccepterTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/OfferAccepterTest.java
@@ -42,7 +42,7 @@ public class OfferAccepterTest {
         Resource resource = ResourceTestUtils.getUnreservedCpu(1.0);
         Offer offer = OfferTestUtils.getOffer(resource);
         TaskInfo taskInfo = TaskTestUtils.getTaskInfo(resource);
-        taskInfo = CommonTaskUtils.setTransient(taskInfo);
+        taskInfo = CommonTaskUtils.setTransient(taskInfo.toBuilder()).build();
 
         TestOperationRecorder recorder = new TestOperationRecorder();
         OfferAccepter accepter = new OfferAccepter(recorder);
@@ -59,7 +59,7 @@ public class OfferAccepterTest {
         Resource resource = ResourceTestUtils.getUnreservedCpu(1.0);
         Offer offer = OfferTestUtils.getOffer(resource);
         TaskInfo taskInfo = TaskTestUtils.getTaskInfo(resource);
-        taskInfo = CommonTaskUtils.setTransient(taskInfo);
+        taskInfo = CommonTaskUtils.setTransient(taskInfo.toBuilder()).build();
 
         TestOperationRecorder recorder = new TestOperationRecorder();
         OfferAccepter accepter = new OfferAccepter(recorder);
@@ -70,7 +70,7 @@ public class OfferAccepterTest {
                 anyCollectionOf(Operation.class),
                 anyObject());
 
-        taskInfo = CommonTaskUtils.clearTransient(taskInfo);
+        taskInfo = CommonTaskUtils.clearTransient(taskInfo.toBuilder()).build();
         accepter.accept(driver, Arrays.asList(new LaunchOfferRecommendation(offer, taskInfo)));
         Assert.assertEquals(2, recorder.getLaunches().size());
         verify(driver, times(1)).acceptOffers(

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/TaskUtilsTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/TaskUtilsTest.java
@@ -310,7 +310,7 @@ public class TaskUtilsTest {
                 .setTaskId(Protos.TaskID.newBuilder().setValue(UUID.randomUUID().toString()))
                 .setState(Protos.TaskState.TASK_LOST)
                 .build();
-        Assert.assertTrue(CommonTaskUtils.needsRecovery(taskStatus));
+        Assert.assertTrue(CommonTaskUtils.isRecoveryNeeded(taskStatus));
     }
 
     private static Protos.TaskID getTaskId(String value) {

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/plan/DefaultPlanCoordinatorTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/plan/DefaultPlanCoordinatorTest.java
@@ -163,8 +163,10 @@ public class DefaultPlanCoordinatorTest {
     @Test
     public void testOnePlanManagerPendingSufficientOffer() throws Exception {
         final Plan plan = new DefaultPlanFactory(phaseFactory).getPlan(serviceSpecification);
+        final PlanManager planManager = new DefaultPlanManager(plan);
+        planManager.getPlan().getStrategy().proceed();
         final DefaultPlanCoordinator coordinator = new DefaultPlanCoordinator(
-                Arrays.asList(new DefaultPlanManager(plan)), planScheduler);
+                Arrays.asList(planManager), planScheduler);
         Assert.assertEquals(1, coordinator.processOffers(schedulerDriver, getOffers(SUFFICIENT_CPUS,
                 SUFFICIENT_MEM, SUFFICIENT_DISK)).size());
     }
@@ -194,6 +196,8 @@ public class DefaultPlanCoordinatorTest {
         final Plan planB = new DefaultPlanFactory(phaseFactory).getPlan(serviceSpecificationB);
         final DefaultPlanManager planManagerA = new DefaultPlanManager(planA);
         final DefaultPlanManager planManagerB = new DefaultPlanManager(planB);
+        planManagerA.getPlan().getStrategy().proceed();
+        planManagerB.getPlan().getStrategy().proceed();
         final DefaultPlanCoordinator coordinator = new DefaultPlanCoordinator(
                 Arrays.asList(planManagerA, planManagerB), planScheduler);
         Assert.assertEquals(2, coordinator.processOffers(schedulerDriver, getOffers(SUFFICIENT_CPUS,
@@ -209,6 +213,8 @@ public class DefaultPlanCoordinatorTest {
         final Plan planB = new DefaultPlanFactory(phaseFactory).getPlan(serviceSpecB);
         final PlanManager planManagerA = new DefaultPlanManager(planA);
         final PlanManager planManagerB = new DefaultPlanManager(planB);
+        planManagerA.getPlan().getStrategy().proceed();
+        planManagerB.getPlan().getStrategy().proceed();
         final DefaultPlanCoordinator coordinator = new DefaultPlanCoordinator(
                 Arrays.asList(planManagerA, planManagerB),
                 planScheduler);
@@ -246,6 +252,8 @@ public class DefaultPlanCoordinatorTest {
         final Plan planB = new DefaultPlanFactory(phaseFactory).getPlan(serviceSpecification);
         final PlanManager planManagerA = new DefaultPlanManager(planA);
         final PlanManager planManagerB = new DefaultPlanManager(planB);
+        planManagerA.getPlan().getStrategy().proceed();
+        planManagerB.getPlan().getStrategy().proceed();
         final DefaultPlanCoordinator coordinator = new DefaultPlanCoordinator(
                 Arrays.asList(planManagerA, planManagerB),
                 planScheduler);

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/plan/DefaultPlanManagerTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/plan/DefaultPlanManagerTest.java
@@ -36,6 +36,7 @@ public class DefaultPlanManagerTest {
         secondStep = new TestStep();
         plan = getTestPlan(firstStep, secondStep);
         planManager = new DefaultPlanManager(plan);
+        planManager.getPlan().getStrategy().proceed();
         MockitoAnnotations.initMocks(this);
     }
 

--- a/sdk/scheduler/src/test/resources/partial-manual-plan.yml
+++ b/sdk/scheduler/src/test/resources/partial-manual-plan.yml
@@ -1,0 +1,57 @@
+name: "hello-world"
+principal: "hello-world-principal"
+zookeeper: master.mesos:2181
+api-port: 8080
+pods:
+  hello:
+    count: 2
+    resource-sets:
+      hello-resources:
+        cpus: {{HELLO_CPUS}}
+        memory: 256
+        ports:
+          - name: http
+            port: 8080
+        volumes:
+          - path: "hello-container-path"
+            type: ROOT
+            size: 1024
+      once-resources:
+        cpus: 1
+        memory: 256
+        volumes:
+          - path: "once-container-path"
+            type: ROOT
+            size: 1024
+    tasks:
+      server:
+        goal: RUNNING
+        cmd: "echo $TASK_NAME >> hello-container-path/output && sleep $SLEEP_DURATION"
+        resource-set: hello-resources
+        env:
+          SLEEP_DURATION: 1000
+        health-checks:
+          check-up:
+            cmd: "stat hello-container-path/output"
+            interval: 5
+            grace-period: 30
+            max-consecutive-failures: 3
+            delay: 0
+            timeout: 10
+      once:
+        goal: FINISHED
+        cmd: "echo 'I run only once' >> once-container-path/runonce"
+        resource-set: once-resources
+
+plans:
+  deploy:
+    strategy: serial
+    phases:
+      server-deploy:
+        strategy: parallel
+        pod: hello
+        tasks: [server]
+      once-deploy:
+        strategy: parallel
+        pod: hello
+        tasks: [once]

--- a/sdk/scheduler/src/test/resources/partial-manual-plan.yml
+++ b/sdk/scheduler/src/test/resources/partial-manual-plan.yml
@@ -30,14 +30,13 @@ pods:
         resource-set: hello-resources
         env:
           SLEEP_DURATION: 1000
-        health-checks:
-          check-up:
-            cmd: "stat hello-container-path/output"
-            interval: 5
-            grace-period: 30
-            max-consecutive-failures: 3
-            delay: 0
-            timeout: 10
+        health-check:
+          cmd: "stat hello-container-path/output"
+          interval: 5
+          grace-period: 30
+          max-consecutive-failures: 3
+          delay: 0
+          timeout: 10
       once:
         goal: FINISHED
         cmd: "echo 'I run only once' >> once-container-path/runonce"


### PR DESCRIPTION
Any number of plans may be defined.  All plans apart from the "deploy" plan are initialized in an interrupted state.  The PlanResource now has endpoints for starting arbitrary plans.  These plans may refer to tasks which should be launched in already running pod instances (executors).  These two features allow for the execution of sidecar plans.

One may verify this by deploying the hello-world service with `sidecar.yml` and starting the sidecar plan.  Integration tests are included which exercise deployment and execution of the sidecar plan.