### PR TITLE
[KAFKA] Change repo name to kafka for compatability

### DIFF
--- a/frameworks/kafka/src/main/dist/server.properties.mustache
+++ b/frameworks/kafka/src/main/dist/server.properties.mustache
@@ -53,7 +53,7 @@ socket.request.max.bytes={{KAFKA_SOCKET_REQUEST_MAX_BYTES}}
 ############################# Log Basics #############################
 
 # A comma seperated list of directories under which to store log files
-log.dirs={{BROKER_DISK_PATH}}/broker-{{POD_INSTANCE_INDEX}}
+log.dirs={{KAFKA_DISK_PATH}}/broker-{{POD_INSTANCE_INDEX}}
 
 # The default number of log partitions per topic. More partitions allow greater
 # parallelism for consumption, but this will also result in more files across

--- a/frameworks/kafka/src/main/dist/svc.yml
+++ b/frameworks/kafka/src/main/dist/svc.yml
@@ -9,6 +9,8 @@ pods:
     uris:
       - {{KAFKA_URI}}
       - {{BOOTSTRAP_URI}}
+      - {{EXECUTOR_URI}}
+      - {{LIBMESOS_URI}}
     tasks:
       broker:
         cpus: {{BROKER_CPUS}}
@@ -17,17 +19,22 @@ pods:
           broker:
             port: {{BROKER_PORT}}
             env-key: KAFKA_BROKER_PORT
