### PR TITLE
proxylite: Fix bug with stale backends

### DIFF
--- a/docs/pages/dev-guide/developer-guide.md
+++ b/docs/pages/dev-guide/developer-guide.md
@@ -1353,7 +1353,7 @@ web-url: http://proxylite-0-server.{{FRAMEWORK_NAME}}.mesos:{{PROXYLITE_PORT}}
 pods:
   proxylite:
     container:
-      image-name: mesosphere/proxylite:2.0.0
+      image-name: mesosphere/proxylite:2.1.0
     count: 1
     tasks:
       server:

--- a/frameworks/proxylite/src/main/dist/svc.yml
+++ b/frameworks/proxylite/src/main/dist/svc.yml
@@ -32,7 +32,7 @@ pods:
   proxylite:
     container:
       # The image here is built and pushed
-      image-name: mesosphere/proxylite:2.0.0
+      image-name: mesosphere/proxylite:2.1.0
     count: 1
     tasks:
       server:

--- a/frameworks/proxylite/src/main/docker/files/configure.py
+++ b/frameworks/proxylite/src/main/docker/files/configure.py
@@ -32,7 +32,7 @@ backend {name}
     reqirep  "^([^ :]*)\ {incomingpath}/?(.*)" "\\1\ {outgoingpath}/\\2"
     acl hdr_location res.hdr(Location) -m found
     rspirep "^Location: (https?://{hostname}(:[0-9]+)?)?{outgoingpath}(/.*)" "Location: {incomingpath}\\3" if hdr_location
-    server x{name}x {fullhost} {ssl}
+    server x{name}x {fullhost} resolvers dns check {ssl}
 
 """
 

--- a/frameworks/proxylite/src/main/docker/files/haproxy.cfg.raw
+++ b/frameworks/proxylite/src/main/docker/files/haproxy.cfg.raw
@@ -34,6 +34,7 @@ defaults
   option            dontlognull
   option            http-server-close
   option            redispatch
+  default-server resolve-prefer ipv4
 
 listen stats
   bind 0.0.0.0:9090
@@ -41,3 +42,14 @@ listen stats
   mode http
   stats enable
   monitor-uri /_haproxy_health_check
+
+resolvers dns
+  nameserver ns1 198.51.100.1:53
+  nameserver ns2 198.51.100.2:53
+  nameserver ns3 198.51.100.3:53
+  hold valid           2s
+  hold other           2s
+  hold refused         2s
+  hold nx              2s
+  hold timeout         2s
+  hold valid           2s


### PR DESCRIPTION
Previously HAProxy was not re-resolving dns addresses, leaving it pointing to stale and potentially incorrect backends. This change re-resolves dns on a 2 second interval.