### PR TITLE
[INFINITY-1171]Centralize cli downloading in our scripts.

### DIFF
--- a/test.py
+++ b/test.py
@@ -296,8 +296,12 @@ def teardown_clusters():
     clustinfo.shutdown_clusters()
 
 def _one_cluster_linear_tests(run_attrs, repo_root):
-    start_config = launch_ccm_cluster.StartConfig(private_agents=6)
-    clustinfo.start_cluster(start_config)
+    if run_attrs.cluster_url:
+        clustinfo.add_running_cluster(run_attrs.cluster_url,
+                                      run_attrs.cluster_token)
+    else:
+        start_config = launch_ccm_cluster.StartConfig(private_agents=6)
+        clustinfo.start_cluster(start_config)
 
     cluster = clustinfo._clusters[0]
     for framework in fwinfo.get_frameworks():
@@ -470,7 +474,9 @@ def start_test_background(framework, cluster, repo_root):
 
     custom_env = os.environ.copy()
     custom_env['TEST_GITHUB_LABEL'] = framework.name
-    custom_env['STUB_UNIVERSE_URL'] = framework.stub_universe_url
+    if framework.stub_universe_url:
+        # XXX test-only broken here
+        custom_env['STUB_UNIVERSE_URL'] = framework.stub_universe_url
     custom_env['CLUSTER_URL'] = cluster.url
     custom_env['CLUSTER_AUTH_TOKEN'] = cluster.auth_token
 
@@ -499,7 +505,9 @@ def run_test(framework, cluster, repo_root):
 
     logger.info("launching shakedown for %s", framework.name)
     custom_env = os.environ.copy()
-    custom_env['STUB_UNIVERSE_URL'] = framework.stub_universe_url
+    if framework.stub_universe_url:
+        # XXX test-only broken here
+        custom_env['STUB_UNIVERSE_URL'] = framework.stub_universe_url
     custom_env['TEST_GITHUB_LABEL'] = framework.name
     custom_env['CLUSTER_URL'] = cluster.url
     custom_env['CLUSTER_AUTH_TOKEN'] = cluster.auth_token

--- a/test.py
+++ b/test.py
@@ -296,12 +296,8 @@ def teardown_clusters():
     clustinfo.shutdown_clusters()
 
 def _one_cluster_linear_tests(run_attrs, repo_root):
-    if run_attrs.cluster_url:
-        clustinfo.add_running_cluster(run_attrs.cluster_url,
-                                      run_attrs.cluster_token)
-    else:
-        start_config = launch_ccm_cluster.StartConfig(private_agents=6)
-        clustinfo.start_cluster(start_config)
+    start_config = launch_ccm_cluster.StartConfig(private_agents=6)
+    clustinfo.start_cluster(start_config)
 
     cluster = clustinfo._clusters[0]
     for framework in fwinfo.get_frameworks():
@@ -474,9 +470,7 @@ def start_test_background(framework, cluster, repo_root):
 
     custom_env = os.environ.copy()
     custom_env['TEST_GITHUB_LABEL'] = framework.name
-    if framework.stub_universe_url:
-        # XXX test-only broken here
-        custom_env['STUB_UNIVERSE_URL'] = framework.stub_universe_url
+    custom_env['STUB_UNIVERSE_URL'] = framework.stub_universe_url
     custom_env['CLUSTER_URL'] = cluster.url
     custom_env['CLUSTER_AUTH_TOKEN'] = cluster.auth_token
 
@@ -505,9 +499,7 @@ def run_test(framework, cluster, repo_root):
 
     logger.info("launching shakedown for %s", framework.name)
     custom_env = os.environ.copy()
-    if framework.stub_universe_url:
-        # XXX test-only broken here
-        custom_env['STUB_UNIVERSE_URL'] = framework.stub_universe_url
+    custom_env['STUB_UNIVERSE_URL'] = framework.stub_universe_url
     custom_env['TEST_GITHUB_LABEL'] = framework.name
     custom_env['CLUSTER_URL'] = cluster.url
     custom_env['CLUSTER_AUTH_TOKEN'] = cluster.auth_token

--- a/test.sh
+++ b/test.sh
@@ -59,24 +59,6 @@ cd $REPO_ROOT_DIR
 
 # Get a CCM cluster if not already configured (see available settings in dcos-commons/tools/README.md):
 if [ -z "$CLUSTER_URL" ]; then
