### PR TITLE
Make zookeeper connection string optional

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultServiceSpec.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultServiceSpec.java
@@ -66,7 +66,9 @@ public class DefaultServiceSpec implements ServiceSpec {
         this.role = role;
         this.principal = principal;
         this.apiPort = apiPort;
-        this.zookeeperConnection = zookeeperConnection;
+        // If no zookeeperConnection string is configured, fallback to the default value.
+        this.zookeeperConnection = StringUtils.isBlank(zookeeperConnection)
+                ? DEFAULT_ZK_CONNECTION : zookeeperConnection;
         this.pods = pods;
         this.replacementFailurePolicy = replacementFailurePolicy;
     }
@@ -76,7 +78,9 @@ public class DefaultServiceSpec implements ServiceSpec {
         role = builder.role;
         principal = builder.principal;
         apiPort = builder.apiPort;
-        zookeeperConnection = builder.zookeeperConnection;
+        // If no zookeeperConnection string is configured, fallback to the default value.
+        zookeeperConnection = StringUtils.isBlank(builder.zookeeperConnection)
+                ? DEFAULT_ZK_CONNECTION : builder.zookeeperConnection;
         pods = builder.pods;
         replacementFailurePolicy = builder.replacementFailurePolicy;
     }
@@ -119,8 +123,7 @@ public class DefaultServiceSpec implements ServiceSpec {
 
     @Override
     public String getZookeeperConnection() {
-        // If no zookeeperConnection string is configured, fallback to the default value.
-        return StringUtils.isNotBlank(zookeeperConnection) ? zookeeperConnection : DEFAULT_ZK_CONNECTION;
+        return zookeeperConnection;
     }
 
     @Override

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultServiceSpec.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultServiceSpec.java
@@ -3,6 +3,7 @@ package com.mesosphere.sdk.specification;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import com.mesosphere.sdk.config.ConfigStoreException;
@@ -28,6 +29,8 @@ import java.util.List;
  */
 public class DefaultServiceSpec implements ServiceSpec {
     private static final Comparator COMPARATOR = new Comparator();
+
+    public static final String DEFAULT_ZK_CONNECTION = "master.mesos:2181";
 
     @NotNull(message = "Service name cannot be empty")
     @Size(min = 1, message = "Service name cannot be empty")
@@ -116,7 +119,8 @@ public class DefaultServiceSpec implements ServiceSpec {
 
     @Override
     public String getZookeeperConnection() {
-        return zookeeperConnection;
+        // If no zookeeperConnection string is configured, fallback to the default value.
+        return StringUtils.isNotBlank(zookeeperConnection) ? zookeeperConnection : DEFAULT_ZK_CONNECTION;
     }
 
     @Override

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/specification/DefaultServiceSpecTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/specification/DefaultServiceSpecTest.java
@@ -206,4 +206,28 @@ public class DefaultServiceSpecTest {
             }
         }
     }
+
+    @Test
+    public void defaultZKConnection() throws Exception {
+        environmentVariables.set("PORT0", "8080");
+        ClassLoader classLoader = getClass().getClassLoader();
+        File file = new File(classLoader.getResource("valid-minimal.yml").getFile());
+        DefaultServiceSpec serviceSpec = YAMLServiceSpecFactory
+                .generateServiceSpec(YAMLServiceSpecFactory.generateRawSpecFromYAML(file));
+        Assert.assertNotNull(serviceSpec);
+        Assert.assertNotNull(serviceSpec.getZookeeperConnection());
+        Assert.assertEquals(DefaultServiceSpec.DEFAULT_ZK_CONNECTION, serviceSpec.getZookeeperConnection());
+    }
+
+    @Test
+    public void customZKConnection() throws Exception {
+        environmentVariables.set("PORT0", "8080");
+        ClassLoader classLoader = getClass().getClassLoader();
+        File file = new File(classLoader.getResource("valid-customzk.yml").getFile());
+        DefaultServiceSpec serviceSpec = YAMLServiceSpecFactory
+                .generateServiceSpec(YAMLServiceSpecFactory.generateRawSpecFromYAML(file));
+        Assert.assertNotNull(serviceSpec);
+        Assert.assertNotNull(serviceSpec.getZookeeperConnection());
+        Assert.assertEquals("custom.master.mesos:2181", serviceSpec.getZookeeperConnection());
+    }
 }

