### PR TITLE
Raise an error if any field has duplicates in the yaml

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/YAMLServiceSpecFactory.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/YAMLServiceSpecFactory.java
@@ -1,5 +1,6 @@
 package com.mesosphere.sdk.specification.yaml;
 
+import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.google.common.annotations.VisibleForTesting;
@@ -22,6 +23,10 @@ import java.nio.charset.StandardCharsets;
 public class YAMLServiceSpecFactory {
     private static final Logger LOGGER = LoggerFactory.getLogger(YAMLServiceSpecFactory.class);
     private static final ObjectMapper YAML_MAPPER = new ObjectMapper(new YAMLFactory());
+    static {
+        // If the user provides duplicate fields (e.g. 'count' twice), throw an error instead of silently dropping data:
+        YAML_MAPPER.enable(JsonParser.Feature.STRICT_DUPLICATE_DETECTION);
+    }
     private static final Charset CHARSET = StandardCharsets.UTF_8;
 
     /**

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/YAMLToInternalMappers.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/YAMLToInternalMappers.java
@@ -246,6 +246,10 @@ public class YAMLToInternalMappers {
         DefaultResourceSet.Builder resourceSetBuilder = DefaultResourceSet.newBuilder(role, principal);
 
         if (rawVolumes != null) {
+            if (rawSingleVolume != null) {
+                throw new IllegalArgumentException(String.format(
+                        "Both 'volume' and 'volumes' may not be specified at the same time: %s", id));
+            }
             // Note: volume names for multiple volumes are currently ignored
             for (RawVolume rawVolume : rawVolumes.values()) {
                 resourceSetBuilder.addVolume(

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/specification/DefaultServiceSpecTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/specification/DefaultServiceSpecTest.java
@@ -1,5 +1,6 @@
 package com.mesosphere.sdk.specification;
 
+import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import org.apache.mesos.Protos;
 import com.mesosphere.sdk.testutils.OfferRequirementTestUtils;
@@ -118,17 +119,42 @@ public class DefaultServiceSpecTest {
     }
 
     @Test
-    public void invalidPodName() throws Exception {
+    public void invalidDuplicatePodName() throws Exception {
         ClassLoader classLoader = getClass().getClassLoader();
         File file = new File(classLoader.getResource("invalid-pod-name.yml").getFile());
         try {
             generateServiceSpec(generateRawSpecFromYAML(file));
+            Assert.fail("Expected exception");
         } catch (JsonMappingException e) {
-            if (e.getCause() instanceof ConstraintViolationException) {
-                ConstraintViolationException cause = (ConstraintViolationException) e.getCause();
-                Set<ConstraintViolation<?>> constraintViolations = cause.getConstraintViolations();
-                Assert.assertTrue(constraintViolations.size() > 0);
-            }
+            Assert.assertTrue(e.getCause().toString(), e.getCause() instanceof JsonParseException);
+            JsonParseException cause = (JsonParseException) e.getCause();
+            Assert.assertTrue(cause.getMessage(), cause.getMessage().contains("Duplicate field 'meta-data'"));
+        }
+    }
+
+    @Test
+    public void invalidDuplicateCount() throws Exception {
+        ClassLoader classLoader = getClass().getClassLoader();
+        File file = new File(classLoader.getResource("invalid-duplicate-count.yml").getFile());
+        try {
+            generateServiceSpec(generateRawSpecFromYAML(file));
+            Assert.fail("Expected exception");
+        } catch (JsonMappingException e) {
+            Assert.assertTrue(e.getCause().toString(), e.getCause() instanceof JsonParseException);
+            JsonParseException cause = (JsonParseException) e.getCause();
+            Assert.assertTrue(cause.getMessage().contains("Duplicate field 'count'"));
+        }
+    }
+
+    @Test
+    public void invalidVolumeAndVolumes() throws Exception {
+        ClassLoader classLoader = getClass().getClassLoader();
+        File file = new File(classLoader.getResource("invalid-volume-and-volumes.yml").getFile());
+        try {
+            generateServiceSpec(generateRawSpecFromYAML(file));
+            Assert.fail("Expected exception");
+        } catch (IllegalArgumentException e) {
+            Assert.assertTrue(e.getMessage(), e.getMessage().contains("Both 'volume' and 'volumes'"));
         }
     }
 
@@ -167,6 +193,7 @@ public class DefaultServiceSpecTest {
             DefaultServiceSpec.newBuilder(defaultServiceSpec)
                     .pods(pods)
                     .build();
+            Assert.fail("Expected exception");
         } catch (ConstraintViolationException e) {
             Set<ConstraintViolation<?>> constraintViolations = e.getConstraintViolations();
             Assert.assertTrue(constraintViolations.size() > 0);
@@ -179,12 +206,11 @@ public class DefaultServiceSpecTest {
         File file = new File(classLoader.getResource("invalid-task-name.yml").getFile());
         try {
             generateServiceSpec(generateRawSpecFromYAML(file));
+            Assert.fail("Expected exception");
         } catch (JsonMappingException e) {
-            if (e.getCause() instanceof ConstraintViolationException) {
-                ConstraintViolationException cause = (ConstraintViolationException) e.getCause();
-                Set<ConstraintViolation<?>> constraintViolations = cause.getConstraintViolations();
-                Assert.assertTrue(constraintViolations.size() > 0);
-            }
+            Assert.assertTrue(e.getCause().toString(), e.getCause() instanceof JsonParseException);
+            JsonParseException cause = (JsonParseException) e.getCause();
+            Assert.assertTrue(cause.getMessage(), cause.getMessage().contains("Duplicate field 'meta-data-task'"));
         }
     }
 
@@ -213,6 +239,7 @@ public class DefaultServiceSpecTest {
             DefaultPodSpec.newBuilder(aPod)
                     .tasks(tasks)
                     .build();
+            Assert.fail("Expected exception");
         } catch (ConstraintViolationException e) {
             Set<ConstraintViolation<?>> constraintViolations = e.getConstraintViolations();
             Assert.assertTrue(constraintViolations.size() > 0);
@@ -225,6 +252,7 @@ public class DefaultServiceSpecTest {
         File file = new File(classLoader.getResource("invalid-task-resources.yml").getFile());
         try {
             generateServiceSpec(generateRawSpecFromYAML(file));
+            Assert.fail("Expected exception");
         } catch (ConstraintViolationException e) {
             Set<ConstraintViolation<?>> constraintViolations = e.getConstraintViolations();
             Assert.assertTrue(constraintViolations.size() > 0);
@@ -232,17 +260,17 @@ public class DefaultServiceSpecTest {
     }
 
     @Test
-    public void invalidResourceSetName() throws Exception {
+    public void invalidDuplicateResourceSetName() throws Exception {
         ClassLoader classLoader = getClass().getClassLoader();
         File file = new File(classLoader.getResource("invalid-resource-set-name.yml").getFile());
         try {
             generateServiceSpec(generateRawSpecFromYAML(file));
+            Assert.fail("Expected exception");
         } catch (JsonMappingException e) {
-            if (e.getCause() instanceof ConstraintViolationException) {
-                ConstraintViolationException cause = (ConstraintViolationException) e.getCause();
-                Set<ConstraintViolation<?>> constraintViolations = cause.getConstraintViolations();
-                Assert.assertTrue(constraintViolations.size() > 0);
-            }
+            Assert.assertTrue(e.getCause().toString(), e.getCause() instanceof JsonParseException);
+            JsonParseException cause = (JsonParseException) e.getCause();
+            Assert.assertTrue(cause.getMessage(),
+                    cause.getMessage().contains("Duplicate field 'data-store-resources'"));
         }
     }
 

--- a/sdk/scheduler/src/test/resources/invalid-duplicate-count.yml
+++ b/sdk/scheduler/src/test/resources/invalid-duplicate-count.yml
@@ -1,0 +1,11 @@
+name: "hello-world"
+pods:
+  pod-type:
+    count: 1
+    tasks:
+      meta-data-task:
+        goal: RUNNING
+        cmd: "./task-cmd"
+        cpus: 0.1
+        memory: 512
+    count: 2

--- a/sdk/scheduler/src/test/resources/invalid-pod-name.yml
+++ b/sdk/scheduler/src/test/resources/invalid-pod-name.yml
@@ -6,7 +6,7 @@ pods:
     resource-sets:
       meta-data-resources:
         cpus: 0.1
-        mem: 512
+        memory: 512
         volume:
           path: "/meta-data-container-path"
           type: ROOT
@@ -22,7 +22,7 @@ pods:
     resource-sets:
       data-store-resources:
         cpus: 0.2
-        mem: 1024
+        memory: 1024
         volume:
           path: "/data-store-container-path"
           type: ROOT

--- a/sdk/scheduler/src/test/resources/invalid-task-name.yml
+++ b/sdk/scheduler/src/test/resources/invalid-task-name.yml
@@ -6,7 +6,7 @@ pods:
     resource-sets:
       meta-data-resources:
         cpus: 0.1
-        mem: 512
+        memory: 512
     tasks:
       meta-data-task:
         goal: RUNNING

--- a/sdk/scheduler/src/test/resources/invalid-volume-and-volumes.yml
+++ b/sdk/scheduler/src/test/resources/invalid-volume-and-volumes.yml
@@ -1,0 +1,19 @@
+name: "hello-world"
+pods:
+  pod-type:
+    count: 1
+    tasks:
+      meta-data-task:
+        goal: RUNNING
+        cmd: "./task-cmd"
+        cpus: 0.1
+        memory: 512
+        volume:
+          path: "index-container-path"
+          type: MOUNT
+          size: 4321
+        volumes:
+          metadata:
+            path: "meta-data-container-path"
+            type: ROOT
+            size: 5000


### PR DESCRIPTION
- Specified 'memory' or 'count' twice? That's an error
- Also an explicit check disallowing both 'volume' and 'volumes' at once