### PR TITLE
Added teardown_module to uninstall/janitor frameworks after tests run

### DIFF
--- a/frameworks/cassandra/tests/test_shakedown.py
+++ b/frameworks/cassandra/tests/test_shakedown.py
@@ -3,10 +3,12 @@ import pytest
 from tests.config import *
 import sdk_install as install
 import sdk_tasks as tasks
+import sdk_utils as utils
 
 
 def setup_module(module):
     install.uninstall(PACKAGE_NAME)
+    utils.gc_frameworks()
     install.install(PACKAGE_NAME, DEFAULT_TASK_COUNT)
 
 

--- a/frameworks/elastic/tests/config.py
+++ b/frameworks/elastic/tests/config.py
@@ -21,11 +21,6 @@ REQUEST_HEADERS = {
 }
 
 
-def gc_frameworks():
-    for host in shakedown.get_private_agents():
-        shakedown.run_command(host, "sudo rm -rf /var/lib/mesos/slave/slaves/*/frameworks/*")
-
-
 def as_json(fn):
     @wraps(fn)
     def wrapper(*args, **kwargs):

--- a/frameworks/elastic/tests/test_shakedown.py
+++ b/frameworks/elastic/tests/test_shakedown.py
@@ -4,6 +4,7 @@ from tests.config import *
 import sdk_install as install
 import sdk_tasks as tasks
 import sdk_marathon as marathon
+import sdk_utils as utils
 
 DEFAULT_NUMBER_OF_SHARDS = 1
 DEFAULT_NUMBER_OF_REPLICAS = 1
