### PR TITLE
[TESTS][INFINITY-1108] Added more validation in the upgrade test

### DIFF
--- a/frameworks/elastic/tests/test_shakedown.py
+++ b/frameworks/elastic/tests/test_shakedown.py
@@ -129,6 +129,7 @@ def test_kibana_proxylite_adminrouter_integration():
     check_kibana_proxylite_adminrouter_integration()
 
 
+@pytest.mark.skip(reason="https://jira.mesosphere.com/browse/ELASTIC-58")
 @pytest.mark.upgrade
 @pytest.mark.sanity
 def test_upgrade_downgrade():

--- a/frameworks/helloworld/tests/test_sanity.py
+++ b/frameworks/helloworld/tests/test_sanity.py
@@ -276,6 +276,7 @@ def test_lock():
     assert zk_config_old == zk_config_new
 
 
+@pytest.mark.skip(reason="https://jira.mesosphere.com/browse/INFINITY-1114")
 @pytest.mark.upgrade
 @pytest.mark.sanity
 def test_upgrade_downgrade():

--- a/testing/sdk_test_upgrade.py
+++ b/testing/sdk_test_upgrade.py
@@ -5,7 +5,9 @@ import shakedown
 import sdk_cmd as cmd
 import sdk_install as install
 import sdk_marathon as marathon
+import sdk_plan as plan
 import sdk_spin as spin
+import sdk_tasks as tasks
 
 
 # (1) Installs Universe version of framework.
@@ -44,24 +46,32 @@ def upgrade_downgrade(package_name, running_task_count):
     add_last_repo('Universe', universe_url, universe_version, package_name)
 
     print('Upgrading to test version')
-    marathon.destroy_app(package_name)
-    install.install(package_name, running_task_count)
+    upgrade_or_downgrade(package_name, running_task_count)
 
     # Move the Universe repo to the top of the repo list
     shakedown.remove_package_repo('Universe')
     add_repo('Universe', universe_url, test_version, 0, package_name)
 
     print('Downgrading to master version')
-    marathon.destroy_app(package_name)
-    install.install(package_name, running_task_count)
+    upgrade_or_downgrade(package_name, running_task_count)
 
     # Move the Universe repo to the bottom of the repo list
     shakedown.remove_package_repo('Universe')
     add_last_repo('Universe', universe_url, universe_version, package_name)
 
     print('Upgrading to test version')
+    upgrade_or_downgrade(package_name, running_task_count)
+
+
+def upgrade_or_downgrade(package_name, running_task_count):
+    task_ids = tasks.get_task_ids(package_name, '')
     marathon.destroy_app(package_name)
     install.install(package_name, running_task_count)
+    print('Waiting for upgrade / downgrade deployment to complete')
+    spin.time_wait_noisy(lambda: (
+        plan.get_deployment_plan(package_name).json()['status'] == 'COMPLETE'))
+    print('Checking that all tasks have restarted')
+    tasks.check_tasks_updated(package_name, '', task_ids)
 
 
 def get_test_repo_info():


### PR DESCRIPTION
Added the following to the upgrade test:
- Check that the deployment finishes => this catches a failure in Elastic upgrades where the deployment never finishes.
- Check that all tasks have restarted => this catches an issue with Hello-world upgrades where the tasks are not restarted.

Elastic and hello-world upgrade tests will fail with this change.