### PR TITLE
Require `default` step to get `default` behavior

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultPlanGenerator.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultPlanGenerator.java
@@ -75,13 +75,7 @@ public class DefaultPlanGenerator implements PlanGenerator {
                 if (taskLists == null) {
                     taskLists = validatedSteps.get("default");
 
-                    if (taskLists == null) {
-                        // Fall back to default plan generation behavior
-                        List<String> taskNames = podSpec.getTasks().stream()
-                                .map(taskSpec -> taskSpec.getName())
-                                .collect(Collectors.toList());
-                        steps.add(from(new DefaultPodInstance(podSpec, i), taskNames));
-                    } else {
+                    if (taskLists != null) {
                         // Use default defined behavior (e.g. default: [[foo, bar], [baz]])
                         for (List<String> taskNames : taskLists) {
                             steps.add(from(new DefaultPodInstance(podSpec, i), taskNames));

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/specification/DefaultPlanGeneratorTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/specification/DefaultPlanGeneratorTest.java
@@ -68,13 +68,14 @@ public class DefaultPlanGeneratorTest {
         for (Map.Entry<String, RawPlan> entry : rawServiceSpec.getPlans().entrySet()) {
             Plan plan = generator.generate(entry.getValue(), entry.getKey(), serviceSpec.getPods());
             Assert.assertNotNull(plan);
-            Assert.assertEquals(5, plan.getChildren().size());
+            Assert.assertEquals(6, plan.getChildren().size());
 
             Phase serverPhase = plan.getChildren().get(0);
             Phase oncePhase = plan.getChildren().get(1);
             Phase interleavePhase = plan.getChildren().get(2);
             Phase fullCustomPhase = plan.getChildren().get(3);
             Phase partialCustomPhase = plan.getChildren().get(4);
+            Phase omitStepPhase = plan.getChildren().get(5);
 
             validatePhase(
                     serverPhase,
@@ -118,6 +119,14 @@ public class DefaultPlanGeneratorTest {
                             Arrays.asList("server"),
                             Arrays.asList("server"),
                             Arrays.asList("once")));
+
+            validatePhase(
+                    omitStepPhase,
+                    Arrays.asList(
+                            Arrays.asList("once"),
+                            Arrays.asList("server")));
+            Assert.assertEquals("hello-1:[once]", omitStepPhase.getChildren().get(0).getName());
+            Assert.assertEquals("hello-1:[server]", omitStepPhase.getChildren().get(1).getName());
         }
     }
 

--- a/sdk/scheduler/src/test/resources/custom-phases.yml
+++ b/sdk/scheduler/src/test/resources/custom-phases.yml
@@ -43,31 +43,36 @@ plans:
   deploy:
     strategy: serial
     phases:
-      server-deploy:
+      server:
         strategy: parallel
         pod: hello
         steps:
           - default: [[server]]
-      once-deploy:
+      once:
         strategy: parallel
         pod: hello
         steps:
           - default: [[once]]
-      interleave-deploy:
+      interleave:
         strategy: serial
         pod: hello
         steps:
           - default: [[once], [server]]
-      full-custom-deploy:
+      full-custom:
         strategy: serial
         pod: hello
         steps:
           - 0: [[once], [server]]
           - 1: [[server], [once]]
           - 2: [[server]]
-      partial-custom-deploy:
+      partial-custom:
         strategy: serial
         pod: hello
         steps:
           - 1: [[once], [server]]
           - default: [[server], [once]]
+      omit-step:
+        strategy: serial
+        pod: hello
+        steps:
+          - 1: [[once], [server]]


### PR DESCRIPTION
Omitting a `default` element in the `steps` section of a custom plan should indicate that only explicitly designated pod instances have steps generated for them.