### PR TITLE
[SDK] Expose PodInstanceRequirement from Step

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/DeploymentStep.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/DeploymentStep.java
@@ -71,6 +71,11 @@ public class DeploymentStep extends AbstractStep {
     }
 
     @Override
+    public Optional<PodInstanceRequirement> getPodInstanceRequirement() {
+        return Optional.of(podInstanceRequirement.withParameters(parameters));
+    }
+
+    @Override
     public void updateOfferStatus(Collection<OfferRecommendation> recommendations) {
         // log a bulleted list of operations, with each operation on one line:
         logger.info("Updated step '{} [{}]' with {} recommendations:", getName(), getId(), recommendations.size());

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/Step.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/Step.java
@@ -29,6 +29,12 @@ public interface Step extends Element, Interruptible {
     Optional<PodInstanceRequirement> start();
 
     /**
+     * Returns an {@link OfferRequirement}, or an empty Optional if obtaining/updating resource requirements are not
+     * applicable to the Step. Unlike {@link #start()} it has no connotation of performing any work.
+     */
+    Optional<PodInstanceRequirement> getPodInstanceRequirement();
+
+    /**
      * Notifies the Step whether the {@link PodInstanceRequirement} previously returned by
      * {@link #start()} has been successfully accepted/fulfilled. The {@code recommendations} param is
      * empty when no offers matching the requirement previously returned by {@link #start()}

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/plan/TestStep.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/plan/TestStep.java
@@ -27,6 +27,11 @@ public class TestStep extends AbstractStep {
     }
 
     @Override
+    public Optional<PodInstanceRequirement> getPodInstanceRequirement() {
+        return Optional.empty();
+    }
+
+    @Override
     public void updateOfferStatus(Collection<OfferRecommendation> recommendations) {
         if (recommendations.isEmpty()) {
             setStatus(Status.PREPARED);


### PR DESCRIPTION
It is desirable to be able to inspect what Task related work a Step wishes to accomplish without actually initiating that work.