-    if [ "$SECURITY" = "strict" ]; then
-        # in launch_ccm_cluster, for strict, we run
-        # tools/create_service_account.sh which depends on the dcos binary.
-        if ! which dcos >/dev/null 2>&1; then
-            echo "Will fetch dcos binary for use by strict mode cluster setup"
-            dcos_cli_bindir="$REPO_ROOT_DIR"/tmp/dcos_bin
-            if [ -d $dcos_cli_bindir ]; then
-                echo "Wiping prior dcos bin dir $dcos_cli_bindir"
-                rm -rf "$dcos_cli_bindir"
-            fi
-            mkdir -p "$dcos_cli_bindir"
-            echo "curl https://downloads.dcos.io/binaries/cli/linux/x86-64/dcos-1.8/dcos --output $dcos_cli_bindir/dcos"
-            curl https://downloads.dcos.io/binaries/cli/linux/x86-64/dcos-1.8/dcos --output "$dcos_cli_bindir/dcos"
-            chmod a+x "$dcos_cli_bindir/dcos"
-            export PATH="$PATH":"$dcos_cli_bindir"
-        fi
-    fi
-
     echo "CLUSTER_URL is empty/unset, launching new cluster."
     export CCM_AGENTS=6
     CLUSTER_INFO=$(${REPO_ROOT_DIR}/tools/launch_ccm_cluster.py)

--- a/tools/cli_install.py
+++ b/tools/cli_install.py
@@ -44,6 +44,8 @@ def get_download_platform():
 
 
 def get_cluster_version(dcos_url):
+    """Given a cluster url, return its version string, such as 1.7, 1.8, 1.9,
+    1.9-dev, etc"""
     version_url = "%s/%s" % (dcos_url, "dcos-metadata/dcos-version.json")
     # Since our test clusters have weird certs that won't validate, turn off
     # validation
@@ -71,7 +73,6 @@ def get_cluster_version(dcos_url):
     response = urlopen(version_url, context=noverify_context)
     json_s = response.read()
     ver_s = json.loads(json_s)['version']
-    ver_s, _ = ver_s.split('-', 1) # "1.9-dev" -> 1.9
     return ver_s
 
 def _get_tempfilename(a_dir):
@@ -84,6 +85,8 @@ def _mark_executable(path):
     os.chmod(path, 0o755)
 
 def install_cli(src_file, write_dir):
+    """Copy an existing cli to a target directory path, updating the target
+    atomically."""
     output_filepath = os.path.join(write_dir, get_cli_filename())
     logger.info('Copying {} to {}'.format(src_file, output_filepath))
     try:
@@ -100,8 +103,12 @@ def install_cli(src_file, write_dir):
     return output_filepath
 
 def download_cli(dcos_url, write_dir):
+    """Download the correct cli version for a given cluster url, placing it in
+    a target directory and causing the target executable to update atomically"""
     url_template = 'https://downloads.dcos.io/binaries/cli/{}/x86-64/dcos-{}/{}'
     cluster_version = get_cluster_version(dcos_url)
+    # we only care about the target release number
+    cluster_version, _ = cluster_version.split('-', 1) # "1.9-dev" -> 1.9
     cli_url = url_template.format(get_download_platform(), cluster_version,
                                   get_cli_filename())
     # actually download to unique filename, then rename into place atomically.

