### PR TITLE
Use Mesos 1.2.0-rc1 instead of SNAPSHOT

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,7 +79,7 @@ allprojects {
 }
 
 ext {
-    mesosVer = "1.2.0-SNAPSHOT"
+    mesosVer = "1.2.0-rc1"
 }
 
 subprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -32,9 +32,6 @@ allprojects {
     targetCompatibility = '1.8'
 
     repositories {
-        maven {
-            url 'https://repository.apache.org/content/repositories/snapshots'
-        }
         mavenLocal()
         mavenCentral()
     }


### PR DESCRIPTION
Fetch RC1 from Maven Central instead of SNAPSHOT from the less available repository.apache.org to make CI work more reliably.