### PR TITLE
[SDK] Fix CanaryStrategy. Remove isWaiting()

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/DefaultPlanCoordinator.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/DefaultPlanCoordinator.java
@@ -50,14 +50,14 @@ public class DefaultPlanCoordinator extends ChainedObserver implements PlanCoord
         // with offers first, does not accidentally schedule an asset that's actively being worked upon by another
         // PlanManager that is presented offers later.
         dirtiedAssets.addAll(planManagers.stream()
-                .filter(planManager -> !planManager.getPlan().isWaiting())
+                .filter(planManager -> !planManager.getPlan().isInterrupted())
                 .flatMap(planManager -> planManager.getDirtyAssets().stream())
                 .collect(Collectors.toList()));
 
         LOGGER.info("Initial dirtied assets: {}", dirtiedAssets);
 
         for (final PlanManager planManager : getPlanManagers()) {
-            if (planManager.getPlan().isWaiting()) {
+            if (planManager.getPlan().isInterrupted()) {
                 LOGGER.info("Skipping interrupted plan: {}", planManager.getPlan().getName());
                 continue;
             }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/Element.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/Element.java
@@ -84,13 +84,6 @@ public interface Element extends Observable {
     }
 
     /**
-     * Indicates whether this Element is waiting for external input to proceed.
-     */
-    default boolean isWaiting() {
-        return getStatus().equals(Status.WAITING);
-    }
-
-    /**
      * Indicates whether this Element is complete.
      */
     default boolean isComplete() {

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/strategy/CanaryStrategy.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/strategy/CanaryStrategy.java
@@ -106,10 +106,22 @@ public class CanaryStrategy implements Strategy<Step> {
     @Override
     public boolean isInterrupted() {
         Step canaryStep = getNextCanaryStep();
-        if (canaryStep != null) {
+        if (canaryStep != null && getNextProceedPendingStep() == null) {
             return true;
         }
         return strategy.isInterrupted();
+    }
+
+    private  Step getNextProceedPendingStep() {
+        if (canarySteps == null) {
+            return null;
+        }
+        for (Step proceedStep : canarySteps) {
+            if (!proceedStep.isInterrupted() && proceedStep.isPending()) {
+                return proceedStep;
+            }
+        }
+        return null;
     }
 
     private Step getNextCanaryStep() {

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/strategy/CanaryStrategy.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/strategy/CanaryStrategy.java
@@ -106,18 +106,18 @@ public class CanaryStrategy implements Strategy<Step> {
     @Override
     public boolean isInterrupted() {
         Step canaryStep = getNextCanaryStep();
-        if (canaryStep != null && getNextProceedPendingStep() == null) {
+        if (canaryStep != null && getNextProceedStep() == null) {
             return true;
         }
         return strategy.isInterrupted();
     }
 
-    private  Step getNextProceedPendingStep() {
+    private Step getNextProceedStep() {
         if (canarySteps == null) {
             return null;
         }
         for (Step proceedStep : canarySteps) {
-            if (!proceedStep.isInterrupted() && proceedStep.isPending()) {
+            if (!proceedStep.isInterrupted() && !proceedStep.isComplete()) {
                 return proceedStep;
             }
         }


### PR DESCRIPTION
Problem: After first continue request, first step should start in Canary. It was not starting any step till all required continues are received.

See commit descriptions:
* Fix Canary Strategy: return phase not interrupted, after first continue, till proceeded step is started.
* Remove isWaiting(). isWaiting() != isInterrupted(), WAITING is a special status, only used to show/print plan/phase/step details.