### PR TITLE
Add read-only access to the StateStore

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/curator/CuratorStateStore.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/curator/CuratorStateStore.java
@@ -5,14 +5,11 @@ import com.mesosphere.sdk.dcos.DcosConstants;
 import com.mesosphere.sdk.offer.CommonTaskUtils;
 import com.mesosphere.sdk.offer.TaskException;
 import com.mesosphere.sdk.state.*;
-import com.mesosphere.sdk.storage.Persister;
 import com.mesosphere.sdk.storage.StorageError.Reason;
 
 import org.apache.curator.RetryPolicy;
 import org.apache.mesos.Protos;
 import org.apache.zookeeper.KeeperException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.*;
@@ -39,27 +36,7 @@ import java.util.*;
  * Note that for frameworks which don't use custom executors, the same structure is used, except
  * where ExecutorName values are equal to TaskName values.
  */
-public class CuratorStateStore implements StateStore {
-
-    private static final Logger logger = LoggerFactory.getLogger(CuratorStateStore.class);
-
-    /**
-     * @see CuratorSchemaVersionStore#CURRENT_SCHEMA_VERSION
-     */
-    private static final int MIN_SUPPORTED_SCHEMA_VERSION = 1;
-    private static final int MAX_SUPPORTED_SCHEMA_VERSION = 1;
-
-    private static final String TASK_INFO_PATH_NAME = "TaskInfo";
-    private static final String TASK_STATUS_PATH_NAME = "TaskStatus";
-    private static final String FWK_ID_PATH_NAME = "FrameworkID";
-    private static final String PROPERTIES_PATH_NAME = "Properties";
-    private static final String TASKS_ROOT_NAME = "Tasks";
-    private static final String SUPPRESSED_KEY = "suppressed";
-
-    private final Persister curator;
-    private final TaskPathMapper taskPathMapper;
-    private final String fwkIdPath;
-    private final String propertiesPath;
+public class CuratorStateStore extends CuratorStateStoreReadOnly implements StateStore {
 
     /**
      * Creates a new {@link StateStore} which uses Curator with a default {@link RetryPolicy} and
@@ -109,22 +86,7 @@ public class CuratorStateStore implements StateStore {
             RetryPolicy retryPolicy,
             String username,
             String password) {
-        this.curator = new CuratorPersister(connectionString, retryPolicy, username, password);
-
-        // Check version up-front:
-        int currentVersion = new CuratorSchemaVersionStore(curator, frameworkName).fetch();
-        if (!SchemaVersionStore.isSupported(
-                currentVersion, MIN_SUPPORTED_SCHEMA_VERSION, MAX_SUPPORTED_SCHEMA_VERSION)) {
-            throw new IllegalStateException(String.format(
-                    "Storage schema version %d is not supported by this software " +
-                            "(support: min=%d, max=%d)",
-                    currentVersion, MIN_SUPPORTED_SCHEMA_VERSION, MAX_SUPPORTED_SCHEMA_VERSION));
-        }
-
-        final String rootPath = CuratorUtils.toServiceRootPath(frameworkName);
-        this.taskPathMapper = new TaskPathMapper(rootPath);
-        this.fwkIdPath = CuratorUtils.join(rootPath, FWK_ID_PATH_NAME);
-        this.propertiesPath = CuratorUtils.join(rootPath, PROPERTIES_PATH_NAME);
+        super(frameworkName, connectionString, retryPolicy, username, password);
     }
 
     // Framework ID
@@ -149,25 +111,6 @@ public class CuratorStateStore implements StateStore {
             // Clearing a non-existent FrameworkID should not result in an exception from us.
             logger.warn("Cleared unset FrameworkID, continuing silently", e);
             return;
-        } catch (Exception e) {
-            throw new StateStoreException(Reason.STORAGE_ERROR, e);
-        }
-    }
-
-    @Override
-    public Optional<Protos.FrameworkID> fetchFrameworkId() throws StateStoreException {
-        try {
-            logger.debug("Fetching FrameworkID from '{}'", fwkIdPath);
-            byte[] bytes = curator.get(fwkIdPath);
-            if (bytes.length > 0) {
-                return Optional.of(Protos.FrameworkID.parseFrom(bytes));
-            } else {
-                throw new StateStoreException(Reason.SERIALIZATION_ERROR, String.format(
-                        "Empty FrameworkID in '%s'", fwkIdPath));
-            }
-        } catch (KeeperException.NoNodeException e) {
-            logger.warn("No FrameworkId found at: {}", fwkIdPath);
-            return Optional.empty();
         } catch (Exception e) {
             throw new StateStoreException(Reason.STORAGE_ERROR, e);
         }
@@ -262,105 +205,6 @@ public class CuratorStateStore implements StateStore {
         }
     }
 
-    // Read Tasks
-
-    @Override
-    public Collection<String> fetchTaskNames() throws StateStoreException {
-        String path = taskPathMapper.getTasksRootPath();
-        logger.debug("Fetching task names from '{}'", path);
-        try {
-            Collection<String> taskNames = new ArrayList<>();
-            for (String childNode : curator.getChildren(path)) {
-                taskNames.add(childNode);
-            }
-            return taskNames;
-        } catch (KeeperException.NoNodeException e) {
-            // Root path doesn't exist yet. Treat as an empty list of tasks. This scenario is
-            // expected to commonly occur when the Framework is being run for the first time.
-            return Collections.emptyList();
-        } catch (Exception e) {
-            throw new StateStoreException(Reason.STORAGE_ERROR, e);
-        }
-    }
-
-    @Override
-    public Collection<Protos.TaskInfo> fetchTasks() throws StateStoreException {
-        Collection<Protos.TaskInfo> taskInfos = new ArrayList<>();
-        for (String taskName : fetchTaskNames()) {
-            Optional<Protos.TaskInfo> taskInfoOptional = fetchTask(taskName);
-            if (taskInfoOptional.isPresent()) {
-                taskInfos.add(taskInfoOptional.get());
-            } else {
-                // We should always have a TaskInfo for every name entry we just got
-                throw new StateStoreException(Reason.NOT_FOUND,
-                        String.format("Expected task named %s to be present when retrieving all tasks", taskName));
-            }
-        }
-        return taskInfos;
-    }
-
-    @Override
-    public Optional<Protos.TaskInfo> fetchTask(String taskName) throws StateStoreException {
-        String path = taskPathMapper.getTaskInfoPath(taskName);
-        logger.debug("Fetching TaskInfo {} from '{}'", taskName, path);
-        try {
-            byte[] bytes = curator.get(path);
-            if (bytes.length > 0) {
-                // TODO(nick): This unpack operation is no longer needed, but it doesn't hurt anything to leave it in
-                // place to support reading older data. Remove this unpack call after services have had time to stop
-                // storing packed TaskInfos in zk (after June 2017 or so?).
-                return Optional.of(CommonTaskUtils.unpackTaskInfo(Protos.TaskInfo.parseFrom(bytes)));
-            } else {
-                throw new StateStoreException(Reason.SERIALIZATION_ERROR, String.format(
-                        "Empty TaskInfo for TaskName: %s", taskName));
-            }
-        } catch (KeeperException.NoNodeException e) {
-            logger.warn("No TaskInfo found for the requested name: {} at: {}", taskName, path);
-            return Optional.empty();
-        } catch (Exception e) {
-            throw new StateStoreException(Reason.STORAGE_ERROR,
-                    String.format("Failed to retrieve task named %s", taskName), e);
-        }
-    }
-
-    @Override
-    public Collection<Protos.TaskStatus> fetchStatuses() throws StateStoreException {
-        Collection<Protos.TaskStatus> taskStatuses = new ArrayList<>();
-        for (String taskName : fetchTaskNames()) {
-            try {
-                byte[] bytes = curator.get(taskPathMapper.getTaskStatusPath(taskName));
-                taskStatuses.add(Protos.TaskStatus.parseFrom(bytes));
-            } catch (KeeperException.NoNodeException e) {
-                // The task node exists, but it doesn't contain a TaskStatus node. This may occur if
-                // the only contents are a TaskInfo.
-                continue;
-            } catch (Exception e) {
-                throw new StateStoreException(Reason.STORAGE_ERROR, e);
-            }
-        }
-        return taskStatuses;
-    }
-
-    @Override
-    public Optional<Protos.TaskStatus> fetchStatus(String taskName) throws StateStoreException {
-        String path = taskPathMapper.getTaskStatusPath(taskName);
-        logger.debug("Fetching status for '{}' in '{}'", taskName, path);
-        try {
-            byte[] bytes = curator.get(path);
-            if (bytes.length > 0) {
-                return Optional.of(Protos.TaskStatus.parseFrom(bytes));
-            } else {
-                throw new StateStoreException(Reason.SERIALIZATION_ERROR, String.format(
-                        "Empty TaskStatus for TaskName: %s", taskName));
-            }
-        } catch (KeeperException.NoNodeException e) {
-            logger.warn("No TaskStatus found for the requested name: {} at: {}", taskName, path);
-            return Optional.empty();
-        } catch (Exception e) {
-            throw new StateStoreException(Reason.STORAGE_ERROR, e);
-        }
-    }
-
     @Override
     public void storeProperty(final String key, final byte[] value) throws StateStoreException {
         StateStoreUtils.validateKey(key);
@@ -374,32 +218,6 @@ public class CuratorStateStore implements StateStore {
         }
     }
 
-    @Override
-    public byte[] fetchProperty(final String key) throws StateStoreException {
-        StateStoreUtils.validateKey(key);
-        try {
-            final String path = CuratorUtils.join(this.propertiesPath, key);
-            logger.debug("Fetching property key: {} from path: {}", key, path);
-            return curator.get(path);
-        } catch (KeeperException.NoNodeException e) {
-            throw new StateStoreException(Reason.NOT_FOUND, e);
-        } catch (Exception e) {
-            throw new StateStoreException(Reason.STORAGE_ERROR, e);
-        }
-    }
-
-    @Override
-    public Collection<String> fetchPropertyKeys() throws StateStoreException {
-        try {
-            return curator.getChildren(this.propertiesPath);
-        } catch (KeeperException.NoNodeException e) {
-            // Root path doesn't exist yet. Treat as an empty list of properties. This scenario is
-            // expected to commonly occur when the Framework is being run for the first time.
-            return Collections.emptyList();
-        } catch (Exception e) {
-            throw new StateStoreException(Reason.STORAGE_ERROR, e);
-        }
-    }
 
     @Override
     public void clearProperty(final String key) throws StateStoreException {
@@ -423,45 +241,6 @@ public class CuratorStateStore implements StateStore {
     }
 
     // Internals
-
-    private static class TaskPathMapper {
-        private final String tasksRootPath;
-
-        private TaskPathMapper(String rootPath) {
-            this.tasksRootPath = CuratorUtils.join(rootPath, TASKS_ROOT_NAME);
-        }
-
-        private String getTaskInfoPath(String taskName) {
-            return CuratorUtils.join(getTaskPath(taskName), TASK_INFO_PATH_NAME);
-        }
-
-        private String getTaskStatusPath(String taskName) {
-            return CuratorUtils.join(getTaskPath(taskName), TASK_STATUS_PATH_NAME);
-        }
-
-        private String getTaskPath(String taskName) {
-            return CuratorUtils.join(getTasksRootPath(), taskName);
-        }
-
-        private String getTasksRootPath() {
-            return tasksRootPath;
-        }
-    }
-
-    public boolean isSuppressed() throws StateStoreException {
-        byte[] bytes = StateStoreUtils.fetchPropertyOrEmptyArray(this, SUPPRESSED_KEY);
-        Serializer serializer = new JsonSerializer();
-
-        boolean suppressed;
-        try {
-            suppressed = serializer.deserialize(bytes, Boolean.class);
-        } catch (IOException e){
-            logger.error(String.format("Error converting property %s to boolean.", SUPPRESSED_KEY), e);
-            throw new StateStoreException(Reason.SERIALIZATION_ERROR, e);
-        }
-
-        return suppressed;
-    }
 
     public void setSuppressed(final boolean isSuppressed) {
         byte[] bytes;

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/curator/CuratorStateStoreReadOnly.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/curator/CuratorStateStoreReadOnly.java
@@ -1,0 +1,298 @@
+package com.mesosphere.sdk.curator;
+
+import com.mesosphere.sdk.dcos.DcosConstants;
+import com.mesosphere.sdk.offer.CommonTaskUtils;
+import com.mesosphere.sdk.state.*;
+import com.mesosphere.sdk.storage.Persister;
+import com.mesosphere.sdk.storage.StorageError;
+import com.mesosphere.sdk.storage.StorageError.Reason;
+import org.apache.curator.RetryPolicy;
+import org.apache.mesos.Protos;
+import org.apache.zookeeper.KeeperException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
+
+/**
+ * CuratorStateStoreReadonly is an implementation of {@link StateStoreReadOnly} which reads data persisted in Zookeeper.
+ * See {@link CuratorStateStore} for a description of the structure of the data persited in Zookeeper.
+ */
+public class CuratorStateStoreReadOnly implements StateStoreReadOnly {
+    protected Logger logger = LoggerFactory.getLogger(getClass());
+
+    /**
+     * @see CuratorSchemaVersionStore#CURRENT_SCHEMA_VERSION
+     */
+    protected static final int MIN_SUPPORTED_SCHEMA_VERSION = 1;
+    protected static final int MAX_SUPPORTED_SCHEMA_VERSION = 1;
+
+    protected static final String TASK_INFO_PATH_NAME = "TaskInfo";
+    protected static final String TASK_STATUS_PATH_NAME = "TaskStatus";
+    protected static final String FWK_ID_PATH_NAME = "FrameworkID";
+    protected static final String PROPERTIES_PATH_NAME = "Properties";
+    protected static final String TASKS_ROOT_NAME = "Tasks";
+    protected static final String SUPPRESSED_KEY = "suppressed";
+
+    protected final Persister curator;
+    protected final TaskPathMapper taskPathMapper;
+    protected final String fwkIdPath;
+    protected final String propertiesPath;
+
+    /**
+     * Creates a new {@link StateStore} which uses Curator with a default {@link RetryPolicy} and
+     * connection string.
+     *
+     * @param frameworkName    The name of the framework
+     */
+    public CuratorStateStoreReadOnly(String frameworkName) {
+        this(frameworkName, DcosConstants.MESOS_MASTER_ZK_CONNECTION_STRING);
+    }
+
+    /**
+     * Creates a new {@link StateStore} which uses Curator with a default {@link RetryPolicy}.
+     *
+     * @param frameworkName    The name of the framework
+     * @param connectionString The host/port of the ZK server, eg "master.mesos:2181"
+     */
+    public CuratorStateStoreReadOnly(String frameworkName, String connectionString) {
+        this(frameworkName, connectionString, CuratorUtils.getDefaultRetry(), "", "");
+    }
+
+    public CuratorStateStoreReadOnly(
+            String frameworkName,
+            String connectionString,
+            RetryPolicy retryPolicy) {
+        this(frameworkName, connectionString, retryPolicy, "", "");
+    }
+
+    public CuratorStateStoreReadOnly(
+            String frameworkName,
+            String connectionString,
+            String username,
+            String password) {
+        this(frameworkName, connectionString, CuratorUtils.getDefaultRetry(), username, password);
+    }
+
+    /**
+     * Creates a new {@link StateStore} which uses Curator with a custom {@link RetryPolicy}.
+     *
+     * @param frameworkName    The name of the framework
+     * @param connectionString The host/port of the ZK server, eg "master.mesos:2181"
+     * @param retryPolicy      The custom {@link RetryPolicy}
+     */
+    public CuratorStateStoreReadOnly(
+            String frameworkName,
+            String connectionString,
+            RetryPolicy retryPolicy,
+            String username,
+            String password) {
+        this.curator = new CuratorPersister(connectionString, retryPolicy, username, password);
+
+        // Check version up-front:
+        int currentVersion = new CuratorSchemaVersionStore(curator, frameworkName).fetch();
+        if (!SchemaVersionStore.isSupported(
+                currentVersion, MIN_SUPPORTED_SCHEMA_VERSION, MAX_SUPPORTED_SCHEMA_VERSION)) {
+            throw new IllegalStateException(String.format(
+                    "Storage schema version %d is not supported by this software " +
+                            "(support: min=%d, max=%d)",
+                    currentVersion, MIN_SUPPORTED_SCHEMA_VERSION, MAX_SUPPORTED_SCHEMA_VERSION));
+        }
+
+        final String rootPath = CuratorUtils.toServiceRootPath(frameworkName);
+        this.taskPathMapper = new TaskPathMapper(rootPath);
+        this.fwkIdPath = CuratorUtils.join(rootPath, FWK_ID_PATH_NAME);
+        this.propertiesPath = CuratorUtils.join(rootPath, PROPERTIES_PATH_NAME);
+    }
+
+    @Override
+    public Optional<Protos.FrameworkID> fetchFrameworkId() throws StateStoreException {
+        try {
+            logger.debug("Fetching FrameworkID from '{}'", fwkIdPath);
+            byte[] bytes = curator.get(fwkIdPath);
+            if (bytes.length > 0) {
+                return Optional.of(Protos.FrameworkID.parseFrom(bytes));
+            } else {
+                throw new StateStoreException(StorageError.Reason.SERIALIZATION_ERROR, String.format(
+                        "Empty FrameworkID in '%s'", fwkIdPath));
+            }
+        } catch (KeeperException.NoNodeException e) {
+            logger.warn("No FrameworkId found at: {}", fwkIdPath);
+            return Optional.empty();
+        } catch (Exception e) {
+            throw new StateStoreException(StorageError.Reason.STORAGE_ERROR, e);
+        }
+    }
+
+
+    @Override
+    public Collection<String> fetchTaskNames() throws StateStoreException {
+        String path = taskPathMapper.getTasksRootPath();
+        logger.debug("Fetching task names from '{}'", path);
+        try {
+            Collection<String> taskNames = new ArrayList<>();
+            for (String childNode : curator.getChildren(path)) {
+                taskNames.add(childNode);
+            }
+            return taskNames;
+        } catch (KeeperException.NoNodeException e) {
+            // Root path doesn't exist yet. Treat as an empty list of tasks. This scenario is
+            // expected to commonly occur when the Framework is being run for the first time.
+            return Collections.emptyList();
+        } catch (Exception e) {
+            throw new StateStoreException(Reason.STORAGE_ERROR, e);
+        }
+    }
+
+    @Override
+    public Collection<Protos.TaskInfo> fetchTasks() throws StateStoreException {
+        Collection<Protos.TaskInfo> taskInfos = new ArrayList<>();
+        for (String taskName : fetchTaskNames()) {
+            Optional<Protos.TaskInfo> taskInfoOptional = fetchTask(taskName);
+            if (taskInfoOptional.isPresent()) {
+                taskInfos.add(taskInfoOptional.get());
+            } else {
+                // We should always have a TaskInfo for every name entry we just got
+                throw new StateStoreException(Reason.NOT_FOUND,
+                        String.format("Expected task named %s to be present when retrieving all tasks", taskName));
+            }
+        }
+        return taskInfos;
+    }
+
+    @Override
+    public Optional<Protos.TaskInfo> fetchTask(String taskName) throws StateStoreException {
+        String path = taskPathMapper.getTaskInfoPath(taskName);
+        logger.debug("Fetching TaskInfo {} from '{}'", taskName, path);
+        try {
+            byte[] bytes = curator.get(path);
+            if (bytes.length > 0) {
+                // TODO(nick): This unpack operation is no longer needed, but it doesn't hurt anything to leave it in
+                // place to support reading older data. Remove this unpack call after services have had time to stop
+                // storing packed TaskInfos in zk (after June 2017 or so?).
+                return Optional.of(CommonTaskUtils.unpackTaskInfo(Protos.TaskInfo.parseFrom(bytes)));
+            } else {
+                throw new StateStoreException(Reason.SERIALIZATION_ERROR, String.format(
+                        "Empty TaskInfo for TaskName: %s", taskName));
+            }
+        } catch (KeeperException.NoNodeException e) {
+            logger.warn("No TaskInfo found for the requested name: {} at: {}", taskName, path);
+            return Optional.empty();
+        } catch (Exception e) {
+            throw new StateStoreException(Reason.STORAGE_ERROR,
+                    String.format("Failed to retrieve task named %s", taskName), e);
+        }
+    }
+
+    @Override
+    public Collection<Protos.TaskStatus> fetchStatuses() throws StateStoreException {
+        Collection<Protos.TaskStatus> taskStatuses = new ArrayList<>();
+        for (String taskName : fetchTaskNames()) {
+            try {
+                byte[] bytes = curator.get(taskPathMapper.getTaskStatusPath(taskName));
+                taskStatuses.add(Protos.TaskStatus.parseFrom(bytes));
+            } catch (KeeperException.NoNodeException e) {
+                // The task node exists, but it doesn't contain a TaskStatus node. This may occur if
+                // the only contents are a TaskInfo.
+                continue;
+            } catch (Exception e) {
+                throw new StateStoreException(Reason.STORAGE_ERROR, e);
+            }
+        }
+        return taskStatuses;
+    }
+
+    @Override
+    public Optional<Protos.TaskStatus> fetchStatus(String taskName) throws StateStoreException {
+        String path = taskPathMapper.getTaskStatusPath(taskName);
+        logger.debug("Fetching status for '{}' in '{}'", taskName, path);
+        try {
+            byte[] bytes = curator.get(path);
+            if (bytes.length > 0) {
+                return Optional.of(Protos.TaskStatus.parseFrom(bytes));
+            } else {
+                throw new StateStoreException(Reason.SERIALIZATION_ERROR, String.format(
+                        "Empty TaskStatus for TaskName: %s", taskName));
+            }
+        } catch (KeeperException.NoNodeException e) {
+            logger.warn("No TaskStatus found for the requested name: {} at: {}", taskName, path);
+            return Optional.empty();
+        } catch (Exception e) {
+            throw new StateStoreException(Reason.STORAGE_ERROR, e);
+        }
+    }
+
+
+    @Override
+    public byte[] fetchProperty(final String key) throws StateStoreException {
+        StateStoreUtils.validateKey(key);
+        try {
+            final String path = CuratorUtils.join(this.propertiesPath, key);
+            logger.debug("Fetching property key: {} from path: {}", key, path);
+            return curator.get(path);
+        } catch (KeeperException.NoNodeException e) {
+            throw new StateStoreException(Reason.NOT_FOUND, e);
+        } catch (Exception e) {
+            throw new StateStoreException(Reason.STORAGE_ERROR, e);
+        }
+    }
+
+    @Override
+    public Collection<String> fetchPropertyKeys() throws StateStoreException {
+        try {
+            return curator.getChildren(this.propertiesPath);
+        } catch (KeeperException.NoNodeException e) {
+            // Root path doesn't exist yet. Treat as an empty list of properties. This scenario is
+            // expected to commonly occur when the Framework is being run for the first time.
+            return Collections.emptyList();
+        } catch (Exception e) {
+            throw new StateStoreException(Reason.STORAGE_ERROR, e);
+        }
+    }
+
+    public boolean isSuppressed() throws StateStoreException {
+        byte[] bytes = StateStoreUtils.fetchPropertyOrEmptyArray(this, SUPPRESSED_KEY);
+        Serializer serializer = new JsonSerializer();
+
+        boolean suppressed;
+        try {
+            suppressed = serializer.deserialize(bytes, Boolean.class);
+        } catch (IOException e){
+            logger.error(String.format("Error converting property %s to boolean.", SUPPRESSED_KEY), e);
+            throw new StateStoreException(Reason.SERIALIZATION_ERROR, e);
+        }
+
+        return suppressed;
+    }
+
+    /**
+     * Provides paths for the various hierarchies of data stored in ZK.
+     */
+    protected static class TaskPathMapper {
+        private final String tasksRootPath;
+
+        protected TaskPathMapper(String rootPath) {
+            this.tasksRootPath = CuratorUtils.join(rootPath, TASKS_ROOT_NAME);
+        }
+
+        protected String getTaskInfoPath(String taskName) {
+            return CuratorUtils.join(getTaskPath(taskName), TASK_INFO_PATH_NAME);
+        }
+
+        protected String getTaskStatusPath(String taskName) {
+            return CuratorUtils.join(getTaskPath(taskName), TASK_STATUS_PATH_NAME);
+        }
+
+        protected String getTaskPath(String taskName) {
+            return CuratorUtils.join(getTasksRootPath(), taskName);
+        }
+
+        protected String getTasksRootPath() {
+            return tasksRootPath;
+        }
+    }
+}

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/state/StateStore.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/state/StateStore.java
@@ -16,7 +16,7 @@ import java.util.*;
  * TaskStatus is reported by Mesos to Frameworks at various points including at Task Reconciliation and when Tasks
  * change state.  The TaskStatus of a Task should be recorded so that the state of a Framework's Tasks can be queried.
  */
-public interface StateStore {
+public interface StateStore extends StateStoreReadOnly {
 
 
     // Write Framework ID
@@ -38,17 +38,6 @@ public interface StateStore {
      */
     void clearFrameworkId() throws StateStoreException;
 
-
-    // Read Framework ID
-
-
-    /**
-     * Fetches the previously stored FrameworkID, or returns an empty Optional if no FrameworkId was previously stored.
-     *
-     * @return The previously stored FrameworkID, or an empty Optional indicating the FrameworkID has not been set.
-     * @throws StateStoreException when fetching the FrameworkID fails
-     */
-    Optional<Protos.FrameworkID> fetchFrameworkId() throws StateStoreException;
 
 
     // Write Tasks
@@ -86,63 +75,7 @@ public interface StateStore {
     void clearTask(String taskName) throws StateStoreException;
 
 
-    // Read Tasks
-
-
-    /**
-     * Fetches all the Task names listed in the underlying storage. Note that these should always have a TaskInfo, but
-     * may lack TaskStatus.
-     *
-     * @return All the Task names stored so far, or an empty list if none are found
-     * @throws StateStoreException when fetching the data fails
-     */
-    Collection<String> fetchTaskNames() throws StateStoreException;
-
-
-    /**
-     * Fetches and returns all {@link TaskInfo}s from the underlying storage, or an empty list if none are found. This
-     * list should be a superset of the list returned by {@link #fetchStatuses()}.
-     *
-     * @return All TaskInfos
-     * @throws StateStoreException if fetching the TaskInfo information otherwise fails
-     */
-    Collection<TaskInfo> fetchTasks() throws StateStoreException;
-
-
-    /**
-     * Fetches the TaskInfo for a particular Task, or returns an empty Optional if no matching task is found.
-     *
-     * @param taskName The name of the Task
-     * @return The corresponding TaskInfo object
-     * @throws StateStoreException if no data was found for the requested name, or if fetching the TaskInfo otherwise
-     *                             fails
-     */
-    Optional<TaskInfo> fetchTask(String taskName) throws StateStoreException;
-
-
-    /**
-     * Fetches all {@link TaskStatus}es from the underlying storage, or an empty list if none are found. Note that this
-     * list may have fewer entries than {@link #fetchTasks()} if some tasks are lacking statuses.
-     *
-     * @return The TaskStatus objects associated with all tasks
-     * @throws StateStoreException if fetching the TaskStatus information fails
-     */
-    Collection<TaskStatus> fetchStatuses() throws StateStoreException;
-
-
-    /**
-     * Fetches the TaskStatus for a particular Task, or returns an empty Optional if no matching status is found.
-     * A given task may sometimes have {@link TaskInfo} while lacking {@link TaskStatus}.
-     *
-     * @param taskName The name of the Task which should have its status retrieved
-     * @return The TaskStatus associated with a particular Task
-     * @throws StateStoreException if no data was found for the requested name, or if fetching the TaskStatus
-     *                             information otherwise fails
-     */
-    Optional<TaskStatus> fetchStatus(String taskName) throws StateStoreException;
-
-
-    // Read/Write Properties
+    // Write Properties
 
 
     /**
@@ -157,35 +90,12 @@ public interface StateStore {
     void storeProperty(String key, byte[] value) throws StateStoreException;
 
     /**
-     * Fetches the value byte array, stored against the Property {@code key}, or throws an error if no matching {@code
-     * key} is found.
-     *
-     * @param key must be a non-blank String without any forward slashes ('/')
-     * @throws StateStoreException if no data was found for the requested key, or if fetching the data otherwise fails
-     * @see StateStoreUtils#validateKey(String)
-     */
-    byte[] fetchProperty(String key) throws StateStoreException;
-
-    /**
-     * Fetches the list of Property keys, or an empty list if none are found.
-     *
-     * @throws StateStoreException if fetching the list otherwise fails
-     */
-    Collection<String> fetchPropertyKeys() throws StateStoreException;
-
-    /**
      * Clears a given property from the StateStore, or does nothing if no such property exists.
      *
      * @param key must be a non-blank String without any forward slashes ('/')
      * @throws StateStoreException if key validation fails or clearing the entry fails
      */
     void clearProperty(final String key) throws StateStoreException;
-
-    /**
-     * @return true if the offers are suppressed.
-     * @throws StateStoreException
-     */
-    boolean isSuppressed() throws StateStoreException;
 
     /**
      * Sets the suppression state of the framework.

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/state/StateStoreReadOnly.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/state/StateStoreReadOnly.java
@@ -1,0 +1,118 @@
+package com.mesosphere.sdk.state;
+
+import org.apache.mesos.Protos.FrameworkID;
+import org.apache.mesos.Protos.TaskInfo;
+import org.apache.mesos.Protos.TaskStatus;
+
+import java.util.Collection;
+import java.util.Optional;
+
+/**
+ * A {@code StateStore} stores the state of the frameworks, including tasks' TaskInfo and TaskStatus objects. Each
+ * distinct Task is expected to have a unique Task Name, determined by the framework developer.
+ *
+ * This interface exposes only methods which perform read operations on the StateStore.
+ * <p>
+ * TaskInfo objects should be persisted when a Task is launched or when reserved resources associated with a potential
+ * future Task launch should be recorded.
+ * <p>
+ * TaskStatus is reported by Mesos to Frameworks at various points including at Task Reconciliation and when Tasks
+ * change state.  The TaskStatus of a Task should be recorded so that the state of a Framework's Tasks can be queried.
+ */
+public interface StateStoreReadOnly {
+
+    // Read Framework ID
+
+
+    /**
+     * Fetches the previously stored FrameworkID, or returns an empty Optional if no FrameworkId was previously stored.
+     *
+     * @return The previously stored FrameworkID, or an empty Optional indicating the FrameworkID has not been set.
+     * @throws StateStoreException when fetching the FrameworkID fails
+     */
+    Optional<FrameworkID> fetchFrameworkId() throws StateStoreException;
+
+
+    // Read Tasks
+
+
+    /**
+     * Fetches all the Task names listed in the underlying storage. Note that these should always have a TaskInfo, but
+     * may lack TaskStatus.
+     *
+     * @return All the Task names stored so far, or an empty list if none are found
+     * @throws StateStoreException when fetching the data fails
+     */
+    Collection<String> fetchTaskNames() throws StateStoreException;
+
+
+    /**
+     * Fetches and returns all {@link TaskInfo}s from the underlying storage, or an empty list if none are found. This
+     * list should be a superset of the list returned by {@link #fetchStatuses()}.
+     *
+     * @return All TaskInfos
+     * @throws StateStoreException if fetching the TaskInfo information otherwise fails
+     */
+    Collection<TaskInfo> fetchTasks() throws StateStoreException;
+
+
+    /**
+     * Fetches the TaskInfo for a particular Task, or returns an empty Optional if no matching task is found.
+     *
+     * @param taskName The name of the Task
+     * @return The corresponding TaskInfo object
+     * @throws StateStoreException if no data was found for the requested name, or if fetching the TaskInfo otherwise
+     *                             fails
+     */
+    Optional<TaskInfo> fetchTask(String taskName) throws StateStoreException;
+
+
+    /**
+     * Fetches all {@link TaskStatus}es from the underlying storage, or an empty list if none are found. Note that this
+     * list may have fewer entries than {@link #fetchTasks()} if some tasks are lacking statuses.
+     *
+     * @return The TaskStatus objects associated with all tasks
+     * @throws StateStoreException if fetching the TaskStatus information fails
+     */
+    Collection<TaskStatus> fetchStatuses() throws StateStoreException;
+
+
+    /**
+     * Fetches the TaskStatus for a particular Task, or returns an empty Optional if no matching status is found.
+     * A given task may sometimes have {@link TaskInfo} while lacking {@link TaskStatus}.
+     *
+     * @param taskName The name of the Task which should have its status retrieved
+     * @return The TaskStatus associated with a particular Task
+     * @throws StateStoreException if no data was found for the requested name, or if fetching the TaskStatus
+     *                             information otherwise fails
+     */
+    Optional<TaskStatus> fetchStatus(String taskName) throws StateStoreException;
+
+
+    // Read Properties
+
+
+    /**
+     * Fetches the value byte array, stored against the Property {@code key}, or throws an error if no matching {@code
+     * key} is found.
+     *
+     * @param key must be a non-blank String without any forward slashes ('/')
+     * @throws StateStoreException if no data was found for the requested key, or if fetching the data otherwise fails
+     * @see StateStoreUtils#validateKey(String)
+     */
+    byte[] fetchProperty(String key) throws StateStoreException;
+
+    /**
+     * Fetches the list of Property keys, or an empty list if none are found.
+     *
+     * @throws StateStoreException if fetching the list otherwise fails
+     */
+    Collection<String> fetchPropertyKeys() throws StateStoreException;
+
+
+    /**
+     * @return true if the offers are suppressed.
+     * @throws StateStoreException
+     */
+    boolean isSuppressed() throws StateStoreException;
+}

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/state/StateStoreUtils.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/state/StateStoreUtils.java
@@ -40,7 +40,7 @@ public class StateStoreUtils {
     /**
      * Returns the requested property, or an empty array if the property is not present.
      */
-    public static byte[] fetchPropertyOrEmptyArray(StateStore stateStore, String key) {
+    public static byte[] fetchPropertyOrEmptyArray(StateStoreReadOnly stateStore, String key) {
         if (stateStore.fetchPropertyKeys().contains(key)) {
             return stateStore.fetchProperty(key);
         } else {


### PR DESCRIPTION
Components (Tasks) other than the scheduler may wish to understand the state of a given service without having access to modifying service state.  The addition of a read-only StateStore interfaces allows for this.

Example uses include:
* Cassandra seed provider
* Cross-service locality

This PR looks like it has many changes when in fact it is a pure lift of methods from `StateStore` to `StateStoreReadOnly` in both interfaces and implementation.