### PR TITLE
Extend LD_LIBRARY_PATH instead of a complete override

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/DefaultOfferRequirementProvider.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/DefaultOfferRequirementProvider.java
@@ -470,7 +470,7 @@ public class DefaultOfferRequirementProvider implements OfferRequirementProvider
         // command and user:
 
         Protos.CommandInfo.Builder commandInfoBuilder = executorInfoBuilder.getCommandBuilder()
-                .setValue("export LD_LIBRARY_PATH=$MESOS_SANDBOX/libmesos-bundle/lib && " +
+                .setValue("export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$MESOS_SANDBOX/libmesos-bundle/lib && " +
                         "export MESOS_NATIVE_JAVA_LIBRARY=$(ls $MESOS_SANDBOX/libmesos-bundle/lib/libmesos-*.so) && " +
                         "export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jre*/) && " +
                         "./executor/bin/executor");


### PR DESCRIPTION
`LD_LIBRARY_PATH` of the task should be extended to also include libmesos, instead of overriding it to just include libmesos. Not extending `LD_LIBRARY_PATH` causes other system utilities to not work as expected.

Basically, we should be doing:
```
export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:<libmesos-stuff>
```
v/s
```
export LD_LIBRARY_PATH=<libmesos-stuff>
```