### PR TITLE
Remove merge conflict with bad streaming socket timeout

### DIFF
--- a/frameworks/cassandra/universe/config.json
+++ b/frameworks/cassandra/universe/config.json
@@ -480,11 +480,6 @@
           "description": "The maximum throughput of all streaming file transfers between datacenters",
           "default": 200
         },
-        "streaming_socket_timeout_in_ms": {
-          "type": "integer",
-          "description": "The socket timeout for streaming operations",
-          "default": 3600000
-        },
         "phi_convict_threshold": {
           "type": "integer",
           "description": "The sensitivity of the failure detector on an exponential scale",


### PR DESCRIPTION
It's already defined in another stanza below, with the more forgiving timeout of `86400000`. This was causing the last node to fail to deploy.