### PR TITLE
Fix double entry of socket timeout in cassandra.yaml

### DIFF
--- a/frameworks/cassandra/src/main/dist/cassandra.yaml
+++ b/frameworks/cassandra/src/main/dist/cassandra.yaml
@@ -125,6 +125,5 @@ streaming_socket_timeout_in_ms: {{CASSANDRA_STREAMING_SOCKET_TIMEOUT_IN_MS}}
 phi_convict_threshold: {{CASSANDRA_PHI_CONVICT_THRESHOLD}}
 buffer_pool_use_heap_if_exhausted: {{CASSANDRA_BUFFER_POOL_USE_HEAP_IF_EXHAUSTED}}
 disk_optimization_strategy: {{CASSANDRA_DISK_OPTIMIZATION_STRATEGY}}
-streaming_socket_timeout_in_ms: {{CASSANDRA_STREAMING_SOCKET_TIMOUT_IN_MS}}
 max_value_size_in_mb: {{CASSANDRA_MAX_VALUE_SIZE_IN_MB}}
 otc_coalescing_strategy: {{CASSANDRA_OTC_COALESCING_STRATEGY}}


### PR DESCRIPTION
This was again causing non-seed nodes to fail to deploy.