### PR TITLE
[SDK] Fix footprint reservation calculation

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/curator/CuratorStateStore.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/curator/CuratorStateStore.java
@@ -17,6 +17,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * CuratorStateStore is an implementation of {@link StateStore} which persists data in Zookeeper.
@@ -473,6 +474,9 @@ public class CuratorStateStore implements StateStore {
         }
 
         storeTasks(repairedTasks);
+        repairedStatuses = repairedStatuses.stream()
+                .filter(status -> !status.getTaskId().getValue().equals(""))
+                .collect(Collectors.toList());
         repairedStatuses.forEach(taskStatus -> storeStatus(taskStatus));
     }
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/OfferAccepter.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/OfferAccepter.java
@@ -17,7 +17,6 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * The OfferAccepter extracts the Mesos Operations encapsulated by the OfferRecommendation and accepts Offers with those
@@ -51,11 +50,8 @@ public class OfferAccepter {
             return new ArrayList<>();
         }
 
-        recommendations = getRecommendations(recommendations);
         List<OfferID> offerIds = getOfferIds(recommendations);
-        List<Operation> operations = recommendations.stream()
-                .map(offerRecommendation -> offerRecommendation.getOperation())
-                .collect(Collectors.toList());
+        List<Operation> operations = getOperations(recommendations);
 
         logOperations(operations);
 
@@ -83,8 +79,8 @@ public class OfferAccepter {
         }
     }
 
-    private static List<OfferRecommendation> getRecommendations(List<OfferRecommendation> recommendations) {
-        List<OfferRecommendation> filteredRecommendations = new ArrayList<>();
+    private static List<Operation> getOperations(List<OfferRecommendation> recommendations) {
+        List<Operation> operations = new ArrayList<>();
 
         for (OfferRecommendation recommendation : recommendations) {
             if (recommendation instanceof LaunchOfferRecommendation &&
@@ -92,11 +88,11 @@ public class OfferAccepter {
                 logger.info("Skipping launch of transient Operation: {}",
                         TextFormat.shortDebugString(recommendation.getOperation()));
             } else {
-                filteredRecommendations.add(recommendation);
+                operations.add(recommendation.getOperation());
             }
         }
 
-        return filteredRecommendations;
+        return operations;
     }
 
     private static List<OfferID> getOfferIds(List<OfferRecommendation> recommendations) {

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/OfferAccepterTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/OfferAccepterTest.java
@@ -47,7 +47,11 @@ public class OfferAccepterTest {
         TestOperationRecorder recorder = new TestOperationRecorder();
         OfferAccepter accepter = new OfferAccepter(recorder);
         accepter.accept(driver, Arrays.asList(new LaunchOfferRecommendation(offer, taskInfo)));
-        Assert.assertEquals(0, recorder.getLaunches().size());
+        Assert.assertEquals(1, recorder.getLaunches().size());
+        verify(driver, times(0)).acceptOffers(
+                anyCollectionOf(OfferID.class),
+                anyCollectionOf(Operation.class),
+                anyObject());
     }
 
     @Test
@@ -60,11 +64,15 @@ public class OfferAccepterTest {
         TestOperationRecorder recorder = new TestOperationRecorder();
         OfferAccepter accepter = new OfferAccepter(recorder);
         accepter.accept(driver, Arrays.asList(new LaunchOfferRecommendation(offer, taskInfo)));
-        Assert.assertEquals(0, recorder.getLaunches().size());
+        Assert.assertEquals(1, recorder.getLaunches().size());
+        verify(driver, times(0)).acceptOffers(
+                anyCollectionOf(OfferID.class),
+                anyCollectionOf(Operation.class),
+                anyObject());
 
         taskInfo = CommonTaskUtils.clearTransient(taskInfo.toBuilder()).build();
         accepter.accept(driver, Arrays.asList(new LaunchOfferRecommendation(offer, taskInfo)));
-        Assert.assertEquals(1, recorder.getLaunches().size());
+        Assert.assertEquals(2, recorder.getLaunches().size());
         verify(driver, times(1)).acceptOffers(
                 anyCollectionOf(OfferID.class),
                 anyCollectionOf(Operation.class),


### PR DESCRIPTION
The reverted commit was not recording Task's filling out the pod footprint was causing those resources to be `UNRESERVE`d.  They must be recorded, however the `TaskStatus`es with empty TaskIDs should not be recorded.  The original bug of failing StateStore validation on Scheduler restart is fixed.