### PR TITLE
[ELASTIC-56] Bouncing the elected master node brings the whole cluster down

### DIFF
--- a/frameworks/elastic/src/main/dist/svc.yml
+++ b/frameworks/elastic/src/main/dist/svc.yml
@@ -43,7 +43,7 @@ pods:
             dest: "kibana-{{ELASTIC_VERSION}}-linux-x86_64/config/kibana.yml"
         health-check:
           cmd: "curl -I -s -f localhost:$PORT_HTTP/login"
-          interval: 5
+          interval: 30
           grace-period: 900
           max-consecutive-failures: 3
           delay: 0
@@ -102,7 +102,7 @@ pods:
           cmd: "curl -I -s -f -u kibana:{{KIBANA_PASSWORD}} localhost:$PORT_HTTP"
           grace-period: 180
           interval: 1
-          max-consecutive-failures: 1
+          max-consecutive-failures: 5
           delay: 0
           timeout: 10
         readiness-check:
@@ -159,7 +159,7 @@ pods:
           cmd: "curl -I -s -f -u kibana:{{KIBANA_PASSWORD}} localhost:$PORT_HTTP"
           grace-period: 180
           interval: 1
-          max-consecutive-failures: 1
+          max-consecutive-failures: 5
           delay: 0
           timeout: 10
         readiness-check:
@@ -216,7 +216,7 @@ pods:
           cmd: "curl -I -s -f -u kibana:{{KIBANA_PASSWORD}} localhost:$PORT_HTTP"
           grace-period: 180
           interval: 1
-          max-consecutive-failures: 1
+          max-consecutive-failures: 5
           delay: 0
           timeout: 10
         readiness-check:
@@ -273,7 +273,7 @@ pods:
           cmd: "curl -I -s -f -u kibana:{{KIBANA_PASSWORD}} localhost:$PORT_HTTP"
           grace-period: 180
           interval: 1
-          max-consecutive-failures: 1
+          max-consecutive-failures: 5
           delay: 0
           timeout: 10
         readiness-check:

--- a/frameworks/elastic/tests/test_shakedown.py
+++ b/frameworks/elastic/tests/test_shakedown.py
@@ -1,11 +1,13 @@
+import time
+
 import pytest
 
-from tests.config import *
 import sdk_install as install
-import sdk_tasks as tasks
 import sdk_marathon as marathon
-import sdk_utils as utils
+import sdk_tasks as tasks
 import sdk_test_upgrade
+import sdk_utils as utils
+from tests.config import *
 
 DEFAULT_NUMBER_OF_SHARDS = 1
 DEFAULT_NUMBER_OF_REPLICAS = 1
@@ -96,6 +98,8 @@ def test_losing_and_regaining_index_health(default_populated_index):
 def test_master_reelection():
     initial_master = get_elasticsearch_master()
     shakedown.kill_process_on_host("{}.{}.mesos".format(initial_master, PACKAGE_NAME), "master__.*Elasticsearch")
+    # Master re-election can take up to 3 seconds by default
+    time.sleep(3)
     new_master = get_elasticsearch_master()
     assert new_master.startswith("master") and new_master != initial_master
 

--- a/frameworks/elastic/tests/test_shakedown.py
+++ b/frameworks/elastic/tests/test_shakedown.py
@@ -92,10 +92,12 @@ def test_losing_and_regaining_index_health(default_populated_index):
 
 
 @pytest.mark.recovery
+@pytest.mark.sanity
 def test_master_reelection():
     initial_master = get_elasticsearch_master()
     shakedown.kill_process_on_host("{}.{}.mesos".format(initial_master, PACKAGE_NAME), "master__.*Elasticsearch")
-    check_new_elasticsearch_master_elected(initial_master)
+    new_master = get_elasticsearch_master()
+    assert new_master.startswith("master") and new_master != initial_master
 
 
 @pytest.mark.recovery


### PR DESCRIPTION
- Give the cluster a few seconds to elect a new master before failing the health check
- Rewrote shakedown test to expect immediate re-election or fail