### PR TITLE
Allows optional values to be cleared

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/DefaultScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/DefaultScheduler.java
@@ -154,7 +154,7 @@ public class DefaultScheduler implements Scheduler, Observer {
                 // Any customization of the state store must be applied BEFORE getStateStore() is ever called.
                 throw new IllegalStateException("State store is already set. Was getStateStore() invoked before this?");
             }
-            this.stateStoreOptional = Optional.of(stateStore);
+            this.stateStoreOptional = Optional.ofNullable(stateStore);
             return this;
         }
 
@@ -180,7 +180,7 @@ public class DefaultScheduler implements Scheduler, Observer {
          * while also storing historical configurations.
          */
         public Builder setConfigStore(ConfigStore<ServiceSpec> configStore) {
-            this.configStoreOptional = Optional.of(configStore);
+            this.configStoreOptional = Optional.ofNullable(configStore);
             return this;
         }
 
@@ -192,7 +192,7 @@ public class DefaultScheduler implements Scheduler, Observer {
          * invoked.
          */
         public Builder setConfigValidators(Collection<ConfigValidator<ServiceSpec>> configValidators) {
-            this.configValidatorsOptional = Optional.of(configValidators);
+            this.configValidatorsOptional = Optional.ofNullable(configValidators);
             return this;
         }
 
@@ -202,7 +202,7 @@ public class DefaultScheduler implements Scheduler, Observer {
          * and/or replaced.
          */
         public Builder setRestartHook(RestartHook restartHook) {
-            this.restartHookOptional = Optional.of(restartHook);
+            this.restartHookOptional = Optional.ofNullable(restartHook);
             return this;
         }
 


### PR DESCRIPTION
It looks like the intention here was to allow these values to be set or "empty" as they are initially. However, `Optional.of` does a null check which prevents a consumer from clearing these values once they are set.
The use case for clearing is a class using `DefaultScheduler` that wants to remove the default config validators.
Current workaround is
```
DefaultScheduler.Builder builder =
                DefaultScheduler.newBuilder(serviceSpecWithCustomizedPods(rawServiceSpec))
                        .setPlansFrom(rawServiceSpec)
                .setConfigValidators(Collections.emptyList());
```