### PR TITLE
Configuring hello-world to use V1 HTTP API by default

### DIFF
--- a/frameworks/helloworld/universe/config.json
+++ b/frameworks/helloworld/universe/config.json
@@ -23,7 +23,7 @@
           "mesos_api_version" : {
             "description":"Configures the Mesos API version to use. Possible values: V0 (non-HTTP), V1 (HTTP)",
             "type":"string",
-            "default":"V0"
+            "default":"V1"
           },
           "cmd_prefix" : {
             "description":"A generic prefix to start the scheduler.",


### PR DESCRIPTION
Configuring default value of `mesos_api_version` property to `V1`, so that it uses HTTP by default.