### PR TITLE
Update CanaryStrategy.java

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/strategy/CanaryStrategy.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/strategy/CanaryStrategy.java
@@ -30,7 +30,7 @@ public class CanaryStrategy<C extends Element> extends SerialStrategy<C> {
                     .filter(element -> element.isPending())
                     .collect(Collectors.toList());
 
-            for (int i = 0; i < 2 && i < parentElement.getChildren().size(); i++) {
+            for (int i = 0; i < 2 && i < children.size(); i++) {
                 children.get(i).getStrategy().interrupt();
             }
 


### PR DESCRIPTION
instead of parentElement.getChildren(), it should be children list (after filter) because it can be empty