### PR TITLE
Add support for joining overlay networks with CNI

### DIFF
--- a/docs/pages/dev-guide/developer-guide.md
+++ b/docs/pages/dev-guide/developer-guide.md
@@ -798,7 +798,7 @@ The most basic set of features present in the YAML representation of the `Servic
 
 ### Containers
 
-Each pod runs inside a single container. The `ServiceSpec` specifies the Docker image to run for that container and the POSIX resource limits for every task that runs inside that container. In the example below, the soft limit for number of open file descriptors for any task in the "hello" pod is set to 1024, and the hard limit to 2048:
+Each pod runs inside a single container. The `ServiceSpec` specifies the Docker image to run for that container, the virtual network memberships, and the POSIX resource limits for every task that runs inside that container. In the example below, the soft limit for number of open file descriptors for any task in the "hello" pod is set to 1024, and the hard limit to 2048:
 
 ```yaml
 name: "hello-world"
@@ -807,6 +807,8 @@ pods:
     count: 1
     container:
       image-name: ubuntu
+      networks:
+        dcos: {}
       rlimits:
         RLIMIT_NOFILE:
           soft: 1024
@@ -818,6 +820,8 @@ pods:
         cpus: 1.0
         memory: 256
 ```
+
+Currently an empty YAML dictionary is passed as the body for each network definition under `networks`, since we only support joining virtual networks by name, but in the future it will be possible to specify port mappings and other information in a network definition.
 
 **Note:** Your framework must be run as the root user in order to raise rlimits beyond the default for a process. For a full list of which rlimits are supported, refer to [the Mesos documentation on rlimits](https://github.com/apache/mesos/blob/master/docs/posix_rlimits.md).
 

--- a/frameworks/helloworld/src/main/dist/examples/cni.yml
+++ b/frameworks/helloworld/src/main/dist/examples/cni.yml
@@ -1,0 +1,31 @@
+name: "hello-world"
+pods:
+  hello:
+    count: {{HELLO_COUNT}}
+    container:
+      networks:
+        dcos: {}
+    resource-sets:
+      hello-resource:
+        cpus: {{HELLO_CPUS}}
+        memory: {{HELLO_MEM}}
+    tasks:
+      network-test:
+        goal: FINISHED
+        cmd: "ip addr show eth0 | grep -Eo 'inet 9\\.[0-9\\.]+' >> output"
+        resource-set: hello-resource
+      server:
+        goal: RUNNING
+        cmd: "echo world >> output && sleep $SLEEP_DURATION"
+        resource-set: hello-resource
+        env:
+          SLEEP_DURATION: {{SLEEP_DURATION}}
+plans:
+  deploy:
+    strategy: serial
+    phases:
+      all-deploy:
+        strategy: serial
+        pod: hello
+        steps:
+          - default: [[network-test], [server]]

--- a/frameworks/helloworld/src/main/dist/svc.yml
+++ b/frameworks/helloworld/src/main/dist/svc.yml
@@ -3,6 +3,9 @@ pods:
   hello:
     count: {{HELLO_COUNT}}
     placement: {{HELLO_PLACEMENT}}
+    container:
+      networks:
+        dcos: {}
     tasks:
       server:
         goal: RUNNING

--- a/frameworks/helloworld/src/main/resources/examples/cni.yml
+++ b/frameworks/helloworld/src/main/resources/examples/cni.yml
@@ -1,0 +1,1 @@
+../../dist/examples/cni.yml

--- a/frameworks/helloworld/tests/test_networking.py
+++ b/frameworks/helloworld/tests/test_networking.py
@@ -18,11 +18,11 @@ def setup_module(module):
     }
 
     install.install(PACKAGE_NAME, 1, additional_options=options)
-    print('done installing...')
 
 
 @pytest.mark.sanity
 def test_deploy():
+    """Verify that the current deploy plan matches the expected plan from the spec."""
     deployment_plan = plan.get_deployment_plan(PACKAGE_NAME).json()
     print("deployment_plan: " + str(deployment_plan))
 
@@ -33,5 +33,9 @@ def test_deploy():
 
 @pytest.mark.sanity
 def test_joins_overlay_network():
+    """Verify that the container joined the dcos subnet at 9.0.0.0/24.
+    
+    The logic for this is in the task itself, which will check the container IP address
+    and fail if incorrect, thus preventing the plan from reaching the COMPLETE state."""
     spin.time_wait_noisy(lambda: (
         plan.get_deployment_plan(PACKAGE_NAME).json()['status'] == 'COMPLETE'))

--- a/frameworks/helloworld/tests/test_networking.py
+++ b/frameworks/helloworld/tests/test_networking.py
@@ -1,0 +1,37 @@
+import pytest
+
+import sdk_install as install
+import sdk_plan as plan
+import sdk_spin as spin
+
+from tests.config import (
+    PACKAGE_NAME
+)
+
+
+def setup_module(module):
+    install.uninstall(PACKAGE_NAME)
+    options = {
+        "service": {
+            "spec_file": "examples/cni.yml"
+        }
+    }
+
+    install.install(PACKAGE_NAME, 1, additional_options=options)
+    print('done installing...')
+
+
+@pytest.mark.sanity
+def test_deploy():
+    deployment_plan = plan.get_deployment_plan(PACKAGE_NAME).json()
+    print("deployment_plan: " + str(deployment_plan))
+
+    assert(len(deployment_plan['phases']) == 1)
+    assert(deployment_plan['phases'][0]['name'] == 'all-deploy')
+    assert(len(deployment_plan['phases'][0]['steps']) == 2)
+
+
+@pytest.mark.sanity
+def test_joins_overlay_network():
+    spin.time_wait_noisy(lambda: (
+        plan.get_deployment_plan(PACKAGE_NAME).json()['status'] == 'COMPLETE'))

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/DefaultOfferRequirementProvider.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/DefaultOfferRequirementProvider.java
@@ -526,11 +526,20 @@ public class DefaultOfferRequirementProvider implements OfferRequirementProvider
                                     .setName(containerSpec.getImageName().get())));
         }
 
+        if (!containerSpec.getNetworks().isEmpty()) {
+            containerInfo.addAllNetworkInfos(
+                    containerSpec.getNetworks().stream().map(n -> getNetworkInfo(n)).collect(Collectors.toList()));
+        }
+
         if (!containerSpec.getRLimits().isEmpty()) {
             containerInfo.setRlimitInfo(getRLimitInfo(containerSpec.getRLimits()));
         }
 
         return containerInfo.build();
+    }
+
+    private static Protos.NetworkInfo getNetworkInfo(NetworkSpec networkSpec) {
+        return Protos.NetworkInfo.newBuilder().setName(networkSpec.getName()).build();
     }
 
     private static Protos.RLimitInfo getRLimitInfo(Collection<RLimit> rlimits) {

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/ContainerSpec.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/ContainerSpec.java
@@ -15,6 +15,9 @@ public interface ContainerSpec {
     @JsonProperty("image-name")
     Optional<String> getImageName();
 
+    @JsonProperty("networks")
+    Collection<NetworkSpec> getNetworks();
+
     @JsonProperty("rlimits")
     Collection<RLimit> getRLimits();
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultContainerSpec.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultContainerSpec.java
@@ -19,13 +19,17 @@ public class DefaultContainerSpec implements ContainerSpec {
     @Size(min = 1)
     private String imageName;
     @Valid
+    private Collection<NetworkSpec> networks;
+    @Valid
     private Collection<RLimit> rlimits;
 
     @JsonCreator
     public DefaultContainerSpec(
             @JsonProperty("image-name") String imageName,
+            @JsonProperty("networks") Collection<NetworkSpec> networks,
             @JsonProperty("rlimits") Collection<RLimit> rlimits) {
         this.imageName = imageName;
+        this.networks = networks;
         this.rlimits = rlimits;
     }
 
@@ -35,10 +39,14 @@ public class DefaultContainerSpec implements ContainerSpec {
     }
 
     @Override
+    public Collection<NetworkSpec> getNetworks() {
+        return networks == null ? Collections.emptyList() : networks;
+    }
+
+    @Override
     public Collection<RLimit> getRLimits() {
         return rlimits == null ? Collections.emptyList() : rlimits;
     }
-
     @Override
     public boolean equals(Object o) {
         return EqualsBuilder.reflectionEquals(this, o);

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultNetworkSpec.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultNetworkSpec.java
@@ -1,0 +1,39 @@
+package com.mesosphere.sdk.specification;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+/**
+ * Default implementation of {@link NetworkSpec}.
+ */
+public class DefaultNetworkSpec implements NetworkSpec {
+    @NotNull
+    @Size(min = 1)
+    private String name;
+
+    @JsonCreator
+    public DefaultNetworkSpec(
+            @JsonProperty("name") String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return EqualsBuilder.reflectionEquals(this, o);
+    }
+
+    @Override
+    public int hashCode() {
+        return HashCodeBuilder.reflectionHashCode(this);
+    }
+}

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/NetworkSpec.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/NetworkSpec.java
@@ -1,0 +1,13 @@
+package com.mesosphere.sdk.specification;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+/**
+ * Spec for defining a container's network membership.
+ */
+@JsonDeserialize(as = DefaultNetworkSpec.class)
+public interface NetworkSpec {
+    @JsonProperty("name")
+    String getName();
+}

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/RawContainer.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/RawContainer.java
@@ -9,18 +9,20 @@ import java.util.LinkedHashMap;
  */
 public class RawContainer {
     private final String imageName;
+    private final WriteOnceLinkedHashMap<String, RawNetwork> networks;
     private final WriteOnceLinkedHashMap<String, RawRLimit> rlimits;
 
     private RawContainer(
             @JsonProperty("image-name") String imageName,
+            @JsonProperty("networks") WriteOnceLinkedHashMap<String, RawNetwork> networks,
             @JsonProperty("rlimits") WriteOnceLinkedHashMap<String, RawRLimit> rlimits) {
         this.imageName = imageName;
+        this.networks = networks == null ? new WriteOnceLinkedHashMap<>() : networks;
+        this.rlimits = rlimits == null ? new WriteOnceLinkedHashMap<>() : rlimits;
+    }
 
-        if (rlimits != null) {
-            this.rlimits = rlimits;
-        } else {
-            this.rlimits = new WriteOnceLinkedHashMap<>();
-        }
+    public LinkedHashMap<String, RawNetwork> getNetworks() {
+        return networks;
     }
 
     public LinkedHashMap<String, RawRLimit> getRLimits() {

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/RawNetwork.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/RawNetwork.java
@@ -1,0 +1,6 @@
+package com.mesosphere.sdk.specification.yaml;
+
+/**
+ * Raw YAML network. Null class for now, since only network name is supported, but will gain fields in the future.
+ */
+public class RawNetwork { }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/YAMLToInternalMappers.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/YAMLToInternalMappers.java
@@ -156,7 +156,14 @@ public class YAMLToInternalMappers {
                 RawRLimit rawRLimit = entry.getValue();
                 rlimits.add(new RLimit(entry.getKey(), rawRLimit.getSoft(), rawRLimit.getHard()));
             }
-            builder.container(new DefaultContainerSpec(rawPod.getContainer().getImageName(), rlimits));
+
+            List<NetworkSpec> networks = new ArrayList<>();
+            for (Map.Entry<String, RawNetwork> entry : rawPod.getContainer().getNetworks().entrySet()) {
+                // When features other than network name are added, we'll want to use the RawNetwork entry value here.
+                networks.add(new DefaultNetworkSpec(entry.getKey()));
+            }
+
+            builder.container(new DefaultContainerSpec(rawPod.getContainer().getImageName(), networks, rlimits));
         }
 
         return builder.build();


### PR DESCRIPTION
This change adds a new field under `container` in each pod called `networks` that allows the user to specify which overlay networks to join by name:
```
container:
  networks:
    dcos: {}
```
An empty dictionary must be passed for the body right now, due to the fact that we only currently support joining networks by name, but was designed this way to allow backwards-compatible addition of e.g. port mappings in the future.

This was tested by creating a container that joins the `dcos` virtual network included by default in DC/OS installs and verifying that the IP for interface eth0 is in the 9.0.0.0/24 subnet.