### PR TITLE
return WAITING in Plan and Phase, if interrupted and not completed.

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/DefaultScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/DefaultScheduler.java
@@ -757,6 +757,7 @@ public class DefaultScheduler implements Scheduler, Observer {
                 try {
                     stateStore.storeStatus(status);
                     planCoordinator.getPlanManagers().stream()
+                            //TODO: why do you ignore waiting plan here?
                             .filter(planManager -> !planManager.getPlan().isWaiting())
                             .forEach(planManager -> planManager.update(status));
                     reconciler.update(status);

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/DefaultScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/DefaultScheduler.java
@@ -757,8 +757,6 @@ public class DefaultScheduler implements Scheduler, Observer {
                 try {
                     stateStore.storeStatus(status);
                     planCoordinator.getPlanManagers().stream()
-                            //TODO: why do you ignore waiting plan here?
-                            .filter(planManager -> !planManager.getPlan().isWaiting())
                             .forEach(planManager -> planManager.update(status));
                     reconciler.update(status);
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/DefaultScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/DefaultScheduler.java
@@ -616,7 +616,7 @@ public class DefaultScheduler implements Scheduler, Observer {
     private void initializeResources() throws InterruptedException {
         LOGGER.info("Initializing resources...");
         Collection<Object> resources = new ArrayList<>();
-        resources.add(new ConfigResource<ServiceSpec>(configStore));
+        resources.add(new ConfigResource<>(configStore));
         EndpointsResource endpointsResource = new EndpointsResource(stateStore, serviceSpec.getName());
         for (Map.Entry<String, EndpointProducer> entry : customEndpointProducers.entrySet()) {
             endpointsResource.setCustomEndpoint(entry.getKey(), entry.getValue());

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/AbstractStep.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/AbstractStep.java
@@ -44,7 +44,7 @@ public abstract class AbstractStep extends DefaultObservable implements Step {
     @Override
     public Status getStatus() {
         synchronized (statusLock) {
-            if (interrupted && status == Status.PENDING) {
+            if (interrupted &&  ( status == Status.PENDING || status == Status.PREPARED)) {
                 return Status.WAITING;
             }
             return status;

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/DefaultPlanScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/DefaultPlanScheduler.java
@@ -78,6 +78,7 @@ public class DefaultPlanScheduler implements PlanScheduler {
             return Collections.emptyList();
         }
 
+        //TODO: if you interrupt in the middle, after getCandidates, it will still omit it, correct?
         if (!(step.isPending() || step.isPrepared())) {
             logger.info("Ignoring resource offers for step: {} status: {}", step.getName(), step.getStatus());
             return Collections.emptyList();

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/DefaultPlanScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/DefaultPlanScheduler.java
@@ -78,7 +78,6 @@ public class DefaultPlanScheduler implements PlanScheduler {
             return Collections.emptyList();
         }
 
-        //TODO: if you interrupt in the middle, after getCandidates, it will still omit it, correct?
         if (!(step.isPending() || step.isPrepared())) {
             logger.info("Ignoring resource offers for step: {} status: {}", step.getName(), step.getStatus());
             return Collections.emptyList();

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/Element.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/Element.java
@@ -96,10 +96,4 @@ public interface Element extends Observable {
         return getStatus().equals(Status.COMPLETE);
     }
 
-    /**
-     * Indicates whether this Element is in progress.
-     */
-    default boolean isInProgress() {
-        return isPrepared() || isStarting();
-    }
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/PlanUtils.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/PlanUtils.java
@@ -125,7 +125,7 @@ public class PlanUtils {
             result = Status.WAITING;
             LOGGER.debug("({} status={}) At least one element has status: {}",
                     parent.getName(), result, Status.WAITING);
-        }  else if (allHaveStatus(Status.PENDING, children)) {
+        } else if (allHaveStatus(Status.PENDING, children)) {
             result = Status.PENDING;
             LOGGER.debug("({} status={}) All elements have status: {}",
                     parent.getName(), result, Status.PENDING);

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/Status.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/Status.java
@@ -29,6 +29,8 @@ public enum Status {
 
     /**
      * Execution has been interrupted.
+     *
+     * This value is only returned and never set to a variable.
      */
     WAITING,
 
@@ -56,8 +58,8 @@ public enum Status {
     //TODO: make enum implement an interface, forbid step status to be set to WAITING or IN_PROGRESS
 
     /**
-     * Only returned by Phase and Plan getStatus, to state that at least one child is complete and at least one child
-     * is in progress (either PENDING or PREPARED).
+     * Only returned by Phase and Plan getStatus, to state that at least one child is complete and at
+     * least one child is in progress (either PENDING or PREPARED).
      *
      * This value is only returned and never set to a variable.
      */

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/Status.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/Status.java
@@ -22,6 +22,8 @@ public enum Status {
 
     /**
      * Execution experienced an error.
+     *
+     * This value is only returned and never set to a variable.
      */
     ERROR,
 
@@ -49,6 +51,15 @@ public enum Status {
     /**
      * Execution has completed.
      */
-    COMPLETE
+    COMPLETE,
 
+    //TODO: make enum implement an interface, forbid step status to be set to WAITING or IN_PROGRESS
+
+    /**
+     * Only returned by Phase and Plan getStatus, to state that at least one child is complete and at least one child
+     * is in progress (either PENDING or PREPARED).
+     *
+     * This value is only returned and never set to a variable.
+     */
+    IN_PROGRESS
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/Status.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/Status.java
@@ -22,8 +22,6 @@ public enum Status {
 
     /**
      * Execution experienced an error.
-     *
-     * This value is only returned and never set to a variable.
      */
     ERROR,
 
@@ -56,7 +54,6 @@ public enum Status {
     COMPLETE,
 
     //TODO: make enum implement an interface, forbid step status to be set to WAITING or IN_PROGRESS
-
     /**
      * Only returned by Phase and Plan getStatus, to state that at least one child is complete and at
      * least one child is in progress (either PENDING or PREPARED).

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/Step.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/Step.java
@@ -47,7 +47,7 @@ public interface Step extends Element, Interruptible {
      * Reports whether the Asset associated with this Step is dirty.
      */
     default boolean isAssetDirty() {
-        return isInProgress();
+        return isPrepared() || isStarting();
     }
 
     /**

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/plan/DefaultPlanManagerTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/plan/DefaultPlanManagerTest.java
@@ -59,7 +59,7 @@ public class DefaultPlanManagerTest {
         Assert.assertEquals(Status.PENDING, firstPhase.getStatus());
 
         firstStep.setStatus(Status.PREPARED);
-        Assert.assertEquals(Status.PREPARED, firstPhase.getStatus());
+        Assert.assertEquals(Status.IN_PROGRESS, firstPhase.getStatus());
 
         firstStep.setStatus(Status.COMPLETE);
         Assert.assertEquals(Status.COMPLETE, firstPhase.getStatus());
@@ -83,10 +83,10 @@ public class DefaultPlanManagerTest {
         Assert.assertEquals(Status.WAITING, planManager.getPlan().getStatus());
 
         firstStep.setStatus(Status.PREPARED);
-        Assert.assertEquals(Status.PREPARED, planManager.getPlan().getStatus());
+        Assert.assertEquals(Status.IN_PROGRESS, planManager.getPlan().getStatus());
 
         completePhase(plan.getChildren().get(0));
-        Assert.assertEquals(Status.PREPARED, planManager.getPlan().getStatus());
+        Assert.assertEquals(Status.IN_PROGRESS, planManager.getPlan().getStatus());
 
         completePhase(plan.getChildren().get(1));
         Assert.assertEquals(Status.COMPLETE, planManager.getPlan().getStatus());
@@ -115,7 +115,7 @@ public class DefaultPlanManagerTest {
         PlanManager manager = new DefaultPlanManager(inProgressPlan);
         Assert.assertEquals(Status.WAITING, manager.getPlan().getStatus());
         manager.getPlan().proceed();
-        Assert.assertEquals(Status.PREPARED, manager.getPlan().getStatus());
+        Assert.assertEquals(Status.IN_PROGRESS, manager.getPlan().getStatus());
     }
 
     @Test
@@ -231,8 +231,8 @@ public class DefaultPlanManagerTest {
 
         PlanManager waitingManager = new DefaultPlanManager(waitingPlan);
         Assert.assertEquals(Status.WAITING, waitingManager.getPlan().getStatus());
-        waitingPlan.proceed();
-        Assert.assertEquals(Status.PREPARED, waitingManager.getPlan().getStatus());
+        waitingManager.getPlan().proceed();
+        Assert.assertEquals(Status.IN_PROGRESS, waitingManager.getPlan().getStatus());
 
         final Set<String> dirtyAssets = waitingManager.getDirtyAssets();
         Assert.assertEquals(2, dirtyAssets.size());
@@ -263,7 +263,7 @@ public class DefaultPlanManagerTest {
         PlanManager waitingManager = new DefaultPlanManager(waitingPlan);
         Assert.assertEquals(Status.WAITING, waitingManager.getPlan().getStatus());
         waitingPlan.proceed();
-        Assert.assertEquals(Status.PREPARED, waitingManager.getPlan().getStatus());
+        Assert.assertEquals(Status.IN_PROGRESS, waitingManager.getPlan().getStatus());
 
         final Set<String> dirtyAssets = waitingManager.getDirtyAssets();
         Assert.assertEquals(1, dirtyAssets.size());
@@ -291,13 +291,16 @@ public class DefaultPlanManagerTest {
         step2.setStatus(Status.PREPARED);
 
         PlanManager waitingManager = new DefaultPlanManager(waitingPlan);
+
+        Assert.assertFalse(phase.isInterrupted());
         Assert.assertEquals(Status.WAITING, waitingManager.getPlan().getStatus());
-        waitingPlan.proceed();
-        Assert.assertEquals(Status.PREPARED, waitingManager.getPlan().getStatus());
 
         final Set<String> dirtyAssets = waitingManager.getDirtyAssets();
         Assert.assertEquals(1, dirtyAssets.size());
         Assert.assertTrue(dirtyAssets.contains("test-step-2"));
+
+        waitingManager.getPlan().proceed();
+        Assert.assertEquals(Status.IN_PROGRESS, waitingManager.getPlan().getStatus());
     }
 
     private static void completePhase(Phase phase) {


### PR DESCRIPTION
-Plan and Phase return WAITING, if interrupted and not completed.
-IN_PROGRESS status only for plans and phases

DefaultPlan and DefaultPhase used to check if interrupted in getStatus. That is omitted when we remove Element.setStatus. Putting back this feature in PlanUtils.getStatus (only Plan and Phase call PlanUtils.getStatus)!