### PR TITLE
[SDK][INFINITY-966] Correctly reuse existing VIP port on discovery info after task restart

### DIFF
--- a/sdk/common/src/main/java/com/mesosphere/sdk/testutils/TaskTestUtils.java
+++ b/sdk/common/src/main/java/com/mesosphere/sdk/testutils/TaskTestUtils.java
@@ -8,6 +8,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.Random;
+import java.util.UUID;
 
 /**
  * This class provides utility method for Tests concerned with Tasks.
@@ -30,11 +31,14 @@ public class TaskTestUtils {
         for (Protos.Resource r : resources) {
             String resourceId = "";
             String dynamicPortAssignment = null;
+            String vipAssignment = null;
             for (Protos.Label l : r.getReservation().getLabels().getLabelsList()) {
                 if (Objects.equals(l.getKey(), "resource_id")) {
                    resourceId = l.getValue();
                 } else if (Objects.equals(l.getKey(), TestConstants.HAS_DYNAMIC_PORT_ASSIGNMENT_LABEL)) {
                     dynamicPortAssignment = l.getValue();
+                } else if (Objects.equals(l.getKey(), TestConstants.HAS_VIP_LABEL)) {
+                    vipAssignment = l.getValue();
                 }
             }
 
@@ -46,6 +50,19 @@ public class TaskTestUtils {
                         .addVariablesBuilder()
                         .setName(TestConstants.PORT_ENV_NAME)
                         .setValue(portValue);
+
+                if (vipAssignment != null) {
+                    Protos.DiscoveryInfo.Builder discoveryBuilder = builder.getDiscoveryBuilder();
+                    discoveryBuilder.setVisibility(Protos.DiscoveryInfo.Visibility.CLUSTER);
+                    discoveryBuilder.setName(builder.getName());
+                    discoveryBuilder.getPortsBuilder()
+                            .addPortsBuilder()
+                            .setNumber(Integer.parseInt(portValue))
+                            .getLabelsBuilder()
+                            .addLabelsBuilder()
+                            .setKey("VIP_" + UUID.randomUUID().toString())
+                            .setValue(vipAssignment);
+                }
             }
         }
         return builder.addAllResources(resources).build();

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/NamedVIPEvaluationStage.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/NamedVIPEvaluationStage.java
@@ -6,6 +6,9 @@ import com.mesosphere.sdk.offer.ResourceUtils;
 import org.apache.mesos.Protos;
 import org.apache.mesos.Protos.DiscoveryInfo;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 /**
  * This class evaluates an offer against a given {@link OfferRequirement} for port resources as in
  * {@link PortEvaluationStage}, additionally setting {@link org.apache.mesos.Protos.DiscoveryInfo} properly for
@@ -62,7 +65,10 @@ public class NamedVIPEvaluationStage extends PortEvaluationStage {
     }
 
     private boolean isVIPSet(Protos.DiscoveryInfo discoveryInfo) {
-        for (Protos.Label l : discoveryInfo.getLabels().getLabelsList()) {
+        List<Protos.Label> portLabels = discoveryInfo.getPorts().getPortsList().stream()
+                .flatMap(p -> p.getLabels().getLabelsList().stream())
+                .collect(Collectors.toList());
+        for (Protos.Label l : portLabels) {
             if (l.getKey().startsWith(ResourceUtils.VIP_PREFIX) &&
                     l.getValue().equals(String.format("%s:%d", vipName, vipPort))) {
                 return true;

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/NamedVIPEvaluationStageTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/NamedVIPEvaluationStageTest.java
@@ -1,7 +1,9 @@
 package com.mesosphere.sdk.offer.evaluate;
 
+import com.mesosphere.sdk.offer.InvalidRequirementException;
 import com.mesosphere.sdk.offer.MesosResourcePool;
 import com.mesosphere.sdk.offer.OfferRequirement;
+import com.mesosphere.sdk.offer.ResourceUtils;
 import com.mesosphere.sdk.testutils.OfferRequirementTestUtils;
 import com.mesosphere.sdk.testutils.OfferTestUtils;
 import com.mesosphere.sdk.testutils.ResourceTestUtils;
@@ -10,6 +12,8 @@ import org.apache.mesos.Protos;
 import org.apache.mesos.Protos.DiscoveryInfo;
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.util.UUID;
 
 public class NamedVIPEvaluationStageTest {
     @Test
@@ -44,5 +48,41 @@ public class NamedVIPEvaluationStageTest {
         Assert.assertEquals(discoveryInfo.getName(), TestConstants.TASK_NAME);
         Assert.assertTrue(vipLabel.getKey().startsWith("VIP_"));
         Assert.assertEquals(vipLabel.getValue(), "test-vip:80");
+    }
+
+    @Test
+    public void testVIPIsReused() throws InvalidRequirementException {
+        String resourceId = UUID.randomUUID().toString();
+        Protos.Resource expectedPorts = ResourceUtils.setLabel(
+                ResourceTestUtils.getExpectedRanges("ports", 10000, 10000, resourceId),
+                TestConstants.HAS_VIP_LABEL,
+                "test-vip:80");
+        Protos.Resource offeredResource = ResourceTestUtils.getExpectedRanges("ports", 10000, 10000, resourceId);
+        Protos.Offer offer = OfferTestUtils.getOffer(offeredResource);
+
+        OfferRequirement offerRequirement = OfferRequirementTestUtils.getOfferRequirement(expectedPorts);
+        PodInfoBuilder podInfoBuilder = new PodInfoBuilder(offerRequirement);
+
+        PortEvaluationStage portEvaluationStage = new NamedVIPEvaluationStage(
+                expectedPorts,
+                TestConstants.TASK_NAME,
+                "test-port",
+                10000,
+                "sctp",
+                DiscoveryInfo.Visibility.CLUSTER,
+                "test-vip",
+                80);
+
+        EvaluationOutcome outcome = portEvaluationStage.evaluate(new MesosResourcePool(offer), podInfoBuilder);
+        Assert.assertTrue(outcome.isPassing());
+
+        Protos.DiscoveryInfo discoveryInfo = podInfoBuilder.getTaskBuilder(TestConstants.TASK_NAME).getDiscovery();
+        Assert.assertEquals(1, discoveryInfo.getPorts().getPortsList().size());
+        Assert.assertEquals(1, discoveryInfo.getPorts().getPorts(0).getLabels().getLabelsList().size());
+
+        String portVIPLabel = discoveryInfo.getPorts().getPorts(0).getLabels().getLabels(0).getKey();
+        String taskVIPLabel = offerRequirement.getTaskRequirements().iterator().next()
+                .getTaskInfo().getDiscovery().getPorts().getPorts(0).getLabels().getLabels(0).getKey();
+        Assert.assertEquals(portVIPLabel, taskVIPLabel);
     }
 }


### PR DESCRIPTION
`NamedVIPEvaluationStage` was using the wrong criterion to determine whether a VIP for a given port was already set on the `DiscoveryInfo` (i.e. whether a VIP label existed on the `DiscoveryInfo` itself rather than on a particular `Port`) leading it to unnecessarily re-add those port definitions on task restart.