### PR TITLE
Refrain from running mustache {{ }} templates in dev guide

### DIFF
--- a/docs/pages/dev-guide/developer-guide.md
+++ b/docs/pages/dev-guide/developer-guide.md
@@ -2,6 +2,7 @@
 layout: dev-basic
 title: SDK Developer Guide
 ---
+<!-- {{=<% %>=}} disable mustache templating in this file: retain templated examples as-is -->
 
 This developer guide explains how to create a stateful DC/OS service using the DC/OS SDK. The DC/OS SDK is a collection of tools, libraries, and documentation that facilitates the creation of DC/OS services.
 


### PR DESCRIPTION
See https://mesosphere.github.io/dcos-commons/dev-guide/developer-guide.html, where all the examples have had any mustache templates replaced with empty strings

In theory this should fix it, per http://stackoverflow.com/questions/11042926/how-does-one-use-a-literal-in-a-mustache-template