--- a/sdk/scheduler/src/test/resources/dynamic-port.yml
+++ b/sdk/scheduler/src/test/resources/dynamic-port.yml
@@ -1,6 +1,5 @@
 name: "hello-world"
 principal: "test-principal"
-zookeeper: master.mesos:2181
 api-port: {{PORT0}}
 pods:
   pod-type:

--- a/sdk/scheduler/src/test/resources/dynamic-vip-port.yml
+++ b/sdk/scheduler/src/test/resources/dynamic-vip-port.yml
@@ -1,6 +1,5 @@
 name: "hello-world"
 principal: "test-principal"
-zookeeper: master.mesos:2181
 api-port: {{PORT0}}
 pods:
   pod-type:

--- a/sdk/scheduler/src/test/resources/full-manual-plan.yml
+++ b/sdk/scheduler/src/test/resources/full-manual-plan.yml
@@ -1,6 +1,5 @@
 name: "hello-world"
 principal: "hello-world-principal"
-zookeeper: master.mesos:2181
 api-port: 8080
 replacement-failure-policy:
   permanent-failure-timeout-ms: 10

--- a/sdk/scheduler/src/test/resources/invalid-pod-name.yml
+++ b/sdk/scheduler/src/test/resources/invalid-pod-name.yml
@@ -1,6 +1,5 @@
 name:
 principal: "data-store-principal"
-zookeeper: master.mesos:2181
 api-port:
 replacement-failure-policy:
   permanent-failure-timeout-ms: -1

--- a/sdk/scheduler/src/test/resources/invalid-replacement-failure-policy.yml
+++ b/sdk/scheduler/src/test/resources/invalid-replacement-failure-policy.yml
@@ -1,6 +1,5 @@
 name:
 principal: "data-store-principal"
-zookeeper: master.mesos:2181
 api-port:
 replacement-failure-policy:
   permanent-failure-timeout-ms: -1

--- a/sdk/scheduler/src/test/resources/invalid-resource-set-name.yml
+++ b/sdk/scheduler/src/test/resources/invalid-resource-set-name.yml
@@ -1,6 +1,5 @@
 name:
 principal: "data-store-principal"
-zookeeper: master.mesos:2181
 api-port:
 replacement-failure-policy:
   permanent-failure-timeout-ms: -1

--- a/sdk/scheduler/src/test/resources/invalid-rlimit-name.yml
+++ b/sdk/scheduler/src/test/resources/invalid-rlimit-name.yml
@@ -1,6 +1,5 @@
 name: "data-store"
 principal: "data-store-principal"
-zookeeper: master.mesos:2181
 api-port: {{PORT0}}
 pods:
   meta-data:

--- a/sdk/scheduler/src/test/resources/invalid-task-name.yml
+++ b/sdk/scheduler/src/test/resources/invalid-task-name.yml
@@ -1,6 +1,5 @@
 name:
 principal: "data-store-principal"
-zookeeper: master.mesos:2181
 api-port:
 replacement-failure-policy:
   permanent-failure-timeout-ms: -1

--- a/sdk/scheduler/src/test/resources/invalid-task-resources.yml
+++ b/sdk/scheduler/src/test/resources/invalid-task-resources.yml
@@ -1,6 +1,5 @@
 name: "data-store"
 principal: "data-store-principal"
-zookeeper: master.mesos:2181
 api-port: {{PORT0}}
 replacement-failure-policy:
   permanent-failure-timeout-ms: 10

--- a/sdk/scheduler/src/test/resources/invalid.yml.mustache
+++ b/sdk/scheduler/src/test/resources/invalid.yml.mustache
@@ -1,6 +1,5 @@
 name:
 principal: "data-store-principal"
-zookeeper: master.mesos:2181
 api-port:
 replacement-failure-policy:
   permanent-failure-timeout-ms: -1

--- a/sdk/scheduler/src/test/resources/multiple-dynamic-port.yml
+++ b/sdk/scheduler/src/test/resources/multiple-dynamic-port.yml
@@ -1,6 +1,5 @@
 name: "hello-world"
 principal: "test-principal"
-zookeeper: master.mesos:2181
 api-port: {{PORT0}}
 pods:
   pod-type:

--- a/sdk/scheduler/src/test/resources/multiple-port-with-finished.yml
+++ b/sdk/scheduler/src/test/resources/multiple-port-with-finished.yml
@@ -1,6 +1,5 @@
 name: "hello-world"
 principal: "test-principal"