--- a/tools/cli_install.py
+++ b/tools/cli_install.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python
+
+import json
+import logging
+import os
+import os.path
+import shutil
+import ssl
+import sys
+import tempfile
+import time
+
+try:
+    from urllib.request import URLopener
+    from urllib.request import urlopen
+except ImportError:
+    # Python 2
+    from urllib import URLopener
+    from urllib import urlopen
+
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.DEBUG, format="%(message)s")
+
+
+def get_cli_filename():
+    if sys.platform == 'win32':
+        return 'dcos.exe'
+    elif sys.platform in ('linux2', 'linux', 'darwin'):
+        return 'dcos'
+    else:
+        raise Exception('Unsupported platform: {}'.format(sys.platform))
+
+
+def get_download_platform():
+    if sys.platform == 'win32':
+        return 'windows'
+    elif sys.platform == 'linux2' or sys.platform == 'linux':
+        return 'linux'
+    elif sys.platform == 'darwin':
+        return 'darwin'
+    else:
+        raise Exception('Unsupported platform: {}'.format(sys.platform))
+
+
+def get_cluster_version(dcos_url):
+    version_url = "%s/%s" % (dcos_url, "dcos-metadata/dcos-version.json")
+    # Since our test clusters have weird certs that won't validate, turn off
+    # validation
+    try:
+        # this will handle a variety of versions, including some 2.7.x
+        # (haven't investigated which) and all recent 3.x
+        noverify_context = ssl.SSLContext()
+    except:
+        if hasattr(ssl, 'PROTOCOL_TLS'):
+            # 2.7.13
+            noverify_context = ssl.SSLContext(ssl.PROTOCOL_TLS)
+        elif hasattr(ssl, 'OP_NO_SSLv2'):
+            # 2.7.9-2.7.12
+            logger.warn("Old python; Asking for something better than sslv2 or 3")
+            noverify_context =  ssl.SSLContext(ssl.PROTOCOL_SSLv23)
+            # explicitly switch these off.  This is recommended for ancient
+            # versions as per https://docs.python.org/2/library/ssl.html#protocol-versions
+            noverify_context.options |=  ssl.OP_NO_SSLv2
+            noverify_context.options |=  ssl.OP_NO_SSLv3
+        else:
+            # before 2.7.9
+            logger.error("*VERY* old python.  Very weak/unsafe encryption ahoy.")
+            noverify_context =  ssl.SSLContext(ssl.PROTOCOL_SSLv23)
+
+    response = urlopen(version_url, context=noverify_context)
+    json_s = response.read()
+    ver_s = json.loads(json_s)['version']
+    ver_s, _ = ver_s.split('-', 1) # "1.9-dev" -> 1.9
+    return ver_s
+
+def _get_tempfilename(a_dir):
+    temp_target_f = tempfile.NamedTemporaryFile(dir=a_dir, delete=False)
+    temp_target_f.close()
+    return temp_target_f.name
+
+
+def _mark_executable(path):
+    os.chmod(path, 0o755)
+
+def install_cli(src_file, write_dir):
+    output_filepath = os.path.join(write_dir, get_cli_filename())
+    logger.info('Copying {} to {}'.format(src_file, output_filepath))
+    try:
+        # actually copy to unique filename, then rename into place atomically.
+        temp_target = _get_tempfilename(write_dir)
+        shutil.copyfile(src_file, temp_target)
+        _mark_executable(temp_target)
+        # This could fail, which means probably it's already running and maybe
+        # it's even the right version, but not hiding the exception.
+        os.rename(temp_target, output_filepath)
+    finally:
+        if os.path.exists(temp_target):
+            os.unlink(temp_target)
+    return output_filepath
+
+def download_cli(dcos_url, write_dir):
+    url_template = 'https://downloads.dcos.io/binaries/cli/{}/x86-64/dcos-{}/{}'
+    cluster_version = get_cluster_version(dcos_url)
+    cli_url = url_template.format(get_download_platform(), cluster_version,
+                                  get_cli_filename())
+    # actually download to unique filename, then rename into place atomically.
+    try:
+        temp_target = _get_tempfilename(write_dir)
+        output_filepath = os.path.join(write_dir, get_cli_filename())
+        for attempt in (1,2,3):
+            # this seems to flake out more than you'd expect, DNS mostly
+            logger.info('Downloading {} to {} attempt {}/3'.format(cli_url,
+                                                                   output_filepath,
+                                                                   attempt))
+            try:
+                URLopener().retrieve(cli_url, temp_target)
+                break
+            except Exception as e:
+                logger.info("Attempt {} failed: {}".format(attempt, e))
+                if attempt == 3:
+                    raise
+                time.sleep(1)
+        _mark_executable(temp_target)
+        os.rename(temp_target, output_filepath)
+    finally:
+        if os.path.exists(temp_target):
+            os.unlink(temp_target)
+    logger.info("Download complete")
+    return output_filepath
+
+
+if __name__ == "__main__":
+    def usage(f=sys.stderr):
+        f.write("usage: cli_install.py <path_to_existing_cli> <target_dir>\n")
+        f.write("  OR\n")
+        f.write("usage: cli_install.py <cluster_url> <target_dir>\n")
+
+
+    if not len(sys.argv) == 3:
+        usage()
+        sys.exit(1)
+
+    source = sys.argv[1]
+    target_dir = sys.argv[2]
+
+    # convenience for command line
+    if not os.path.exists(target_dir):
+        os.makedirs(target_dir)
+
+    if source.startswith('http://') or source.startswith('https://'):
+        download_cli(source, target_dir)
+    elif os.path.isfile(source):
+        install_cli(source, target_dir)
+    else:
+        sys.stderr.write("No such file to copy: {}".format(source))
+        usage()
+        sys.exit(1)

--- a/tools/cli_install.py
+++ b/tools/cli_install.py
@@ -108,7 +108,8 @@ def download_cli(dcos_url, write_dir):
     url_template = 'https://downloads.dcos.io/binaries/cli/{}/x86-64/dcos-{}/{}'
     cluster_version = get_cluster_version(dcos_url)
     # we only care about the target release number
