### PR TITLE
Set cluster configs if necessary in create_service_account.sh

### DIFF
--- a/tools/create_service_account.sh
+++ b/tools/create_service_account.sh
@@ -1,6 +1,17 @@
 set -x
 MODE=
 
+if [ "$#" -ge 2 ]; then
+    # Set some cluster configs if they are passed in.
+    echo At least 2 arguments, must be dcos_url and acs_token
+    DCOS_URL=$1
+    ACS_TOKEN=$2
+
+    dcos config set core.dcos_url $DCOS_URL
+    dcos config set core.dcos_acs_token $ACS_TOKEN
+    dcos config set core.ssl_verify false
+fi
+
 while [ ! $# -eq 0 ]
 do
     case "$1" in

--- a/tools/launch_ccm_cluster.py
+++ b/tools/launch_ccm_cluster.py
@@ -272,6 +272,12 @@ class CCMLauncher(object):
             enable_mount_volumes.main(stack_id)
             sys.stdout = stdout
 
+        # we fetch the token once up-front because on Open clusters it must be reused.
+        # given that, we may as well use the same flow across both Open and EE.
+        logger.info('Fetching auth token')
+        dcos_url = 'https://' + dns_address
+        auth_token = dcos_login.DCOSLogin(dcos_url).get_acs_token()
+
         if config.permissions:
             logger.info('Setting up permissions for cluster {} (stack id {})'.format(cluster_id, stack_id))
 
@@ -284,18 +290,12 @@ class CCMLauncher(object):
                 subprocess.check_call(['bash', script_path] + args)
                 sys.stdout = stdout
 
-            run_script('create_service_account.sh', ['--strict'])
+            run_script('create_service_account.sh', [dcos_url, auth_token, '--strict'])
             # Examples of what individual tests should run. See respective projects' "test.sh":
             #run_script('setup_permissions.sh', 'nobody cassandra-role'.split())
             #run_script('setup_permissions.sh', 'nobody hdfs-role'.split())
             #run_script('setup_permissions.sh', 'nobody kafka-role'.split())
             #run_script('setup_permissions.sh', 'nobody spark-role'.split())
-
-        # we fetch the token once up-front because on Open clusters it must be reused.
-        # given that, we may as well use the same flow across both Open and EE.
-        logger.info('Fetching auth token')
-        dcos_url = 'https://' + dns_address
-        auth_token = dcos_login.DCOSLogin(dcos_url).get_acs_token()
 
         return {
             'id': cluster_id,


### PR DESCRIPTION
Fixed the create_service_account.sh script. For strict mode, you have to set core.dcos_url, core.dcos_acs_token, inside that script. So, I added them as arguments, and they're set inside the script.