### PR TITLE
Add web-url to ServiceSpec

### DIFF
--- a/frameworks/helloworld/integration/tests/test_web_url.py
+++ b/frameworks/helloworld/integration/tests/test_web_url.py
@@ -1,0 +1,43 @@
+import dcos.http
+import json
+import pytest
+import re
+import shakedown
+
+from tests.test_utils import (
+    PACKAGE_NAME,
+    check_health,
+    get_marathon_config,
+    get_deployment_plan,
+    get_sidecar_plan,
+    get_task_count,
+    install,
+    marathon_api_url,
+    request,
+    run_dcos_cli_cmd,
+    uninstall,
+    spin,
+    start_sidecar_plan
+)
+
+
+def setup_module(module):
+    uninstall()
+    options = {
+        "service": {
+            "spec_file": "examples/web-url.yml"
+        }
+    }
+
+    install(None, PACKAGE_NAME, options)
+
+
+@pytest.mark.sanity
+def test_deploy():
+    deployment_plan = get_deployment_plan().json()
+    print("deployment_plan: " + str(deployment_plan))
+
+    assert(len(deployment_plan['phases']) == 1)
+    assert(deployment_plan['phases'][0]['name'] == 'hello')
+    assert(len(deployment_plan['phases'][0]['steps']) == 1)
+

--- a/frameworks/helloworld/src/main/dist/examples/web-url.yml
+++ b/frameworks/helloworld/src/main/dist/examples/web-url.yml
@@ -2,6 +2,7 @@ name: "hello-world"
 principal: "hello-world-principal"
 zookeeper: master.mesos:2181
 api-port: {{PORT0}}
+web-url: http://hello-world.marathon.mesos:{{PORT0}}
 pods:
   hello:
     count: {{HELLO_COUNT}}

--- a/frameworks/helloworld/src/main/resources/examples/web-url.yml
+++ b/frameworks/helloworld/src/main/resources/examples/web-url.yml
@@ -1,0 +1,1 @@
+../../dist/examples/web-url.yml

--- a/frameworks/helloworld/src/test/java/com/mesosphere/sdk/helloworld/scheduler/ServiceSpecTest.java
+++ b/frameworks/helloworld/src/test/java/com/mesosphere/sdk/helloworld/scheduler/ServiceSpecTest.java
@@ -55,39 +55,45 @@ public class ServiceSpecTest {
     }
 
     @Test