@@ -21,7 +22,7 @@ DEFAULT_SETTINGS_MAPPINGS = {
 
 def setup_module(module):
     install.uninstall(PACKAGE_NAME)
-    gc_frameworks()
+    utils.gc_frameworks()
     install.install(PACKAGE_NAME, DEFAULT_TASK_COUNT)
 
 

--- a/frameworks/hdfs/tests/test_alternate_name.py
+++ b/frameworks/hdfs/tests/test_alternate_name.py
@@ -1,7 +1,7 @@
 import pytest
 
 import sdk_install as install
-import sdk_plan as plan
+import sdk_utils as utils
 
 from tests.config import (
     PACKAGE_NAME,
@@ -13,6 +13,7 @@ SERVICE_NAME="hdfs2"
 
 def setup_module(module):
     install.uninstall(SERVICE_NAME, PACKAGE_NAME)
+    utils.gc_frameworks()
     options = {
         "service": {
             "name": "hdfs2"

--- a/frameworks/helloworld/tests/test_networking.py
+++ b/frameworks/helloworld/tests/test_networking.py
@@ -20,6 +20,10 @@ def setup_module(module):
     install.install(PACKAGE_NAME, 1, additional_options=options)
 
 
+def teardown_module(module):
+    install.uninstall(PACKAGE_NAME)
+
+
 @pytest.mark.sanity
 def test_deploy():
     """Verify that the current deploy plan matches the expected plan from the spec."""

--- a/frameworks/helloworld/tests/test_networking.py
+++ b/frameworks/helloworld/tests/test_networking.py
@@ -3,6 +3,7 @@ import pytest
 import sdk_install as install
 import sdk_plan as plan
 import sdk_spin as spin
+import sdk_utils as utils
 
 from tests.config import (
     PACKAGE_NAME
@@ -11,6 +12,7 @@ from tests.config import (
 
 def setup_module(module):
     install.uninstall(PACKAGE_NAME)
+    utils.gc_frameworks()
     options = {
         "service": {
             "spec_file": "examples/cni.yml"

--- a/frameworks/helloworld/tests/test_parameterized_plan.py
+++ b/frameworks/helloworld/tests/test_parameterized_plan.py
@@ -21,6 +21,10 @@ def setup_module(module):
     install.install(PACKAGE_NAME, 2, additional_options=options)
 
 
+def teardown_module(module):
+    install.uninstall(PACKAGE_NAME)
+
+
 @pytest.mark.sanity
 def test_deploy():
     deployment_plan = plan.get_deployment_plan(PACKAGE_NAME).json()

--- a/frameworks/helloworld/tests/test_sanity.py
+++ b/frameworks/helloworld/tests/test_sanity.py
@@ -23,6 +23,10 @@ def setup_module(module):
     install.install(PACKAGE_NAME, DEFAULT_TASK_COUNT)
 
 
+def teardown_module(module):
+    install.uninstall(PACKAGE_NAME)
+
+
 @pytest.mark.smoke
 def test_install():
     check_running()

--- a/frameworks/helloworld/tests/test_sidecar.py
+++ b/frameworks/helloworld/tests/test_sidecar.py
@@ -2,7 +2,6 @@ import pytest
 
 import sdk_install as install
 import sdk_plan as plan
-import sdk_spin as spin
 
 from tests.config import (
     PACKAGE_NAME
@@ -19,6 +18,10 @@ def setup_module(module):
 
     # this yml has 2 hello's + 0 world's:
     install.install(PACKAGE_NAME, 2, additional_options=options)
+
+
+def teardown_module(module):
+    install.uninstall(PACKAGE_NAME)
 
 
 @pytest.mark.sanity

--- a/frameworks/helloworld/tests/test_taskcfg.py
+++ b/frameworks/helloworld/tests/test_taskcfg.py
@@ -1,4 +1,3 @@
-import dcos.http
 import pytest
 import shakedown
 
@@ -9,7 +8,6 @@ import sdk_spin as spin
 
 from tests.config import (
     PACKAGE_NAME,
-    DEFAULT_TASK_COUNT,
     check_running
 )
 
@@ -19,6 +17,10 @@ def setup_module(module):
     options = install.get_package_options({ "service": { "spec_file": "examples/taskcfg.yml" } })
     # don't wait for install to complete successfully:
     shakedown.install_package(PACKAGE_NAME, options_json=options)
+
+
+def teardown_module(module):
+    install.uninstall(PACKAGE_NAME)
 
 
 @pytest.mark.sanity

--- a/frameworks/helloworld/tests/test_web_url.py
+++ b/frameworks/helloworld/tests/test_web_url.py
@@ -4,8 +4,7 @@ import sdk_install as install
 import sdk_plan as plan
 
 from tests.config import (
-    PACKAGE_NAME,
-    DEFAULT_TASK_COUNT
+    PACKAGE_NAME
 )
 
 
@@ -19,6 +18,10 @@ def setup_module(module):
 
     # this config produces 1 hello's + 0 world's:
     install.install(PACKAGE_NAME, 1, additional_options=options)
+
+
+def teardown_module(module):
+    install.uninstall(PACKAGE_NAME)
 
 
 @pytest.mark.sanity

--- a/frameworks/kafka/tests/test_sanity.py
+++ b/frameworks/kafka/tests/test_sanity.py
@@ -13,6 +13,10 @@ def setup_module(module):
     install.install(PACKAGE_NAME, DEFAULT_TASK_COUNT)
 
 
+def teardown_module(module):
+    install.uninstall(PACKAGE_NAME)
+
+
 @pytest.mark.sanity
 @pytest.mark.smoke
 def test_install():

--- a/frameworks/kafka/tests/test_sanity.py
+++ b/frameworks/kafka/tests/test_sanity.py
@@ -1,6 +1,7 @@
 import pytest
 
 import sdk_install as install
+import sdk_utils as utils
 
 from tests.config import (
     PACKAGE_NAME,
@@ -10,6 +11,7 @@ from tests.config import (
 
 def setup_module(module):
     install.uninstall(PACKAGE_NAME)
+    utils.gc_frameworks()
     install.install(PACKAGE_NAME, DEFAULT_TASK_COUNT)
 
 

--- a/frameworks/prototype/tests/test_sanity.py
+++ b/frameworks/prototype/tests/test_sanity.py
@@ -1,15 +1,16 @@
 import pytest
 
 import sdk_install as install
+import sdk_utils as utils
 
 from tests.config import (
-    PACKAGE_NAME,
-    DEFAULT_TASK_COUNT
+    PACKAGE_NAME
 )
 
 
 def setup_module(module):
     install.uninstall(PACKAGE_NAME)
+    utils.gc_frameworks()
 
 
 def teardown_module(module):

--- a/frameworks/prototype/tests/test_sanity.py
+++ b/frameworks/prototype/tests/test_sanity.py
@@ -12,16 +12,8 @@ def setup_module(module):
     install.uninstall(PACKAGE_NAME)
 
 
-def setup_module(module):
+def teardown_module(module):
     install.uninstall(PACKAGE_NAME)
-    options = {
-        "service": {
-            "specification_uri": "https://gist.githubusercontent.com/mohitsoni/29d03e7d73135d4a8d2ea54b508bbcf9/raw/fb495434dcc507d3afc79fa761afe57bb31975c4/service.yml"
-        }
-    }
-
-    # this config produces 1 hello's + 0 world's:
-    install.install(PACKAGE_NAME, DEFAULT_TASK_COUNT, additional_options=options)
 
 
 @pytest.mark.sanity

--- a/frameworks/proxylite/tests/test_sanity.py
+++ b/frameworks/proxylite/tests/test_sanity.py
@@ -4,6 +4,7 @@ import shakedown
 import sdk_cmd as cmd
 import sdk_install as install
 import sdk_plan as plan
+import sdk_utils as utils
 
 from tests.config import (
     PACKAGE_NAME,
@@ -13,6 +14,7 @@ from tests.config import (
 
 def setup_module(module):
     install.uninstall(PACKAGE_NAME)
+    utils.gc_frameworks()
     install.install(PACKAGE_NAME, DEFAULT_TASK_COUNT)
 
 

--- a/frameworks/proxylite/tests/test_sanity.py
+++ b/frameworks/proxylite/tests/test_sanity.py
@@ -16,6 +16,10 @@ def setup_module(module):
     install.install(PACKAGE_NAME, DEFAULT_TASK_COUNT)
 
 
+def teardown_module(module):
+    install.uninstall(PACKAGE_NAME)
+
+
 @pytest.mark.smoke
 def test_install():
     pass # Setup makes sure install has completed

--- a/frameworks/template/tests/test_sanity.py
+++ b/frameworks/template/tests/test_sanity.py
@@ -13,6 +13,10 @@ def setup_module(module):
     install.install(PACKAGE_NAME, DEFAULT_TASK_COUNT)
 
 
+def teardown_module(module):
+    install.uninstall(PACKAGE_NAME)
+
+
 @pytest.mark.sanity
 @pytest.mark.smoke
 def test_install():

--- a/frameworks/template/tests/test_sanity.py
+++ b/frameworks/template/tests/test_sanity.py
@@ -1,6 +1,7 @@
 import pytest
 
 import sdk_install as install
+import sdk_utils as utils
 
 from tests.config import (
     PACKAGE_NAME,
@@ -10,6 +11,7 @@ from tests.config import (
 
 def setup_module(module):
     install.uninstall(PACKAGE_NAME)
+    utils.gc_frameworks()
     install.install(PACKAGE_NAME, DEFAULT_TASK_COUNT)
 
 

--- a/test.sh
+++ b/test.sh
@@ -44,6 +44,8 @@ function run_framework_tests {
     TEST_GITHUB_LABEL="${framework}" ${REPO_ROOT_DIR}/tools/run_tests.py shakedown ${FRAMEWORK_DIR}/tests/
 }
 
+echo "Beginning integration tests at "`date`
+
 REPO_ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd $REPO_ROOT_DIR
 
@@ -66,6 +68,7 @@ if [ -n "$1" ]; then
     run_framework_tests $1
 else
     for framework in $(ls $REPO_ROOT_DIR/frameworks); do
+        echo "Starting shakedown tests for $framework at "`date`
         run_framework_tests $framework
     done
 fi

--- a/testing/sdk_utils.py
+++ b/testing/sdk_utils.py
@@ -1,0 +1,8 @@
+'''Utilities relating to reclaiming private agent disk space consumed by Mesos but not yet garbage collected'''
+
+import shakedown
+
+
+def gc_frameworks():
+    for host in shakedown.get_private_agents():
+        shakedown.run_command(host, "sudo rm -rf /var/lib/mesos/slave/slaves/*/frameworks/*")


### PR DESCRIPTION
- Removed unneeded imports
- Deleted duplicate setup_module method in prototype framework