### PR TITLE
[SDK] New StateStore with a filter to ignore old TaskInfo and TaskStatus.

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/curator/CuratorStateStore.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/curator/CuratorStateStore.java
@@ -3,7 +3,6 @@ package com.mesosphere.sdk.curator;
 import com.google.common.annotations.VisibleForTesting;
 import com.mesosphere.sdk.dcos.DcosConstants;
 import com.mesosphere.sdk.offer.CommonTaskUtils;
-import com.mesosphere.sdk.offer.TaskException;
 import com.mesosphere.sdk.state.*;
 import com.mesosphere.sdk.storage.Persister;
 import com.mesosphere.sdk.storage.StorageError.Reason;
@@ -193,14 +192,45 @@ public class CuratorStateStore implements StateStore {
 
     @Override
     public void storeStatus(Protos.TaskStatus status) throws StateStoreException {
-        String taskName;
+        Optional<String> optionalTaskName = Optional.empty();
+
+        //TODO(MB): keep the commented code below: original approach for getting TaskName
+        /* We used to get TaskName from TaskID's prefix, instead of comparing TaskIDs.
+           TaskID is our unique identifier, can not change, but we can modify TaskName
+
+           Getting TaskName from prefix may be more efficient, however it prevents us from changing TaskName.
+           For further investigation, keep the commented code below:
+         */
+        /*
         try {
-            taskName = CommonTaskUtils.toTaskName(status.getTaskId());
+            optionalTaskName = Optional.of(CommonTaskUtils.toTaskName(status.getTaskId()));
         } catch (TaskException e) {
             throw new StateStoreException(Reason.LOGIC_ERROR, String.format(
                     "Failed to parse the Task Name from TaskStatus.task_id: '%s'", status), e);
         }
+        */
 
+        for (Protos.TaskInfo taskInfo : fetchTasks()) {
+            if (taskInfo.getTaskId().equals(status.getTaskId())) {
+                if (optionalTaskName.isPresent()) {
+                    logger.error("Found identical task ids in Task {} and  Task {}",
+                            optionalTaskName.get(), taskInfo.getName());
+                    throw new StateStoreException(Reason.LOGIC_ERROR, String.format(
+                            "There are more than one tasks with the same TaskStatus.task_id: %s", status));
+                }
+                    optionalTaskName = Optional.of(taskInfo.getName());
+            }
+        }
+        if (!optionalTaskName.isPresent()) {
+            throw new StateStoreException(Reason.NOT_FOUND, String.format(
+                    "Failed to find a task with matching TaskStatus.task_id: %s", status));
+        }
+
+        storeStatus(optionalTaskName.get(), status);
+    }
+
+    @Override
+    public void storeStatus(String taskName, Protos.TaskStatus status) throws StateStoreException {
         // Validate that a TaskInfo with the exact same UUID is currently present. We intentionally
         // ignore TaskStatuses whose TaskID doesn't (exactly) match the current TaskInfo: We will
         // occasionally get these for stale tasks that have since been changed (with new UUIDs).
@@ -226,6 +256,7 @@ public class CuratorStateStore implements StateStore {
                     status.getTaskId().getValue(), optionalTaskInfo.get().getTaskId().getValue(),
                     status, optionalTaskInfo));
         }
