### PR TITLE
Small java fixes: Logging and custom env

### DIFF
--- a/sdk/executor/src/main/java/com/mesosphere/sdk/executor/CustomExecutor.java
+++ b/sdk/executor/src/main/java/com/mesosphere/sdk/executor/CustomExecutor.java
@@ -148,7 +148,7 @@ public class CustomExecutor implements Executor {
                     try {
                         Optional<HealthCheckStats> optionalHealthCheckStats = futureOptionalHealthCheckStats.get();
                         if (optionalHealthCheckStats.isPresent()) {
-                            LOGGER.error("Check exited with statistics: {}", optionalHealthCheckStats.get());
+                            LOGGER.info("Check exited with statistics: {}", optionalHealthCheckStats.get());
                         }
                     } catch (InterruptedException | ExecutionException e) {
                         LOGGER.error("Failed to get check stats with exception: ", e);

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/YAMLServiceSpecFactory.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/YAMLServiceSpecFactory.java
@@ -16,6 +16,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.Map;
 
 /**
  * Generates {@link ServiceSpec} from a given YAML definition.
@@ -35,16 +36,26 @@ public class YAMLServiceSpecFactory {
     @VisibleForTesting
     public static class FileReader {
         public String read(String path) throws IOException {
-            return FileUtils.readFileToString(new File(path), "UTF-8");
+            return FileUtils.readFileToString(new File(path), CHARSET);
         }
     }
 
     public static final RawServiceSpec generateRawSpecFromYAML(File pathToYaml) throws Exception {
-        return generateRawSpecFromYAML(FileUtils.readFileToString(pathToYaml, CHARSET));
+        return generateRawSpecFromYAML(FileUtils.readFileToString(pathToYaml, CHARSET), System.getenv());
+    }
+
+    public static final RawServiceSpec generateRawSpecFromYAML(File pathToYaml, Map<String, String> env)
+            throws Exception {
+        return generateRawSpecFromYAML(FileUtils.readFileToString(pathToYaml, CHARSET), env);
     }
 
     public static final RawServiceSpec generateRawSpecFromYAML(final String yaml) throws Exception {
-        final String yamlWithEnv = CommonTaskUtils.applyEnvToMustache(yaml, System.getenv());
+        return generateRawSpecFromYAML(yaml, System.getenv());
+    }
+
+    public static final RawServiceSpec generateRawSpecFromYAML(final String yaml, Map<String, String> env)
+            throws Exception {
+        final String yamlWithEnv = CommonTaskUtils.applyEnvToMustache(yaml, env);
         LOGGER.info("Rendered ServiceSpec:\n{}", yamlWithEnv);
         if (!CommonTaskUtils.isMustacheFullyRendered(yamlWithEnv)) {
             throw new IllegalStateException("YAML contains unsubstitued variables.");

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/testutils/OfferRequirementTestUtils.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/testutils/OfferRequirementTestUtils.java
@@ -149,14 +149,30 @@ public class OfferRequirementTestUtils {
 
     public static final EnvironmentVariables getApiPortEnvironment() {
         EnvironmentVariables env = new EnvironmentVariables();
-        env.set("PORT_API", String.valueOf(TestConstants.PORT_API_VALUE));
+        for (Map.Entry<String, String> entry : getApiPortMap().entrySet()) {
+            env.set(entry.getKey(), entry.getValue());
+        }
         return env;
     }
 
     public static EnvironmentVariables getOfferRequirementProviderEnvironment() {
-        EnvironmentVariables env = getApiPortEnvironment();
-        env.set("EXECUTOR_URI", "test-executor-uri");
-        env.set("LIBMESOS_URI", "test-libmesos-uri");
+        EnvironmentVariables env = new EnvironmentVariables();
+        for (Map.Entry<String, String> entry : getOfferRequirementProviderMap().entrySet()) {
+            env.set(entry.getKey(), entry.getValue());
+        }
+        return env;
+    }
+
+    public static final Map<String, String> getApiPortMap() {
+        Map<String, String> env = new HashMap<>();
+        env.put("PORT_API", String.valueOf(TestConstants.PORT_API_VALUE));
+        return env;
+    }
+
+    public static Map<String, String> getOfferRequirementProviderMap() {
+        Map<String, String> env = getApiPortMap();
+        env.put("EXECUTOR_URI", "test-executor-uri");
+        env.put("LIBMESOS_URI", "test-libmesos-uri");
         return env;
     }
 }


### PR DESCRIPTION
- Health check success shouldn't be logged as an error
- Allow java schedulers to customize env when rendering yaml. This allows a developer to apply logic to envvars for mustache templating, e.g. "false" -> "".