### PR TITLE
[HDFS] Expose hdfs-site.xml and core-site.xml through Endpoints endpoint.

### DIFF
--- a/frameworks/hdfs/src/main/dist/svc.yml
+++ b/frameworks/hdfs/src/main/dist/svc.yml
@@ -108,8 +108,6 @@ pods:
           hdfs-site:
             template: {{CONFIG_TEMPLATE_PATH}}/hdfs-site.xml
             dest: {{HDFS_VERSION}}/etc/hadoop/hdfs-site.xml
-        env:
-          SERVICE_ZK_ROOT: dcos-service-{{SERVICE_NAME}}
       format:
         goal: FINISHED
         cmd: ./bootstrap && ./{{HDFS_VERSION}}/bin/hdfs zkfc -formatZK
@@ -121,8 +119,6 @@ pods:
           hdfs-site:
             template: {{CONFIG_TEMPLATE_PATH}}/hdfs-site.xml
             dest: {{HDFS_VERSION}}/etc/hadoop/hdfs-site.xml
-        env:
-          SERVICE_ZK_ROOT: dcos-service-{{SERVICE_NAME}}
   data:
     count: {{DATA_COUNT}}
     uris:

--- a/frameworks/hdfs/src/main/java/com/mesosphere/sdk/hdfs/scheduler/Main.java
+++ b/frameworks/hdfs/src/main/java/com/mesosphere/sdk/hdfs/scheduler/Main.java
@@ -1,6 +1,9 @@
 package com.mesosphere.sdk.hdfs.scheduler;
 
+import com.google.common.collect.ImmutableMap;
 import com.mesosphere.sdk.api.types.EndpointProducer;
+import com.mesosphere.sdk.config.DefaultTaskConfigRouter;
+import com.mesosphere.sdk.offer.CommonTaskUtils;
 import com.mesosphere.sdk.offer.evaluate.placement.AndRule;
 import com.mesosphere.sdk.offer.evaluate.placement.TaskTypeRule;
 import com.mesosphere.sdk.scheduler.DefaultScheduler;
@@ -11,6 +14,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Optional;
 
@@ -35,13 +43,33 @@ public class Main {
         DefaultScheduler.Builder builder =
                 DefaultScheduler.newBuilder(serviceSpecWithCustomizedPods(rawServiceSpec))
                 .setPlansFrom(rawServiceSpec);
-        // TODO(nick): The endpointproducers should produce valid HDFS xml files. They can get the info they need from
-        // scheduler envvars and/or the ServiceSpec. If they need current task state, they could be passed the
-        // StateStore from builder.getStateStore() when they're constructed, which they could then access to get current
-        // task state when EndpointProducer.getEndpoint() is called.
         return builder
-                .setEndpointProducer("hdfs-site.xml", EndpointProducer.constant("TODO: hdfs-site.xml content"))
-                .setEndpointProducer("core-site.xml", EndpointProducer.constant("TODO: core-site.xml content"));
+                .setEndpointProducer("hdfs-site.xml", EndpointProducer.constant(getHdfsSiteXml()))
+                .setEndpointProducer("core-site.xml", EndpointProducer.constant(getCoreSiteXml()));
+    }
+
+    private static String getHdfsSiteXml() {
+        return renderTemplate(System.getProperty("user.dir") + "/hdfs-scheduler/hdfs-site.xml");
+    }
+
+    private static String getCoreSiteXml() {
+        return renderTemplate(System.getProperty("user.dir") + "/hdfs-scheduler/core-site.xml");
+    }
+
+    private static String renderTemplate(String pathStr) {
+        Path path = Paths.get(pathStr);
+        byte[] bytes;
+        try {
+            bytes = Files.readAllBytes(path);
+        } catch (IOException e) {
+            String error = String.format("Failed to render %s", pathStr);
+            LOGGER.error(error, e);
+            return error;
+        }
+
+        String fileStr = new String(bytes, Charset.defaultCharset());
+        ImmutableMap<String, String> allEnv = new DefaultTaskConfigRouter().getConfig("ALL").getAllEnv();
+        return CommonTaskUtils.applyEnvToMustache(fileStr, allEnv);
     }
 
     private static ServiceSpec serviceSpecWithCustomizedPods(RawServiceSpec rawServiceSpec)

