### PR TITLE
Test runs should not by default create clusters and not tear them down.

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -85,6 +85,6 @@ fi
 
 # Tests succeeded. Out of courtesy, trigger a teardown of the cluster if we created it ourselves.
 # Don't wait for the cluster to complete teardown.
-#if [ -n "${CLUSTER_CREATED}" ]; then
-#    ${REPO_ROOT_DIR}/tools/launch_ccm_cluster.py trigger-stop ${CLUSTER_ID}
-#fi
+if [ -n "${CLUSTER_CREATED}" ]; then
+    ${REPO_ROOT_DIR}/tools/launch_ccm_cluster.py trigger-stop ${CLUSTER_ID}
+fi


### PR DESCRIPTION
Possibly this might be okay as a build parameter.

It's not okay to, on developer machines, leave the clusters running by default.  How are they expected to clean it up when the CLUSTER_URL can be easily lost?

cc: @colin-msphere @gabrielhartmann @loren @susanxhuynh 

