### PR TITLE
Enable the propagation of additional envvars to tasks at plan start

### DIFF
--- a/frameworks/helloworld/src/main/dist/examples/parameterized-plan.yml
+++ b/frameworks/helloworld/src/main/dist/examples/parameterized-plan.yml
@@ -1,0 +1,49 @@
+name: "hello-world"
+pods:
+  hello:
+    count: 2
+    resource-sets:
+      hello-resources:
+        cpus: {{HELLO_CPUS}}
+        memory: 256
+        volume:
+          path: "hello-container-path"
+          type: ROOT
+          size: 1024
+      sidecar-resources:
+        cpus: 1
+        memory: 256
+    tasks:
+      server:
+        goal: RUNNING
+        cmd: "echo $TASK_NAME >> hello-container-path/output && sleep $SLEEP_DURATION"
+        resource-set: hello-resources
+        env:
+          SLEEP_DURATION: 1000
+      once:
+        goal: FINISHED
+        cmd: "echo 'I run only once' >> hello-container-path/output"
+        resource-set: sidecar-resources
+      sidecar:
+        goal: FINISHED
+        cmd: "echo $PLAN_PARAMETER >> hello-container-path/output && grep parameterized < hello-container-path/output"
+        resource-set: sidecar-resources
+plans:
+  deploy:
+    strategy: serial
+    phases:
+      server-deploy:
+        strategy: parallel
+        pod: hello
+        tasks: [server]
+      once-deploy:
+        strategy: parallel
+        pod: hello
+        tasks: [once]
+  sidecar:
+    strategy: serial
+    phases:
+      sidecar-deploy:
+        strategy: parallel
+        pod: hello
+        tasks: [sidecar]

--- a/frameworks/helloworld/src/main/resources/examples/parameterized-plan.yml
+++ b/frameworks/helloworld/src/main/resources/examples/parameterized-plan.yml
@@ -1,0 +1,1 @@
+../../dist/examples/parameterized-plan.yml

--- a/frameworks/helloworld/tests/test_parameterized_plan.py
+++ b/frameworks/helloworld/tests/test_parameterized_plan.py
@@ -13,7 +13,7 @@ def setup_module(module):
     install.uninstall(PACKAGE_NAME)
     options = {
         "service": {
-            "spec_file": "examples/sidecar.yml"
+            "spec_file": "examples/parameterized-plan.yml"
         }
     }
 
@@ -35,10 +35,13 @@ def test_deploy():
 
 @pytest.mark.sanity
 def test_sidecar():
-    plan.start_sidecar_plan(PACKAGE_NAME)
+    plan.start_sidecar_plan(PACKAGE_NAME, {'PLAN_PARAMETER': 'parameterized'})
     sidecar_plan = plan.get_sidecar_plan(PACKAGE_NAME).json()
     print("sidecar_plan: " + str(sidecar_plan))
 
     assert(len(sidecar_plan['phases']) == 1)
     assert(sidecar_plan['phases'][0]['name'] == 'sidecar-deploy')
     assert(len(sidecar_plan['phases'][0]['steps']) == 2)
+
+    spin.time_wait_noisy(lambda: (
+        plan.get_sidecar_plan(PACKAGE_NAME).json()['status'] == 'COMPLETE'))

--- a/frameworks/helloworld/tests/test_sidecar.py
+++ b/frameworks/helloworld/tests/test_sidecar.py
@@ -2,6 +2,7 @@ import pytest
 
 import sdk_install as install
 import sdk_plan as plan