--- a/frameworks/hdfs/src/test/java/com/mesosphere/sdk/hdfs/scheduler/ServiceSpecTest.java
+++ b/frameworks/hdfs/src/test/java/com/mesosphere/sdk/hdfs/scheduler/ServiceSpecTest.java
@@ -1,46 +1,102 @@
 package com.mesosphere.sdk.hdfs.scheduler;
 
+import com.google.common.collect.ImmutableMap;
+import com.mesosphere.sdk.config.DefaultTaskConfigRouter;
+import com.mesosphere.sdk.offer.CommonTaskUtils;
 import com.mesosphere.sdk.testing.BaseServiceSpecTest;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 public class ServiceSpecTest extends BaseServiceSpecTest {
 
     @BeforeClass
     public static void beforeAll() {
-        ENV_VARS.set("EXECUTOR_URI", "");
-        ENV_VARS.set("LIBMESOS_URI", "");
         ENV_VARS.set("PORT_API", "8080");
+        ENV_VARS.set("HDFS_VERSION", "hadoop-2.6.0-cdh5.9.1");
         ENV_VARS.set("SERVICE_NAME", "hdfs");
-        ENV_VARS.set("SERVICE_PRINCIPAL", "principal");
+        ENV_VARS.set("SERVICE_PRINCIPAL", "hdfs-principal");
         ENV_VARS.set("JOURNAL_CPUS", "1.0");
-        ENV_VARS.set("JOURNAL_MEM", "1024");
-        ENV_VARS.set("JOURNAL_DISK", "1024");
-        ENV_VARS.set("JOURNAL_DISK_TYPE", "MOUNT");
-        ENV_VARS.set("TASKCFG_ALL_JOURNAL_NODE_RPC_PORT", "1");
-        ENV_VARS.set("TASKCFG_ALL_JOURNAL_NODE_HTTP_PORT", "1");
-        ENV_VARS.set("ZKFC_CPUS", "1.0");
-        ENV_VARS.set("ZKFC_MEM", "1024");
+        ENV_VARS.set("JOURNAL_MEM", "256");
+        ENV_VARS.set("JOURNAL_DISK", "5000");
+        ENV_VARS.set("JOURNAL_DISK_TYPE", "ROOT");
+        ENV_VARS.set("JOURNAL_STRATEGY", "parallel");
         ENV_VARS.set("NAME_CPUS", "1.0");
-        ENV_VARS.set("NAME_MEM", "1024");
-        ENV_VARS.set("NAME_DISK", "1024");
-        ENV_VARS.set("NAME_DISK_TYPE", "MOUNT");
-        ENV_VARS.set("TASKCFG_ALL_NAME_NODE_RPC_PORT", "1");
-        ENV_VARS.set("TASKCFG_ALL_NAME_NODE_HTTP_PORT", "1");
+        ENV_VARS.set("NAME_MEM", "256");
+        ENV_VARS.set("NAME_DISK", "5000");
+        ENV_VARS.set("NAME_DISK_TYPE", "ROOT");
+        ENV_VARS.set("ZKFC_CPUS", "1.0");
+        ENV_VARS.set("ZKFC_MEM", "256");
         ENV_VARS.set("DATA_COUNT", "3");
         ENV_VARS.set("DATA_CPUS", "1.0");
-        ENV_VARS.set("DATA_MEM", "1024");
-        ENV_VARS.set("DATA_DISK", "1024");
-        ENV_VARS.set("DATA_DISK_TYPE", "MOUNT");
-        ENV_VARS.set("TASKCFG_ALL_DATA_NODE_RPC_PORT", "1");
-        ENV_VARS.set("TASKCFG_ALL_DATA_NODE_HTTP_PORT", "1");
-        ENV_VARS.set("TASKCFG_ALL_DATA_NODE_IPC_PORT", "1");
-        ENV_VARS.set("JOURNAL_STRATEGY", "parallel");
+        ENV_VARS.set("DATA_MEM", "256");
+        ENV_VARS.set("DATA_DISK", "5000");
+        ENV_VARS.set("DATA_DISK_TYPE", "ROOT");
         ENV_VARS.set("DATA_STRATEGY", "parallel");
+        ENV_VARS.set("EXECUTOR_URI", "");
+        ENV_VARS.set("LIBMESOS_URI", "");
+        ENV_VARS.set("HDFS_URI", "");
+        ENV_VARS.set("BOOTSTRAP_URI", "");
+        ENV_VARS.set("TASKCFG_ALL_NAME_NODE_RPC_PORT","9001");
+        ENV_VARS.set("TASKCFG_ALL_NAME_NODE_HTTP_PORT","9002");
+        ENV_VARS.set("TASKCFG_ALL_JOURNAL_NODE_RPC_PORT","8485");
+        ENV_VARS.set("TASKCFG_ALL_JOURNAL_NODE_HTTP_PORT","8480");
+        ENV_VARS.set("TASKCFG_ALL_DATA_NODE_RPC_PORT","9003");
+        ENV_VARS.set("TASKCFG_ALL_DATA_NODE_HTTP_PORT","9004");
+        ENV_VARS.set("TASKCFG_ALL_DATA_NODE_IPC_PORT","9005");
+        ENV_VARS.set("TASKCFG_ALL_DATA_NODE_BALANCE_BANDWIDTH_PER_SEC","41943040");
+        ENV_VARS.set("TASKCFG_ALL_NAME_NODE_SAFEMODE_THRESHOLD_PCT","0.9");
+        ENV_VARS.set("TASKCFG_ALL_DATA_NODE_HANDLER_COUNT","10");
+        ENV_VARS.set("TASKCFG_ALL_NAME_NODE_HANDLER_COUNT","20");
+        ENV_VARS.set("TASKCFG_ALL_PERMISSIONS_ENABLED","false");
+        ENV_VARS.set("TASKCFG_ALL_NAME_NODE_HEARTBEAT_RECHECK_INTERVAL","60000");
+        ENV_VARS.set("TASKCFG_ALL_IMAGE_COMPRESS","true");
+        ENV_VARS.set("TASKCFG_ALL_IMAGE_COMPRESSION_CODEC","org.apache.hadoop.io.compress.SnappyCodec");
+        ENV_VARS.set("TASKCFG_ALL_NAME_NODE_INVALIDATE_WORK_PCT_PER_ITERATION","0.95");
+        ENV_VARS.set("TASKCFG_ALL_NAME_NODE_REPLICATION_WORK_MULTIPLIER_PER_ITERATION","4");
+        ENV_VARS.set("TASKCFG_ALL_CLIENT_READ_SHORTCIRCUIT","true");
+        ENV_VARS.set("TASKCFG_ALL_CLIENT_READ_SHORTCIRCUIT_PATH","/var/lib/hadoop-hdfs/dn_socket");
+        ENV_VARS.set("TASKCFG_ALL_CLIENT_READ_SHORTCIRCUIT_STREAMS_CACHE_SIZE","1000");
+        ENV_VARS.set("TASKCFG_ALL_CLIENT_READ_SHORTCIRCUIT_STREAMS_CACHE_SIZE_EXPIRY_MS","1000");
+        ENV_VARS.set("TASKCFG_ALL_NAME_NODE_DATA_NODE_REGISTRATION_IP_HOSTNAME_CHECK", "false");
+        ENV_VARS.set("TASKCFG_ALL_HA_FENCING_METHODS", "shell(/bin/true)");
+        ENV_VARS.set("TASKCFG_ALL_HA_AUTOMATIC_FAILURE", "true");
+        ENV_VARS.set("TASKCFG_ALL_CLIENT_FAILOVER_PROXY_PROVIDER_HDFS", "org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider");
+        ENV_VARS.set("TASKCFG_ALL_HADOOP_PROXYUSER_HUE_HOSTS", "*");
+        ENV_VARS.set("TASKCFG_ALL_HADOOP_PROXYUSER_HUE_GROUPS", "*");
+        ENV_VARS.set("TASKCFG_ALL_HADOOP_PROXYUSER_ROOT_HOSTS", "*");
+        ENV_VARS.set("TASKCFG_ALL_HADOOP_PROXYUSER_ROOT_GROUPS", "*");
+        ENV_VARS.set("TASKCFG_ALL_HADOOP_PROXYUSER_HTTPFS_GROUPS", "*");
+        ENV_VARS.set("TASKCFG_ALL_HADOOP_PROXYUSER_HTTPFS_HOSTS", "*");
     }
 
     @Test
     public void testYaml() throws Exception {
         super.testYaml("svc.yml");
+    }
+
+    @Test
+    public void renderHdfsSiteXml() throws IOException {
+        renderTemplate(System.getProperty("user.dir") + "/src/main/dist/hdfs-site.xml");
+    }
+
+    @Test
+    public void renderCoreSiteXml() throws IOException {
+        renderTemplate(System.getProperty("user.dir") + "/src/main/dist/core-site.xml");
+    }
+
+    private void renderTemplate(String pathStr) throws IOException {
+        Path path = Paths.get(pathStr);
+        byte[] bytes = Files.readAllBytes(path);
+        String fileStr = new String(bytes, Charset.defaultCharset());
+        ImmutableMap<String, String> allEnv = new DefaultTaskConfigRouter().getConfig("ALL").getAllEnv();
+        String renderedFileStr = CommonTaskUtils.applyEnvToMustache(fileStr, allEnv);
+        Assert.assertEquals(-1, renderedFileStr.indexOf("<value></value>"));
     }
 }

