### PR TITLE
[SDK] Fix Darwin CLI build, add uninstall instructions to build.sh footer

### DIFF
--- a/tools/build_go_exe.sh
+++ b/tools/build_go_exe.sh
@@ -20,9 +20,9 @@ REPO_NAME=dcos-commons # CI dir does not match repo name
 GOPATH_MESOSPHERE="$GOPATH/src/github.com/mesosphere"
 GOPATH_EXE_DIR="$GOPATH_MESOSPHERE/$REPO_NAME/$1"
 if [ $2 = "windows" ]; then
-    EXE_FILENAME=$(basename $1).exe
+    EXE_FILENAME=$(basename $1).exe # dcos-kafka.exe
 else
-    EXE_FILENAME=$(basename $1)-$2
+    EXE_FILENAME=$(basename $1)-$2 # dcos-kafka-linux
 fi
 
 # Detect Go version to determine:
@@ -84,8 +84,13 @@ else
     # https://golang.org/doc/install/source#environment
     CGO_ENABLED=0 GOOS=$2 GOARCH=386 go build -ldflags="-s -w" -o $EXE_FILENAME
 
-    # use upx if available and if golang's output doesn't have problems with it:
-    if [ -n "$UPX_BINARY" ]; then
+    # use upx if:
+    # - upx is installed
+    # - golang is recent enough to be compatible with upx
+    # - the target OS isn't darwin: compressed darwin builds immediately fail with "Killed: 9"
+    if [ -n "$UPX_BINARY" -a $2 != "darwin" ]; then
         $UPX_BINARY -q --best $EXE_FILENAME
+    else
+        echo "Skipping UPX compression of $EXE_FILENAME"
     fi
 fi

--- a/tools/publish_aws.py
+++ b/tools/publish_aws.py
@@ -152,9 +152,6 @@ class AWSPublisher(object):
         # print universe url early
         universe_url = self._upload_artifact(universe_path)
         logger.info('---')
-        logger.info('Built and uploaded stub universe:')
-        logger.info(universe_url)
-        logger.info('---')
         logger.info('Uploading {} artifacts:'.format(len(self._artifact_paths)))
 
         for path in self._artifact_paths:
@@ -166,7 +163,10 @@ class AWSPublisher(object):
         print(universe_url)
 
         logger.info('---')
-        logger.info('Install your package using the following commands:')
+        logger.info('(Re)install your package using the following commands:')
+        logger.info('dcos package uninstall {}'.format(self._pkg_name))
+        logger.info('dcos node ssh --master-proxy --leader ' +
+                    '"docker run mesosphere/janitor /janitor.py -r {0}-role -p {0}-principal -z dcos-service-{0}"'.format(self._pkg_name))
         logger.info('dcos package repo remove {}-aws'.format(self._pkg_name))
         logger.info('dcos package repo add --index=0 {}-aws {}'.format(self._pkg_name, universe_url))
         logger.info('dcos package install --yes {}'.format(self._pkg_name))

--- a/tools/publish_http.py
+++ b/tools/publish_http.py
@@ -224,10 +224,11 @@ Artifacts:       {}
     universe_url = publisher.build(http_url_root)
     repo_added = publisher.add_repo_to_cli(universe_url)
     logger.info('---')
-    if repo_added:
-        logger.info('Install your package using the following command:')
-    else:
-        logger.info('Install your package using the following commands:')
+    logger.info('(Re)install your package using the following commands:')
+    logger.info('dcos package uninstall {}'.format(package_name))
+    logger.info('dcos node ssh --master-proxy --leader ' +
+                '"docker run mesosphere/janitor /janitor.py -r {0}-role -p {0}-principal -z dcos-service-{0}"'.format(package_name))
+    if not repo_added:
         logger.info('dcos package repo remove {}-local'.format(package_name))
         logger.info('dcos package repo add --index=0 {}-local {}'.format(package_name, universe_url))
     logger.info('dcos package install --yes {}'.format(package_name))


### PR DESCRIPTION
- Darwin binary must not be UPX-encoded, or else it immediately produces `Killed: 9`
- Include all steps to reinstall a service in build output