-    cluster_version, _ = cluster_version.split('-', 1) # "1.9-dev" -> 1.9
+    if '-' in cluster_version:
+        cluster_version, _ = cluster_version.split('-', 1) # "1.9-dev" -> 1.9
     cli_url = url_template.format(get_download_platform(), cluster_version,
                                   get_cli_filename())
     # actually download to unique filename, then rename into place atomically.

--- a/tools/cli_install.py
+++ b/tools/cli_install.py
@@ -71,7 +71,15 @@ def get_cluster_version(dcos_url):
             noverify_context =  ssl.SSLContext(ssl.PROTOCOL_SSLv23)
 
     response = urlopen(version_url, context=noverify_context)
-    json_s = response.read()
+    encoding = 'utf-8' # default
+    try:
+        #python3
+        provided_encoding = response.headers.get_content_charset()
+        if provided_encoding:
+            encoding =  provided_encoding
+    except:
+        pass
+    json_s = response.read().decode(encoding)
     ver_s = json.loads(json_s)['version']
     return ver_s
 

--- a/tools/run_tests.py
+++ b/tools/run_tests.py
@@ -6,20 +6,14 @@ import os
 import os.path
 import random
 import shutil
-import stat
 import string
 import subprocess
 import sys
 import tempfile
 
+import cli_install
 import dcos_login
 import github_update
-
-try:
-    from urllib.request import URLopener
-except ImportError:
-    # Python 2
-    from urllib import URLopener
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.DEBUG, format="%(message)s")
@@ -27,15 +21,16 @@ logging.basicConfig(level=logging.DEBUG, format="%(message)s")
 
 class CITester(object):
 
-    def __init__(self, dcos_url, github_label):
-        self._CLI_URL_TEMPLATE = 'https://downloads.dcos.io/binaries/cli/{}/x86-64/latest/{}'
+    def __init__(self, dcos_url, github_label, sandbox_path='', cli_path=None):
         self._dcos_url = dcos_url
-        self._sandbox_path = ''
+        self._sandbox_path = sandbox_path
+        self._cli_path = cli_path
         self._github_updater = github_update.GithubStatusUpdater('test:{}'.format(github_label))
 
 
     def _configure_cli_sandbox(self):
-        self._sandbox_path = tempfile.mkdtemp(prefix='ci-test-')
+        if not self._sandbox_path:
+            self._sandbox_path = tempfile.mkdtemp(prefix='ci-test-')
         custom_env = {}
         # must be custom for CLI to behave properly:
         custom_env['HOME'] = self._sandbox_path
@@ -52,26 +47,12 @@ class CITester(object):
 
 
     def _download_cli_to_sandbox(self):
-        cli_filename = 'dcos'
-        if sys.platform == 'win32':
-            cli_platform = 'windows'
-            cli_filename = 'dcos.exe'
-        elif sys.platform == 'linux2' or sys.platform == 'linux':
-            cli_platform = 'linux'
-        elif sys.platform == 'darwin':
-            cli_platform = 'darwin'
-        else:
-            raise Exception('Unsupported platform: {}'.format(sys.platform))
-        cli_url = self._CLI_URL_TEMPLATE.format(cli_platform, cli_filename)
-        cli_filepath = os.path.join(self._sandbox_path, cli_filename)
-        local_path = os.environ.get('DCOS_CLI_PATH', '')
+        # TODO: provide non-env interface to copy a dcos cli
+        local_path = os.environ.get('DCOS_CLI_PATH')
         if local_path:
-            logger.info('Copying {} to {}'.format(local_path, cli_filepath))
-            shutil.copyfile(local_path, cli_filepath)
+            cli_filepath = cli_install.install_cli(local_path, self._sandbox_path)
         else:
-            logger.info('Downloading {} to {}'.format(cli_url, cli_filepath))
-            URLopener().retrieve(cli_url, cli_filepath)
-        os.chmod(cli_filepath, 0o755)
+            cli_filepath = cli_install.download_cli(self.dcos_url, self._sandbox_path)
         return cli_filepath
 
 

--- a/tools/run_tests.py
+++ b/tools/run_tests.py
@@ -52,7 +52,7 @@ class CITester(object):
         if local_path:
             cli_filepath = cli_install.install_cli(local_path, self._sandbox_path)
         else:
-            cli_filepath = cli_install.download_cli(self.dcos_url, self._sandbox_path)
+            cli_filepath = cli_install.download_cli(self._dcos_url, self._sandbox_path)
         return cli_filepath
 
 


### PR DESCRIPTION
@susanxhuynh & @nickbp I'd appreciate your comments.

* Extract cli download to separate module.
* Expose as script in case shell needs it (I don't need that now) -- also enables easy testing
* Update cli atomically in case of goofy redownload while running
* Automatically get the right version for the cluster
* launch_ccm_cluster fetches dcos cli itself if required.