### PR TITLE
All task env-vars including ports are now also available on health and readiness checks

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/PortEvaluationStage.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/PortEvaluationStage.java
@@ -2,6 +2,8 @@ package com.mesosphere.sdk.offer.evaluate;
 
 import com.mesosphere.sdk.offer.*;
 import org.apache.mesos.Protos;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.HashSet;
 import java.util.Optional;
@@ -17,6 +19,7 @@ import static com.mesosphere.sdk.offer.evaluate.EvaluationOutcome.*;
  * environments.
  */
 public class PortEvaluationStage extends ResourceEvaluationStage implements OfferEvaluationStage {
+    private static final Logger LOGGER = LoggerFactory.getLogger(PortEvaluationStage.class);
     private final String portName;
     private final int port;
 
@@ -82,6 +85,36 @@ public class PortEvaluationStage extends ResourceEvaluationStage implements Offe
             taskInfoBuilder.setCommand(
                     CommandUtils.addEnvVar(
                             taskInfoBuilder.getCommand(), getPortEnvironmentVariable(portName), Long.toString(port)));
+
+            // Add port to the health check (if defined)
+            if (taskInfoBuilder.hasHealthCheck()) {
+                taskInfoBuilder.getHealthCheckBuilder().setCommand(
+                        CommandUtils.addEnvVar(
+                                taskInfoBuilder.getHealthCheckBuilder().getCommand(),
+                                getPortEnvironmentVariable(portName),
+                                Long.toString(port)));
+            } else {
+                LOGGER.info("Health check is not defined for task: {}", taskName);
+            }
+
+            // Add port to the readiness check (if defined)
+            try {
+                Optional<Protos.HealthCheck> readinessCheck = CommonTaskUtils.getReadinessCheck(taskInfo);
+                if (readinessCheck.isPresent()) {
+                    Protos.HealthCheck readinessCheckToMutate = readinessCheck.get();
+                    Protos.CommandInfo readinessCommandWithPort = CommandUtils.addEnvVar(
+                            readinessCheckToMutate.getCommand(),
+                            getPortEnvironmentVariable(portName),
+                            Long.toString(port));
+                    Protos.HealthCheck readinessCheckWithPort = Protos.HealthCheck.newBuilder(readinessCheckToMutate)
+                            .setCommand(readinessCommandWithPort).build();
+                    CommonTaskUtils.setReadinessCheck(taskInfoBuilder, readinessCheckWithPort);
+                } else {
+                    LOGGER.info("Readiness check is not defined for task: {}", taskName);
+                }
+            } catch (TaskException e) {
+                LOGGER.error("Got exception while adding PORT env vars to ReadinessCheck", e);
+            }
             offerRequirement.updateTaskRequirement(taskName, taskInfoBuilder.build());
         } else {
             Protos.ExecutorInfo executorInfo = offerRequirement.getExecutorRequirementOptional()

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/DefaultOfferRequirementProviderTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/DefaultOfferRequirementProviderTest.java
@@ -4,12 +4,8 @@ import com.mesosphere.sdk.offer.evaluate.EvaluationOutcome;
 import com.mesosphere.sdk.offer.evaluate.placement.PlacementRule;
 import com.mesosphere.sdk.scheduler.plan.DefaultPodInstance;
 import com.mesosphere.sdk.specification.*;
-import com.mesosphere.sdk.specification.yaml.YAMLServiceSpecFactory;
 import com.mesosphere.sdk.state.StateStore;
-import com.mesosphere.sdk.testutils.OfferRequirementTestUtils;
-import com.mesosphere.sdk.testutils.ResourceTestUtils;
-import com.mesosphere.sdk.testutils.TaskTestUtils;
-import com.mesosphere.sdk.testutils.TestConstants;
+import com.mesosphere.sdk.testutils.*;
 import org.apache.mesos.Protos;
 import org.apache.mesos.Protos.Offer;
 import org.apache.mesos.Protos.TaskInfo;
@@ -21,7 +17,6 @@ import org.junit.contrib.java.lang.system.EnvironmentVariables;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import java.io.File;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -58,10 +53,7 @@ public class DefaultOfferRequirementProviderTest {
     }
 
     private DefaultPodInstance getPodInstance(String serviceSpecFileName) throws Exception {
-        ClassLoader classLoader = getClass().getClassLoader();
-        File file = new File(classLoader.getResource(serviceSpecFileName).getFile());
-        DefaultServiceSpec serviceSpec = YAMLServiceSpecFactory.generateServiceSpec(
-                YAMLServiceSpecFactory.generateRawSpecFromYAML(file));
+        DefaultServiceSpec serviceSpec = ServiceSpecTestUtils.getPodInstance(serviceSpecFileName);
 
         PodSpec podSpec = DefaultPodSpec.newBuilder(serviceSpec.getPods().get(0))
                 .placementRule(ALLOW_ALL)

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/PortEvaluationStageTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/PortEvaluationStageTest.java
@@ -1,17 +1,29 @@
 package com.mesosphere.sdk.offer.evaluate;
 
 import com.mesosphere.sdk.offer.*;
-import com.mesosphere.sdk.testutils.OfferRequirementTestUtils;
-import com.mesosphere.sdk.testutils.OfferTestUtils;
-import com.mesosphere.sdk.testutils.ResourceTestUtils;
-import com.mesosphere.sdk.testutils.TestConstants;
+import com.mesosphere.sdk.scheduler.plan.DefaultPodInstance;
+import com.mesosphere.sdk.specification.DefaultPodSpec;
+import com.mesosphere.sdk.specification.DefaultServiceSpec;
+import com.mesosphere.sdk.specification.PodSpec;
+import com.mesosphere.sdk.state.StateStore;
+import com.mesosphere.sdk.testutils.*;
 import org.apache.mesos.Protos;
 import org.junit.Assert;
+import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
+import org.mockito.Mockito;
 
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.UUID;
 
 public class PortEvaluationStageTest {
+    @ClassRule
+    public static final EnvironmentVariables environmentVariables =
+            OfferRequirementTestUtils.getOfferRequirementProviderEnvironment();
+
     @Test
     public void testReserveDynamicPort() throws Exception {
         Protos.Resource desiredPorts = ResourceTestUtils.getDesiredRanges("ports", 0, 0)
@@ -119,5 +131,124 @@ public class PortEvaluationStageTest {
 
         Assert.assertEquals(0, offerRecommendationSlate.getRecommendations().size());
         Assert.assertEquals(0, mesosResourcePool.getReservedPool().size());
+    }
+
+    @Test
+    public void testPortOnHealthCheck() throws Exception {
+        DefaultPodInstance podInstance = getPodInstance("valid-port-healthcheck.yml");
+        StateStore stateStore = Mockito.mock(StateStore.class);
+        DefaultOfferRequirementProvider provider = new DefaultOfferRequirementProvider(stateStore, UUID.randomUUID());
+        OfferRequirement offerRequirement = provider.getNewOfferRequirement(podInstance,
+                TaskUtils.getTaskNames(podInstance));
+
+        OfferRecommendationSlate offerRecommendationSlate = new OfferRecommendationSlate();
+
+        Protos.Resource desiredPorts = ResourceTestUtils.getDesiredRanges("ports", 10000, 10000)
+                .toBuilder().clearRanges().build();
+        Protos.Resource offeredPorts = ResourceTestUtils.getUnreservedPorts(10000, 10000);
+        Protos.Offer offer = OfferTestUtils.getOffer(offeredPorts);
+
+        String taskName = "pod-type-0-" + TestConstants.TASK_NAME;
+        PortEvaluationStage portEvaluationStage =
+                new PortEvaluationStage(desiredPorts, taskName, "test-port", 10000);
+        EvaluationOutcome outcome =
+                portEvaluationStage.evaluate(new MesosResourcePool(offer), offerRequirement, offerRecommendationSlate);
+        Assert.assertTrue(outcome.isPassing());
+
+        Assert.assertEquals(1, offerRecommendationSlate.getRecommendations().size());
+
+        OfferRecommendation recommendation = offerRecommendationSlate.getRecommendations().get(0);
+        Assert.assertEquals(Protos.Offer.Operation.Type.RESERVE, recommendation.getOperation().getType());
+
+        Protos.Resource resource = recommendation.getOperation().getReserve().getResources(0);
+        Assert.assertEquals(
+                10000, resource.getRanges().getRange(0).getBegin(), resource.getRanges().getRange(0).getEnd());
+
+        Protos.TaskInfo taskInfo = offerRequirement.getTaskRequirement(taskName).getTaskInfo();
+        boolean portInTaskEnv = false;
+        for (int i = 0; i < taskInfo.getCommand().getEnvironment().getVariablesCount(); i++) {
+            Protos.Environment.Variable variable = taskInfo.getCommand().getEnvironment().getVariables(i);
+            if (Objects.equals(variable.getName(), "PORT_TEST_PORT")) {
+                Assert.assertEquals(variable.getValue(), "10000");
+                portInTaskEnv = true;
+            }
+        }
+        Assert.assertTrue(portInTaskEnv);
+        boolean portInHealthEnv = false;
+        for (int i = 0; i < taskInfo.getHealthCheck().getCommand().getEnvironment().getVariablesCount(); i++) {
+            Protos.Environment.Variable variable = taskInfo.getHealthCheck().getCommand().getEnvironment().getVariables(i);
+            if (Objects.equals(variable.getName(), "PORT_TEST_PORT")) {
+                Assert.assertEquals(variable.getValue(), "10000");
+                portInHealthEnv = true;
+            }
+        }
+        Assert.assertTrue(portInHealthEnv);
+    }
+
+    @Test
+    public void testPortOnReadinessCheck() throws Exception {
+        DefaultPodInstance podInstance = getPodInstance("valid-port-readinesscheck.yml");
+        StateStore stateStore = Mockito.mock(StateStore.class);
+        DefaultOfferRequirementProvider provider = new DefaultOfferRequirementProvider(stateStore, UUID.randomUUID());
+        OfferRequirement offerRequirement = provider.getNewOfferRequirement(podInstance,
+                TaskUtils.getTaskNames(podInstance));
+
+        OfferRecommendationSlate offerRecommendationSlate = new OfferRecommendationSlate();
+
+        Protos.Resource desiredPorts = ResourceTestUtils.getDesiredRanges("ports", 10000, 10000)
+                .toBuilder().clearRanges().build();
+        Protos.Resource offeredPorts = ResourceTestUtils.getUnreservedPorts(10000, 10000);
+        Protos.Offer offer = OfferTestUtils.getOffer(offeredPorts);
+
+        String taskName = "pod-type-0-" + TestConstants.TASK_NAME;
+        PortEvaluationStage portEvaluationStage =
+                new PortEvaluationStage(desiredPorts, taskName, "test-port", 10000);
+        EvaluationOutcome outcome =
+                portEvaluationStage.evaluate(new MesosResourcePool(offer), offerRequirement, offerRecommendationSlate);
+        Assert.assertTrue(outcome.isPassing());
+
+        Assert.assertEquals(1, offerRecommendationSlate.getRecommendations().size());
+
+        OfferRecommendation recommendation = offerRecommendationSlate.getRecommendations().get(0);
+        Assert.assertEquals(Protos.Offer.Operation.Type.RESERVE, recommendation.getOperation().getType());
+
+        Protos.Resource resource = recommendation.getOperation().getReserve().getResources(0);
+        Assert.assertEquals(
+                10000, resource.getRanges().getRange(0).getBegin(), resource.getRanges().getRange(0).getEnd());
+
+        Protos.TaskInfo taskInfo = offerRequirement.getTaskRequirement(taskName).getTaskInfo();
+        boolean portInTaskEnv = false;
+        for (int i = 0; i < taskInfo.getCommand().getEnvironment().getVariablesCount(); i++) {
+            Protos.Environment.Variable variable = taskInfo.getCommand().getEnvironment().getVariables(i);
+            if (Objects.equals(variable.getName(), "PORT_TEST_PORT")) {
+                Assert.assertEquals(variable.getValue(), "10000");
+                portInTaskEnv = true;
+            }
+        }
+        Assert.assertTrue(portInTaskEnv);
+        boolean portInHealthEnv = false;
+        Optional<Protos.HealthCheck> readinessCheck = CommonTaskUtils.getReadinessCheck(taskInfo);
+        for (int i = 0; i < readinessCheck.get().getCommand().getEnvironment().getVariablesCount(); i++) {
+            Protos.Environment.Variable variable = readinessCheck.get().getCommand().getEnvironment().getVariables(i);
+            if (Objects.equals(variable.getName(), "PORT_TEST_PORT")) {
+                Assert.assertEquals(variable.getValue(), "10000");
+                portInHealthEnv = true;
+            }
+        }
+        Assert.assertTrue(portInHealthEnv);
+    }
+
+    private DefaultPodInstance getPodInstance(String serviceSpecFileName) throws Exception {
+        DefaultServiceSpec serviceSpec = ServiceSpecTestUtils.getPodInstance(serviceSpecFileName);
+
+        PodSpec podSpec = DefaultPodSpec.newBuilder(serviceSpec.getPods().get(0))
+                .placementRule((offer, offerRequirement, taskInfos) -> EvaluationOutcome.pass(this, "pass for test"))
+                .build();
+
+        serviceSpec = DefaultServiceSpec.newBuilder(serviceSpec)
+                .pods(Arrays.asList(podSpec))
+                .build();
+
+        return new DefaultPodInstance(serviceSpec.getPods().get(0), 0);
     }
 }

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/testutils/ServiceSpecTestUtils.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/testutils/ServiceSpecTestUtils.java
@@ -1,0 +1,18 @@
+package com.mesosphere.sdk.testutils;
+
+import com.mesosphere.sdk.specification.DefaultServiceSpec;
+import com.mesosphere.sdk.specification.yaml.YAMLServiceSpecFactory;
+
+import java.io.File;
+
+/**
+ * Test utils for {@code {@link com.mesosphere.sdk.specification.ServiceSpec}}.
+ */
+public class ServiceSpecTestUtils {
+    public static DefaultServiceSpec getPodInstance(String serviceSpecFileName) throws Exception {
+        ClassLoader classLoader = ServiceSpecTestUtils.class.getClassLoader();
+        File file = new File(classLoader.getResource(serviceSpecFileName).getFile());
+        return YAMLServiceSpecFactory.generateServiceSpec(
+                YAMLServiceSpecFactory.generateRawSpecFromYAML(file));
+    }
+}

--- a/sdk/scheduler/src/test/resources/valid-port-healthcheck.yml
+++ b/sdk/scheduler/src/test/resources/valid-port-healthcheck.yml
@@ -1,0 +1,18 @@
+name: "hello-world"
+pods:
+  pod-type:
+    count: 1
+    tasks:
+      test-task-name:
+        goal: RUNNING
+        cmd: "./task-cmd"
+        ports:
+          test-port:
+            port: 10000
+        health-check:
+          cmd: "/bin/true"
+          interval: 5
+          grace-period: 30
+          max-consecutive-failures: 3
+          delay: 0
+          timeout: 10

--- a/sdk/scheduler/src/test/resources/valid-port-readinesscheck.yml
+++ b/sdk/scheduler/src/test/resources/valid-port-readinesscheck.yml
@@ -1,0 +1,16 @@
+name: "hello-world"
+pods:
+  pod-type:
+    count: 1
+    tasks:
+      test-task-name:
+        goal: RUNNING
+        cmd: "./task-cmd"
+        ports:
+          test-port:
+            port: 10000
+        readiness-check:
+          cmd: "/bin/true"
+          interval: 5
+          delay: 0
+          timeout: 10


### PR DESCRIPTION
Both health checks and readiness checks will now get all the env vars of the task they are associated with.

/cc: @loren 