### PR TITLE
[INFINITY-1153] Fix pod replacement failure during deployment

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/ResourceUtils.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/ResourceUtils.java
@@ -405,8 +405,9 @@ public class ResourceUtils {
         List<Protos.Resource> resources = new ArrayList<>();
         for (Protos.Resource resource : taskInfo.getResourcesList()) {
             if (resource.hasDisk()) {
-                resource = Protos.Resource.newBuilder(resource).setDisk(
-                    Protos.Resource.DiskInfo.newBuilder(resource.getDisk()).clearPersistence()
+                resource = Protos.Resource.newBuilder(resource)
+                        .setDisk(resource.getDisk().toBuilder()
+                                .setPersistence(Persistence.newBuilder().setId(""))
                 ).build();
             }
             resources.add(resource);

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/DefaultPlanCoordinator.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/DefaultPlanCoordinator.java
@@ -69,8 +69,9 @@ public class DefaultPlanCoordinator extends ChainedObserver implements PlanCoord
 
                 // Get candidate steps to be scheduled
                 Collection<? extends Step> candidateSteps = planManager.getCandidates(relevantDirtyAssets);
-                LOGGER.info("Attempting to process candidates: {}",
-                        candidateSteps.stream().map(step -> step.getName()).collect(Collectors.toList()));
+                LOGGER.info("Attempting to process candidates: {}, from plan: {}",
+                        candidateSteps.stream().map(step -> step.getName()).collect(Collectors.toList()),
+                        planManager.getPlan().getName());
 
                 // Try scheduling candidate steps using the available offers
                 Collection<OfferID> usedOffers = planScheduler.resourceOffers(driver, offers, candidateSteps);

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluatorTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluatorTest.java
@@ -2,7 +2,9 @@ package com.mesosphere.sdk.offer.evaluate;
 
 import com.mesosphere.sdk.offer.*;
 import com.mesosphere.sdk.offer.evaluate.placement.PlacementUtils;
-import com.mesosphere.sdk.scheduler.plan.DefaultPodInstance;
+import com.mesosphere.sdk.scheduler.plan.*;
+import com.mesosphere.sdk.scheduler.plan.Status;
+import com.mesosphere.sdk.scheduler.recovery.FailureUtils;
 import com.mesosphere.sdk.specification.DefaultServiceSpec;
 import com.mesosphere.sdk.specification.PodInstance;
 import com.mesosphere.sdk.specification.PodSpec;
@@ -14,7 +16,6 @@ import com.mesosphere.sdk.testutils.*;
 import org.apache.mesos.Protos;
 import org.apache.mesos.Protos.*;
 import org.apache.mesos.Protos.Offer.Operation;
-import com.mesosphere.sdk.scheduler.plan.PodInstanceRequirement;
 import org.junit.*;
 import org.mockito.Mock;
 
@@ -973,6 +974,58 @@ public class OfferEvaluatorTest extends OfferEvaluatorTestBase {
         Assert.assertEquals(Operation.Type.RESERVE, operation.getType());
         operation = recommendations.get(5).getOperation();
         Assert.assertEquals(Operation.Type.LAUNCH, operation.getType());
+    }
+
+    @Test
+    public void testReplaceDeployStep() throws Exception {
+        ClassLoader classLoader = getClass().getClassLoader();
+        File file = new File(classLoader.getResource("valid-minimal-volume.yml").getFile());
+        RawServiceSpec rawServiceSpec = YAMLServiceSpecFactory.generateRawSpecFromYAML(file);
+        DefaultServiceSpec serviceSpec = YAMLServiceSpecFactory.generateServiceSpec(rawServiceSpec);
+
+        PodSpec podSpec = serviceSpec.getPods().get(0);
+        PodInstance podInstance = new DefaultPodInstance(podSpec, 0);
+        PodInstanceRequirement podInstanceRequirement =
+                PodInstanceRequirement.create(podInstance, Arrays.asList("task-name"));
+        DeploymentStep deploymentStep = new DeploymentStep(
+                "test-step",
+                Status.PENDING,
+                podInstanceRequirement,
+                Collections.emptyList());
+
+        Offer sufficientOffer = OfferTestUtils.getOffer(Arrays.asList(
+                ResourceUtils.getUnreservedScalar("cpus", 3.0),
+                ResourceUtils.getUnreservedScalar("mem", 1024),
+                ResourceUtils.getUnreservedScalar("disk", 500.0)));
+
+        List<OfferRecommendation> recommendations = evaluator.evaluate(
+                deploymentStep.start().get(),
+                Arrays.asList(sufficientOffer));
+
+        Assert.assertEquals(recommendations.toString(), 5, recommendations.size());
+        Operation launchOperation = recommendations.get(4).getOperation();
+        TaskInfo taskInfo = launchOperation.getLaunch().getTaskInfos(0);
+        recordOperations(recommendations);
+
+        deploymentStep.updateOfferStatus(recommendations);
+        Assert.assertEquals(Status.STARTING, deploymentStep.getStatus());
+
+        // Simulate an initial failure to deploy.  Perhaps the CREATE operation failed
+        deploymentStep.update(
+                TaskStatus.newBuilder()
+                        .setTaskId(taskInfo.getTaskId())
+                        .setState(TaskState.TASK_ERROR)
+                        .build());
+
+        Assert.assertEquals(Status.PENDING, deploymentStep.getStatus());
+        stateStore.storeTasks(Arrays.asList(FailureUtils.markFailed(taskInfo)));
+
+        Assert.assertTrue(FailureUtils.isLabeledAsFailed(stateStore.fetchTask(taskInfo.getName()).get()));
+
+        recommendations = evaluator.evaluate(
+                deploymentStep.start().get(),
+                Arrays.asList(sufficientOffer));
+        Assert.assertEquals(recommendations.toString(), 5, recommendations.size());
     }
 
     private void recordOperations(List<OfferRecommendation> recommendations) throws Exception {

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluatorTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluatorTest.java
@@ -2,7 +2,9 @@ package com.mesosphere.sdk.offer.evaluate;
 
 import com.mesosphere.sdk.offer.*;
 import com.mesosphere.sdk.offer.evaluate.placement.PlacementUtils;
-import com.mesosphere.sdk.scheduler.plan.*;
+import com.mesosphere.sdk.scheduler.plan.DefaultPodInstance;
+import com.mesosphere.sdk.scheduler.plan.DeploymentStep;
+import com.mesosphere.sdk.scheduler.plan.PodInstanceRequirement;
 import com.mesosphere.sdk.scheduler.plan.Status;
 import com.mesosphere.sdk.scheduler.recovery.FailureUtils;
 import com.mesosphere.sdk.specification.DefaultServiceSpec;
@@ -12,11 +14,15 @@ import com.mesosphere.sdk.specification.ServiceSpec;
 import com.mesosphere.sdk.specification.yaml.RawServiceSpec;
 import com.mesosphere.sdk.specification.yaml.YAMLServiceSpecFactory;
 import com.mesosphere.sdk.state.PersistentLaunchRecorder;
-import com.mesosphere.sdk.testutils.*;
+import com.mesosphere.sdk.testutils.OfferRequirementTestUtils;
+import com.mesosphere.sdk.testutils.OfferTestUtils;
+import com.mesosphere.sdk.testutils.ResourceTestUtils;
+import com.mesosphere.sdk.testutils.TestConstants;
 import org.apache.mesos.Protos;
 import org.apache.mesos.Protos.*;
 import org.apache.mesos.Protos.Offer.Operation;
-import org.junit.*;
+import org.junit.Assert;
+import org.junit.Test;
 import org.mockito.Mock;
 
 import java.io.File;
@@ -1026,6 +1032,18 @@ public class OfferEvaluatorTest extends OfferEvaluatorTestBase {
                 deploymentStep.start().get(),
                 Arrays.asList(sufficientOffer));
         Assert.assertEquals(recommendations.toString(), 5, recommendations.size());
+
+        Operation operation = recommendations.get(0).getOperation();
+        Assert.assertEquals(Operation.Type.RESERVE, operation.getType());
+        operation = recommendations.get(1).getOperation();
+        Assert.assertEquals(Operation.Type.RESERVE, operation.getType());
+        operation = recommendations.get(2).getOperation();
+        Assert.assertEquals(Operation.Type.RESERVE, operation.getType());
+        operation = recommendations.get(3).getOperation();
+        Assert.assertEquals(Operation.Type.CREATE, operation.getType());
+        operation = recommendations.get(4).getOperation();
+        Assert.assertEquals(Operation.Type.LAUNCH, operation.getType());
+
     }
 
     private void recordOperations(List<OfferRecommendation> recommendations) throws Exception {

--- a/sdk/scheduler/src/test/resources/valid-minimal-volume.yml
+++ b/sdk/scheduler/src/test/resources/valid-minimal-volume.yml
@@ -1,0 +1,14 @@
+name: "hello-world"
+pods:
+  pod-type:
+    count: 1
+    tasks:
+      task-name:
+        goal: RUNNING
+        cmd: "./task-cmd"
+        cpus: 1.0
+        memory: 512
+        volume:
+          path: container-path
+          size: 10
+          type: ROOT


### PR DESCRIPTION
The SDK assumes that when generating operations to be performed on an Offer, that those operations will be successful.  Mesos does not provide feedback for any operation other than LAUNCH.  Typically the initial deployment of a pod involves operations like:
```
RESERVE
RESERVE
CREATE
LAUNCH
```
It's possible (and sometimes occurs that an operation can fail).  Typically the failed operation is CREATE.  The scheduler doesn't currently support automatic recovery from this kind of failure.  However the `dcos <service> pods replace <pod>` method should work. It doesn't.  This PR fixes that bug.

The problem was that when marking a pod failed, the clearing of persistence information on the `Persistence` element of the `DiskInfo` did not accord with what was expected in `ResourceRequirement` to determine whether a requirement `createsVolume`.  This PR includes a unit test that fails in exactly the way described in INFINITY-1153.  The change makes that test pass.