### PR TITLE
Ccm cluster launch log template url

### DIFF
--- a/tools/launch_ccm_cluster.py
+++ b/tools/launch_ccm_cluster.py
@@ -213,6 +213,7 @@ class CCMLauncher(object):
             hostrepo, config.ccm_channel, config.cf_template)
         if config.template_url:
             template_url = config.template_url
+            logger.info("Accepting externally provided template_url from environment.")
         cluster_name = config.name_prefix + self._rand_str(8)
         payload = {
             'template_url': template_url,

--- a/tools/launch_ccm_cluster.py
+++ b/tools/launch_ccm_cluster.py
@@ -233,14 +233,16 @@ class CCMLauncher(object):
   mountvols={}
   permissions={}
   channel={}
-  template={}'''.format(
+  template={}
+  template_url={}'''.format(
       cluster_name,
       config.private_agents, config.public_agents,
       config.duration_mins,
       config.mount_volumes,
       config.permissions,
       config.ccm_channel,
-      config.cf_template))
+      config.cf_template,
+      template_url))
         response = self._query_http('POST', self._CCM_PATH, request_json_payload=payload)
         if not response:
             raise Exception('CCM cluster creation request failed')


### PR DESCRIPTION
Log the actual url that launch_ccm_cluster.py is using, and whether we're taking it from the environment (thus ignoring other logged values).