### PR TITLE
Replace string URIs in Specs with UriSpec

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/DefaultOfferRequirementProvider.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/DefaultOfferRequirementProvider.java
@@ -9,7 +9,6 @@ import org.apache.mesos.Protos;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.net.URI;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -211,8 +210,17 @@ public class DefaultOfferRequirementProvider implements OfferRequirementProvider
                     .setValue(commandSpec.getValue())
                     .setEnvironment(mergeEnvironments(getTaskEnvironment(
                             podInstance, taskSpec, commandSpec), taskInfo.getCommand().getEnvironment()));
-            for (URI uri : commandSpec.getUris()) {
-                commandBuilder.addUrisBuilder().setValue(uri.toString());
+            for (UriSpec uri : commandSpec.getUris()) {
+                commandBuilder.addUrisBuilder()
+                        .setValue(uri.toString())
+                        .setExecutable(uri.isExecutable())
+                        .setExtract(uri.shouldExtract())
+                        .setCache(uri.shouldCache());
+
+                if (uri.getOutputFile().isPresent()) {
+                    commandBuilder.addUrisBuilder()
+                            .setOutputFile(uri.getOutputFile().get());
+                }
             }
             // Overwrite any prior CommandInfo:
             taskInfoBuilder.setCommand(commandBuilder);
@@ -504,8 +512,17 @@ public class DefaultOfferRequirementProvider implements OfferRequirementProvider
             if (!taskSpec.getCommand().isPresent()) {
                 continue;
             }
-            for (URI uri : taskSpec.getCommand().get().getUris()) {
-                commandInfoBuilder.addUrisBuilder().setValue(uri.toString());
+            for (UriSpec uri : taskSpec.getCommand().get().getUris()) {
+                commandInfoBuilder.addUrisBuilder()
+                        .setValue(uri.toString())
+                        .setExecutable(uri.isExecutable())
+                        .setExtract(uri.shouldExtract())
+                        .setCache(uri.shouldCache());
+
+                if (uri.getOutputFile().isPresent()) {
+                    commandInfoBuilder.addUrisBuilder()
+                            .setOutputFile(uri.getOutputFile().get());
+                }
             }
         }
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/CommandSpec.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/CommandSpec.java
@@ -3,7 +3,6 @@ package com.mesosphere.sdk.specification;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
-import java.net.URI;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
@@ -23,5 +22,5 @@ public interface CommandSpec {
     Optional<String> getUser();
 
     @JsonProperty("uris")
-    Collection<URI> getUris();
+    Collection<UriSpec> getUris();
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultCommandSpec.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultCommandSpec.java
@@ -2,15 +2,14 @@ package com.mesosphere.sdk.specification;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
-
 import com.mesosphere.sdk.config.ConfigNamespace;
 import com.mesosphere.sdk.config.DefaultTaskConfigRouter;
 import com.mesosphere.sdk.specification.validation.ValidationUtils;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
+import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
-import java.net.URI;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
@@ -24,18 +23,20 @@ public class DefaultCommandSpec implements CommandSpec {
     private String value;
     private Map<String, String> environment;
     private String user;
-    private Collection<URI> uris;
+    @Valid
+    private Collection<UriSpec> uris;
 
     @JsonCreator
     public DefaultCommandSpec(
             @JsonProperty("value") String value,
             @JsonProperty("environment") Map<String, String> environment,
             @JsonProperty("user") String user,
-            @JsonProperty("uris") Collection<URI> uris) {
+            @JsonProperty("uris") Collection<UriSpec> uris) {
         this.value = value;
         this.environment = environment;
         this.user = user;
         this.uris = uris;
+        ValidationUtils.validate(this);
     }
 
     private DefaultCommandSpec(Builder builder) {
@@ -88,7 +89,7 @@ public class DefaultCommandSpec implements CommandSpec {
     }
 
     @Override
-    public Collection<URI> getUris() {
+    public Collection<UriSpec> getUris() {
         return uris;
     }
 
@@ -111,7 +112,7 @@ public class DefaultCommandSpec implements CommandSpec {
         private String value;
         private Map<String, String> environment;
         private String user;
-        private Collection<URI> uris;
+        private Collection<UriSpec> uris;
 
         /**
          * Creates a new {@link Builder} with the provided {@link ConfigNamespace} containing override envvars.
@@ -175,7 +176,7 @@ public class DefaultCommandSpec implements CommandSpec {
          * @param uris the {@code uris} to set
          * @return a reference to this Builder
          */
-        public Builder uris(Collection<URI> uris) {
+        public Builder uris(Collection<UriSpec> uris) {
             this.uris = uris;
             return this;
         }
@@ -186,9 +187,7 @@ public class DefaultCommandSpec implements CommandSpec {
          * @return a {@code DefaultCommandSpec} built with parameters of this {@code DefaultCommandSpec.Builder}
          */
         public DefaultCommandSpec build() {
-            DefaultCommandSpec defaultCommandSpec = new DefaultCommandSpec(this);
-            ValidationUtils.validate(defaultCommandSpec);
-            return defaultCommandSpec;
+            return new DefaultCommandSpec(this);
         }
     }
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultServiceSpec.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultServiceSpec.java
@@ -3,9 +3,6 @@ package com.mesosphere.sdk.specification;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
 import com.mesosphere.sdk.config.ConfigStoreException;
 import com.mesosphere.sdk.config.ConfigurationComparator;
 import com.mesosphere.sdk.config.ConfigurationFactory;
@@ -13,6 +10,9 @@ import com.mesosphere.sdk.config.SerializationUtils;
 import com.mesosphere.sdk.offer.constrain.*;
 import com.mesosphere.sdk.specification.validation.UniquePodType;
 import com.mesosphere.sdk.specification.validation.ValidationUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import javax.validation.Valid;
 import javax.validation.constraints.Min;
@@ -225,6 +225,8 @@ public class DefaultServiceSpec implements ServiceSpec {
                 AndRule.class,
                 AnyMatcher.class,
                 AttributeRule.class,
+                DefaultResourceSpec.class,
+                DefaultUriSpec.class,
                 ExactMatcher.class,
                 HostnameRule.class,
                 MaxPerAttributeRule.class,

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultTaskSpec.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultTaskSpec.java
@@ -2,15 +2,14 @@ package com.mesosphere.sdk.specification;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import com.mesosphere.sdk.offer.TaskUtils;
 import com.mesosphere.sdk.specification.validation.ValidationUtils;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
-import java.net.URI;
 import java.util.Collection;
 import java.util.Optional;
 
@@ -38,7 +37,7 @@ public class DefaultTaskSpec implements TaskSpec {
     @NotNull
     private ResourceSet resourceSet;
 
-    private Collection<URI> uris;
+    private Collection<UriSpec> uris;
     private Collection<ConfigFileSpec> configFiles;
 
     @JsonCreator
@@ -49,7 +48,7 @@ public class DefaultTaskSpec implements TaskSpec {
             @JsonProperty("command-spec") CommandSpec commandSpec,
             @JsonProperty("health-check-spec") HealthCheckSpec healthCheckSpec,
             @JsonProperty("readiness-check-spec") ReadinessCheckSpec readinessCheckSpec,
-            @JsonProperty("uris") Collection<URI> uris,
+            @JsonProperty("uris") Collection<UriSpec> uris,
             @JsonProperty("config-files") Collection<ConfigFileSpec> configFiles) {
         this.name = name;
         this.goalState = goalState;
@@ -59,6 +58,7 @@ public class DefaultTaskSpec implements TaskSpec {
         this.readinessCheckSpec = readinessCheckSpec;
         this.uris = uris;
         this.configFiles = configFiles;
+        ValidationUtils.validate(this);
     }
 
     private DefaultTaskSpec(Builder builder) {
@@ -120,7 +120,7 @@ public class DefaultTaskSpec implements TaskSpec {
     }
 
     @Override
-    public Collection<URI> getUris() {
+    public Collection<UriSpec> getUris() {
         return uris;
     }
 
@@ -157,9 +157,9 @@ public class DefaultTaskSpec implements TaskSpec {
         private ResourceSet resourceSet;
         private CommandSpec commandSpec;
         private HealthCheckSpec healthCheckSpec;
-        private ReadinessCheckSpec readinessCheckSpec;
-        private Collection<URI> uris;
+        private Collection<UriSpec> uris;
         private Collection<ConfigFileSpec> configFiles;
+        private ReadinessCheckSpec readinessCheckSpec;
 
         private Builder() {
         }
@@ -234,7 +234,7 @@ public class DefaultTaskSpec implements TaskSpec {
          * @param uris the {@code uris} to set
          * @return a reference to this Builder
          */
-        public Builder uris(Collection<URI> uris) {
+        public Builder uris(Collection<UriSpec> uris) {
             this.uris = uris;
             return this;
         }
@@ -257,9 +257,7 @@ public class DefaultTaskSpec implements TaskSpec {
          * @return a {@code DefaultTaskSpec} built with parameters of this {@code DefaultTaskSpec.Builder}
          */
         public DefaultTaskSpec build() {
-            DefaultTaskSpec defaultTaskSpec = new DefaultTaskSpec(this);
-            ValidationUtils.validate(defaultTaskSpec);
-            return defaultTaskSpec;
+            return new DefaultTaskSpec(this);
         }
     }
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultUriSpec.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultUriSpec.java
@@ -1,0 +1,176 @@
+package com.mesosphere.sdk.specification;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.mesosphere.sdk.specification.validation.ValidationUtils;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+import javax.validation.constraints.NotNull;
+import java.net.URI;
+import java.util.Optional;
+
+/**
+ * Default implementation of {@link UriSpec}.
+ */
+public class DefaultUriSpec implements UriSpec {
+    @NotNull
+    private final String value;
+    private final boolean isExecutable;
+    private final boolean shouldExtract;
+    private final boolean shouldCache;
+    private final String outputFile;
+
+    @JsonCreator
+    public DefaultUriSpec(
+            @JsonProperty("value") String value,
+            @JsonProperty("executable") boolean isExecutable,
+            @JsonProperty("extract") boolean shouldExtract,
+            @JsonProperty("cache") boolean shouldCache,
+            @JsonProperty("output-file") String outputFile) {
+        this.value = value;
+        this.isExecutable = isExecutable;
+        this.shouldExtract = shouldExtract;
+        this.shouldCache = shouldCache;
+        this.outputFile = outputFile;
+        ValidationUtils.validate(this);
+    }
+
+    public DefaultUriSpec(String value) {
+        this(value, false, true, true, null);
+    }
+
+    public DefaultUriSpec(URI uri) {
+        this(uri.toString());
+    }
+
+    public DefaultUriSpec(Builder builder) {
+        this(
+                builder.value,
+                builder.isExecutable,
+                builder.shouldExtract,
+                builder.shouldCache,
+                builder.outputFile);
+    }
+
+    @Override
+    @JsonProperty("value")
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    @JsonProperty("executable")
+    public boolean isExecutable() {
+        return isExecutable;
+    }
+
+    @Override
+    @JsonProperty("extract")
+    public boolean shouldExtract() {
+        return shouldExtract;
+    }
+
+    @Override
+    @JsonProperty("cache")
+    public boolean shouldCache() {
+        return shouldCache;
+    }
+
+    @Override
+    @JsonProperty("output-file")
+    public Optional<String> getOutputFile() {
+        return Optional.ofNullable(outputFile);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return EqualsBuilder.reflectionEquals(this, o);
+    }
+
+    @Override
+    public int hashCode() {
+        return HashCodeBuilder.reflectionHashCode(this);
+    }
+
+    /**
+     * {@code DefaultUriSpec} builder static inner class.
+     */
+    public static final class Builder {
+        private String value;
+        private boolean isExecutable;
+        private boolean shouldExtract;
+        private boolean shouldCache;
+        private String outputFile;
+
+        private Builder() {
+        }
+
+        /**
+         * Sets the {@code value} and returns a reference to this Builder so that the methods can be chained together.
+         *
+         * @param value the {@code value} to set
+         * @return a reference to this Builder
+         */
+        public Builder value(String value) {
+            this.value = value;
+            return this;
+        }
+
+        /**
+         * Sets {@code executable} and returns a reference to this Builder so that the methods can be chained together.
+         *
+         * @param isExecutable sets a flag to indicate the content of the URI is executable
+         * @return a reference to this Builder
+         */
+        public Builder executable(boolean isExecutable) {
+            this.isExecutable = isExecutable;
+            return this;
+        }
+
+        /**
+         * Sets {@code extractable} and returns a reference to this Builder so that the methods can be chained together.
+         *
+         * @param shouldExtract sets a flag to indicate the content of the URI should be extracted
+         * @return a reference to this Builder
+         */
+        public Builder extract(boolean shouldExtract) {
+            this.shouldExtract = shouldExtract;
+            return this;
+        }
+
+        /**
+         * Sets {@code extractable} and returns a reference to this Builder so that the methods can be chained together.
+         *
+         * @param shouldCache sets a flag to indicate the content of the URI should be extracted
+         * @return a reference to this Builder
+         */
+        public Builder cache(boolean shouldCache) {
+            this.shouldCache = shouldCache;
+            return this;
+        }
+
+        /**
+         * Sets the {@code outputFile} and returns a reference to this Builder so that the methods can be chained
+         * together.
+         *
+         * @param outputFile the {@code outputFile} to set
+         * @return a reference to this Builder
+         */
+        public Builder outputFile(String outputFile) {
+            this.outputFile = outputFile;
+            return this;
+        }
+
+
+        /**
+         * Returns a {@code DefaultResourceSpecification} built from the parameters previously set.
+         *
+         * @return a {@code DefaultResourceSpecification} built with parameters of this
+         * {@code DefaultResourceSpecification.Builder}
+         */
+        public DefaultUriSpec build() {
+            return new DefaultUriSpec(this);
+        }
+    }
+}

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/TaskSpec.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/TaskSpec.java
@@ -3,7 +3,6 @@ package com.mesosphere.sdk.specification;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
-import java.net.URI;
 import java.util.Collection;
 import java.util.Optional;
 
@@ -31,7 +30,7 @@ public interface TaskSpec {
     Optional<ReadinessCheckSpec> getReadinessCheck();
 
     @JsonProperty("uris")
-    Collection<URI> getUris();
+    Collection<UriSpec> getUris();
 
     @JsonProperty("config-files")
     Collection<ConfigFileSpec> getConfigFiles();

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/UriSpec.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/UriSpec.java
@@ -1,0 +1,27 @@
+package com.mesosphere.sdk.specification;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+import java.util.Optional;
+
+/**
+ * Specification for defining a URI.
+ */
+@JsonDeserialize(as = DefaultUriSpec.class)
+public interface UriSpec {
+    @JsonProperty("value")
+    String getValue();
+
+    @JsonProperty("executable")
+    boolean isExecutable();
+
+    @JsonProperty("extract")
+    boolean shouldExtract();
+
+    @JsonProperty("cache")
+    boolean shouldCache();
+
+    @JsonProperty("output-file")
+    Optional<String> getOutputFile();
+}

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/YAMLToInternalMappers.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/YAMLToInternalMappers.java
@@ -176,11 +176,14 @@ public class YAMLToInternalMappers {
             Collection<ResourceSet> resourceSets,
             String role,
             String principal) throws Exception {
-        Collection<URI> uris = new ArrayList<>();
+        Collection<UriSpec> uris = new ArrayList<>();
         for (String uriStr : rawTask.getUris()) {
-            uris.add(new URI(uriStr));
+            uris.add(new DefaultUriSpec(uriStr));
         }
-        uris.addAll(podUris);
+
+        for (URI uri : podUris) {
+            uris.add(new DefaultUriSpec(uri));
+        }
 
         DefaultCommandSpec.Builder commandSpecBuilder = DefaultCommandSpec.newBuilder(configNamespace)
                 .environment(rawTask.getEnv())


### PR DESCRIPTION
This allows configuration of all the features avaiable to URIs
as defined in Mesos protobufs including in particular caching
features.  The UriSpec differs from the Mesos protobuf representation
of a URI in caching URIs by default.