### PR TITLE
Making StateStoreCache's fetchXXX similar to CuratorStateStore

### DIFF
--- a/sdk/common/src/main/java/com/mesosphere/sdk/offer/CommonTaskUtils.java
+++ b/sdk/common/src/main/java/com/mesosphere/sdk/offer/CommonTaskUtils.java
@@ -9,6 +9,7 @@ import com.mesosphere.sdk.specification.ConfigFileSpec;
 import com.mesosphere.sdk.specification.DefaultConfigFileSpec;
 import com.mesosphere.sdk.specification.GoalState;
 import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.mesos.ExecutorDriver;
 import org.apache.mesos.Protos.*;
@@ -199,7 +200,7 @@ public class CommonTaskUtils {
     /**
      * Returns the pod instance index of the provided task, or throws {@link TaskException} if no index data was found.
      *
-     * @throws TaskException if the index data wasn't found
+     * @throws TaskException         if the index data wasn't found
      * @throws NumberFormatException if parsing the index as an integer failed
      */
     public static int getIndex(TaskInfo taskInfo) throws TaskException {
@@ -320,7 +321,8 @@ public class CommonTaskUtils {
      * failures to parse readiness checks are interpreted as readiness check failures.  If some value other
      * than "true" is present in the readiness check label of the TaskStatus, the readiness check has
      * failed.
-     * @param taskInfo A TaskInfo which may or may not have a readiness check defined.
+     *
+     * @param taskInfo   A TaskInfo which may or may not have a readiness check defined.
      * @param taskStatus A TaskStatus which may or may not contain a readiness check label.
      * @return the result of a readiness check for the indicated TaskInfo and TaskStatus.
      */
@@ -510,6 +512,24 @@ public class CommonTaskUtils {
                     .clearCommand()
                     .build();
         }
+    }
+
+    /**
+     * This method is similar to {@link #unpackTaskInfo(TaskInfo)}, just applied over a {@link Collection} of
+     * {@link TaskInfo}s.
+     *
+     * @param packedTaskInfos Collection of TaskInfos to be unpacked.
+     * @return
+     */
+    public static Collection<TaskInfo> unpackTaskInfos(Collection<TaskInfo> packedTaskInfos)
+            throws InvalidProtocolBufferException {
+        Collection<TaskInfo> unpackedTaskInfos = new ArrayList<>();
+        if (!CollectionUtils.isEmpty(packedTaskInfos)) {
+            for (TaskInfo packedTaskInfo : packedTaskInfos) {
+                unpackedTaskInfos.add(unpackTaskInfo(packedTaskInfo));
+            }
+        }
+        return unpackedTaskInfos;
     }
 
     /**

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/curator/CuratorStateStore.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/curator/CuratorStateStore.java
@@ -328,7 +328,7 @@ public class CuratorStateStore implements StateStore {
                         "Failed to retrieve TaskStatus for TaskName: %s", taskName));
             }
         } catch (KeeperException.NoNodeException e) {
-            logger.warn("No TaskInfo found for the requested name: " + taskName + " at: " + path);
+            logger.warn("No TaskStatus found for the requested name: " + taskName + " at: " + path);
             return Optional.empty();
         } catch (Exception e) {
             throw new StateStoreException(e);

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/state/StateStoreCacheTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/state/StateStoreCacheTest.java
@@ -1,18 +1,15 @@
 package com.mesosphere.sdk.state;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
-
+import com.mesosphere.sdk.curator.CuratorStateStore;
+import com.mesosphere.sdk.offer.CommonTaskUtils;
+import com.mesosphere.sdk.testutils.CuratorTestUtils;
+import com.mesosphere.sdk.testutils.TaskTestUtils;
 import org.apache.curator.test.TestingServer;
 import org.apache.mesos.Protos;
 import org.apache.mesos.Protos.FrameworkID;
 import org.apache.mesos.Protos.TaskInfo;
 import org.apache.mesos.Protos.TaskState;
 import org.apache.mesos.Protos.TaskStatus;
-import com.mesosphere.sdk.curator.CuratorStateStore;
-import com.mesosphere.sdk.offer.CommonTaskUtils;
-import com.mesosphere.sdk.testutils.CuratorTestUtils;
-import com.mesosphere.sdk.testutils.TaskTestUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -21,15 +18,10 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import java.nio.charset.Charset;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
 
 /**
  * Tests for {@link StateStoreCache}
@@ -110,30 +102,6 @@ public class StateStoreCacheTest {
         when(mockStore.fetchTasks()).thenReturn(Arrays.asList(TASK));
         when(mockStore.fetchStatuses()).thenReturn(Arrays.asList(STATUS, STATUS2));
         mockedCache = new StateStoreCache(mockStore);
-    }
-
-    @Test
-    public void testFetchTaskUnpacked() {
-        TaskInfo packedTaskInfo = CommonTaskUtils.packTaskInfo(TaskInfo.newBuilder(TASK)
-                .setExecutor(TaskTestUtils.getExecutorInfo(Collections.EMPTY_LIST)).build());
-        when(mockStore.fetchTasks()).thenReturn(Arrays.asList(packedTaskInfo));
-        when(mockStore.fetchStatuses()).thenReturn(Arrays.asList(STATUS));
-        mockedCache = new StateStoreCache(mockStore);
-        Optional<TaskInfo> taskInfoOptional = mockedCache.fetchTask(packedTaskInfo.getName());
-        assertTrue(taskInfoOptional.isPresent());
-        assertTrue(taskInfoOptional.get().hasCommand());
-    }
-
-    @Test
-    public void testFetchTasksUnpacked() {
-        TaskInfo packedTaskInfo = CommonTaskUtils.packTaskInfo(TaskInfo.newBuilder(TASK)
-                .setExecutor(TaskTestUtils.getExecutorInfo(Collections.EMPTY_LIST)).build());
-        when(mockStore.fetchTasks()).thenReturn(Arrays.asList(packedTaskInfo));
-        when(mockStore.fetchStatuses()).thenReturn(Arrays.asList(STATUS));
-        mockedCache = new StateStoreCache(mockStore);
-        Optional<TaskInfo> taskInfoOptional = mockedCache.fetchTask(packedTaskInfo.getName());
-        assertTrue(taskInfoOptional.isPresent());
-        assertTrue(taskInfoOptional.get().hasCommand());
     }
 
     @Test

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/state/StateStoreCacheTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/state/StateStoreCacheTest.java
@@ -113,6 +113,30 @@ public class StateStoreCacheTest {
     }
 
     @Test
+    public void testFetchTaskUnpacked() {
+        TaskInfo packedTaskInfo = CommonTaskUtils.packTaskInfo(TaskInfo.newBuilder(TASK)
+                .setExecutor(TaskTestUtils.getExecutorInfo(Collections.EMPTY_LIST)).build());
+        when(mockStore.fetchTasks()).thenReturn(Arrays.asList(packedTaskInfo));
+        when(mockStore.fetchStatuses()).thenReturn(Arrays.asList(STATUS));
+        mockedCache = new StateStoreCache(mockStore);
+        Optional<TaskInfo> taskInfoOptional = mockedCache.fetchTask(packedTaskInfo.getName());
+        assertTrue(taskInfoOptional.isPresent());
+        assertTrue(taskInfoOptional.get().hasCommand());
+    }
+
+    @Test
+    public void testFetchTasksUnpacked() {
+        TaskInfo packedTaskInfo = CommonTaskUtils.packTaskInfo(TaskInfo.newBuilder(TASK)
+                .setExecutor(TaskTestUtils.getExecutorInfo(Collections.EMPTY_LIST)).build());
+        when(mockStore.fetchTasks()).thenReturn(Arrays.asList(packedTaskInfo));
+        when(mockStore.fetchStatuses()).thenReturn(Arrays.asList(STATUS));
+        mockedCache = new StateStoreCache(mockStore);
+        Optional<TaskInfo> taskInfoOptional = mockedCache.fetchTask(packedTaskInfo.getName());
+        assertTrue(taskInfoOptional.isPresent());
+        assertTrue(taskInfoOptional.get().hasCommand());
+    }
+
+    @Test
     public void testFrameworkIdSingleThread() {
         cache.consistencyCheckForTests();
         assertFalse(cache.fetchFrameworkId().isPresent());


### PR DESCRIPTION
StateStoreCache was not unpacking TaskInfo for fetch calls, which was causing problems elsewhere in `PortEvaluationStage` class (kind of like butterfly effect). More specifically, PortEvaluationStage expects certain env vars in TaskInfo's CommandInfo proto which are only available once the TaskInfo it belongs to is unpacked.

This PR does following:
1. Makes StateStoreCache unpack TaskInfo for fetch calls just like CuratorStateStore
2. Adds corresponding tests inside StateStoreCacheTest
3. Minor fix to a logging statement.

cc: @loren 