### PR TITLE
Versioned artifacts

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -9,6 +9,8 @@ cd $REPO_ROOT_DIR
 # Build and upload Java library to Maven repo:
 ./build.sh
 ./gradlew publish
+
+# Scripts below expects S3_BUCKET and SDK_VERSION env vars. To be supplied by Jenkins.
 ./tools/build_publishable.sh
 ./tools/release_artifacts.sh
 

--- a/release.sh
+++ b/release.sh
@@ -9,6 +9,8 @@ cd $REPO_ROOT_DIR
 # Build and upload Java library to Maven repo:
 ./build.sh
 ./gradlew publish
+./tools/build_publishable.sh
+./tools/release_artifacts.sh
 
 # Note: We *don't* run /tools/release.sh here, and instead have CI run it manually.
 # This ensures that builds against different tags don't step on each other.

--- a/tools/build_publishable.sh
+++ b/tools/build_publishable.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+source ./tools/init_paths.sh
+
+# Build executor.zip
+echo "Building executor.zip"
+${REPO_ROOT_DIR}/gradlew distZip -p ${REPO_ROOT_DIR}/sdk/executor
+
+# Build bootstrap
+echo "Building bootstrap.zip"
+${REPO_ROOT_DIR}/sdk/bootstrap/build.sh

--- a/tools/release_artifacts.sh
+++ b/tools/release_artifacts.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -e
+source ${TOOLS_DIR}/init_paths.sh
+
+S3_BUCKET=${S3_BUCKET:=infinity-artifacts}
+SDK_VERSION=${SDK_VERSION:=stub}
+PREFIX_PATH=artifacts/$SDK_VERSION
+EXECUTOR_ZIP=${REPO_ROOT_DIR}/sdk/executor/build/distributions/executor.zip
+BOOTSTRAP_ZIP=${REPO_ROOT_DIR}/sdk/bootstrap/bootstrap.zip
+
+echo $S3_BUCKET
+echo $SDK_VERSION
+echo $EXECUTOR_ZIP
+echo $BOOTSTRAP_ZIP
+
+echo "Uploading executor.zip to: https://downloads.mesosphere.com/$S3_BUCKET/$PREFIX_PATH/executor.zip"
+aws s3 cp --acl public-read $EXECUTOR_ZIP s3://$S3_BUCKET/$PREFIX_PATH/executor.zip 1>&2
+echo "Uploaded executor.zip to: https://downloads.mesosphere.com/$S3_BUCKET/$PREFIX_PATH/executor.zip"
+
+echo "Uploading bootstrap.zip to: https://downloads.mesosphere.com/$S3_BUCKET/$PREFIX_PATH/bootstrap.zip"
+aws s3 cp --acl public-read $BOOTSTRAP_ZIP s3://$S3_BUCKET/$PREFIX_PATH/bootstrap.zip 1>&2
+echo "Uploaded bootstrap.zip to: https://downloads.mesosphere.com/$S3_BUCKET/$PREFIX_PATH/bootstrap.zip"
+

--- a/tools/release_artifacts.sh
+++ b/tools/release_artifacts.sh
@@ -9,11 +9,6 @@ PREFIX_PATH=artifacts/$SDK_VERSION
 EXECUTOR_ZIP=${REPO_ROOT_DIR}/sdk/executor/build/distributions/executor.zip
 BOOTSTRAP_ZIP=${REPO_ROOT_DIR}/sdk/bootstrap/bootstrap.zip
 
-echo $S3_BUCKET
-echo $SDK_VERSION
-echo $EXECUTOR_ZIP
-echo $BOOTSTRAP_ZIP
-
 echo "Uploading executor.zip to: https://downloads.mesosphere.com/$S3_BUCKET/$PREFIX_PATH/executor.zip"
 aws s3 cp --acl public-read $EXECUTOR_ZIP s3://$S3_BUCKET/$PREFIX_PATH/executor.zip 1>&2
 echo "Uploaded executor.zip to: https://downloads.mesosphere.com/$S3_BUCKET/$PREFIX_PATH/executor.zip"
@@ -21,4 +16,3 @@ echo "Uploaded executor.zip to: https://downloads.mesosphere.com/$S3_BUCKET/$PRE
 echo "Uploading bootstrap.zip to: https://downloads.mesosphere.com/$S3_BUCKET/$PREFIX_PATH/bootstrap.zip"
 aws s3 cp --acl public-read $BOOTSTRAP_ZIP s3://$S3_BUCKET/$PREFIX_PATH/bootstrap.zip 1>&2
 echo "Uploaded bootstrap.zip to: https://downloads.mesosphere.com/$S3_BUCKET/$PREFIX_PATH/bootstrap.zip"
-


### PR DESCRIPTION
Adds additional scripts to upload versioned bootstrap.zip and executor.zip as part of the release process. These artifacts are meant to be consumed by frameworks, especially, the ones that reside outside the monorepo.