### PR TITLE
Add ability to provide custom RestartHook to DefaultScheduler.Builder

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/api/types/RestartHook.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/api/types/RestartHook.java
@@ -9,11 +9,11 @@ import java.util.Collection;
 public interface RestartHook {
 
     /**
-     * Notifies the hook that the provided {@code taskInfos} are about to be restarted or replaced. The hook should
+     * Notifies the hook that the provided {@code tasks} are about to be restarted or replaced. The hook should
      * determine based on the provided data whether any custom work is needed before the provided tasks are killed by
      * Mesos. The hook should only return once that work is completed (or has failed).
      *
-     * @param tasks the task(s) to be restarted or replaced along with any associated status
+     * @param tasks the task(s) to be restarted or replaced along with any associated statuses
      * @param replace whether the operation is a replacement ({@code true}) or an in-place restart ({@code false})
      * @return whether to proceed with the restart operation ({@code true}), or to abort the restart operation
      *     ({@code false})


### PR DESCRIPTION
Allows developers to specify custom teardown logic when 'pod restart' and/or 'pod replace' is invoked.