--- a/frameworks/hdfs/src/test/java/com/mesosphere/sdk/hdfs/scheduler/ServiceSpecTest.java
+++ b/frameworks/hdfs/src/test/java/com/mesosphere/sdk/hdfs/scheduler/ServiceSpecTest.java
@@ -98,5 +98,6 @@ public class ServiceSpecTest extends BaseServiceSpecTest {
         ImmutableMap<String, String> allEnv = new DefaultTaskConfigRouter().getConfig("ALL").getAllEnv();
         String renderedFileStr = CommonTaskUtils.applyEnvToMustache(fileStr, allEnv);
         Assert.assertEquals(-1, renderedFileStr.indexOf("<value></value>"));
+        Assert.assertTrue(CommonTaskUtils.isMustacheFullyRendered(renderedFileStr));
     }
 }

--- a/frameworks/hdfs/src/test/java/com/mesosphere/sdk/hdfs/scheduler/ServiceSpecTest.java
+++ b/frameworks/hdfs/src/test/java/com/mesosphere/sdk/hdfs/scheduler/ServiceSpecTest.java
@@ -82,12 +82,12 @@ public class ServiceSpecTest extends BaseServiceSpecTest {
     }
 
     @Test
-    public void renderHdfsSiteXml() throws IOException {
+    public void testRenderHdfsSiteXml() throws IOException {
         renderTemplate(System.getProperty("user.dir") + "/src/main/dist/hdfs-site.xml");
     }
 
     @Test
-    public void renderCoreSiteXml() throws IOException {
+    public void testRenderCoreSiteXml() throws IOException {
         renderTemplate(System.getProperty("user.dir") + "/src/main/dist/core-site.xml");
     }
 

--- a/frameworks/hdfs/universe/marathon.json.mustache
+++ b/frameworks/hdfs/universe/marathon.json.mustache
@@ -69,6 +69,7 @@
     "TASKCFG_ALL_HADOOP_PROXYUSER_ROOT_GROUPS": "*",
     "TASKCFG_ALL_HADOOP_PROXYUSER_HTTPFS_GROUPS": "*",
     "TASKCFG_ALL_HADOOP_PROXYUSER_HTTPFS_HOSTS": "*",
+    "TASKCFG_ALL_SERVICE_ZK_ROOT": "dcos-service-{{service.name}}",
     "CONFIG_TEMPLATE_PATH": "hdfs-scheduler"
   },
   "uris": [

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/api/EndpointsResourceTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/api/EndpointsResourceTest.java
@@ -126,8 +126,8 @@ public class EndpointsResourceTest {
             TASK_WITH_HIDDEN_DISCOVERY,
             TASK_WITH_VIPS_1,
             TASK_WITH_VIPS_2);
+    private static final String CUSTOM_KEY = "custom";
     private static final String CUSTOM_VALUE = "hi\nhey\nhello";
-
 
     @Mock private StateStore mockStateStore;
 
@@ -137,7 +137,7 @@ public class EndpointsResourceTest {
     public void beforeAll() {
         MockitoAnnotations.initMocks(this);
         resource = new EndpointsResource(mockStateStore, "svc-name");
-        resource.setCustomEndpoint("custom", EndpointProducer.constant(CUSTOM_VALUE));
+        resource.setCustomEndpoint(CUSTOM_KEY, EndpointProducer.constant(CUSTOM_VALUE));
     }
 
     @Test
@@ -145,12 +145,15 @@ public class EndpointsResourceTest {
         when(mockStateStore.fetchTasks()).thenReturn(TASK_INFOS);
         Response response = resource.getEndpoints(null);
         assertEquals(200, response.getStatus());
-        JSONObject json = new JSONObject((String) response.getEntity());
+        JSONArray json = new JSONArray((String) response.getEntity());
         assertEquals(json.toString(), 4, json.length());
 
-        assertEquals(CUSTOM_VALUE, json.get("custom"));
+        assertEquals(CUSTOM_KEY, json.get(0));
+        assertEquals("vip2", json.get(1));
+        assertEquals("vip1", json.get(2));
+        assertEquals("some-task-type", json.get(3));
 
-        JSONObject vip1 = json.getJSONObject("vip1");
+        JSONObject vip1 = new JSONObject((String) resource.getEndpoint("vip1", null).getEntity());
         assertEquals(2, vip1.length());
         assertEquals("vip1.svc-name.l4lb.thisdcos.directory:5432", vip1.get("vip"));
         JSONArray direct = vip1.getJSONArray("direct");
@@ -158,7 +161,7 @@ public class EndpointsResourceTest {
         assertEquals("with-vips-1.svc-name.mesos:2345", direct.get(0));
         assertEquals("with-vips-2.svc-name.mesos:3456", direct.get(1));
 
-        JSONObject vip2 = json.getJSONObject("vip2");
+        JSONObject vip2 = new JSONObject((String) resource.getEndpoint("vip2", null).getEntity());
         assertEquals(2, vip2.length());
         assertEquals("vip2.svc-name.l4lb.thisdcos.directory:6432", vip2.get("vip"));
         direct = vip2.getJSONArray("direct");
@@ -166,9 +169,9 @@ public class EndpointsResourceTest {
         assertEquals("with-vips-1.svc-name.mesos:2346", direct.get(0));
         assertEquals("with-vips-2.svc-name.mesos:3457", direct.get(1));
 
-        JSONObject tasktype = json.getJSONObject("some-task-type");
-        assertEquals(1, tasktype.length());
-        direct = tasktype.getJSONArray("direct");
+        JSONObject taskType = new JSONObject((String) resource.getEndpoint("some-task-type", null).getEntity());
+        assertEquals(1, taskType.length());
+        direct = taskType.getJSONArray("direct");
         assertEquals(6, direct.length());
         assertEquals("with-ports-1.svc-name.mesos:1234", direct.get(0));
         assertEquals("with-ports-1.svc-name.mesos:1235", direct.get(1));
@@ -184,12 +187,15 @@ public class EndpointsResourceTest {
         when(mockStateStore.fetchTasks()).thenReturn(TASK_INFOS);
         Response response = resource.getEndpoints("native");
         assertEquals(200, response.getStatus());
-        JSONObject json = new JSONObject((String) response.getEntity());
+        JSONArray json = new JSONArray((String) response.getEntity());
         assertEquals(json.toString(), 4, json.length());
 
-        assertEquals(CUSTOM_VALUE, json.get("custom"));
+        assertEquals(CUSTOM_KEY, json.get(0));
+        assertEquals("vip2", json.get(1));
+        assertEquals("vip1", json.get(2));
+        assertEquals("some-task-type", json.get(3));
 
-        JSONObject vip1 = json.getJSONObject("vip1");
+        JSONObject vip1 = new JSONObject((String) resource.getEndpoint("vip1", "native").getEntity());
         assertEquals(2, vip1.length());
         assertEquals("vip1.svc-name.l4lb.thisdcos.directory:5432", vip1.get("vip"));
         JSONArray direct = vip1.getJSONArray("direct");
@@ -197,7 +203,7 @@ public class EndpointsResourceTest {
         assertEquals(TestConstants.HOSTNAME + ":2345", direct.get(0));
         assertEquals(TestConstants.HOSTNAME + ":3456", direct.get(1));
 
-        JSONObject vip2 = json.getJSONObject("vip2");
+        JSONObject vip2 = new JSONObject((String) resource.getEndpoint("vip2", "native").getEntity());
         assertEquals(2, vip2.length());
         assertEquals("vip2.svc-name.l4lb.thisdcos.directory:6432", vip2.get("vip"));
         direct = vip2.getJSONArray("direct");
@@ -205,9 +211,9 @@ public class EndpointsResourceTest {
         assertEquals(TestConstants.HOSTNAME + ":2346", direct.get(0));
         assertEquals(TestConstants.HOSTNAME + ":3457", direct.get(1));
 
-        JSONObject tasktype = json.getJSONObject("some-task-type");
-        assertEquals(1, tasktype.length());
-        direct = tasktype.getJSONArray("direct");
+        JSONObject taskType = new JSONObject((String) resource.getEndpoint("some-task-type", "native").getEntity());
+        assertEquals(1, taskType.length());
+        direct = taskType.getJSONArray("direct");
         assertEquals(6, direct.length());
         assertEquals(TestConstants.HOSTNAME + ":1234", direct.get(0));
         assertEquals(TestConstants.HOSTNAME + ":1235", direct.get(1));


### PR DESCRIPTION
Output looks like this:
```bash
$ dcos hdfs endpoints
[
  "hdfs-site.xml",
  "core-site.xml"
]
```

```bash
$ dcos hdfs endpoints hdfs-site.xml
<?xml version="1.0" encoding="UTF-8" standalone="no"?>
<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
<configuration>
    <property>
        <name>dfs.nameservice.id</name>
        <value>hdfs</value>
    </property>
    <property>
        <name>dfs.nameservices</name>
        <value>hdfs</value>
    </property>
    <property>
        <name>dfs.ha.namenodes.hdfs</name>
        <value>name-0-node,name-1-node</value>
    </property>
    <property>
        <name>dfs.namenode.http-address.hdfs.name-0-node</name>
        <value>name-0-node.hdfs.mesos:9002</value>
    </property>
    <property>
        <name>dfs.namenode.rpc-address.hdfs.name-0-node</name>
        <value>name-0-node.hdfs.mesos:9001</value>
    </property>
    <property>
        <name>dfs.namenode.rpc-bind-host.hdfs.name-0-node</name>
        <value>0.0.0.0</value>
    </property>
    <property>
        <name>dfs.namenode.http-bind-host.hdfs.name-0-node</name>
        <value>0.0.0.0</value>
    </property>
    <property>
        <name>dfs.namenode.http-address.hdfs.name-1-node</name>
        <value>name-1-node.hdfs.mesos:9002</value>
    </property>
    <property>
        <name>dfs.namenode.rpc-address.hdfs.name-1-node</name>
        <value>name-1-node.hdfs.mesos:9001</value>
    </property>
    <property>
        <name>dfs.namenode.rpc-bind-host.hdfs.name-1-node</name>
        <value>0.0.0.0</value>
    </property>
    <property>
        <name>dfs.namenode.http-bind-host.hdfs.name-1-node</name>
        <value>0.0.0.0</value>
    </property>
    <property>
        <name>dfs.journalnode.rpc-address</name>
        <value>0.0.0.0:8485</value>
    </property>
    <property>
        <name>dfs.journalnode.http-address</name>
        <value>0.0.0.0:8480</value>
    </property>
    <property>
        <name>dfs.namenode.shared.edits.dir</name>
        <value>qjournal://journal-0-node.hdfs.mesos:8485;journal-1-node.hdfs.mesos:8485;journal-2-node.hdfs.mesos:8485/hdfs</value>
    </property>
    <property>
        <name>dfs.datanode.address</name>
        <value>0.0.0.0:9003</value>
    </property>
    <property>
        <name>dfs.datanode.http.address</name>
        <value>0.0.0.0:9004</value>
    </property>
    <property>
        <name>dfs.datanode.ipc.address</name>
        <value>0.0.0.0:9005</value>
    </property>
    <property>
        <name>ha.zookeeper.quorum</name>
        <value>master.mesos:2181</value>
    </property>
    <property>
        <name>dfs.namenode.name.dir</name>
        <value>file:/name-data</value>
    </property>
    <property>
        <name>dfs.journalnode.edits.dir</name>
        <value>/journal-data</value>
    </property>
    <property>
        <name>dfs.datanode.data.dir</name>
        <value>file:/data-data</value>
    </property>
    <property>
        <name>dfs.datanode.balance.bandwidthPerSec</name>
        <value>41943040</value>
    </property>
    <property>
        <name>dfs.namenode.safemode.threshold-pct</name>
        <value>0.9</value>
    </property>
    <property>
        <name>dfs.namenode.heartbeat.recheck-interval</name>
        <value>60000</value>
    </property>
    <property>
        <name>dfs.datanode.handler.count</name>
        <value>10</value>
    </property>
    <property>
        <name>dfs.namenode.handler.count</name>
        <value>20</value>
    </property>
    <property>
        <name>dfs.image.compress</name>
        <value>true</value>
    </property>
    <property>
        <name>dfs.image.compression.codec</name>
        <value>org.apache.hadoop.io.compress.SnappyCodec</value>
    </property>
    <property>
        <name>dfs.namenode.invalidate.work.pct.per.iteration</name>
        <value>0.95</value>
    </property>
    <property>
        <name>dfs.namenode.replication.work.multiplier.per.iteration</name>
        <value>4</value>
    </property>
    <property>
        <name>dfs.client.read.shortcircuit</name>
        <value>true</value>
    </property>
    <property>
        <name>dfs.domain.socket.path</name>
        <value>/var/lib/hadoop-hdfs/dn_socket</value>
    </property>
    <property>
        <name>dfs.client.read.shortcircuit.streams.cache.size</name>
        <value>1000</value>
    </property>
    <property>
        <name>dfs.client.read.shortcircuit.streams.cache.size.expiry.ms</name>
        <value>1000</value>
    </property>
    <property>
        <name>dfs.permissions.enabled</name>
        <value>false</value>
    </property>
    <property>
        <name>dfs.namenode.datanode.registration.ip-hostname-check</name>
        <value>false</value>
    </property>
    <property>
        <name>dfs.ha.fencing.methods</name>
        <value>shell(/bin/true)</value>
    </property>
    <property>
        <name>dfs.ha.automatic-failover.enabled</name>
        <value>true</value>
    </property>
    <property>
        <name>dfs.client.failover.proxy.provider.hdfs</name>
        <value>org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider</value>
    </property>

</configuration>
```

```bash
$ dcos hdfs endpoints core-site.xml
<?xml version="1.0" encoding="UTF-8" standalone="no"?>
<?xml-stylesheet type="text/xsl" href="configuration.xsl"?><configuration>
    <property>
        <name>fs.default.name</name>
        <value>hdfs://hdfs</value>
    </property>
    <property>
        <name>hadoop.proxyuser.hue.hosts</name>
        <value>*</value>
    </property>
    <property>
        <name>hadoop.proxyuser.hue.groups</name>
        <value>*</value>
    </property>
    <property>
        <name>hadoop.proxyuser.root.hosts</name>
        <value>*</value>
    </property>
    <property>
        <name>hadoop.proxyuser.root.groups</name>
        <value>*</value>
    </property>
    <property>
        <name>hadoop.proxyuser.httpfs.groups</name>
        <value>*</value>
    </property>
    <property>
        <name>hadoop.proxyuser.httpfs.hosts</name>
        <value>*</value>
    </property>
    <property>
        <name>ha.zookeeper.parent-znode</name>
        <value>/dcos-service-hdfs/hadoop-ha</value>
    </property>
</configuration>
```