### PR TITLE
[CLI] Reduce CLI bootstrapping: remove custom description strings

### DIFF
--- a/frameworks/cassandra/cli/dcos-cassandra/main.go
+++ b/frameworks/cassandra/cli/dcos-cassandra/main.go
@@ -1,31 +1,18 @@
 package main
 
 import (
-	"fmt"
 	"github.com/mesosphere/dcos-commons/cli"
 	"gopkg.in/alecthomas/kingpin.v2"
-	"log"
-	"strings"
 )
 
 func main() {
-	modName, err := cli.GetModuleName()
-	if err != nil {
-		log.Fatalf(err.Error())
-	}
+	app := cli.New()
 
-	app, err := cli.NewApp("0.1.0", "Mesosphere", fmt.Sprintf("Deploy and manage %s clusters", strings.Title(modName)))
-	if err != nil {
-		log.Fatalf(err.Error())
-	}
-
-	cli.HandleCommonFlags(app, modName, fmt.Sprintf("%s DC/OS CLI Module", strings.Title(modName)))
 	cli.HandleConfigSection(app)
 	cli.HandleEndpointsSection(app)
 	cli.HandlePlanSection(app)
 	cli.HandlePodsSection(app)
 	cli.HandleStateSection(app)
 
-	// Omit modname:
 	kingpin.MustParse(app.Parse(cli.GetArguments()))
 }

--- a/frameworks/elastic/cli/dcos-elastic/main.go
+++ b/frameworks/elastic/cli/dcos-elastic/main.go
@@ -3,27 +3,16 @@ package main
 import (
 	"github.com/mesosphere/dcos-commons/cli"
 	"gopkg.in/alecthomas/kingpin.v2"
-	"log"
 )
 
 func main() {
-	modName, err := cli.GetModuleName()
-	if err != nil {
-		log.Fatalf(err.Error())
-	}
+	app := cli.New()
 
-	app, err := cli.NewApp("0.1.0", "Mesosphere", "Manage Elastic framework")
-	if err != nil {
-		log.Fatalf(err.Error())
-	}
-
-	cli.HandleCommonFlags(app, modName, "Elastic CLI")
 	cli.HandleConfigSection(app)
 	cli.HandleEndpointsSection(app)
 	cli.HandlePlanSection(app)
 	cli.HandlePodsSection(app)
 	cli.HandleStateSection(app)
 
-	// Omit modname:
 	kingpin.MustParse(app.Parse(cli.GetArguments()))
 }

--- a/frameworks/hdfs/cli/dcos-hdfs/main.go
+++ b/frameworks/hdfs/cli/dcos-hdfs/main.go
@@ -1,31 +1,18 @@
 package main
 
 import (
-	"fmt"
 	"github.com/mesosphere/dcos-commons/cli"
 	"gopkg.in/alecthomas/kingpin.v2"
-	"log"
-	"strings"
 )
 
 func main() {
-	modName, err := cli.GetModuleName()
-	if err != nil {
-		log.Fatalf(err.Error())
-	}
+	app := cli.New()
 
-	app, err := cli.NewApp("0.1.0", "Mesosphere", fmt.Sprintf("Deploy and manage %s clusters", strings.Title(modName)))
-	if err != nil {
-		log.Fatalf(err.Error())
-	}
-
-	cli.HandleCommonFlags(app, modName, fmt.Sprintf("%s DC/OS CLI Module", strings.Title(modName)))
 	cli.HandleConfigSection(app)
 	cli.HandleEndpointsSection(app)
 	cli.HandlePlanSection(app)
 	cli.HandlePodsSection(app)
 	cli.HandleStateSection(app)
 
-	// Omit modname:
 	kingpin.MustParse(app.Parse(cli.GetArguments()))
 }

--- a/frameworks/helloworld/cli/dcos-hello-world/main.go
+++ b/frameworks/helloworld/cli/dcos-hello-world/main.go
@@ -1,31 +1,18 @@
 package main
 
 import (
-	"fmt"
 	"github.com/mesosphere/dcos-commons/cli"
 	"gopkg.in/alecthomas/kingpin.v2"
-	"log"
-	"strings"
 )
 
 func main() {
-	modName, err := cli.GetModuleName()
-	if err != nil {
-		log.Fatalf(err.Error())
-	}
+	app := cli.New()
 
-	app, err := cli.NewApp("0.1.0", "Mesosphere", fmt.Sprintf("Deploy and manage %s clusters", strings.Title(modName)))
-	if err != nil {
-		log.Fatalf(err.Error())
-	}
-
-	cli.HandleCommonFlags(app, modName, fmt.Sprintf("%s DC/OS CLI Module", strings.Title(modName)))
 	cli.HandleConfigSection(app)
 	cli.HandleEndpointsSection(app)
 	cli.HandlePlanSection(app)
 	cli.HandlePodsSection(app)
 	cli.HandleStateSection(app)
 
-	// Omit modname:
 	kingpin.MustParse(app.Parse(cli.GetArguments()))
 }

