### PR TITLE
[SDK][INFINITY-1058] Fix statestore inconsistencies on startup

### DIFF
--- a/sdk/common/src/main/java/com/mesosphere/sdk/testutils/TestConstants.java
+++ b/sdk/common/src/main/java/com/mesosphere/sdk/testutils/TestConstants.java
@@ -67,4 +67,17 @@ public class TestConstants {
             Protos.CommandInfo.newBuilder()
             .setValue("echo test")
             .build();
+
+    public static final Protos.TaskInfo TASK_INFO =
+            Protos.TaskInfo.newBuilder()
+            .setName(TASK_NAME)
+            .setTaskId(TASK_ID)
+            .setSlaveId(AGENT_ID)
+            .build();
+
+    public static final Protos.TaskStatus TASK_STATUS =
+            Protos.TaskStatus.newBuilder()
+                    .setTaskId(TASK_ID)
+                    .setState(Protos.TaskState.TASK_RUNNING)
+                    .build();
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/api/PodsResource.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/api/PodsResource.java
@@ -295,6 +295,8 @@ public class PodsResource {
             jsonTask.put("name", task.getInfo().getName());
             if (task.hasStatus()) {
                 jsonTask.put("state", task.getStatus().get().getState().toString());
+            } else {
+                jsonTask.put("state", "No state defined");
             }
             jsonPod.put(jsonTask);
         }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/curator/CuratorStateStore.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/curator/CuratorStateStore.java
@@ -6,8 +6,12 @@ import com.mesosphere.sdk.offer.CommonTaskUtils;
 import com.mesosphere.sdk.state.*;
 import com.mesosphere.sdk.storage.Persister;
 import com.mesosphere.sdk.storage.StorageError.Reason;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.curator.RetryPolicy;
 import org.apache.mesos.Protos;
+import org.apache.mesos.Protos.TaskInfo;
+import org.apache.mesos.Protos.TaskStatus;
+import org.apache.mesos.Protos.TaskState;
 import org.apache.zookeeper.KeeperException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -123,6 +127,7 @@ public class CuratorStateStore implements StateStore {
         this.taskPathMapper = new TaskPathMapper(rootPath);
         this.fwkIdPath = CuratorUtils.join(rootPath, FWK_ID_PATH_NAME);
         this.propertiesPath = CuratorUtils.join(rootPath, PROPERTIES_PATH_NAME);
+        repairStateStore();
     }
 
     // Framework ID
@@ -430,6 +435,44 @@ public class CuratorStateStore implements StateStore {
         private String getTasksRootPath() {
             return tasksRootPath;
         }
+    }
+
+    /**
+     * TaskInfo and TaskStatus objects referring to the same Task name are not written to Zookeeper atomicly.
+     * It is therefore possible for the TaskIDs contained within these elements to become out of sync.  While
+     * the scheduler process is up they remain in sync.  This method guarantees produces an initial synchronized
+     * state.
+     */
+    @SuppressFBWarnings("UC_USELESS_OBJECT")
+    private void repairStateStore() {
+        // Findbugs thinks this isn't used, but it is used in the forEach call at the bottom of this method.
+        List<TaskStatus> repairedStatuses = new ArrayList<>();
+        List<TaskInfo> repairedTasks = new ArrayList<>();
+
+        for (TaskInfo task : fetchTasks()) {
+            Optional<TaskStatus> statusOptional = fetchStatus(task.getName());
+
+            if (statusOptional.isPresent()) {
+                TaskStatus status = statusOptional.get();
+                if (!status.getTaskId().equals(task.getTaskId())) {
+                    logger.warn("Found StateStore status inconsistency: task.taskId={}, taskStatus.taskId={}",
+                            task.getTaskId(), status.getTaskId());
+                    repairedTasks.add(task.toBuilder().setTaskId(status.getTaskId()).build());
+                    repairedStatuses.add(status.toBuilder().setState(TaskState.TASK_FAILED).build());
+                }
+            } else {
+                logger.warn("Found StateStore status inconsistency: task.taskId={}", task.getTaskId());
+                TaskStatus status = TaskStatus.newBuilder()
+                        .setTaskId(task.getTaskId())
+                        .setState(TaskState.TASK_FAILED)
+                        .setMessage("Assuming failure for inconsistent TaskIDs")
+                        .build();
+                repairedStatuses.add(status);
+            }
+        }
+
+        storeTasks(repairedTasks);
+        repairedStatuses.forEach(taskStatus -> storeStatus(taskStatus));
     }
 
     public boolean isSuppressed() throws StateStoreException {

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/api/PodsResourceTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/api/PodsResourceTest.java
@@ -161,9 +161,10 @@ public class PodsResourceTest {
         assertEquals("TASK_RUNNING", task.getString("state"));
 
         task = pod.getJSONObject(3);
-        assertEquals(2, task.length());
+        assertEquals(3, task.length());
         assertEquals("d", task.getString("name"));
         assertTrue(task.getString("id").startsWith("d__"));
+        assertEquals("No state defined", task.getString("state"));
 
         pod = json.getJSONArray("test-1");
         assertEquals(2, pod.length());


### PR DESCRIPTION
It is possible in some failure scenarios for TaskInfo and TaskStatus
objects regarding the same Task to have inconsistent TaskIDs.  This
breaks dependent logic that assumes TaskInfo and TaskStatus for the
same Task will share a TaskID.

TaskState is set to TASK_FAILED in the case of any detected inconsistency to
cause a restart of the Task and arrive at a categorically consistent state with Mesos.