### PR TITLE
[TESTS][INFINITY-1042] Changes to get Framework CI Tests to pass in strict mode

### DIFF
--- a/testing/sdk_install.py
+++ b/testing/sdk_install.py
@@ -1,5 +1,6 @@
 '''Utilities relating to installing services'''
 
+import collections
 import dcos.errors
 import dcos.marathon
 import sdk_cmd
@@ -84,26 +85,23 @@ def get_package_options(additional_options={}):
     if os.environ.get('SECURITY', '') == 'strict':
         # strict mode requires correct principal and secret to perform install.
         # see also: tools/setup_permissions.sh and tools/create_service_account.sh
-        return _nested_dict_merge(additional_options, {
+        return _merge_dictionary(additional_options, {
             'service': { 'principal': 'service-acct', 'secret_name': 'secret' }
         })
     else:
         return additional_options
 
 
-def _nested_dict_merge(a, b, path=None):
-    "ripped from http://stackoverflow.com/questions/7204805/dictionaries-of-dictionaries-merge"
-    if path is None:
-        path = []
-    a = a.copy()
-    for key in b:
-        if key in a:
-            if isinstance(a[key], dict) and isinstance(b[key], dict):
-                _nested_dict_merge(a[key], b[key], path + [str(key)])
-            elif a[key] == b[key]:
-                pass # same leaf value
-            else:
-                raise Exception('Conflict at %s' % '.'.join(path + [str(key)]))
+def _merge_dictionary(dict1, dict2):
+    if (not isinstance(dict2, dict)):
+        return dict1
+    ret = {}
+    for k, v in dict1.items():
+        ret[k] = v
+    for k, v in dict2.items():
+        if (k in dict1 and isinstance(dict1[k], dict)
+            and isinstance(dict2[k], collections.Mapping)):
+            ret[k] = _merge_dictionary(dict1[k], dict2[k])
         else:
-            a[key] = b[key]
-    return a
+            ret[k] = dict2[k]
+    return ret


### PR DESCRIPTION
Changes required to get integration tests passing in strict mode: 
- Added calls to setup_permissions.sh in test.sh
- Used CLUSTER_CREATED shell variable to avoid conflict in CI (which defines CLUSTER_ID variable), when deciding to delete a cluster
- Ported Mehmet’s fix of dictionary merge function used by integration tests, see [Kafka #345](https://github.com/mesosphere/dcos-kafka-service/pull/345)