+import sdk_spin as spin
 
 from tests.config import (
     PACKAGE_NAME
@@ -34,10 +35,13 @@ def test_deploy():
 
 @pytest.mark.sanity
 def test_sidecar():
-    plan.start_sidecar_plan(PACKAGE_NAME)
+    plan.start_sidecar_plan(PACKAGE_NAME, {'PLAN_PARAMETER': 'sidecar'})
     sidecar_plan = plan.get_sidecar_plan(PACKAGE_NAME).json()
     print("sidecar_plan: " + str(sidecar_plan))
 
     assert(len(sidecar_plan['phases']) == 1)
     assert(sidecar_plan['phases'][0]['name'] == 'sidecar-deploy')
     assert(len(sidecar_plan['phases'][0]['steps']) == 2)
+
+    spin.time_wait_noisy(lambda: (
+        plan.get_sidecar_plan(PACKAGE_NAME).json()['status'] == 'COMPLETE'))

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/api/PlansResource.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/api/PlansResource.java
@@ -2,6 +2,8 @@ package com.mesosphere.sdk.api;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.mesosphere.sdk.api.types.PlanInfo;
+import com.mesosphere.sdk.offer.evaluate.placement.RegexMatcher;
+import com.mesosphere.sdk.offer.evaluate.placement.StringMatcher;
 import com.mesosphere.sdk.scheduler.plan.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -22,6 +24,7 @@ public class PlansResource {
     static final Response PLAN_ELEMENT_NOT_FOUND_RESPONSE = Response.status(Response.Status.NOT_FOUND)
             .entity("Element not found")
             .build();
+    private static final StringMatcher ENVVAR_MATCHER = RegexMatcher.create("[A-Za-z_][A-Za-z0-9_]*");
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
     private final PlanCoordinator planCoordinator;
@@ -66,10 +69,17 @@ public class PlansResource {
      */
     @POST
     @Path("/plans/{planName}/start")
-    public Response startPlan(@PathParam("planName") String planName) {
+    public Response startPlan(@PathParam("planName") String planName, Map<String, String> parameters) {
+        try {
+            validate(parameters);
+        } catch (ValidationException e) {
+            return invalidParameterResponse(e.getMessage());
+        }
+
         final Optional<PlanManager> planManagerOptional = getPlanManager(planName);
         if (planManagerOptional.isPresent()) {
             Plan plan = planManagerOptional.get().getPlan();
+            plan.updateParameters(parameters);
             if (plan.isComplete()) {
                 plan.restart();
             }
@@ -254,6 +264,27 @@ public class PlansResource {
         return planCoordinator.getPlanManagers().stream()
                 .filter(planManager -> planManager.getPlan().getName().equals(planName))
                 .findFirst();
+    }
+
+    private static Response invalidParameterResponse(String message) {
+        return Response.status(Response.Status.BAD_REQUEST)
+                .entity("Couldn't parse parameters: " + message)
+                .build();
+    }
+
+    private static void validate(Map<String, String> parameters) throws ValidationException {
+        for (Map.Entry<String, String> entry : parameters.entrySet()) {
+            if (!ENVVAR_MATCHER.matches(entry.getKey())) {
+                throw new ValidationException(
+                        String.format("%s is not a valid environment variable name", entry.getKey()));
+            }
+        }
+    }
+
+    static class ValidationException extends Exception {
+        public ValidationException(String message) {
+            super(message);
+        }
     }
 
     static class CommandResultInfo {

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/api/PlansResource.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/api/PlansResource.java
@@ -19,7 +19,6 @@ import java.util.stream.Collectors;
  */
 @Path("/v1")
 @Produces(MediaType.APPLICATION_JSON)
-@Consumes(MediaType.APPLICATION_JSON)
 public class PlansResource {
     static final Response PLAN_ELEMENT_NOT_FOUND_RESPONSE = Response.status(Response.Status.NOT_FOUND)
             .entity("Element not found")
@@ -69,6 +68,7 @@ public class PlansResource {
      */
     @POST
     @Path("/plans/{planName}/start")
+    @Consumes(MediaType.APPLICATION_JSON)
     public Response startPlan(@PathParam("planName") String planName, Map<String, String> parameters) {
         try {
             validate(parameters);

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/OfferRequirementProvider.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/OfferRequirementProvider.java
@@ -1,16 +1,14 @@
 package com.mesosphere.sdk.offer;
 
-import com.mesosphere.sdk.specification.PodInstance;
-
-import java.util.Collection;
+import com.mesosphere.sdk.scheduler.plan.PodInstanceRequirement;
 
 /**
  * An OfferRequirementProvider generates OfferRequirements representing the requirements of a Container in two
  * scenarios: initial launch, and update of an already running container.
  */
 public interface OfferRequirementProvider {
-    OfferRequirement getNewOfferRequirement(PodInstance podInstance, Collection<String> tasksToLaunch)
+    OfferRequirement getNewOfferRequirement(PodInstanceRequirement podInstanceRequirement)
             throws InvalidRequirementException;
-    OfferRequirement getExistingOfferRequirement(PodInstance podInstance, Collection<String> tasksToLaunch)
+    OfferRequirement getExistingOfferRequirement(PodInstanceRequirement podInstanceRequirement)
             throws InvalidRequirementException;
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluator.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluator.java
@@ -144,13 +144,12 @@ public class OfferEvaluator {
             description = "existing";
             shouldGetNewRequirement = false;
         }
-        Collection<String> tasksToLaunch = podInstanceRequirement.getTasksToLaunch();
         logger.info("Generating requirement for {} pod '{}' containing tasks: {}",
-                description, podInstance.getName(), tasksToLaunch);
+                description, podInstance.getName(), podInstanceRequirement.getTasksToLaunch());
         if (shouldGetNewRequirement) {
-            return offerRequirementProvider.getNewOfferRequirement(podInstance, tasksToLaunch);
+            return offerRequirementProvider.getNewOfferRequirement(podInstanceRequirement);
         } else {
-            return offerRequirementProvider.getExistingOfferRequirement(podInstance, tasksToLaunch);
+            return offerRequirementProvider.getExistingOfferRequirement(podInstanceRequirement);
         }
     }
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/DeploymentStep.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/DeploymentStep.java
@@ -20,6 +20,7 @@ public class DeploymentStep extends AbstractStep {
     private final List<String> errors;
     private final PodInstanceRequirement podInstanceRequirement;
 
+    private Map<String, String> parameters;
     private Map<Protos.TaskID, TaskStatusPair> tasks = new HashMap<>();
 
     /**
@@ -40,8 +41,8 @@ public class DeploymentStep extends AbstractStep {
      * This method may be triggered by external components via the {@link #updateOfferStatus(Collection)} method in
      * particular, so it is synchronized to avoid inconsistent expectations regarding what TaskIDs are relevant to it.
      *
-     * @param operations The Operations which were performed in response to the {@link PodInstanceRequirement} provided
-     *                   by {@link #start()}
+     * @param recommendations The {@link OfferRecommendation}s returned in response to the
+     *                        {@link PodInstanceRequirement} provided by {@link #start()}
      */
     private synchronized void setTaskIds(Collection<OfferRecommendation> recommendations) {
         tasks.clear();
@@ -60,8 +61,13 @@ public class DeploymentStep extends AbstractStep {
     }
 
     @Override
+    public void updateParameters(Map<String, String> parameters) {
+        this.parameters = parameters;
+    }
+
+    @Override
     public Optional<PodInstanceRequirement> start() {
-        return Optional.of(podInstanceRequirement);
+        return Optional.of(podInstanceRequirement.withParameters(parameters));
     }
 
     @Override

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/Element.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/Element.java
@@ -1,10 +1,11 @@
 package com.mesosphere.sdk.scheduler.plan;
 
+import com.mesosphere.sdk.scheduler.plan.strategy.Strategy;
 import org.apache.mesos.Protos.TaskStatus;
 import com.mesosphere.sdk.scheduler.Observable;
-import com.mesosphere.sdk.scheduler.plan.strategy.Strategy;
 
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 /**
@@ -96,4 +97,9 @@ public interface Element extends Observable {
         return getStatus().equals(Status.COMPLETE);
     }
 
+    /**
+     * Provides the Element with a set of named string parameters that it can either use on start or provide to
+     * children, if it has any.
+     */
+    default void updateParameters(Map<String, String> parameters) { }
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/ParentElement.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/ParentElement.java
@@ -1,11 +1,12 @@
 package com.mesosphere.sdk.scheduler.plan;
 
 import java.util.List;
+import java.util.Map;
 
 import com.mesosphere.sdk.scheduler.plan.strategy.Strategy;
 
 /**
- * A type of {@link Element} which itself is a collection of child {@link Elements}.
+ * A type of {@link Element} which itself is a collection of child {@link Element}s.
  *
  * @param <C> the type of the child elements
  */
@@ -21,15 +22,24 @@ public interface ParentElement<C extends Element> extends Element, Interruptible
      */
     Strategy<C> getStrategy();
 
+    @Override
     default void interrupt() {
         getStrategy().interrupt();
     }
 
+    @Override
     default void proceed() {
         getStrategy().proceed();
     }
 
     default boolean isInterrupted() {
         return getStrategy().isInterrupted();
+    }
+
+    @Override
+    default void updateParameters(Map<String, String> parameters) {
+        for (C child : getChildren()) {
+            child.updateParameters(parameters);
+        }
     }
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/PodInstanceRequirement.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/PodInstanceRequirement.java
@@ -3,6 +3,8 @@ package com.mesosphere.sdk.scheduler.plan;
 import com.mesosphere.sdk.specification.PodInstance;
 
 import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
 
 /**
  * A PodInstanceRequirement encapsulates a {@link PodInstance} and the names of tasks that should be launched in it.
@@ -10,6 +12,7 @@ import java.util.Collection;
 public class PodInstanceRequirement {
     private final PodInstance podInstance;
     private final Collection<String> tasksToLaunch;
+    private final Map<String, String> environment;
     private final boolean isPermanentReplacement;
 
     /**
@@ -18,7 +21,18 @@ public class PodInstanceRequirement {
     public static PodInstanceRequirement create(
             PodInstance podInstance,
             Collection<String> tasksToLaunch) {
-        return new PodInstanceRequirement(podInstance, tasksToLaunch, false);
+        return new PodInstanceRequirement(podInstance, tasksToLaunch, null, false);
+    }
+
+    /**
+     * Creates a new instance with each task's environment extended by the provided envvar name-to-value map that is not
+     * a permanent replacement.
+     */
+    public static PodInstanceRequirement create(
+            PodInstance podInstance,
+            Collection<String> tasksToLaunch,
+            Map<String, String> environment) {
+        return new PodInstanceRequirement(podInstance, tasksToLaunch, environment, false);
     }
 
     /**
@@ -27,7 +41,14 @@ public class PodInstanceRequirement {
     public static PodInstanceRequirement createPermanentReplacement(
             PodInstance podInstance,
             Collection<String> tasksToLaunch) {
-        return new PodInstanceRequirement(podInstance, tasksToLaunch, true);
+        return new PodInstanceRequirement(podInstance, tasksToLaunch, null, true);
+    }
+
+    /**
+     * Returns this same instance, but with the supplied environment variable map applied to each task in this pod.
+     */
+    public PodInstanceRequirement withParameters(Map<String, String> parameters) {
+        return new PodInstanceRequirement(getPodInstance(), getTasksToLaunch(), parameters, isPermanentReplacement());
     }
 
     /**
@@ -36,9 +57,11 @@ public class PodInstanceRequirement {
     private PodInstanceRequirement(
             PodInstance podInstance,
             Collection<String> tasksToLaunch,
+            Map<String, String> environment,
             boolean isPermanentReplacement) {
         this.podInstance = podInstance;
         this.tasksToLaunch = tasksToLaunch;
+        this.environment = environment;
         this.isPermanentReplacement = isPermanentReplacement;
     }
 
@@ -55,6 +78,14 @@ public class PodInstanceRequirement {
      */
     public Collection<String> getTasksToLaunch() {
         return tasksToLaunch;
+    }
+
+    /**
+     * Returns the map of environment variable names to values that extend the existing environments of tasks in this
+     * pod.
+     */
+    public Map<String, String> getEnvironment() {
+        return environment == null ? Collections.emptyMap() : environment;
     }
 
     /**

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/Step.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/Step.java
@@ -23,8 +23,8 @@ public interface Step extends Element, Interruptible {
      * applicable to the Step. This will continue to be called for as long as {@link Element#isPending()} returns
      * true.
      *
-     * @see {@link #updateOfferStatus(Collection<Offer.Operation>)} which returns the outcome of the
-     *      {@link OfferRequirement}
+     * @see {@link #updateOfferStatus(Collection<org.apache.mesos.Protos.Offer.Operation>)} which returns the outcome of
+     *      the {@link OfferRequirement}
      */
     Optional<PodInstanceRequirement> start();
 

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/api/PlansResourceTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/api/PlansResourceTest.java
@@ -12,6 +12,7 @@ import org.mockito.MockitoAnnotations;
 
 import javax.ws.rs.core.Response;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
@@ -113,13 +114,13 @@ public class PlansResourceTest {
 
     @Test
     public void testStart() {
-        Response response = resource.startPlan(planName);
+        Response response = resource.startPlan(planName, Collections.emptyMap());
         assertTrue(response.getStatusInfo().equals(Response.Status.OK));
     }
 
     @Test
     public void testStartInvalid() {
-        Response response = resource.startPlan("bad-plan");
+        Response response = resource.startPlan("bad-plan", Collections.emptyMap());
         assertTrue(response.getStatusInfo().equals(Response.Status.NOT_FOUND));
     }
 

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluatorTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluatorTest.java
@@ -881,7 +881,8 @@ public class OfferEvaluatorTest extends OfferEvaluatorTestBase {
         // Providing sufficient, but unreserved resources should result in no operations.
         Assert.assertEquals(0, recommendations.size());
 
-        List<String> resourceIds = offerRequirementProvider.getExistingOfferRequirement(podInstance, Arrays.asList("node"))
+        List<String> resourceIds = offerRequirementProvider.getExistingOfferRequirement(
+                PodInstanceRequirement.create(podInstance, Arrays.asList("node")))
                 .getTaskRequirements().stream()
                 .flatMap(taskRequirement -> taskRequirement.getResourceRequirements().stream())
                 .map(resourceRequirement -> resourceRequirement.getResourceId())

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/PortEvaluationStageTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/PortEvaluationStageTest.java
@@ -2,6 +2,7 @@ package com.mesosphere.sdk.offer.evaluate;
 
 import com.mesosphere.sdk.offer.*;
 import com.mesosphere.sdk.scheduler.plan.DefaultPodInstance;
+import com.mesosphere.sdk.scheduler.plan.PodInstanceRequirement;
 import com.mesosphere.sdk.specification.DefaultPodSpec;
 import com.mesosphere.sdk.specification.DefaultServiceSpec;
 import com.mesosphere.sdk.specification.PodSpec;
@@ -129,8 +130,8 @@ public class PortEvaluationStageTest {
         StateStore stateStore = Mockito.mock(StateStore.class);
         DefaultOfferRequirementProvider provider =
                 new DefaultOfferRequirementProvider(stateStore, TestConstants.SERVICE_NAME, UUID.randomUUID());
-        OfferRequirement offerRequirement = provider.getNewOfferRequirement(podInstance,
-                TaskUtils.getTaskNames(podInstance));
+        OfferRequirement offerRequirement = provider.getNewOfferRequirement(
+                PodInstanceRequirement.create(podInstance, TaskUtils.getTaskNames(podInstance)));
         PodInfoBuilder podInfoBuilder = new PodInfoBuilder(offerRequirement);
 
         Protos.Resource desiredPorts = ResourceTestUtils.getDesiredRanges("ports", 10000, 10000);
@@ -179,8 +180,8 @@ public class PortEvaluationStageTest {
         StateStore stateStore = Mockito.mock(StateStore.class);
         DefaultOfferRequirementProvider provider =
                 new DefaultOfferRequirementProvider(stateStore, TestConstants.SERVICE_NAME, UUID.randomUUID());
-        OfferRequirement offerRequirement = provider.getNewOfferRequirement(podInstance,
-                TaskUtils.getTaskNames(podInstance));
+        OfferRequirement offerRequirement = provider.getNewOfferRequirement(
+                PodInstanceRequirement.create(podInstance, TaskUtils.getTaskNames(podInstance)));
         PodInfoBuilder podInfoBuilder = new PodInfoBuilder(offerRequirement);
 
         Protos.Resource desiredPorts = ResourceTestUtils.getDesiredRanges("ports", 10000, 10000);
@@ -188,8 +189,7 @@ public class PortEvaluationStageTest {
         Protos.Offer offer = OfferTestUtils.getOffer(offeredPorts);
 
         String taskName = "pod-type-0-" + TestConstants.TASK_NAME;
-        PortEvaluationStage portEvaluationStage =
-                new PortEvaluationStage(desiredPorts, taskName, "test-port", 10000);
+        PortEvaluationStage portEvaluationStage = new PortEvaluationStage(desiredPorts, taskName, "test-port", 10000);
         EvaluationOutcome outcome = portEvaluationStage.evaluate(new MesosResourcePool(offer), podInfoBuilder);
         Assert.assertTrue(outcome.isPassing());
 

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/plan/DefaultPlanManagerTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/plan/DefaultPlanManagerTest.java
@@ -209,6 +209,31 @@ public class DefaultPlanManagerTest {
     }
 
     @Test
+    public void testUpdateParameters() {
+        when(mockStep.getId()).thenReturn(UUID.randomUUID());
+
+        DefaultPhase phase0 = new DefaultPhase(
+                "phase-0",
+                Arrays.asList(mockStep),
+                new SerialStrategy<>(),
+                Collections.emptyList());
+
+        DefaultPlan plan = new DefaultPlan(
+                "test-plan",
+                Arrays.asList(phase0),
+                new SerialStrategy<>(),
+                Collections.emptyList());
+
+        verify(mockStep, times(0)).update(any());
+
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("PARAM1", "value1");
+        plan.updateParameters(parameters);
+
+        verify(mockStep, times(1)).updateParameters(parameters);
+    }
+
+    @Test
     public void testAllDirtyAssets() {
         when(reconciler.isReconciled()).thenReturn(false);
         final TestStep step1 = new TestStep("test-step-1");

--- a/testing/sdk_plan.py
+++ b/testing/sdk_plan.py
@@ -7,20 +7,25 @@ import shakedown
 
 
 def get_deployment_plan(service_name):
-    return _get_plan(service_name, "deploy")
+    return get_plan(service_name, "deploy")
 
 
 def get_sidecar_plan(service_name):
-    return _get_plan(service_name, "sidecar")
+    return get_plan(service_name, "sidecar")
 
 
 def start_sidecar_plan(service_name, parameters=None):
+    start_plan(service_name, "sidecar", parameters)
+
+
+def start_plan(service_name, plan, parameters=None):
     return dcos.http.post(
-        shakedown.dcos_service_url(service_name) + "/v1/plans/sidecar/start",
-        json=parameters)
+        shakedown.dcos_service_url(service_name) +
+            "/v1/plans/{}/start".format(plan),
+        json=parameters if parameters is not None else {})
 
 
-def _get_plan(service_name, plan):
+def get_plan(service_name, plan):
     def fn():
         response = dcos.http.get("{}/v1/plans/{}".format(
             shakedown.dcos_service_url(service_name), plan))

--- a/testing/sdk_plan.py
+++ b/testing/sdk_plan.py
@@ -14,8 +14,10 @@ def get_sidecar_plan(service_name):
     return _get_plan(service_name, "sidecar")
 
 
-def start_sidecar_plan(service_name):
-    return dcos.http.post(shakedown.dcos_service_url(service_name) + "/v1/plans/sidecar/start")
+def start_sidecar_plan(service_name, parameters=None):
+    return dcos.http.post(
+        shakedown.dcos_service_url(service_name) + "/v1/plans/sidecar/start",
+        json=parameters)
 
 
 def _get_plan(service_name, plan):


### PR DESCRIPTION
This change allows plans to keep parameters, which are subject to change over their lifetimes, and which are propagated to all `Phase`s and `Step`s belong to them. It is ultimately up to the `Step` instances at the leaves of a `Plan` what it wants to do with those parameters -- `DeploymentStep` will make sure to incorporate them as environment variables into the `PodInstanceRequirement` returned by `start()`, for example (`PodInstanceRequirement` now has a `environment` member, which extends the environments of all tasks contained by it). This allows sidecar plans to have parameters that are only supplied when the `{plan}/start` endpoint is invoked (via JSON in the POST request body), which is useful for e.g. backup operations that may have a changing or unknown-at-install-time backup location. 