### PR TITLE
Fix multi-volume support

### DIFF
--- a/frameworks/helloworld/src/main/dist/svc.yml
+++ b/frameworks/helloworld/src/main/dist/svc.yml
@@ -1,4 +1,4 @@
-name: "hello-world"
+name: hello-world
 pods:
   hello:
     count: {{HELLO_COUNT}}
@@ -6,17 +6,17 @@ pods:
     tasks:
       server:
         goal: RUNNING
-        cmd: "echo hello >> hello-container-path/output && sleep $SLEEP_DURATION"
+        cmd: echo hello >> hello-container-path/output && sleep $SLEEP_DURATION
         cpus: {{HELLO_CPUS}}
         memory: {{HELLO_MEM}}
         volume:
-          path: "hello-container-path"
+          path: hello-container-path
           type: ROOT
           size: {{HELLO_DISK}}
         env:
           SLEEP_DURATION: {{SLEEP_DURATION}}
         health-check:
-          cmd: "stat hello-container-path/output"
+          cmd: stat hello-container-path/output
           interval: 5
           grace-period: 30
           delay: 0
@@ -28,17 +28,25 @@ pods:
     tasks:
       server:
         goal: RUNNING
-        cmd: "echo world >> world-container-path/output && sleep $SLEEP_DURATION"
+        cmd: >
+               echo world1 >> world-container-path1/output &&
+               echo world2 >> world-container-path2/output &&
+               sleep $SLEEP_DURATION
         cpus: {{WORLD_CPUS}}
         memory: {{WORLD_MEM}}
-        volume:
-          path: "world-container-path"
-          type: ROOT
-          size: {{WORLD_DISK}}
+        volumes:
+          vol1:
+            path: world-container-path1
+            type: ROOT
+            size: {{HELLO_DISK}}
+          vol2:
+            path: world-container-path2
+            type: ROOT
+            size: {{HELLO_DISK}}
         env:
           SLEEP_DURATION: {{SLEEP_DURATION}}
         readiness-check:
-          cmd: BYTES="$(wc -c world-container-path/output | awk '{print $1;}')" && [ $BYTES -gt 0 ]
+          cmd: BYTES="$(wc -c world-container-path2/output | awk '{print $1;}')" && [ $BYTES -gt 0 ]
           interval: 5
           delay: 0
           timeout: 10

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluator.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluator.java
@@ -66,16 +66,17 @@ public class OfferEvaluator {
                 }
             }
 
+            StringBuilder stringBuilder = new StringBuilder();
+            stringBuilder.append("\n");
+            for (EvaluationOutcome outcome : outcomes) {
+                logOutcome(stringBuilder, outcome, "");
+            }
+            logger.info(stringBuilder.toString().trim());
+
             if (failedOutcomeCount != 0) {
                 recommendations.clear();
-                StringBuilder stringBuilder = new StringBuilder();
-                stringBuilder.append(String.format(
-                        "- %d: failed %d of %d evaluation stages with the following reasons:%n",
-                        i + 1, failedOutcomeCount, evaluationStages.size()));
-                for (EvaluationOutcome outcome : outcomes) {
-                    logOutcome(stringBuilder, outcome, "");
-                }
-                logger.info(stringBuilder.toString().trim());
+                logger.info("- %d: failed %d of %d evaluation stages.",
+                        i + 1, failedOutcomeCount, evaluationStages.size());
 
                 continue;
             }
