### PR TITLE
[SDK] Fix failed tasks being recovered by deploy plan

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/DefaultScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/DefaultScheduler.java
@@ -572,9 +572,10 @@ public class DefaultScheduler implements Scheduler, Observer {
         Plan deployPlan;
         if (!deploy.isPresent()) {
             LOGGER.info("No deploy plan provided. Generating one");
-             deployPlan = new DefaultPlanFactory(
-                     new DefaultPhaseFactory(new DefaultStepFactory(configStore, stateStore)))
-                     .getPlan(serviceSpec);
+            deployPlan =
+                    new DefaultPlanFactory(
+                            new DefaultPhaseFactory(
+                                    new DefaultStepFactory(configStore, stateStore))).getPlan(serviceSpec);
         } else {
             deployPlan = deploy.get();
         }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/DefaultStepFactory.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/DefaultStepFactory.java
@@ -3,6 +3,7 @@ package com.mesosphere.sdk.scheduler.plan;
 import com.mesosphere.sdk.config.ConfigStoreException;
 import com.mesosphere.sdk.config.ConfigTargetStore;
 import com.mesosphere.sdk.offer.*;
+import com.mesosphere.sdk.scheduler.recovery.FailureUtils;
 import com.mesosphere.sdk.specification.GoalState;
 import com.mesosphere.sdk.specification.PodInstance;
 import com.mesosphere.sdk.specification.TaskSpec;
@@ -107,10 +108,11 @@ public class DefaultStepFactory implements StepFactory {
             }
         }
 
-        LOGGER.info("Task: '{}' is on target: {} and has reached goal: {}.",
-                taskInfo.getName(), isOnTarget, hasReachedGoal);
+        boolean hasPermanentlyFailed = FailureUtils.isLabeledAsFailed(taskInfo);
+        LOGGER.info("Task: '{}' is on target: {} and has reached goal: {} or has permanently failed: {}.",
+                taskInfo.getName(), isOnTarget, hasReachedGoal, hasPermanentlyFailed);
 
-        if (isOnTarget && hasReachedGoal) {
+        if ((isOnTarget && hasReachedGoal) || hasPermanentlyFailed) {
             return Status.COMPLETE;
         } else {
             return Status.PENDING;


### PR DESCRIPTION
Resolves https://jira.mesosphere.com/browse/INFINITY-962
On scheduler restart, permanently failed tasks were incorrectly being picked up by the deployment plan which doesn't have the correct logic for dealing with permanent failures.