### PR TITLE
Fix the build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,13 @@ allprojects {
             events "passed", "skipped", "failed"
         }
     }
+
+    task copyExecutor(type: Copy) {
+        from('src/../../../sdk/executor/build/distributions/') {
+            include '**/*'
+        }
+        into('build/distributions')
+    }
 }
 
 ext {

--- a/frameworks/hdfs/build.gradle
+++ b/frameworks/hdfs/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 }
 
 distZip.dependsOn ":executor:distZip"
+distZip.finalizedBy copyExecutor
 
 distributions {
     main {

--- a/frameworks/hdfs/build.gradle
+++ b/frameworks/hdfs/build.gradle
@@ -28,19 +28,12 @@ dependencies {
     testCompile "org.mockito:mockito-all:${mockitoVer}"
 }
 
-buildDir = new File(rootProject.projectDir, "build/")
+distZip.dependsOn ":executor:distZip"
 
 distributions {
     main {
         baseName = 'hdfs-scheduler'
         version = ''
-    }
-}
-
-test {
-    filter {
-        //include all tests from package
-        includeTestsMatching "com.mesosphere.sdk.hdfs.*"
     }
 }
 

--- a/frameworks/hdfs/build.sh
+++ b/frameworks/hdfs/build.sh
@@ -6,7 +6,7 @@ curl https://mesosphere.com/wp-content/themes/mesosphere/library/images/assets/s
 
 FRAMEWORK_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOT_DIR=$FRAMEWORK_DIR/../..
-BUILD_DIR=$ROOT_DIR/build/distributions
+BUILD_DIR=$FRAMEWORK_DIR/build/distributions
 PUBLISH_STEP=${1-none}
 ${ROOT_DIR}/gradlew distZip -p ${ROOT_DIR}/sdk/executor
 ${ROOT_DIR}/tools/build_framework.sh $PUBLISH_STEP hdfs $FRAMEWORK_DIR $BUILD_DIR/executor.zip $BUILD_DIR/hdfs-scheduler.zip

--- a/frameworks/helloworld/build.gradle
+++ b/frameworks/helloworld/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 }
 
 distZip.dependsOn ":executor:distZip"
+distZip.finalizedBy copyExecutor
 
 distributions {
     main {

--- a/frameworks/helloworld/build.gradle
+++ b/frameworks/helloworld/build.gradle
@@ -28,19 +28,12 @@ dependencies {
     testCompile "org.mockito:mockito-all:${mockitoVer}"
 }
 
-buildDir = new File(rootProject.projectDir, "build/")
+distZip.dependsOn ":executor:distZip"
 
 distributions {
     main {
         baseName = 'hello-world-scheduler'
         version = ''
-    }
-}
-
-test {
-    filter {
-        //include all tests from package
-        includeTestsMatching "com.mesosphere.sdk.helloworld.*"
     }
 }
 

--- a/frameworks/helloworld/build.sh
+++ b/frameworks/helloworld/build.sh
@@ -6,7 +6,7 @@ curl https://mesosphere.com/wp-content/themes/mesosphere/library/images/assets/s
 
 FRAMEWORK_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOT_DIR=$FRAMEWORK_DIR/../..
-BUILD_DIR=$ROOT_DIR/build/distributions
+BUILD_DIR=$FRAMEWORK_DIR/build/distributions
 PUBLISH_STEP=${1-none}
 ${ROOT_DIR}/gradlew distZip -p ${ROOT_DIR}/sdk/executor
 ${ROOT_DIR}/tools/build_framework.sh $PUBLISH_STEP hello-world $FRAMEWORK_DIR $BUILD_DIR/executor.zip $BUILD_DIR/hello-world-scheduler.zip

--- a/frameworks/kafka/build.gradle
+++ b/frameworks/kafka/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 }
 
 distZip.dependsOn ":executor:distZip"
+distZip.finalizedBy copyExecutor
 
 distributions {
     main {

--- a/frameworks/kafka/build.gradle
+++ b/frameworks/kafka/build.gradle
@@ -19,8 +19,6 @@ ext {
     mockitoVer = "1.9.5"
 }
 
-buildDir = new File(rootProject.projectDir, "build/")
-
 dependencies {
     compile project(":scheduler")
     compile group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.21'
@@ -29,17 +27,12 @@ dependencies {
     testCompile "org.mockito:mockito-all:${mockitoVer}"
 }
 
+distZip.dependsOn ":executor:distZip"
+
 distributions {
     main {
         baseName = 'kafka-scheduler'
         version = ''
-    }
-}
-
-test {
-    filter {
-        //include all tests from package
-        includeTestsMatching "com.mesosphere.sdk.kafka.*"
     }
 }
 

--- a/frameworks/kafka/build.sh
+++ b/frameworks/kafka/build.sh
@@ -3,6 +3,6 @@ set -e
 
 FRAMEWORK_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOT_DIR=$FRAMEWORK_DIR/../..
-BUILD_DIR=$ROOT_DIR/build/distributions
+BUILD_DIR=$FRAMEWORK_DIR/build/distributions
 PUBLISH_STEP=${1-none}
 ${ROOT_DIR}/tools/build_framework.sh $PUBLISH_STEP kafka $FRAMEWORK_DIR $BUILD_DIR/kafka-scheduler.zip

--- a/sdk/executor/build.gradle
+++ b/sdk/executor/build.gradle
@@ -23,8 +23,6 @@ dependencies {
 apply plugin: 'java'
 apply plugin: 'application'
 
-buildDir = new File(rootProject.projectDir, "build/")
-
 distributions {
     main {
         baseName = 'executor'


### PR DESCRIPTION
`./gradlew build` works now, so you don't have to clean all the time
All the subprojects have isolated build directories.
They continue to work for building Universe packages and uploading binaries.