--- a/frameworks/kafka/cli/dcos-kafka/main.go
+++ b/frameworks/kafka/cli/dcos-kafka/main.go
@@ -7,21 +7,11 @@ import (
 	"log"
 	"net/url"
 	"strconv"
-	"strings"
 )
 
 func main() {
-	modName, err := cli.GetModuleName()
-	if err != nil {
-		log.Fatalf(err.Error())
-	}
+	app := cli.New()
 
-	app, err := cli.NewApp("0.1.0", "Mesosphere", "Manage Apache Kafka framework")
-	if err != nil {
-		log.Fatalf(err.Error())
-	}
-
-	cli.HandleCommonFlags(app, modName, fmt.Sprintf("%s DC/OS CLI Module", strings.Title(modName)))
 	cli.HandleConfigSection(app)
 	cli.HandleEndpointsSection(app)
 	cli.HandlePlanSection(app)
@@ -31,7 +21,6 @@ func main() {
 	handleBrokerSection(app)
 	handleTopicSection(app)
 
-	// Omit modname:
 	kingpin.MustParse(app.Parse(cli.GetArguments()))
 }
 

--- a/frameworks/prototype/cli/dcos-prototype/main.go
+++ b/frameworks/prototype/cli/dcos-prototype/main.go
@@ -1,31 +1,18 @@
 package main
 
 import (
-	"fmt"
 	"github.com/mesosphere/dcos-commons/cli"
 	"gopkg.in/alecthomas/kingpin.v2"
-	"log"
-	"strings"
 )
 
 func main() {
-	modName, err := cli.GetModuleName()
-	if err != nil {
-		log.Fatalf(err.Error())
-	}
+	app := cli.New()
 
-	app, err := cli.NewApp("0.1.0", "Mesosphere", fmt.Sprintf("Deploy and manage %s clusters", strings.Title(modName)))
-	if err != nil {
-		log.Fatalf(err.Error())
-	}
-
-	cli.HandleCommonFlags(app, modName, fmt.Sprintf("%s DC/OS CLI Module", strings.Title(modName)))
 	cli.HandleConfigSection(app)
 	cli.HandleEndpointsSection(app)
 	cli.HandlePlanSection(app)
 	cli.HandlePodsSection(app)
 	cli.HandleStateSection(app)
 
-	// Omit modname:
 	kingpin.MustParse(app.Parse(cli.GetArguments()))
 }

--- a/frameworks/proxylite/cli/dcos-proxylite/main.go
+++ b/frameworks/proxylite/cli/dcos-proxylite/main.go
@@ -1,31 +1,18 @@
 package main
 
 import (
-	"fmt"
 	"github.com/mesosphere/dcos-commons/cli"
 	"gopkg.in/alecthomas/kingpin.v2"
-	"log"
-	"strings"
 )
 
 func main() {
-	modName, err := cli.GetModuleName()
-	if err != nil {
-		log.Fatalf(err.Error())
-	}
+	app := cli.New()
 
-	app, err := cli.NewApp("0.1.0", "Mesosphere", fmt.Sprintf("Deploy and manage %s clusters", strings.Title(modName)))
-	if err != nil {
-		log.Fatalf(err.Error())
-	}
-
-	cli.HandleCommonFlags(app, modName, fmt.Sprintf("%s DC/OS CLI Module", strings.Title(modName)))
 	cli.HandleConfigSection(app)
 	cli.HandleEndpointsSection(app)
 	cli.HandlePlanSection(app)
 	cli.HandlePodsSection(app)
 	cli.HandleStateSection(app)
 
-	// Omit modname:
 	kingpin.MustParse(app.Parse(cli.GetArguments()))
 }

--- a/frameworks/spark/cli/dcos-spark-standalone/main.go
+++ b/frameworks/spark/cli/dcos-spark-standalone/main.go
@@ -3,22 +3,16 @@ package main
 import (
 	"github.com/mesosphere/dcos-commons/cli"
 	"gopkg.in/alecthomas/kingpin.v2"
-	"log"
 )
 
 func main() {
-	app, err := cli.NewApp("0.1.0", "Mesosphere", "Provides an example for DC/OS service developers")
-	if err != nil {
-		log.Fatalf(err.Error())
-	}
+	app := cli.New()
 
-	cli.HandleCommonFlags(app, "spark-standalone", "Apache Spark Standalone CLI")
 	cli.HandleConfigSection(app)
 	cli.HandleEndpointsSection(app)
 	cli.HandlePlanSection(app)
 	cli.HandlePodsSection(app)
 	cli.HandleStateSection(app)
 
-	// Omit modname:
 	kingpin.MustParse(app.Parse(cli.GetArguments()))
 }

--- a/frameworks/template/cli/dcos-template/main.go
+++ b/frameworks/template/cli/dcos-template/main.go
@@ -1,31 +1,18 @@
 package main
 
 import (
-	"fmt"
 	"github.com/mesosphere/dcos-commons/cli"
 	"gopkg.in/alecthomas/kingpin.v2"
-	"log"
-	"strings"
 )
 
 func main() {
-	modName, err := cli.GetModuleName()
-	if err != nil {
-		log.Fatalf(err.Error())
-	}
+	app := cli.New()
 
-	app, err := cli.NewApp("0.1.0", "Mesosphere", fmt.Sprintf("Deploy and manage %s clusters", strings.Title(modName)))
-	if err != nil {
-		log.Fatalf(err.Error())
-	}
-
-	cli.HandleCommonFlags(app, modName, fmt.Sprintf("%s DC/OS CLI Module", strings.Title(modName)))
 	cli.HandleConfigSection(app)
 	cli.HandleEndpointsSection(app)
 	cli.HandlePlanSection(app)
 	cli.HandlePodsSection(app)
 	cli.HandleStateSection(app)
 
-	// Omit modname:
 	kingpin.MustParse(app.Parse(cli.GetArguments()))
 }


### PR DESCRIPTION
Keeps old interfaces intact for a deprecation period to avoid breaking old or external builds