+        /*  All checks till here are redundant if we get TaskName via looking at matching TaskIDs */
 
         Optional<Protos.TaskStatus> currentStatusOptional = fetchStatus(taskName);
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/curator/CuratorStateStore.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/curator/CuratorStateStore.java
@@ -193,22 +193,17 @@ public class CuratorStateStore implements StateStore {
     @Override
     public void storeStatus(Protos.TaskStatus status) throws StateStoreException {
         Optional<String> optionalTaskName = Optional.empty();
-
         //TODO(MB): keep the commented code below: original approach for getting TaskName
         /* We used to get TaskName from TaskID's prefix, instead of comparing TaskIDs.
            TaskID is our unique identifier, can not change, but we can modify TaskName
-
            Getting TaskName from prefix may be more efficient, however it prevents us from changing TaskName.
            For further investigation, keep the commented code below:
-         */
-        /*
         try {
             optionalTaskName = Optional.of(CommonTaskUtils.toTaskName(status.getTaskId()));
         } catch (TaskException e) {
             throw new StateStoreException(Reason.LOGIC_ERROR, String.format(
                     "Failed to parse the Task Name from TaskStatus.task_id: '%s'", status), e);
-        }
-        */
+        }*/
 
         for (Protos.TaskInfo taskInfo : fetchTasks()) {
             if (taskInfo.getTaskId().equals(status.getTaskId())) {

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/curator/CuratorStateStoreFilter.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/curator/CuratorStateStoreFilter.java
@@ -1,0 +1,39 @@
+package com.mesosphere.sdk.curator;
+
+import com.mesosphere.sdk.offer.evaluate.placement.StringMatcher;
+import com.mesosphere.sdk.state.StateStoreException;
+import org.apache.curator.RetryPolicy;
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+/**
+ * Ignore task names that match the filter.
+ */
+public class CuratorStateStoreFilter  extends CuratorStateStore {
+    private  StringMatcher ignoreFilter = null;
+
+    public CuratorStateStoreFilter(
+            String frameworkName,
+            String connectionString,
+            RetryPolicy retryPolicy,
+            String username,
+            String password) {
+        super(frameworkName, connectionString, retryPolicy, username, password);
+    }
+
+    public void setIgnoreFilter(StringMatcher ignoreFilter){
+        this.ignoreFilter = ignoreFilter;
+    }
+
+    @Override
+    public Collection<String> fetchTaskNames() throws StateStoreException {
+        if (ignoreFilter == null) {
+            return super.fetchTaskNames();
+        }
+        return super.fetchTaskNames()
+                    .stream()
+                    .filter( name -> !(ignoreFilter.matches(name)))
+                    .collect(Collectors.toList());
+    }
+
+}

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/curator/CuratorStateStoreFilter.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/curator/CuratorStateStoreFilter.java
@@ -12,6 +12,25 @@ import java.util.stream.Collectors;
 public class CuratorStateStoreFilter  extends CuratorStateStore {
     private  StringMatcher ignoreFilter = null;
 
+    public CuratorStateStoreFilter(String frameworkName, String connectionString) {
+        this(frameworkName, connectionString, CuratorUtils.getDefaultRetry(), "", "");
+    }
+
+    public CuratorStateStoreFilter(
+            String frameworkName,
+            String connectionString,
+            RetryPolicy retryPolicy) {
+        this(frameworkName, connectionString, retryPolicy, "", "");
+    }
+
+    public CuratorStateStoreFilter(
+            String frameworkName,
+            String connectionString,
+            String username,
+            String password) {
+        this(frameworkName, connectionString, CuratorUtils.getDefaultRetry(), username, password);
+    }
+
     public CuratorStateStoreFilter(
             String frameworkName,
             String connectionString,
@@ -31,9 +50,9 @@ public class CuratorStateStoreFilter  extends CuratorStateStore {
             return super.fetchTaskNames();
         }
         return super.fetchTaskNames()
-                    .stream()
-                    .filter( name -> !(ignoreFilter.matches(name)))
-                    .collect(Collectors.toList());
+                .stream()
+                .filter(name -> !(ignoreFilter.matches(name)))
+                .collect(Collectors.toList());
     }
 
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultService.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultService.java
@@ -85,9 +85,6 @@ public class DefaultService implements Service {
         }
     }
 
-    public DefaultService(){
-    }
-
     /**
      * Gets an exclusive lock on service-specific ZK node to ensure two schedulers aren't running simultaneously for the
      * same service.

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/state/StateStore.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/state/StateStore.java
@@ -78,6 +78,19 @@ public interface StateStore {
 
 
     /**
+     * Stores the TaskStatus of a particular Task. The {@link TaskInfo} for this exact task MUST have already been
+     * written via {@link #storeTasks(Collection)} beforehand.
+     *
+     * @param name The name of the task, which has same TaskId with the status
+     * @param status The status to be stored
+     * @throws StateStoreException if storing the TaskStatus fails, or if its TaskId is malformed, or if its matching
+     *                             TaskInfo wasn't stored first
+     */
+    void storeStatus(String name, TaskStatus status) throws StateStoreException;
+
+
+
+    /**
      * Removes all data associated with a particular Task including any stored TaskInfo and/or TaskStatus.
      *
      * @param taskName The name of the task to be cleared

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/state/StateStore.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/state/StateStore.java
@@ -89,7 +89,6 @@ public interface StateStore {
     void storeStatus(String name, TaskStatus status) throws StateStoreException;
 
 
-
     /**
      * Removes all data associated with a particular Task including any stored TaskInfo and/or TaskStatus.
      *

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/state/StateStoreCache.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/state/StateStoreCache.java
@@ -178,6 +178,17 @@ public class StateStoreCache implements StateStore {
     }
 
     @Override
+    public void storeStatus(String name, TaskStatus status) throws StateStoreException {
+        RWLOCK.lock();
+        try {
+            store.storeStatus(name, status);
+            nameToStatus.put(name, status);
+        } finally {
+            RWLOCK.unlock();
+        }
+    }
+
+    @Override
     public void clearTask(String taskName) throws StateStoreException {
         RWLOCK.lock();
         try {

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/curator/CuratorStateStoreFilterTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/curator/CuratorStateStoreFilterTest.java
@@ -1,0 +1,165 @@
+package com.mesosphere.sdk.curator;
+
+import com.mesosphere.sdk.offer.CommonTaskUtils;
+import com.mesosphere.sdk.offer.evaluate.placement.RegexMatcher;
+import com.mesosphere.sdk.testutils.CuratorTestUtils;
+import org.apache.curator.test.TestingServer;
+import org.apache.mesos.Protos;
+import org.apache.mesos.Protos.SlaveID;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import java.util.*;
+import static org.junit.Assert.*;
+
+/**
+ * Tests to validate the operation of the {@link CuratorStateStore}.
+ */
+public class CuratorStateStoreFilterTest {
+    private static final Protos.FrameworkID FRAMEWORK_ID =
+            Protos.FrameworkID.newBuilder().setValue("test-framework-id").build();
+    private static final String ROOT_ZK_PATH = "/test-root-path";
+    private static final Protos.TaskState TASK_STATE = Protos.TaskState.TASK_STAGING;
+    private static final Protos.TaskStatus TASK_STATUS = Protos.TaskStatus.newBuilder()
+            .setTaskId(CommonTaskUtils.toTaskId("taskName"))
+            .setState(TASK_STATE)
+            .build();
+    private static TestingServer testZk;
+    private CuratorStateStoreFilter store;
+
+    @BeforeClass
+    public static void beforeAll() throws Exception {
+        testZk = new TestingServer();
+    }
+
+    @Before
+    public void beforeEach() throws Exception {
+        CuratorTestUtils.clear(testZk);
+        store = new CuratorStateStoreFilter(ROOT_ZK_PATH, testZk.getConnectString());
+    }
+
+    @After
+    public void afterEach() {
+        ((CuratorStateStore) store).closeForTesting();
+    }
+
+    @Test
+    public void testFetchTask() throws Exception {
+        String testTaskNamePrefix = "test-executor";
+        String testTaskName0 = testTaskNamePrefix + "-0";
+        String testTaskName1 = testTaskNamePrefix + "-1";
+
+        store.storeTasks(createTasks(testTaskName0, testTaskName1));
+        Collection<String> taskNames = store.fetchTaskNames();
+        assertEquals(2, taskNames.size());
+        Collection<Protos.TaskInfo> taskInfos = store.fetchTasks();
+        assertEquals(2, taskInfos.size());
+
+        Iterator<String> iter1 =  taskNames.iterator();
+        assertEquals(testTaskName1, iter1.next());
+        assertEquals(testTaskName0, iter1.next());
+
+        Iterator<Protos.TaskInfo> iter2 =  taskInfos.iterator();
+        assertEquals(testTaskName1, iter2.next().getName());
+        assertEquals(testTaskName0, iter2.next().getName());
+
+        store.setIgnoreFilter(RegexMatcher.create("test-executor-[0-9]*"));
+        taskNames = store.fetchTaskNames();
+        assertEquals(0, taskNames.size());
+        taskInfos = store.fetchTasks();
+        assertEquals(0, taskInfos.size());
+
+        testTaskNamePrefix = "test1-executor";
+        testTaskName0 = testTaskNamePrefix + "-0";
+        testTaskName1 = testTaskNamePrefix + "-1";
+
+        store.storeTasks(createTasks(testTaskName0, testTaskName1));
+        taskNames = store.fetchTaskNames();
+        assertEquals(2, taskNames.size());
+        taskInfos = store.fetchTasks();
+        assertEquals(2, taskInfos.size());
+
+        store.setIgnoreFilter(RegexMatcher.create("z*"));
+        taskNames = store.fetchTaskNames();
+        assertEquals(4, taskNames.size());
+        taskInfos = store.fetchTasks();
+        assertEquals(4, taskInfos.size());
+
+        store.setIgnoreFilter(null);
+        taskNames = store.fetchTaskNames();
+        assertEquals(4, taskNames.size());
+        taskInfos = store.fetchTasks();
+        assertEquals(4, taskInfos.size());
+    }
+
+    @Test
+    public void testFetchStatuses() throws Exception {
+        String testTaskNamePrefix = "test-executor";
+        String testTaskName0 = testTaskNamePrefix + "-0";
+        String testTaskName1 = testTaskNamePrefix + "-1";
+
+        store.storeTasks(createTasks(testTaskName0, testTaskName1));
+        createTaskStatuses(testTaskName0, testTaskName1).stream().forEach(status -> store.storeStatus(status));
+        Collection<Protos.TaskStatus> taskStatuses = store.fetchStatuses();
+        Collection<Protos.TaskInfo> taskInfos = store.fetchTasks();
+        assertEquals(2, taskInfos.size());
+        assertEquals(2, taskStatuses.size());
+
+        store.setIgnoreFilter(RegexMatcher.create("test-executor-[0-9]*"));
+        taskStatuses = store.fetchStatuses();
+        taskInfos = store.fetchTasks();
+        assertEquals(0, taskInfos.size());
+        assertEquals(0, taskStatuses.size());
+
+        testTaskNamePrefix = "test1-executor";
+        testTaskName0 = testTaskNamePrefix + "-0";
+        testTaskName1 = testTaskNamePrefix + "-1";
+
+        store.storeTasks(createTasks(testTaskName0, testTaskName1));
+        createTaskStatuses(testTaskName0, testTaskName1).stream().forEach(status -> store.storeStatus(status));
+        taskStatuses = store.fetchStatuses();
+        taskInfos = store.fetchTasks();
+        assertEquals(2, taskInfos.size());
+        assertEquals(2, taskStatuses.size());
+
+        store.setIgnoreFilter(RegexMatcher.create("z*"));
+        taskStatuses = store.fetchStatuses();
+        taskInfos = store.fetchTasks();
+        assertEquals(4, taskInfos.size());
+        assertEquals(4, taskStatuses.size());
+
+        store.setIgnoreFilter(null);
+        taskStatuses = store.fetchStatuses();
+        taskInfos = store.fetchTasks();
+        assertEquals(4, taskInfos.size());
+        assertEquals(4, taskStatuses.size());
+    }
+    private static Collection<Protos.TaskInfo> createTasks(String... taskNames) {
+        Collection<Protos.TaskInfo> taskInfos = new ArrayList<>();
+        for (String taskName : taskNames) {
+            taskInfos.add(Protos.TaskInfo.newBuilder()
+                          .setName(taskName)
+                          .setTaskId(CommonTaskUtils.toTaskId(taskName))
+                          .setSlaveId(SlaveID.newBuilder().setValue("ignored"))
+                          .build());
+        }
+        return taskInfos;
+    }
+
+    private Collection<Protos.TaskStatus> createTaskStatuses(String... taskNames) {
+        Collection<Protos.TaskStatus> taskStatuses = new ArrayList<>();
+        for (String taskName : taskNames) {
+            taskStatuses.add(createTaskStatus(store.fetchTask(taskName).get().getTaskId(), taskName));
+        }
+        return taskStatuses;
+    }
+
+    private Protos.TaskStatus createTaskStatus(Protos.TaskID taskId, String taskName) {
+        return Protos.TaskStatus.newBuilder()
+                .setTaskId(CommonTaskUtils.toTaskId(taskName))
+                .setState(TASK_STATE)
+                .setTaskId(taskId).build();
+    }
+
+}


### PR DESCRIPTION
Config *Upgrade* should be able to handle old and new tasks in StateStore (they have different names and TaskInfo is different, Specs are different) at the same time. Best way is to filter somehow. Not only status update is affected by this, also recovery process will be affected (will try to update old tasks that are only kept for backup/restore).  

Below is an example on how a service can use Ignore filter:

CuratorStateStoreFilter stateStore = new CuratorStateStoreFilter(schedulerBuilder.getServiceSpec().getName(),
                        DcosConstants.MESOS_MASTER_ZK_CONNECTION_STRING);
stateStore.setIgnoreFilter(RegexMatcher.create( "broker-[0-9]*"));
schedulerBuilder.setStateStore(StateStoreCache.getInstance(stateStore));