### PR TITLE
[INFINITY-1128] Reset github statuses on retest, and calculate/emit operation duration

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -10,7 +10,9 @@ set +e
 REPO_ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd $REPO_ROOT_DIR
 
-# GitHub notifier config
+# GitHub notifier: reset any statuses from prior builds for this commit
+$REPO_ROOT_DIR/tools/github_update.py reset
+
 _notify_github() {
     $REPO_ROOT_DIR/tools/github_update.py $1 build:sdk $2
 }

--- a/tools/github_update.py
+++ b/tools/github_update.py
@@ -174,20 +174,23 @@ class GithubStatusUpdater(object):
 
     def _pretty_duration(self, seconds):
         """ Returns a user-friendly representation of the provided duration in seconds.
-        For example: 62.8 => "1m2.8s", or 129837.8 => "2d12h4m57.8s"
+        For example: 62.8 => "1m3s", or 129837.8 => "1d12h"
         """
-        ret = ''
         if seconds >= 86400:
-            ret += '{:.0f}d'.format(int(seconds / 86400))
-            seconds = seconds % 86400
+            # >= 1day: just do XdYh without minutes/seconds. int cast on days to avoid rounding up.
+            return '{:.0f}d{:.0f}h'.format(int(seconds / 86400), (seconds % 86400) / 3600)
         if seconds >= 3600:
-            ret += '{:.0f}h'.format(int(seconds / 3600))
-            seconds = seconds % 3600
+            # >= 1hr: just do XhYm without seconds. int cast on hours to avoid rounding up.
+            return '{:.0f}h{:.0f}m'.format(int(seconds / 3600), (seconds % 3600) / 60)
+
+        ret = ''
         if seconds >= 60:
+            # int cast to avoid rounding up:
             ret += '{:.0f}m'.format(int(seconds / 60))
             seconds = seconds % 60
         if seconds > 0:
-            ret += '{:.1f}s'.format(seconds)
+            # round to nearest second:
+            ret += '{:.0f}s'.format(seconds)
         return ret
 
 

--- a/tools/github_update.py
+++ b/tools/github_update.py
@@ -29,13 +29,13 @@ except ImportError:
     # Python 2
     from httplib import HTTPSConnection
 
-'''reserved contexts which may not be modified by this script'''
+# reserved contexts which may not be modified by this script
 BLACKLISTED_CONTEXT_LABELS = ['velocity'] # not set by us, do not update
 
-'''the pending/incomplete state'''
+# the pending/incomplete state
 PENDING_STATE = 'pending'
 
-'''list of all valid states'''
+# list of all valid states
 VALID_STATES = [PENDING_STATE, 'success', 'error', 'failure']
 
 
@@ -49,7 +49,7 @@ class RepoInfo(object):
             startdir = os.getcwd()
         # starting at 'startdir' search up the tree for a directory named '.git':
         checkdir = os.path.join(startdir, gitdir)
-        while not checkdir == '/' + gitdir:
+        while checkdir != '/' + gitdir:
             if os.path.isdir(checkdir):
                 return checkdir
             checkdir = os.path.join(os.path.dirname(os.path.dirname(checkdir)), gitdir)
@@ -112,14 +112,14 @@ class RepoInfo(object):
 
 class GithubAPI(object):
 
-    def __init__(self, repo_orgname, commit_sha, github_token, debug_requests = False):
+    def __init__(self, repo_orgname, commit_sha, github_token, debug_requests=False):
         self._repo_orgname = repo_orgname
         self._commit_sha = commit_sha
         self._github_token = github_token
         self._debug_requests = debug_requests
 
 
-    def _send_request(self, method, path, json_payload = None):
+    def _send_request(self, method, path, json_payload=None):
         '''sends the provided request to api.github.com and returns the response, or None if the request failed'''
         if json_payload:
             body = json.dumps(json_payload).encode('utf-8')
@@ -135,7 +135,7 @@ class GithubAPI(object):
         conn = HTTPSConnection('api.github.com')
         if self._debug_requests:
             conn.set_debuglevel(999)
-        conn.request(method, path, body = body, headers = headers)
+        conn.request(method, path, body=body, headers=headers)
         response = conn.getresponse()
         if response.status < 200 or response.status >= 300:
             # log failure, but don't abort the build
@@ -171,7 +171,7 @@ class GithubAPI(object):
 
 class GithubStatusUpdater(object):
 
-    def __init__(self, default_context_label = ''):
+    def __init__(self, default_context_label=''):
         info = RepoInfo()
         self._api = GithubAPI(info.repo_orgname(), info.commit_sha(), info.github_auth_token())
         self._default_context_label = default_context_label


### PR DESCRIPTION
- Status reset: Github doesn't allow removing old statuses, only updating statuses. Therefore we just set all non-`velocity` statuses as pending in github if a build is retriggered (via 'retest this please'). Note that this doesn't fix things in all situations: If the old build is still running in jenkins then it can still override the reset-to-pending with additional updates.
- Timers: Stores a timestamp against the operation name when a step calls `pending`, then compares that timestamp when `failed` or `success` is called for that same operation name. End result is we can log duration for each operation.