+            vip:
+              prefix: broker
+              port: 9092
           {{#BROKER_JMX_PORT}}
           jmx:
-            port: {{JMX_PORT}}
+            port: {{BROKER_JMX_PORT}}
             env-key: JMX_PORT
           {{/BROKER_JMX_PORT}}
         volume:
-          path: {{BROKER_DATA_PATH}}
+          path: {{BROKER_DISK_PATH}}
           type: {{BROKER_DISK_TYPE}}
           size: {{BROKER_DISK_SIZE}}
         env:
           KAFKA_ZOOKEEPER_URI: "{{MESOS_ZOOKEEPER_URI}}/dcos-service-{{FRAMEWORK_NAME}}"
+          KAFKA_DISK_PATH: "{{BROKER_DISK_PATH}}"
+          KAFKA_HEAP_OPTS: "-Xms{{BROKER_JAVA_HEAP}}M -Xmx{{BROKER_JAVA_HEAP}}M"
         goal: RUNNING
         cmd: "./bootstrap -resolve=false && exec $MESOS_SANDBOX/{{KAFKA_VERSION_PATH}}/bin/kafka-server-start.sh $MESOS_SANDBOX/{{KAFKA_VERSION_PATH}}/config/server.properties"
         configs:

--- a/frameworks/kafka/src/test/java/com/mesosphere/sdk/kafka/scheduler/ServiceSpecTest.java
+++ b/frameworks/kafka/src/test/java/com/mesosphere/sdk/kafka/scheduler/ServiceSpecTest.java
@@ -22,7 +22,7 @@ public class ServiceSpecTest extends BaseServiceSpecTest {
         ENV_VARS.set("BROKER_MEM", "512");
         ENV_VARS.set("BROKER_DISK_SIZE", "5000");
         ENV_VARS.set("BROKER_DISK_TYPE", "ROOT");
-        ENV_VARS.set("BROKER_DATA_PATH", "ROOT");
+        ENV_VARS.set("BROKER_DISK_PATH", "path");
         ENV_VARS.set("PORT_BROKER_PORT","9999");
         ENV_VARS.set("BROKER_PORT","0");
 

--- a/frameworks/kafka/universe/config.json
+++ b/frameworks/kafka/universe/config.json
@@ -8,7 +8,7 @@
           "name" : {
             "description":"Apache Kafka",
             "type":"string",
-            "default":"apache-kafka"
+            "default":"kafka"
           },
           "mesos_api_version" : {
             "description":"Configures the Mesos API version to use. Possible values: V0 (non-HTTP), V1 (HTTP)",
@@ -28,7 +28,7 @@
           "principal": {
             "description": "The principal for the Kafka service instance.",
             "type": "string",
-            "default": "apache-kafka-principal"
+            "default": "kafka-principal"
           },
           "secret_name": {
             "description": "Name of the Secret Store credentials to use for DC/OS service authentication. This should be left empty unless service authentication is needed.",
@@ -70,7 +70,7 @@
             "properties":{
               "size": {
                 "type":"integer",
-                "description":"The amound of JVM heap, in MB, allocated to the Kafka broker process.",
+                "description":"The amount of JVM heap, in MB, allocated to the Kafka broker process.",
                 "default": 2048
               }
             },
@@ -92,7 +92,7 @@
           "disk_path": {
             "type": "string",
             "description": "Relative path of consistent disk",
-            "default": "kafka_broker-data"
+            "default": "kafka-broker-data"
           },
           "count":{
             "description":"Number of brokers to run",

--- a/frameworks/kafka/universe/marathon.json.mustache
+++ b/frameworks/kafka/universe/marathon.json.mustache
@@ -42,7 +42,7 @@
     "BROKER_DISK_SIZE": "{{brokers.disk}}",
     "BROKER_DISK_TYPE": "{{brokers.disk_type}}",
     "BROKER_DISK_PATH": "{{brokers.disk_path}}",
-    "BROKER_HEAP": "{{brokers.heap}}",
+    "BROKER_JAVA_HEAP": "{{brokers.heap.size}}",
     "BROKER_PORT": "{{brokers.port}}",
 
     {{#service.secret_name}}
@@ -54,18 +54,19 @@
     "CONFIG_TEMPLATE_PATH": "kafka-scheduler",
     "KAFKA_VERSION_PATH": "kafka_2.11-0.10.1.0",
     "MESOS_ZOOKEEPER_URI": "master.mesos:2181",
+
     {{#brokers.jmx.enable}}
-     "TASKCFG_ALL_KAKFA_JMX_OPTS": "-Dcom.sun.management.jmxremote={{brokers.jmx.remote}} -Dcom.sun.management.jmxremote.registry.ssl={{brokers.jmx.remote_registry_ssl}} -Dcom.sun.management.jmxremote.ssl={{brokers.jmx.remote_ssl}} -Dcom.sun.management.jmxremote.ssl.need.client.auth={{brokers.jmx.remote_ssl_need_client_auth}} -Dcom.sun.management.jmxremote.authenticate={{brokers.jmx.remote_authenticate}} {{brokers.additional_kafka_jmx_opts}}"
-     "BROKER_JMX_PORT": "{{brokers.jmx.remote_port}}",
-     {{/brokers.jmx.enable}}
+    "TASKCFG_ALL_KAKFA_JMX_OPTS": "-Dcom.sun.management.jmxremote={{brokers.jmx.remote}} -Dcom.sun.management.jmxremote.registry.ssl={{brokers.jmx.remote_registry_ssl}} -Dcom.sun.management.jmxremote.ssl={{brokers.jmx.remote_ssl}} -Dcom.sun.management.jmxremote.ssl.need.client.auth={{brokers.jmx.remote_ssl_need_client_auth}} -Dcom.sun.management.jmxremote.authenticate={{brokers.jmx.remote_authenticate}} {{brokers.additional_kafka_jmx_opts}}"
+    "BROKER_JMX_PORT": "{{brokers.jmx.remote_port}}",
+    {{/brokers.jmx.enable}}
 
-
-    "TASKCFG_ALL_BROKER_DISK_PATH" : "{{brokers.disk_path}}",
     "TASKCFG_ALL_BROKER_STATSD_HOST": "{{brokers.statsd.host}}",
     "TASKCFG_ALL_BROKER_STATSD_PORT": "{{brokers.statsd.port}}",
+
     {{#kafka.kafka_advertise_host_ip}}
     "TASKCFG_ALL_KAFKA_ADVERTISE_HOST" : "set",
     {{/kafka.kafka_advertise_host_ip}}
+
     "TASKCFG_ALL_KAFKA_RESERVED_BROKER_MAX_ID": "{{kafka.reserved_broker_max_id}}",
     "TASKCFG_ALL_KAFKA_OFFSETS_TOPIC_COMPRESSION_CODEC": "{{kafka.offsets_topic_compression_codec}}",
     "TASKCFG_ALL_KAFKA_REPLICA_FETCH_MIN_BYTES": "{{kafka.replica_fetch_min_bytes}}",

--- a/frameworks/kafka/universe/package.json
+++ b/frameworks/kafka/universe/package.json
@@ -1,6 +1,6 @@
 {
   "packagingVersion": "2.0",
-  "name": "apache-kafka",
+  "name": "kafka",
   "version": "{{package-version}}",
   "maintainer": "support@mesosphere.io",
   "description": "Apache Kafka framework running on DC/OS",


### PR DESCRIPTION
Update universe and yaml to change repo name to kafka. 

Originally it was *kafka*. We later set its name to *apache-kafka* (to differentiate from confluent-kafka).

Role, principle, etc are based on this name. 

To be compatible with all other frameworks and to have the same name with the framework directory (frameworks/kafka), want to change name back to *kafka*.

PS: Description is always "Apache Kafka". 
