### PR TITLE
Faster service rebuilds via caching of go artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ tools/cluster-*.properties
 tools/*.pem
 tools/dcostests_env/
 tools/shakedown_env/
+native-*
 
 # idea
 *.i??

--- a/sdk/bootstrap/build.sh
+++ b/sdk/bootstrap/build.sh
@@ -3,71 +3,19 @@
 # exit immediately on failure
 set -e
 
-BOOTSTRAP_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-REPO_ROOT_DIR="$(dirname $(dirname $BOOTSTRAP_DIR))"
-
-if [ -z "$GOPATH" -o -z "$(which go)" ]; then
-  echo "Missing GOPATH environment variable or 'go' executable. Please configure a Go build environment."
-  exit 1
-fi
-
-REPO_NAME=dcos-commons # CI dir does not match repo name
-GOPATH_MESOSPHERE="$GOPATH/src/github.com/mesosphere"
-GOPATH_BOOTSTRAP="$GOPATH_MESOSPHERE/$REPO_NAME/sdk/bootstrap"
-EXE_FILENAME=bootstrap
-
-GO_VERSION=$(go version | awk '{print $3}')
-UPX_BINARY="" # only enabled for go1.7+
-case "$GO_VERSION" in
-    go1.[7-9]*|go1.1[0-9]*|go[2-9]*) # go1.7+, go2+ (must come before go1.0-go1.4: support e.g. go1.10)
-        echo "Detected Go 1.7.x+: $(which go) $GO_VERSION"
-        UPX_BINARY="$(which upx || which upx-ucl || echo '')" # avoid error code if upx isn't installed
-        ;;
-    go0.*|go1.[0-4]*) # go0.*, go1.0-go1.4
-        echo "Detected Go <=1.4. This is too old, please install Go 1.5+: $(which go) $GO_VERSION"
-        exit 1
-        ;;
-    go1.5*) # go1.5
-        echo "Detected Go 1.5.x: $(which go) $GO_VERSION"
-        export GO15VENDOREXPERIMENT=1
-        ;;
-    go1.6*) # go1.6
-        echo "Detected Go 1.6.x: $(which go) $GO_VERSION"
-        # no experiment, but also no UPX
-        ;;
-    *) # ???
-        echo "Unrecognized go version: $(which go) $GO_VERSION"
-        exit 1
-        ;;
-esac
-
-if [ -n "$UPX_BINARY" ]; then
-    echo "Binary CLI compression enabled: $($UPX_BINARY -V | head -n 1)"
-else
-    echo "Binary CLI compression disabled"
-fi
-
-# Configure GOPATH with dcos-commons symlink (rather than having it pull master):
-echo "Creating GOPATH symlink into dcos-commons: $GOPATH"
-rm -rf "$GOPATH_MESOSPHERE/$REPO_NAME"
-mkdir -p "$GOPATH_MESOSPHERE"
-pushd "$GOPATH_MESOSPHERE"
-ln -s "$REPO_ROOT_DIR" $REPO_NAME
-popd
-echo "Created symlink $GOPATH_MESOSPHERE/$REPO_NAME -> $REPO_ROOT_DIR"
-
-# run get/build from within GOPATH:
-pushd "$GOPATH_BOOTSTRAP"
-go get
-echo "Building ${EXE_FILENAME}"
-rm -f ${EXE_FILENAME}
-CGO_ENABLED=0 GOOS=linux GOARCH=386 go build -ldflags="-s -w"
-# use upx if available and if golang's output doesn't have problems with it:
-if [ -n "$UPX_BINARY" ]; then
-    $UPX_BINARY -q -9 "${EXE_FILENAME}"
-fi
+CUR_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+EXE_FILENAME=$(basename $CUR_DIR)
 PKG_FILENAME=${EXE_FILENAME}.zip
-rm -f ${PKG_FILENAME}
-zip ${PKG_FILENAME} ${EXE_FILENAME}
+
+cd $CUR_DIR
+
+../../tools/build_go_exe.sh sdk/bootstrap/ linux
+
+rm -f $PKG_FILENAME
+# build_go_exe.sh produces 'bootstrap-linux': add to zip as 'bootstrap'
+mv ${EXE_FILENAME}-linux $EXE_FILENAME
+zip -q $PKG_FILENAME $EXE_FILENAME
+# preserve original naming so that build_go_exe.sh can skip builds when unneeded:
+mv $EXE_FILENAME ${EXE_FILENAME}-linux
+
 echo $(pwd)/${PKG_FILENAME}
-popd

--- a/tools/build_cli.sh
+++ b/tools/build_cli.sh
@@ -11,111 +11,19 @@ fi
 CLI_EXE_NAME=$1
 CLI_DIR=$2
 REPO_CLI_RELATIVE_PATH=$3 # eg 'frameworks/helloworld/cli/'
-
 TOOLS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-REPO_ROOT_DIR=$(dirname $TOOLS_DIR) # note: need an absolute path for REPO_CLI_RELATIVE_PATH below
-
-if [ -z "$GOPATH" -o -z "$(which go)" ]; then
-  echo "Missing GOPATH environment variable or 'go' executable. Please configure a Go build environment."
-  exit 1
-fi
-
-print_file_and_shasum() {
-    echo ""
-    # Only show 'file <filename>' if that utility is available: often missing in CI builds.
-    if [ -n "$(which file)" ]; then
-        file "$1"
-    fi
-    ls -lh "$1"
-    echo ""
-}
 
 # ---
 
-# go (static binaries containing the CLI itself)
-
-GO_VERSION=$(go version | awk '{print $3}')
-UPX_BINARY="" # only enabled for go1.7+
-case "$GO_VERSION" in
-    go1.[7-9]*|go1.1[0-9]*|go[2-9]*) # go1.7+, go2+ (must come before go1.0-go1.4: support e.g. go1.10)
-        echo "Detected Go 1.7.x+: $(which go) $GO_VERSION"
-        UPX_BINARY="$(which upx || which upx-ucl || echo '')" # avoid error code if upx isn't installed
-        ;;
-    go0.*|go1.[0-4]*) # go0.*, go1.0-go1.4
-        echo "Detected Go <=1.4. This is too old, please install Go 1.5+: $(which go) $GO_VERSION"
-        exit 1
-        ;;
-    go1.5*) # go1.5
-        echo "Detected Go 1.5.x: $(which go) $GO_VERSION"
-        export GO15VENDOREXPERIMENT=1
-        ;;
-    go1.6*) # go1.6
-        echo "Detected Go 1.6.x: $(which go) $GO_VERSION"
-        # no experiment, but also no UPX
-        ;;
-    *) # ???
-        echo "Unrecognized go version: $(which go) $GO_VERSION"
-        exit 1
-        ;;
-esac
-
-if [ -n "$UPX_BINARY" ]; then
-    echo "Binary CLI compression enabled: $($UPX_BINARY -V | head -n 1)"
-else
-    echo "Binary CLI compression disabled"
-fi
-
-build_cli() {
-    EXE_OUTPUT=${CLI_EXE_NAME}$2
-    if [ "$1" = "darwin" ]; then
-        # do not compress darwin binaries: upx compression results in 'Killed: 9'
-        echo "Building $1 CLI: $EXE_OUTPUT (stripped)"
-        # available GOOS/GOARCH permutations are listed at:
-        # https://golang.org/doc/install/source#environment
-        CGO_ENABLED=0 GOOS=$1 GOARCH=386 go build -ldflags="-s -w"
-        if [ "${EXE_OUTPUT}" != "${CLI_EXE_NAME}" -a -f "${CLI_EXE_NAME}" ]; then
-            mv -vf "${CLI_EXE_NAME}" "${EXE_OUTPUT}"
-        fi
-        print_file_and_shasum "${EXE_OUTPUT}"
-        return
-    fi
-    echo "Building $1 CLI: $EXE_OUTPUT (stripped/compressed)"
-    CGO_ENABLED=0 GOOS=$1 GOARCH=386 go build -ldflags="-s -w"
-    if [ "${EXE_OUTPUT}" != "${CLI_EXE_NAME}" -a -f "${CLI_EXE_NAME}" ]; then
-        mv -vf "${CLI_EXE_NAME}" "${EXE_OUTPUT}"
-    fi
-    # use upx if available and if golang's output doesn't have problems with it:
-    if [ -n "$UPX_BINARY" ]; then
-        $UPX_BINARY -q -9 "${EXE_OUTPUT}"
-    fi
-    print_file_and_shasum "${EXE_OUTPUT}"
-}
-
-# Configure GOPATH with dcos-commons symlink (rather than having it pull master):
-echo "Creating GOPATH symlink into dcos-commons: $GOPATH"
-REPO_NAME=dcos-commons # CI dir does not match repo name
-GOPATH_MESOSPHERE=$GOPATH/src/github.com/mesosphere
-rm -rf $GOPATH_MESOSPHERE/$REPO_NAME
-mkdir -p $GOPATH_MESOSPHERE
-pushd $GOPATH_MESOSPHERE
-ln -s $REPO_ROOT_DIR $REPO_NAME
-popd
-echo "Created symlink $GOPATH_MESOSPHERE/$REPO_NAME -> $REPO_ROOT_DIR"
-
-# run get/build from within GOPATH:
-pushd $GOPATH_MESOSPHERE/$REPO_NAME/$REPO_CLI_RELATIVE_PATH/$CLI_EXE_NAME/
-go get
-build_cli windows .exe # use default .exe suffix
-build_cli darwin -darwin # add -darwin suffix
-build_cli linux -linux # add -linux suffix
-popd
+# go
+$TOOLS_DIR/build_go_exe.sh $REPO_CLI_RELATIVE_PATH/$CLI_EXE_NAME windows
+$TOOLS_DIR/build_go_exe.sh $REPO_CLI_RELATIVE_PATH/$CLI_EXE_NAME darwin
+$TOOLS_DIR/build_go_exe.sh $REPO_CLI_RELATIVE_PATH/$CLI_EXE_NAME linux
 
 # ---
 
 # python (wraps above binaries for compatibility with DC/OS 1.7 and universe-2.x):
 echo "Building Python CLI wrapper (DC/OS 1.7 / universe-2.x compatibility)"
-pushd ${TOOLS_DIR}/pythoncli
+cd $TOOLS_DIR/pythoncli
 rm -rf dist/ binaries/
-EXE_BUILD_DIR=$CLI_DIR/$CLI_EXE_NAME/ python setup.py bdist_wheel
-print_file_and_shasum $CLI_DIR/$CLI_EXE_NAME/*.whl
-popd
+EXE_BUILD_DIR=$CLI_DIR/$CLI_EXE_NAME/ python setup.py -q bdist_wheel

--- a/tools/build_go_exe.sh
+++ b/tools/build_go_exe.sh
@@ -67,7 +67,7 @@ go get
 
 # optimization: build a native version of the executable and check if the sha1 matches a
 # previous native build. if the sha1 matches, then we can skip the rebuild.
-NATIVE_FILENAME="${EXE_FILENAME}.native"
+NATIVE_FILENAME="native-${EXE_FILENAME}"
 NATIVE_SHA1SUM_FILENAME="${NATIVE_FILENAME}.sha1sum"
 go build -o $NATIVE_FILENAME
 NATIVE_SHA1SUM=$(sha1sum $NATIVE_FILENAME | awk '{print $1}')

--- a/tools/build_go_exe.sh
+++ b/tools/build_go_exe.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+
+# exit immediately on failure
+set -e
+
+if [ $# -lt 2 ]; then
+    echo "Syntax: $0 <repo-relative/path/to/executable/> <windows|darwin|linux>"
+    exit 1
+fi
+
+TOOLS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+REPO_ROOT_DIR=$(dirname $TOOLS_DIR)
+
+if [ -z "$GOPATH" -o -z "$(which go)" ]; then
+  echo "Missing GOPATH environment variable or 'go' executable. Please configure a Go build environment."
+  exit 1
+fi
+
+REPO_NAME=dcos-commons # CI dir does not match repo name
+GOPATH_MESOSPHERE="$GOPATH/src/github.com/mesosphere"
+GOPATH_EXE_DIR="$GOPATH_MESOSPHERE/$REPO_NAME/$1"
+if [ $2 = "windows" ]; then
+    EXE_FILENAME=$(basename $1).exe
+else
+    EXE_FILENAME=$(basename $1)-$2
+fi
+
+# Detect Go version to determine:
+# - if UPX should be used to compress binaries (Go 1.7+)
+# - if vendoring needs to be manually enabled (Go 1.5)
+GO_VERSION=$(go version | awk '{print $3}')
+UPX_BINARY="" # only enabled for go1.7+
+case "$GO_VERSION" in
+    go1.[7-9]*|go1.1[0-9]*|go[2-9]*) # go1.7+, go2+ (must come before go1.0-go1.4: support e.g. go1.10)
+        UPX_BINARY="$(which upx || which upx-ucl || echo '')" # avoid error code if upx isn't installed
+        ;;
+    go0.*|go1.[0-4]*) # go0.*, go1.0-go1.4
+        echo "Detected Go <=1.4. This is too old, please install Go 1.5+: $(which go) $GO_VERSION"
+        exit 1
+        ;;
+    go1.5*) # go1.5
+        export GO15VENDOREXPERIMENT=1
+        ;;
+    go1.6*) # go1.6
+        # no experiment, but also no UPX
+        ;;
+    *) # ???
+        echo "Unrecognized go version: $(which go) $GO_VERSION"
+        exit 1
+        ;;
+esac
+
+# Add symlink from GOPATH which points into the repository directory:
+SYMLINK_LOCATION="$GOPATH_MESOSPHERE/$REPO_NAME"
+if [ ! -h "$SYMLINK_LOCATION" -o "$(readlink $SYMLINK_LOCATION)" != "$REPO_ROOT_DIR" ]; then
+    echo "Creating symlink from GOPATH=$SYMLINK_LOCATION to REPOPATH=$REPO_ROOT_DIR"
+    rm -rf "$SYMLINK_LOCATION"
+    mkdir -p "$GOPATH_MESOSPHERE"
+    cd $GOPATH_MESOSPHERE
+    ln -s "$REPO_ROOT_DIR" $REPO_NAME
+fi
+
+# Run 'go get'/'go build' from within GOPATH:
+cd $GOPATH_EXE_DIR
+
+go get
+
+# optimization: build a native version of the executable and check if the sha1 matches a
+# previous native build. if the sha1 matches, then we can skip the rebuild.
+NATIVE_FILENAME="${EXE_FILENAME}.native"
+NATIVE_SHA1SUM_FILENAME="${NATIVE_FILENAME}.sha1sum"
+go build -o $NATIVE_FILENAME
+NATIVE_SHA1SUM=$(sha1sum $NATIVE_FILENAME | awk '{print $1}')
+
+if [ -f $NATIVE_SHA1SUM_FILENAME -a -f $EXE_FILENAME -a "$NATIVE_SHA1SUM" = "$(cat $NATIVE_SHA1SUM_FILENAME)" ]; then
+    # build output hasn't changed. skip.
+    echo "Skipping rebuild of $EXE_FILENAME: No change to native build"
+else
+    # build output is missing, or native build changed. build.
+    echo "Rebuilding $EXE_FILENAME: Native build SHA1 mismatch or missing output"
+    echo $NATIVE_SHA1SUM > $NATIVE_SHA1SUM_FILENAME
+
+    # available GOOS/GOARCH permutations are listed at:
+    # https://golang.org/doc/install/source#environment
+    CGO_ENABLED=0 GOOS=$2 GOARCH=386 go build -ldflags="-s -w" -o $EXE_FILENAME
+
+    # use upx if available and if golang's output doesn't have problems with it:
+    if [ -n "$UPX_BINARY" ]; then
+        $UPX_BINARY -q --best $EXE_FILENAME
+    fi
+fi

--- a/tools/pythoncli/setup.py
+++ b/tools/pythoncli/setup.py
@@ -43,7 +43,8 @@ def main():
             syntax()
             return 1
 
-    print('Packing executables in python wrapper:\n- {}'.format('\n- '.join(bin_paths)))
+    print('Packing {} executables in python wrapper:\n- {}'.format(
+        len(bin_paths), '\n- '.join(bin_paths)))
 
     # wipe/recreate 'binaries' directory
     binaries_dir = 'binaries'


### PR DESCRIPTION
Adds a common `build_go_exe.sh` script which implements caching logic to avoid unnecessary rebuilds of go executables. This is done by comparing the SHA1 of a native/local build (faster than cross-builds) to detect changes in the go build artifact.

This script is now used for building per-service CLI executables as well as the common `bootstrap` executable.

As a result, rebuilding a service goes from ~40s to ~5s (plus the following artifact upload, which mainly depends on bandwidth)