@@ -132,8 +133,8 @@ public class OfferEvaluator {
                 }
 
                 for (VolumeSpec v : taskSpec.getResourceSet().getVolumes()) {
-                    Resource taskResource = ResourceUtils.getResource(
-                            offerRequirement.getTaskRequirement(taskName).getTaskInfo(), v.getName());
+                    Resource taskResource = ResourceUtils.getDiskResource(
+                            offerRequirement.getTaskRequirement(taskName).getTaskInfo(), v.getContainerPath());
                     evaluationPipeline.add(v.getEvaluationStage(taskResource, taskName));
                 }
                 evaluationPipeline.add(new LaunchEvaluationStage(taskName));

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluator.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluator.java
@@ -48,7 +48,13 @@ public class OfferEvaluator {
 
             OfferRequirement offerRequirement = getOfferRequirement(podInstanceRequirement);
             List<OfferEvaluationStage> evaluationStages =
-                    getEvaluationPipeline(podInstanceRequirement, offerRequirement);
+                    null;
+            try {
+                evaluationStages = getEvaluationPipeline(podInstanceRequirement, offerRequirement);
+            } catch (TaskException e) {
+                logger.error("Failed to generate evaluation pipeline.", e);
+                return Collections.emptyList();
+            }
 
             Offer offer = offers.get(i);
             MesosResourcePool resourcePool = new MesosResourcePool(offer);
@@ -98,7 +104,7 @@ public class OfferEvaluator {
 
     private List<OfferEvaluationStage> getEvaluationPipeline(
             PodInstanceRequirement podInstanceRequirement,
-            OfferRequirement offerRequirement) throws InvalidRequirementException {
+            OfferRequirement offerRequirement) throws InvalidRequirementException, TaskException {
         List<OfferEvaluationStage> evaluationPipeline = new ArrayList<>();
 
         evaluationPipeline.add(new PlacementRuleEvaluationStage(stateStore.fetchTasks()));

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/PortEvaluationStage.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/PortEvaluationStage.java
@@ -81,7 +81,12 @@ public class PortEvaluationStage extends ResourceEvaluationStage implements Offe
             }
 
             Protos.TaskInfo.Builder taskInfoBuilder = taskInfo.toBuilder();
-            ResourceUtils.setResource(taskInfoBuilder, ports);
+            try {
+                ResourceUtils.setResource(taskInfoBuilder, ports);
+            } catch (TaskException e) {
+                LOGGER.error("Failed to set resource on TaskInfo.", e);
+            }
+
             taskInfoBuilder.setCommand(
                     CommandUtils.addEnvVar(
                             taskInfoBuilder.getCommand(), getPortEnvironmentVariable(portName), Long.toString(port)));

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/ResourceEvaluationStage.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/ResourceEvaluationStage.java
@@ -129,7 +129,16 @@ public class ResourceEvaluationStage implements OfferEvaluationStage {
         if (failure != null) {
             return failure;
         }
-        setProtos(offerRequirement, fulfilledResource);
+
+        try {
+            setProtos(offerRequirement, fulfilledResource);
+        } catch (TaskException e) {
+            logger.error("Failed to set protos on OfferRequirement.", e);
+            return fail(this, "Failed to satisfy required resource '%s': %s",
+                    resourceRequirement.getName(),
+                    TextFormat.shortDebugString(resourceRequirement.getResource()));
+        }
+
         return pass(this, "Offer contains sufficient '%s'", resourceRequirement.getName());
     }
 
@@ -146,7 +155,7 @@ public class ResourceEvaluationStage implements OfferEvaluationStage {
         return null;
     }
 
-    protected void setProtos(OfferRequirement offerRequirement, Resource resource) {
+    protected void setProtos(OfferRequirement offerRequirement, Resource resource) throws TaskException {
         if (getTaskName().isPresent()) {
             offerRequirement.updateTaskRequirement(
                     getTaskName().get(),

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/VolumeEvaluationStage.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/VolumeEvaluationStage.java
@@ -65,7 +65,14 @@ public class VolumeEvaluationStage extends ResourceEvaluationStage implements Of
         if (failure != null) {
             return failure;
         }
-        setProtos(offerRequirement, fulfilledResource);
+
+        try {
+            setProtos(offerRequirement, fulfilledResource);
+        } catch (TaskException e) {
+            logger.error("Failed to set protos on OfferRequirement.", e);
+            return fail(this, "Setting protos on the OfferRequirement must succeed.");
+        }
+
         return pass(this, "Offer contains sufficient '%s'", resourceRequirement.getName());
     }
 

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/ResourceCleanerTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/ResourceCleanerTest.java
@@ -40,6 +40,7 @@ public class ResourceCleanerTest {
     private static final Resource EXPECTED_RESOURCE_2 = ResourceUtils.getExpectedRootVolume(
             999.0,
             EXPECTED_RESOURCE_2_ID,
+            TestConstants.CONTAINER_PATH,
             TestConstants.ROLE,
             TestConstants.PRINCIPAL,
             EXPECTED_RESOURCE_2_ID);
@@ -47,6 +48,7 @@ public class ResourceCleanerTest {
     private static final Resource UNEXPECTED_RESOURCE_1 = ResourceUtils.getExpectedRootVolume(
             1000.0,
             UNEXPECTED_RESOURCE_1_ID,
+            TestConstants.CONTAINER_PATH,
             TestConstants.ROLE,
             TestConstants.PRINCIPAL,
             UNEXPECTED_RESOURCE_1_ID);
@@ -61,6 +63,7 @@ public class ResourceCleanerTest {
     private static final Resource UNEXPECTED_RESOURCE_3 = ResourceUtils.getExpectedRootVolume(
             1001.0,
             UNEXPECTED_RESOURCE_3_ID,
+            TestConstants.CONTAINER_PATH,
             TestConstants.ROLE,
             TestConstants.PRINCIPAL,
             UNEXPECTED_RESOURCE_3_ID);

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluatorBaseTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluatorBaseTest.java
@@ -1,0 +1,121 @@
+package com.mesosphere.sdk.offer.evaluate;
+
+import com.mesosphere.sdk.curator.CuratorStateStore;
+import com.mesosphere.sdk.offer.DefaultOfferRequirementProvider;
+import com.mesosphere.sdk.offer.OfferRequirementProvider;
+import com.mesosphere.sdk.offer.ResourceUtils;
+import com.mesosphere.sdk.scheduler.plan.DefaultPodInstance;
+import com.mesosphere.sdk.scheduler.plan.PodInstanceRequirement;
+import com.mesosphere.sdk.specification.DefaultServiceSpec;
+import com.mesosphere.sdk.specification.PodSpec;
+import com.mesosphere.sdk.specification.yaml.RawServiceSpec;
+import com.mesosphere.sdk.specification.yaml.YAMLServiceSpecFactory;
+import com.mesosphere.sdk.state.PersistentOperationRecorder;
+import com.mesosphere.sdk.state.StateStore;
+import com.mesosphere.sdk.testutils.CuratorTestUtils;
+import com.mesosphere.sdk.testutils.OfferRequirementTestUtils;
+import com.mesosphere.sdk.testutils.OfferTestUtils;
+import org.apache.curator.test.TestingServer;
+import org.apache.mesos.Protos.Label;
+import org.apache.mesos.Protos.Offer;
+import org.apache.mesos.Protos.Resource;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
+
+import java.io.File;
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * A BaseTest for use in writing offer evaluation tests.
+ */
+public class OfferEvaluatorBaseTest {
+    public static final EnvironmentVariables environmentVariables =
+            OfferRequirementTestUtils.getOfferRequirementProviderEnvironment();
+
+    protected static final String ROOT_ZK_PATH = "/test-root-path";
+    static TestingServer testZk;
+
+    protected OfferRequirementProvider offerRequirementProvider;
+    protected StateStore stateStore;
+    protected OfferEvaluator evaluator;
+     PersistentOperationRecorder operationRecorder;
+
+    @BeforeClass
+    public static void beforeAll() throws Exception {
+        testZk = new TestingServer();
+    }
+
+    @Before
+    public void beforeEach() throws Exception {
+        CuratorTestUtils.clear(testZk);
+        stateStore = new CuratorStateStore(ROOT_ZK_PATH, testZk.getConnectString());
+        offerRequirementProvider = new DefaultOfferRequirementProvider(stateStore, UUID.randomUUID());
+        evaluator = new OfferEvaluator(stateStore, offerRequirementProvider);
+        operationRecorder = new PersistentOperationRecorder(stateStore);
+    }
+
+    protected PodInstanceRequirement getPodInstanceRequirement(Resource resource) throws Exception {
+        return getPodInstanceRequirement(resource, false);
+    }
+
+    protected PodInstanceRequirement getPodInstanceRequirement(
+            Resource resource,
+            List<String> avoidAgents,
+            List<String> collocateAgents,
+            boolean isVolume) throws Exception {
+        return getPodInstanceRequirement(
+                Arrays.asList(resource), avoidAgents, collocateAgents, isVolume, "single-task.yml");
+    }
+
+    protected PodInstanceRequirement getPodInstanceRequirement(boolean isVolume, String yamlFile) throws Exception {
+        return getPodInstanceRequirement(
+                Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), isVolume, yamlFile);
+    }
+
+
+    protected PodInstanceRequirement getPodInstanceRequirement(
+            Collection<Resource> resources,
+            List<String> avoidAgents,
+            List<String> collocateAgents,
+            boolean isVolume,
+            String yamlFile) throws Exception {
+        ClassLoader classLoader = getClass().getClassLoader();
+        File file = new File(classLoader.getResource(yamlFile).getFile());
+        RawServiceSpec rawServiceSpec = YAMLServiceSpecFactory.generateRawSpecFromYAML(file);
+        DefaultServiceSpec serviceSpec = YAMLServiceSpecFactory.generateServiceSpec(rawServiceSpec);
+
+        PodSpec podSpec = serviceSpec.getPods().get(0);
+        if (!resources.isEmpty()) {
+            podSpec = isVolume ?
+                    OfferRequirementTestUtils.withVolume(
+                            serviceSpec.getPods().get(0), resources.iterator().next(), serviceSpec.getPrincipal()) :
+                    OfferRequirementTestUtils.withResources(
+                            serviceSpec.getPods().get(0),
+                            resources,
+                            serviceSpec.getPrincipal(),
+                            avoidAgents,
+                            collocateAgents);
+        }
+
+        return PodInstanceRequirement.create(
+                new DefaultPodInstance(podSpec, 0),
+                podSpec.getTasks().stream().map(t -> t.getName()).collect(Collectors.toList()));
+    }
+
+    protected PodInstanceRequirement getPodInstanceRequirement(Resource resource, boolean isVolume) throws Exception {
+        return getPodInstanceRequirement(resource, Collections.emptyList(), Collections.emptyList(), isVolume);
+    }
+
+    protected static Offer getOffer(Resource resource) {
+        return OfferTestUtils.getOffer(Arrays.asList(
+                ResourceUtils.getUnreservedScalar("cpus", 1.0),
+                ResourceUtils.getUnreservedScalar("mem", 512),
+                resource));
+    }
+
+    protected static Label getFirstLabel(Resource resource) {
+        return resource.getReservation().getLabels().getLabels(0);
+    }
+}

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluatorVolumesTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluatorVolumesTest.java
@@ -1,0 +1,87 @@
+package com.mesosphere.sdk.offer.evaluate;
+
+import com.mesosphere.sdk.offer.OfferRecommendation;
+import com.mesosphere.sdk.scheduler.plan.DefaultPodInstance;
+import com.mesosphere.sdk.scheduler.plan.PodInstanceRequirement;
+import com.mesosphere.sdk.specification.PodInstance;
+import com.mesosphere.sdk.specification.PodSpec;
+import com.mesosphere.sdk.specification.ServiceSpec;
+import com.mesosphere.sdk.specification.yaml.RawServiceSpec;
+import com.mesosphere.sdk.specification.yaml.YAMLServiceSpecFactory;
+import com.mesosphere.sdk.testutils.OfferTestUtils;
+import com.mesosphere.sdk.testutils.ResourceTestUtils;
+import org.apache.mesos.Protos.*;
+import org.apache.mesos.Protos.Offer.Operation;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Offer evaluation tests concerning volumes.
+ */
+public class OfferEvaluatorVolumesTest extends OfferEvaluatorBaseTest {
+    @Test
+    public void testCreateMultipleVolumes() throws Exception {
+        Resource desiredCpu = ResourceTestUtils.getUnreservedCpu(1);
+        Resource desiredDisk = ResourceTestUtils.getUnreservedDisk(3);
+
+        PodInstanceRequirement podInstanceRequirement = getMultiVolumePodInstanceRequirement();
+        Offer offer = OfferTestUtils.getOffer(Arrays.asList(desiredCpu, desiredDisk));
+
+        List<OfferRecommendation> recommendations = evaluator.evaluate(
+                podInstanceRequirement,
+                Arrays.asList(offer));
+        Assert.assertEquals(6, recommendations.size());
+
+        Assert.assertEquals(Operation.Type.RESERVE, recommendations.get(0).getOperation().getType());
+        Assert.assertEquals(Operation.Type.RESERVE, recommendations.get(1).getOperation().getType());
+        Assert.assertEquals(Operation.Type.RESERVE, recommendations.get(2).getOperation().getType());
+        Assert.assertEquals(Operation.Type.CREATE, recommendations.get(3).getOperation().getType());
+        Assert.assertEquals(Operation.Type.CREATE, recommendations.get(4).getOperation().getType());
+        Assert.assertEquals(Operation.Type.LAUNCH, recommendations.get(5).getOperation().getType());
+
+        System.out.println(recommendations.get(5).getOperation());
+
+        // Validate Create Operation
+        Operation createOperation = recommendations.get(3).getOperation();
+        Assert.assertEquals("pv0", createOperation.getCreate().getVolumes(0).getDisk().getVolume().getContainerPath());
+
+        // Validate Create Operation
+        createOperation = recommendations.get(4).getOperation();
+        Assert.assertEquals("pv1", createOperation.getCreate().getVolumes(0).getDisk().getVolume().getContainerPath());
+
+        // Validate Launch Operation
+        Operation launchOperation = recommendations.get(5).getOperation();
+        for (TaskInfo taskInfo : launchOperation.getLaunch().getTaskInfosList()) {
+            for (Resource resource : taskInfo.getResourcesList()) {
+                Label resourceIdLabel = getFirstLabel(resource);
+                Assert.assertTrue(resourceIdLabel.getKey().equals("resource_id"));
+                Assert.assertTrue(resourceIdLabel.getValue().length() > 0);
+            }
+        }
+    }
+
+    private PodInstanceRequirement getMultiVolumePodInstanceRequirement() throws Exception {
+        PodSpec podSpec = getServiceSpec("multi-volume.yml")
+                .getPods().stream().findFirst().get();
+
+        PodInstance podInstance = new DefaultPodInstance(podSpec, 0);
+
+        List<String> taskNames = podSpec.getTasks().stream()
+                .map(taskSpec -> taskSpec.getName())
+                .collect(Collectors.toList());
+
+        return PodInstanceRequirement.create(podInstance, taskNames);
+    }
+
+    private ServiceSpec getServiceSpec(String yamlFile) throws Exception {
+        ClassLoader classLoader = getClass().getClassLoader();
+        File file = new File(classLoader.getResource(yamlFile).getFile());
+        RawServiceSpec rawServiceSpec = YAMLServiceSpecFactory.generateRawSpecFromYAML(file);
+        return YAMLServiceSpecFactory.generateServiceSpec(rawServiceSpec);
+    }
+}

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/testutils/ResourceTestUtils.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/testutils/ResourceTestUtils.java
@@ -50,6 +50,7 @@ public class ResourceTestUtils {
         return ResourceUtils.getExpectedRootVolume(
                 diskSize,
                 resourceId,
+                TestConstants.CONTAINER_PATH,
                 TestConstants.ROLE,
                 TestConstants.PRINCIPAL,
                 TestConstants.PERSISTENCE_ID);

--- a/sdk/scheduler/src/test/resources/multi-volume.yml
+++ b/sdk/scheduler/src/test/resources/multi-volume.yml
@@ -1,0 +1,18 @@
+name: "test-multi-volume"
+pods:
+  hello:
+    count: 1
+    tasks:
+      server:
+        goal: RUNNING
+        cmd: "./cmd"
+        cpus: 1
+        volumes:
+          pv0:
+            path: "pv0"
+            type: ROOT
+            size: 1
+          pv1:
+            path: "pv1"
+            type: ROOT
+            size: 2


### PR DESCRIPTION
The main error was a failure to differentiate disk resouces on container
path.  Other resources may be safely differentiated based on name (e.g.
cpu, mem).  However disk resources must be further compared with
reference to their container path.