-zookeeper: master.mesos:2181
 api-port: {{PORT0}}
 pods:
   pod-type:

--- a/sdk/scheduler/src/test/resources/multiple-task.yml
+++ b/sdk/scheduler/src/test/resources/multiple-task.yml
@@ -1,6 +1,5 @@
 name: "hello-world"
 principal: "test-principal"
-zookeeper: master.mesos:2181
 api-port: {{PORT0}}
 pods:
   pod-type:

--- a/sdk/scheduler/src/test/resources/named-vip.yml
+++ b/sdk/scheduler/src/test/resources/named-vip.yml
@@ -1,6 +1,5 @@
 name: "hello-world"
 principal: "test-principal"
-zookeeper: master.mesos:2181
 api-port: {{PORT0}}
 pods:
   pod-type:

--- a/sdk/scheduler/src/test/resources/partial-manual-plan.yml
+++ b/sdk/scheduler/src/test/resources/partial-manual-plan.yml
@@ -1,6 +1,5 @@
 name: "hello-world"
 principal: "hello-world-principal"
-zookeeper: master.mesos:2181
 api-port: 8080
 pods:
   hello:

--- a/sdk/scheduler/src/test/resources/recovery-plan-manager-test.yml
+++ b/sdk/scheduler/src/test/resources/recovery-plan-manager-test.yml
@@ -1,6 +1,5 @@
 name: "hello-world"
 principal: "hello-world-principal"
-zookeeper: master.mesos:2181
 api-port: {{PORT0}}
 pods:
   test-task-type:

--- a/sdk/scheduler/src/test/resources/resource-set-seq.yml
+++ b/sdk/scheduler/src/test/resources/resource-set-seq.yml
@@ -1,6 +1,5 @@
 name: "test"
 principal: "test-principal"
-zookeeper: master.mesos:2181
 api-port: 8080
 pods:
   name:

--- a/sdk/scheduler/src/test/resources/single-port.yml
+++ b/sdk/scheduler/src/test/resources/single-port.yml
@@ -1,6 +1,5 @@
 name: "hello-world"
 principal: "test-principal"
-zookeeper: master.mesos:2181
 api-port: {{PORT0}}
 pods:
   pod-type:

--- a/sdk/scheduler/src/test/resources/single-task.yml
+++ b/sdk/scheduler/src/test/resources/single-task.yml
@@ -1,6 +1,5 @@
 name: "hello-world"
 principal: "test-principal"
-zookeeper: master.mesos:2181
 api-port: {{PORT0}}
 pods:
   pod-type:

--- a/sdk/scheduler/src/test/resources/valid-customzk.yml
+++ b/sdk/scheduler/src/test/resources/valid-customzk.yml
@@ -1,5 +1,6 @@
 name: "hello-world"
 principal: "hello-world-principal"
+zookeeper: custom.master.mesos:2181
 api-port: {{PORT0}}
 pods:
   pod-type:

--- a/sdk/scheduler/src/test/resources/valid-minimal-health.yml
+++ b/sdk/scheduler/src/test/resources/valid-minimal-health.yml
@@ -1,6 +1,5 @@
 name: "hello-world"
 principal: "hello-world-principal"
-zookeeper: master.mesos:2181
 api-port: {{PORT0}}
 pods:
   pod-type:

--- a/sdk/scheduler/src/test/resources/valid-multiple-ports.yml
+++ b/sdk/scheduler/src/test/resources/valid-multiple-ports.yml
@@ -1,6 +1,5 @@
 name: "data-store"
 principal: "data-store-principal"
-zookeeper: master.mesos:2181
 api-port: {{PORT0}}
 pods:
   meta-data:

--- a/sdk/scheduler/src/test/resources/valid-simple.yml
+++ b/sdk/scheduler/src/test/resources/valid-simple.yml
@@ -1,6 +1,5 @@
 name: "data-store"
 principal: "data-store-principal"
-zookeeper: master.mesos:2181
 api-port: {{PORT0}}
 pods:
   meta-data:


### PR DESCRIPTION
This PR makes configuration of zookeeper connection string optional for both YAML and Java interfaces. By default, the value of zookeeper connection string is "master.mesos:2181". This value can be over-ridden in the YAML interface via:

```yaml
...
zookeeper: custom.master.mesos:2181
...
```

or in Java interface via:

```java
new DefaultService(DefaultServiceSpec.newBuilder()
                    .zookeeperConnection("custom.master.mesos:2181")
```