-    public void test_yml_base() throws Exception {
+    public void testYmlBase() throws Exception {
         deserializeServiceSpec("svc.yml");
         validateServiceSpec("svc.yml");
     }
 
     @Test
-    public void test_yml_simple() throws Exception {
+    public void testYmlSimple() throws Exception {
         deserializeServiceSpec("examples/simple.yml");
         validateServiceSpec("examples/simple.yml");
     }
 
     @Test
-    public void test_yml_plan() throws Exception {
+    public void testYmlPlan() throws Exception {
         deserializeServiceSpec("examples/plan.yml");
         validateServiceSpec("examples/plan.yml");
     }
 
     @Test
-    public void test_yml_sidecar() throws Exception {
+    public void testYmlSidecar() throws Exception {
         deserializeServiceSpec("examples/sidecar.yml");
         validateServiceSpec("examples/sidecar.yml");
     }
 
     @Test
-    public void test_yml_taskcfg() throws Exception {
+    public void testYmlTaskcfg() throws Exception {
         deserializeServiceSpec("examples/taskcfg.yml");
         validateServiceSpec("examples/taskcfg.yml");
     }
 
     @Test
-    public void test_yml_uri() throws Exception {
+    public void testYmlUri() throws Exception {
         deserializeServiceSpec("examples/uri.yml");
         validateServiceSpec("examples/uri.yml");
+    }
+
+    @Test
+    public void testYmlWebUrl() throws Exception {
+        deserializeServiceSpec("examples/web-url.yml");
+        validateServiceSpec("examples/web-url.yml");
     }
 
     private void deserializeServiceSpec(String fileName) throws Exception {

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultService.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultService.java
@@ -163,7 +163,7 @@ public class DefaultService implements Service {
         new SchedulerDriverFactory().create(sched, frameworkInfo, String.format("zk://%s/mesos", zookeeperHost)).run();
     }
 
-    private Protos.FrameworkInfo getFrameworkInfo(ServiceSpec serviceSpec, StateStore stateStore) {
+    protected Protos.FrameworkInfo getFrameworkInfo(ServiceSpec serviceSpec, StateStore stateStore) {
         final String serviceName = serviceSpec.getName();
 
         Protos.FrameworkInfo.Builder fwkInfoBuilder = getFrameworkInfoBuilder(serviceName);
@@ -186,6 +186,10 @@ public class DefaultService implements Service {
         Optional<Protos.FrameworkID> optionalFrameworkId = stateStore.fetchFrameworkId();
         if (optionalFrameworkId.isPresent()) {
             fwkInfoBuilder.setId(optionalFrameworkId.get());
+        }
+
+        if (!StringUtils.isEmpty(serviceSpec.getWebUrl())) {
+            fwkInfoBuilder.setWebuiUrl(serviceSpec.getWebUrl());
         }
 
         return fwkInfoBuilder.build();

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultServiceSpec.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultServiceSpec.java
@@ -41,7 +41,7 @@ public class DefaultServiceSpec implements ServiceSpec {
     @NotNull
     @Min(value = 0, message = "API port value should be >= 0")
     private Integer apiPort;
-
+    private String webUrl;
     private String zookeeperConnection;
 
     @Valid
@@ -59,6 +59,7 @@ public class DefaultServiceSpec implements ServiceSpec {
             @JsonProperty("role") String role,
             @JsonProperty("principal") String principal,
             @JsonProperty("api-port") int apiPort,
+            @JsonProperty("web-url") String webUrl,
             @JsonProperty("zookeeper") String zookeeperConnection,
             @JsonProperty("pod-specs") List<PodSpec> pods,
             @JsonProperty("replacement-failure-policy") ReplacementFailurePolicy replacementFailurePolicy) {
@@ -66,23 +67,25 @@ public class DefaultServiceSpec implements ServiceSpec {
         this.role = role;
         this.principal = principal;
         this.apiPort = apiPort;
+        this.webUrl = webUrl;
         // If no zookeeperConnection string is configured, fallback to the default value.
         this.zookeeperConnection = StringUtils.isBlank(zookeeperConnection)
                 ? DEFAULT_ZK_CONNECTION : zookeeperConnection;
         this.pods = pods;
         this.replacementFailurePolicy = replacementFailurePolicy;
+        ValidationUtils.validate(this);
     }
 
     private DefaultServiceSpec(Builder builder) {
-        name = builder.name;
-        role = builder.role;
-        principal = builder.principal;
-        apiPort = builder.apiPort;
-        // If no zookeeperConnection string is configured, fallback to the default value.
-        zookeeperConnection = StringUtils.isBlank(builder.zookeeperConnection)
-                ? DEFAULT_ZK_CONNECTION : builder.zookeeperConnection;
-        pods = builder.pods;
-        replacementFailurePolicy = builder.replacementFailurePolicy;
+        this(
+                builder.name,
+                builder.role,
+                builder.principal,
+                builder.apiPort,
+                builder.webUrl,
+                builder.zookeeperConnection,
+                builder.pods,
+                builder.replacementFailurePolicy);
     }
 
     public static Builder newBuilder() {
@@ -119,6 +122,11 @@ public class DefaultServiceSpec implements ServiceSpec {
     @Override
     public int getApiPort() {
         return apiPort;
+    }
+
+    @Override
+    public String getWebUrl() {
+        return webUrl;
     }
 
     @Override
@@ -271,6 +279,7 @@ public class DefaultServiceSpec implements ServiceSpec {
         private String role;
         private String principal;
         private Integer apiPort;
+        private String webUrl;
         private String zookeeperConnection;
         private List<PodSpec> pods = new ArrayList<>();
         private ReplacementFailurePolicy replacementFailurePolicy;
@@ -320,6 +329,17 @@ public class DefaultServiceSpec implements ServiceSpec {
          */
         public Builder apiPort(Integer apiPort) {
             this.apiPort = apiPort;
+            return this;
+        }
+
+        /**
+         * Sets the {@code webUrl} and returns a reference to this Builder so that the methods can be chained together.
+         *
+         * @param webUrl the {@code webUrl} to set
+         * @return a reference to this Builder
+         */
+        public Builder webUrl(String webUrl) {
+            this.webUrl = webUrl;
             return this;
         }
 
@@ -375,9 +395,7 @@ public class DefaultServiceSpec implements ServiceSpec {
          * @return a {@code DefaultServiceSpec} built with parameters of this {@code DefaultServiceSpec.Builder}
          */
         public DefaultServiceSpec build() {
-            DefaultServiceSpec defaultServiceSpec = new DefaultServiceSpec(this);
-            ValidationUtils.validate(defaultServiceSpec);
-            return defaultServiceSpec;
+            return new DefaultServiceSpec(this);
         }
     }
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/ServiceSpec.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/ServiceSpec.java
@@ -24,6 +24,9 @@ public interface ServiceSpec extends Configuration {
     @JsonProperty("api-port")
     int getApiPort();
 
+    @JsonProperty("web-url")
+    String getWebUrl();
+
     @JsonProperty("zookeeper")
     String getZookeeperConnection();
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/RawServiceSpec.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/RawServiceSpec.java
@@ -16,11 +16,13 @@ public class RawServiceSpec {
     private final WriteOnceLinkedHashMap<String, RawPod> pods;
     private final WriteOnceLinkedHashMap<String, RawPlan> plans;
     private final RawReplacementFailurePolicy replacementFailurePolicy;
+    private final String webUrl;
 
     private RawServiceSpec(
             @JsonProperty("name") String name,
             @JsonProperty("principal") String principal,
             @JsonProperty("api-port") Integer apiPort,
+            @JsonProperty("web-url") String webUrl,
             @JsonProperty("zookeeper") String zookeeper,
             @JsonProperty("pods") WriteOnceLinkedHashMap<String, RawPod> pods,
             @JsonProperty("plans") WriteOnceLinkedHashMap<String, RawPlan> plans,
@@ -28,6 +30,7 @@ public class RawServiceSpec {
         this.name = name;
         this.principal = principal;
         this.apiPort = apiPort;
+        this.webUrl = webUrl;
         this.zookeeper = zookeeper;
         this.pods = pods;
         this.plans = plans;
@@ -44,6 +47,10 @@ public class RawServiceSpec {
 
     public Integer getApiPort() {
         return apiPort;
+    }
+
+    public String getWebUrl() {
+        return webUrl;
     }
 
     public String getZookeeper() {

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/YAMLToInternalMappers.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/YAMLToInternalMappers.java
@@ -57,6 +57,7 @@ public class YAMLToInternalMappers {
         return builder
                 .name(rawSvcSpec.getName())
                 .apiPort(rawSvcSpec.getApiPort())
+                .webUrl(rawSvcSpec.getWebUrl())
                 .principal(principal)
                 .zookeeperConnection(rawSvcSpec.getZookeeper())
                 .pods(pods)


### PR DESCRIPTION
This is needed for the consumption of proxylite as a custom
proxy to multiple service APIs (e.g. the Scheduler API and Kibana)

Proxylite is a container under development which is deployable as a pod
in each service which will provide routing through admin router to 
framework author specified HTTP endpoints.