### PR TITLE
Implement SchedulerFlags wrapper around scheduler env access

### DIFF
--- a/frameworks/cassandra/src/main/java/com/mesosphere/sdk/cassandra/scheduler/CassandraService.java
+++ b/frameworks/cassandra/src/main/java/com/mesosphere/sdk/cassandra/scheduler/CassandraService.java
@@ -2,6 +2,7 @@ package com.mesosphere.sdk.cassandra.scheduler;
 
 import com.mesosphere.sdk.cassandra.api.SeedsResource;
 import com.mesosphere.sdk.scheduler.DefaultScheduler;
+import com.mesosphere.sdk.scheduler.SchedulerFlags;
 import com.mesosphere.sdk.specification.DefaultService;
 import com.mesosphere.sdk.specification.yaml.RawServiceSpec;
 import com.mesosphere.sdk.specification.yaml.YAMLServiceSpecFactory;
@@ -21,13 +22,14 @@ public class CassandraService extends DefaultService {
     protected static final Logger LOGGER = LoggerFactory.getLogger(CassandraService.class);
 
     public CassandraService(File pathToYamlSpecification) throws Exception {
+        SchedulerFlags schedulerFlags = SchedulerFlags.fromEnv();
         RawServiceSpec rawServiceSpec = YAMLServiceSpecFactory.generateRawSpecFromYAML(pathToYamlSpecification);
         DefaultScheduler.Builder schedulerBuilder =
-                DefaultScheduler.newBuilder(YAMLServiceSpecFactory.generateServiceSpec(rawServiceSpec));
-
-        schedulerBuilder.setPlansFrom(rawServiceSpec);
-        schedulerBuilder.setResources(getResources());
-
+                DefaultScheduler.newBuilder(
+                        YAMLServiceSpecFactory.generateServiceSpec(rawServiceSpec, schedulerFlags),
+                        schedulerFlags)
+                .setPlansFrom(rawServiceSpec)
+                .setCustomResources(getResources());
         initService(schedulerBuilder);
     }
 

--- a/frameworks/elastic/src/main/java/com/mesosphere/sdk/elastic/scheduler/ElasticService.java
+++ b/frameworks/elastic/src/main/java/com/mesosphere/sdk/elastic/scheduler/ElasticService.java
@@ -1,5 +1,6 @@
 package com.mesosphere.sdk.elastic.scheduler;
 
+import com.mesosphere.sdk.scheduler.SchedulerFlags;
 import com.mesosphere.sdk.specification.DefaultService;
 
 import java.io.File;
@@ -10,7 +11,7 @@ import java.io.File;
 public class ElasticService extends DefaultService {
 
     ElasticService(File pathToYamlSpecification) throws Exception {
-        super(pathToYamlSpecification);
+        super(pathToYamlSpecification, SchedulerFlags.fromEnv());
     }
 
 }

--- a/frameworks/hdfs/src/main/java/com/mesosphere/sdk/hdfs/scheduler/Main.java
+++ b/frameworks/hdfs/src/main/java/com/mesosphere/sdk/hdfs/scheduler/Main.java
@@ -7,6 +7,7 @@ import com.mesosphere.sdk.offer.Constants;
 import com.mesosphere.sdk.offer.evaluate.placement.AndRule;
 import com.mesosphere.sdk.offer.evaluate.placement.TaskTypeRule;
 import com.mesosphere.sdk.scheduler.DefaultScheduler;
+import com.mesosphere.sdk.scheduler.SchedulerFlags;
 import com.mesosphere.sdk.specification.*;
 import com.mesosphere.sdk.specification.yaml.RawServiceSpec;
 import com.mesosphere.sdk.specification.yaml.YAMLServiceSpecFactory;
@@ -42,9 +43,11 @@ public class Main {
 
     private static DefaultScheduler.Builder getBuilder(RawServiceSpec rawServiceSpec)
             throws Exception {
-        DefaultScheduler.Builder builder =
-                DefaultScheduler.newBuilder(serviceSpecWithCustomizedPods(rawServiceSpec))
-                        .setRecoveryManagerFactory(new HdfsRecoveryPlanManagerFactory())
+        SchedulerFlags schedulerFlags = SchedulerFlags.fromEnv();
+        DefaultServiceSpec serviceSpec = YAMLServiceSpecFactory.generateServiceSpec(rawServiceSpec, schedulerFlags);
+        DefaultScheduler.Builder builder = DefaultScheduler
+                .newBuilder(serviceSpecWithCustomizedPods(serviceSpec), schedulerFlags)
+                .setRecoveryManagerFactory(new HdfsRecoveryPlanManagerFactory())
                 .setPlansFrom(rawServiceSpec);
         return builder
                 .setEndpointProducer("hdfs-site.xml", EndpointProducer.constant(getHdfsSiteXml()))
@@ -78,10 +81,7 @@ public class Main {
     }
 
 
-    private static ServiceSpec serviceSpecWithCustomizedPods(RawServiceSpec rawServiceSpec)
-            throws Exception {
-        DefaultServiceSpec serviceSpec = YAMLServiceSpecFactory.generateServiceSpec(rawServiceSpec);
-
+    private static ServiceSpec serviceSpecWithCustomizedPods(DefaultServiceSpec serviceSpec) throws Exception {
         // Journal nodes avoid themselves and Name nodes.
         PodSpec journal = DefaultPodSpec.newBuilder(getPodSpec(serviceSpec, "journal"))
                 .placementRule(new AndRule(TaskTypeRule.avoid("journal"), TaskTypeRule.avoid("name")))

--- a/frameworks/helloworld/src/main/java/com/mesosphere/sdk/helloworld/scheduler/Main.java
+++ b/frameworks/helloworld/src/main/java/com/mesosphere/sdk/helloworld/scheduler/Main.java
@@ -1,5 +1,6 @@
 package com.mesosphere.sdk.helloworld.scheduler;
 
+import com.mesosphere.sdk.scheduler.SchedulerFlags;
 import com.mesosphere.sdk.specification.*;
 
 import java.io.File;
@@ -15,8 +16,9 @@ public class Main {
     private static final String TASK_NAME = "hello";
 
     public static void main(String[] args) throws Exception {
+        SchedulerFlags schedulerFlags = SchedulerFlags.fromEnv();
         if (args.length > 0) {
-            new DefaultService(new File(args[0])).run();
+            new DefaultService(new File(args[0]), schedulerFlags).run();
         } else {
             // Example of building a custom ServiceSpec entirely in Java without a YAML file:
             new DefaultService(DefaultServiceSpec.newBuilder()
@@ -24,7 +26,7 @@ public class Main {
                     .principal("hello-world-principal")
                     .zookeeperConnection("master.mesos:2181")
                     .apiPort(8080)
-                    .addPod(DefaultPodSpec.newBuilder()
+                    .addPod(DefaultPodSpec.newBuilder(schedulerFlags.getExecutorURI())
                             .count(COUNT)
                             .type(POD_TYPE)
                             .addTask(DefaultTaskSpec.newBuilder()
@@ -40,6 +42,7 @@ public class Main {
                                             .memory(256.0)
                                             .addVolume("ROOT", 5000.0, "hello-container-path")
                                             .build()).build()).build()).build(),
+                    schedulerFlags,
                     Collections.emptyList())
                     .run();
         }

--- a/frameworks/helloworld/universe/marathon.json.mustache
+++ b/frameworks/helloworld/universe/marathon.json.mustache
@@ -3,7 +3,7 @@
   "cpus": 1.0,
   "mem": 1230,
   "instances": 1,
-  "cmd": "export LD_LIBRARY_PATH=$MESOS_SANDBOX/libmesos-bundle/lib && export MESOS_NATIVE_JAVA_LIBRARY=$(ls $MESOS_SANDBOX/libmesos-bundle/lib/libmesos-*.so) && export PATH=$(ls -d $MESOS_SANDBOX/jre*/bin):$PATH && ./hello-world-scheduler/bin/helloworld ./hello-world-scheduler/{{service.spec_file}}",
+  "cmd": "export LD_LIBRARY_PATH=$MESOS_SANDBOX/libmesos-bundle/lib:$LD_LIBRARY_PATH; export MESOS_NATIVE_JAVA_LIBRARY=$(ls $MESOS_SANDBOX/libmesos-bundle/lib/libmesos-*.so); export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jre*/); export JAVA_HOME=${JAVA_HOME%/}; export PATH=$(ls -d $JAVA_HOME/bin):$PATH && ./hello-world-scheduler/bin/helloworld ./hello-world-scheduler/{{service.spec_file}}",
   "labels": {
     "DCOS_PACKAGE_FRAMEWORK_NAME": "{{service.name}}",
     "DCOS_MIGRATION_API_VERSION": "v1",

--- a/frameworks/kafka/src/main/java/com/mesosphere/sdk/kafka/cmd/CmdExecutor.java
+++ b/frameworks/kafka/src/main/java/com/mesosphere/sdk/kafka/cmd/CmdExecutor.java
@@ -23,7 +23,6 @@ import java.util.ArrayList;
  */
 public class CmdExecutor {
     private static final Log log = LogFactory.getLog(CmdExecutor.class);
-    private static final String BIN_DIR = "/bin/";
 
     private final String binPath;
     private final String zkPath;

--- a/frameworks/kafka/src/main/java/com/mesosphere/sdk/kafka/scheduler/KafkaService.java
+++ b/frameworks/kafka/src/main/java/com/mesosphere/sdk/kafka/scheduler/KafkaService.java
@@ -8,6 +8,7 @@ import com.mesosphere.sdk.kafka.upgrade.CuratorStateStoreFilter;
 import com.mesosphere.sdk.kafka.upgrade.KafkaConfigUpgrade;
 import com.mesosphere.sdk.offer.evaluate.placement.RegexMatcher;
 import com.mesosphere.sdk.scheduler.DefaultScheduler;
+import com.mesosphere.sdk.scheduler.SchedulerFlags;
 import com.mesosphere.sdk.specification.DefaultService;
 import com.mesosphere.sdk.specification.yaml.RawServiceSpec;
 import com.mesosphere.sdk.specification.yaml.YAMLServiceSpecFactory;
@@ -25,12 +26,13 @@ public class KafkaService extends DefaultService {
 
     public KafkaService(File pathToYamlSpecification) throws Exception {
         RawServiceSpec rawServiceSpec = YAMLServiceSpecFactory.generateRawSpecFromYAML(pathToYamlSpecification);
-        DefaultScheduler.Builder schedulerBuilder =
-                DefaultScheduler.newBuilder(YAMLServiceSpecFactory.generateServiceSpec(rawServiceSpec));
-        schedulerBuilder.setPlansFrom(rawServiceSpec);
+        SchedulerFlags schedulerFlags = SchedulerFlags.fromEnv();
+        DefaultScheduler.Builder schedulerBuilder = DefaultScheduler.newBuilder(
+                YAMLServiceSpecFactory.generateServiceSpec(rawServiceSpec, schedulerFlags), schedulerFlags)
+                .setPlansFrom(rawServiceSpec);
 
         /* Upgrade */
-        new KafkaConfigUpgrade(schedulerBuilder.getServiceSpec());
+        new KafkaConfigUpgrade(schedulerBuilder.getServiceSpec(), schedulerFlags);
         CuratorStateStoreFilter stateStore = new CuratorStateStoreFilter(schedulerBuilder.getServiceSpec().getName(),
                 DcosConstants.MESOS_MASTER_ZK_CONNECTION_STRING);
         stateStore.setIgnoreFilter(RegexMatcher.create("broker-[0-9]*"));
@@ -41,7 +43,7 @@ public class KafkaService extends DefaultService {
                 schedulerBuilder.getServiceSpec().getZookeeperConnection() +
                         DcosConstants.SERVICE_ROOT_PATH_PREFIX + schedulerBuilder.getServiceSpec().getName()));
 
-        schedulerBuilder.setResources(
+        schedulerBuilder.setCustomResources(
                 getResources(
                         schedulerBuilder.getServiceSpec().getZookeeperConnection(),
                         schedulerBuilder.getServiceSpec().getName()));

--- a/frameworks/kafka/src/main/java/com/mesosphere/sdk/kafka/upgrade/KafkaConfigUpgrade.java
+++ b/frameworks/kafka/src/main/java/com/mesosphere/sdk/kafka/upgrade/KafkaConfigUpgrade.java
@@ -11,6 +11,7 @@ import com.mesosphere.sdk.offer.CommonTaskUtils;
 import com.mesosphere.sdk.offer.TaskException;
 import com.mesosphere.sdk.offer.TaskUtils;
 import com.mesosphere.sdk.scheduler.DefaultScheduler;
+import com.mesosphere.sdk.scheduler.SchedulerFlags;
 import com.mesosphere.sdk.specification.*;
 import com.mesosphere.sdk.state.StateStore;
 import org.apache.mesos.Protos;
@@ -48,17 +49,17 @@ public class KafkaConfigUpgrade {
     /**
      *  KafkaConfigUpgrade.
      */
-    public KafkaConfigUpgrade(ServiceSpec serviceSpec) throws Exception {
+    public KafkaConfigUpgrade(ServiceSpec serviceSpec, SchedulerFlags schedulerFlags) throws Exception {
         this.stateStore = new CuratorStateStoreUpdate(serviceSpec.getName(),
                 DcosConstants.MESOS_MASTER_ZK_CONNECTION_STRING);
 
         // if framework_id exist and not disabled
         if (!KafkaConfigUpgrade.disabled() && !runningFirstTime(stateStore)) {
-            startUpgrade(serviceSpec);
+            startUpgrade(serviceSpec, schedulerFlags);
         }
     }
 
-    private void startUpgrade(ServiceSpec serviceSpec) throws Exception{
+    private void startUpgrade(ServiceSpec serviceSpec, SchedulerFlags schedulerFlags) throws Exception{
         Optional<KafkaSchedulerConfiguration> kafkaSchedulerConfiguration = getOldConfiguration(serviceSpec);
         if (!kafkaSchedulerConfiguration.isPresent()){
             LOGGER.info("\n ---------------------------------------------------- \n " +
@@ -74,7 +75,8 @@ public class KafkaConfigUpgrade {
             throw new KafkaConfigUpgradeException("Aborting Kafka Configuration Upgrade !!!");
         }
         verifyNewSpec(serviceSpec);
-        ServiceSpec newServiceSpec = generateServiceSpec(kafkaSchedulerConfiguration.get(), serviceSpec);
+        ServiceSpec newServiceSpec =
+                generateServiceSpec(kafkaSchedulerConfiguration.get(), serviceSpec, schedulerFlags);
 
         LOGGER.info("\n ---------------------------------------------------- \n " +
                     "          Kafka Configuration Upgrade started. \n" +
@@ -201,7 +203,8 @@ public class KafkaConfigUpgrade {
     }
 
     private ServiceSpec generateServiceSpec(KafkaSchedulerConfiguration kafkaSchedulerConfiguration,
-                                            ServiceSpec serviceSpec) {
+                                            ServiceSpec serviceSpec,
+                                            SchedulerFlags schedulerFlags) {
         /* TODO(mb): why I can not create RawPort. See below:
         LinkedHashMap<String, RawPort> portMap = new WriteOnceLinkedHashMap<>();
         portMap.put("broker",
@@ -232,7 +235,7 @@ public class KafkaConfigUpgrade {
                 .resourceSet(newResourceSet)
                 .build();
 
-        PodSpec newPodSpec = DefaultPodSpec.newBuilder()
+        PodSpec newPodSpec = DefaultPodSpec.newBuilder(schedulerFlags.getExecutorURI())
                 .user(kafkaSchedulerConfiguration.getServiceConfiguration().getUser())
                 .count(kafkaSchedulerConfiguration.getServiceConfiguration().getCount())
                 .type(serviceSpec.getPods().get(0).getType())

--- a/frameworks/kafka/src/test/java/com/mesosphere/sdk/kafka/upgrade/CuratorStateStoreFilterTest.java
+++ b/frameworks/kafka/src/test/java/com/mesosphere/sdk/kafka/upgrade/CuratorStateStoreFilterTest.java
@@ -24,14 +24,8 @@ public class CuratorStateStoreFilterTest {
     private static final int RETRY_DELAY_MS = 1000;
     private static final String ZOOKEEPER_ROOT_NODE_NAME = "zookeeper";
 
-    private static final Protos.FrameworkID FRAMEWORK_ID =
-            Protos.FrameworkID.newBuilder().setValue("test-framework-id").build();
     private static final String ROOT_ZK_PATH = "/test-root-path";
     private static final Protos.TaskState TASK_STATE = Protos.TaskState.TASK_STAGING;
-    private static final Protos.TaskStatus TASK_STATUS = Protos.TaskStatus.newBuilder()
-            .setTaskId(CommonTaskUtils.toTaskId("taskName"))
-            .setState(TASK_STATE)
-            .build();
     private static TestingServer testZk;
     private CuratorStateStoreFilter store;
 

--- a/frameworks/kafka/universe/marathon.json.mustache
+++ b/frameworks/kafka/universe/marathon.json.mustache
@@ -32,8 +32,7 @@
     "KAFKA_URI": "{{resource.assets.uris.kafka-tgz}}",
     "JAVA_URI": "{{resource.assets.uris.jre-tar-gz}}",
     "MESOS_API_VERSION": "{{service.mesos_api_version}}",
-   
-   
+
     "PLACEMENT_CONSTRAINTS": "{{service.placement_constraint}}",
     "DEPLOY_STRATEGY":"{{service.deploy_strategy}}",
     "BROKER_COUNT": "{{brokers.count}}",

--- a/frameworks/prototype/src/main/java/com/mesosphere/sdk/prototype/scheduler/Main.java
+++ b/frameworks/prototype/src/main/java/com/mesosphere/sdk/prototype/scheduler/Main.java
@@ -1,5 +1,6 @@
 package com.mesosphere.sdk.prototype.scheduler;
 
+import com.mesosphere.sdk.scheduler.SchedulerFlags;
 import com.mesosphere.sdk.specification.DefaultService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -20,7 +21,7 @@ public class Main {
         LOGGER.info("Reading service specification from: {}", pathToServiceSpecification);
         final File serviceSpecificationFile = new File(args[0]);
         if (serviceSpecificationFile.exists()) {
-            new DefaultService(serviceSpecificationFile).run();
+            new DefaultService(serviceSpecificationFile, SchedulerFlags.fromEnv()).run();
         } else {
             LOGGER.error("Service specification file doesn't exist at location: {}", pathToServiceSpecification);
             System.exit(1);

--- a/frameworks/prototype/universe/marathon.json.mustache
+++ b/frameworks/prototype/universe/marathon.json.mustache
@@ -8,7 +8,7 @@
     "DCOS_PACKAGE_FRAMEWORK_NAME": "{{service.name}}",
     "DCOS_MIGRATION_API_VERSION": "v1",
     "DCOS_MIGRATION_API_PATH": "/v1/plan",
-    "MARATHON_SINGLE_INSTANCE_APP":"true",
+    "MARATHON_SINGLE_INSTANCE_APP": "true",
     "DCOS_SERVICE_NAME": "{{service.name}}",
     "DCOS_SERVICE_PORT_INDEX": "0",
     "DCOS_SERVICE_SCHEME": "http"

--- a/frameworks/proxylite/src/main/java/com/mesosphere/sdk/proxylite/scheduler/Main.java
+++ b/frameworks/proxylite/src/main/java/com/mesosphere/sdk/proxylite/scheduler/Main.java
@@ -1,5 +1,6 @@
 package com.mesosphere.sdk.proxylite.scheduler;
 
+import com.mesosphere.sdk.scheduler.SchedulerFlags;
 import com.mesosphere.sdk.specification.*;
 
 import java.io.File;
@@ -10,7 +11,7 @@ import java.io.File;
 public class Main {
     public static void main(String[] args) throws Exception {
         if (args.length > 0) {
-            new DefaultService(new File(args[0])).run();
+            new DefaultService(new File(args[0]), SchedulerFlags.fromEnv()).run();
         }
     }
 }

--- a/frameworks/proxylite/universe/marathon.json.mustache
+++ b/frameworks/proxylite/universe/marathon.json.mustache
@@ -3,12 +3,12 @@
   "cpus": 1.0,
   "mem": 1230,
   "instances": 1,
-  "cmd": "export LD_LIBRARY_PATH=$MESOS_SANDBOX/libmesos-bundle/lib && export MESOS_NATIVE_JAVA_LIBRARY=$(ls $MESOS_SANDBOX/libmesos-bundle/lib/libmesos-*.so) && export PATH=$(ls -d $MESOS_SANDBOX/jre*/bin):$PATH && ./proxylite-scheduler/bin/proxylite ./proxylite-scheduler/svc.yml",
+  "cmd": "export LD_LIBRARY_PATH=$MESOS_SANDBOX/libmesos-bundle/lib:$LD_LIBRARY_PATH; export MESOS_NATIVE_JAVA_LIBRARY=$(ls $MESOS_SANDBOX/libmesos-bundle/lib/libmesos-*.so); export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jre*/); export JAVA_HOME=${JAVA_HOME%/}; export PATH=$(ls -d $JAVA_HOME/bin):$PATH && ./proxylite-scheduler/bin/proxylite ./proxylite-scheduler/svc.yml",
   "labels": {
     "DCOS_PACKAGE_FRAMEWORK_NAME": "{{service.name}}",
     "DCOS_MIGRATION_API_VERSION": "v1",
     "DCOS_MIGRATION_API_PATH": "/v1/plan",
-    "MARATHON_SINGLE_INSTANCE_APP":"true"
+    "MARATHON_SINGLE_INSTANCE_APP": "true"
   },
   "env": {
     "CONFIG_TEMPLATE_PATH": "proxylite-scheduler",

--- a/frameworks/spark/src/main/java/com/mesosphere/sdk/spark/scheduler/Main.java
+++ b/frameworks/spark/src/main/java/com/mesosphere/sdk/spark/scheduler/Main.java
@@ -1,5 +1,6 @@
 package com.mesosphere.sdk.spark.scheduler;
 
+import com.mesosphere.sdk.scheduler.SchedulerFlags;
 import com.mesosphere.sdk.specification.*;
 
 import java.io.File;
@@ -10,7 +11,7 @@ import java.io.File;
 public class Main {
     public static void main(String[] args) throws Exception {
         if (args.length > 0) {
-            new DefaultService(new File(args[0])).run();
+            new DefaultService(new File(args[0]), SchedulerFlags.fromEnv()).run();
         }
     }
 }

--- a/frameworks/spark/universe/marathon.json.mustache
+++ b/frameworks/spark/universe/marathon.json.mustache
@@ -3,12 +3,12 @@
   "cpus": 1.0,
   "mem": 1230,
   "instances": 1,
-  "cmd": "export LD_LIBRARY_PATH=$MESOS_SANDBOX/libmesos-bundle/lib && export MESOS_NATIVE_JAVA_LIBRARY=$(ls $MESOS_SANDBOX/libmesos-bundle/lib/libmesos-*.so) && export PATH=$(ls -d $MESOS_SANDBOX/jre*/bin):$PATH && ./spark-standalone-scheduler/bin/spark ./spark-standalone-scheduler/svc.yml",
+  "cmd": "export LD_LIBRARY_PATH=$MESOS_SANDBOX/libmesos-bundle/lib:$LD_LIBRARY_PATH; export MESOS_NATIVE_JAVA_LIBRARY=$(ls $MESOS_SANDBOX/libmesos-bundle/lib/libmesos-*.so); export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jre*/); export JAVA_HOME=${JAVA_HOME%/}; export PATH=$(ls -d $JAVA_HOME/bin):$PATH && ./spark-standalone-scheduler/bin/spark ./spark-standalone-scheduler/svc.yml",
   "labels": {
     "DCOS_PACKAGE_FRAMEWORK_NAME": "{{service.name}}",
     "DCOS_MIGRATION_API_VERSION": "v1",
     "DCOS_MIGRATION_API_PATH": "/v1/plan",
-    "MARATHON_SINGLE_INSTANCE_APP":"true"
+    "MARATHON_SINGLE_INSTANCE_APP": "true"
   },
   "env": {
     "FRAMEWORK_NAME": "{{service.name}}",

--- a/frameworks/template/src/main/java/com/mesosphere/sdk/template/scheduler/Main.java
+++ b/frameworks/template/src/main/java/com/mesosphere/sdk/template/scheduler/Main.java
@@ -1,5 +1,6 @@
 package com.mesosphere.sdk.template.scheduler;
 
+import com.mesosphere.sdk.scheduler.SchedulerFlags;
 import com.mesosphere.sdk.specification.*;
 
 import java.io.File;
@@ -10,7 +11,7 @@ import java.io.File;
 public class Main {
     public static void main(String[] args) throws Exception {
         if (args.length > 0) {
-            new DefaultService(new File(args[0])).run();
+            new DefaultService(new File(args[0]), SchedulerFlags.fromEnv()).run();
         }
     }
 }

--- a/frameworks/template/universe/marathon.json.mustache
+++ b/frameworks/template/universe/marathon.json.mustache
@@ -3,12 +3,12 @@
   "cpus": 1.0,
   "mem": 1230,
   "instances": 1,
-  "cmd": "export LD_LIBRARY_PATH=$MESOS_SANDBOX/libmesos-bundle/lib && export MESOS_NATIVE_JAVA_LIBRARY=$(ls $MESOS_SANDBOX/libmesos-bundle/lib/libmesos-*.so) && export PATH=$(ls -d $MESOS_SANDBOX/jre*/bin):$PATH && ./template-scheduler/bin/template ./template-scheduler/svc.yml",
+  "cmd": "export LD_LIBRARY_PATH=$MESOS_SANDBOX/libmesos-bundle/lib:$LD_LIBRARY_PATH; export MESOS_NATIVE_JAVA_LIBRARY=$(ls $MESOS_SANDBOX/libmesos-bundle/lib/libmesos-*.so); export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jre*/); export JAVA_HOME=${JAVA_HOME%/}; export PATH=$(ls -d $JAVA_HOME/bin):$PATH && ./template-scheduler/bin/template ./template-scheduler/svc.yml",
   "labels": {
     "DCOS_PACKAGE_FRAMEWORK_NAME": "{{service.name}}",
     "DCOS_MIGRATION_API_VERSION": "v1",
     "DCOS_MIGRATION_API_PATH": "/v1/plan",
-    "MARATHON_SINGLE_INSTANCE_APP":"true",
+    "MARATHON_SINGLE_INSTANCE_APP": "true",
     "DCOS_SERVICE_NAME": "{{service.name}}",
     "DCOS_SERVICE_PORT_INDEX": "0",
     "DCOS_SERVICE_SCHEME": "http"

--- a/sdk/common/src/main/java/com/mesosphere/sdk/offer/Constants.java
+++ b/sdk/common/src/main/java/com/mesosphere/sdk/offer/Constants.java
@@ -40,23 +40,6 @@ public class Constants {
     /** Provides the name of the pod/task within the service. */
     public static final String TASK_NAME_TASKENV = "TASK_NAME";
 
-    // Environment variables read by the scheduler itself
-
-    /** Specifies the URI of the executor artifact to be used when launching tasks. */
-    public static final String EXECUTOR_URI_SCHEDENV = "EXECUTOR_URI";
-    /** Specifies the URI of the libmesos package used by the scheduler itself. */
-    public static final String LIBMESOS_URI_SCHEDENV = "LIBMESOS_URI";
-    /** Specifies the Java URI to be used when launching tasks. */
-    public static final String JAVA_URI_SCHEDENV = "JAVA_URI";
-    /** A reasonable default value for {@code JAVA_URI}. */
-    public static final String JAVA_URI_DEFAULT =
-            "https://downloads.mesosphere.com/java/jre-8u112-linux-x64-jce-unlimited.tar.gz";
-    /**
-     * Controls whether the {@link StateStoreCache} is disabled (enabled by default).
-     * If this envvar is set (to anything at all), the cache is disabled.
-     */
-    public static final String DISABLE_STATE_CACHE_SCHEDENV = "DISABLE_STATE_CACHE";
-
     // Other names/constants
 
     /** Used to mark packed task data within an {@link ExecutorInfo}. */

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/config/DefaultConfigurationUpdater.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/config/DefaultConfigurationUpdater.java
@@ -139,7 +139,9 @@ public class DefaultConfigurationUpdater implements ConfigurationUpdater<Service
      * and updates the embedded config version label in those tasks to point to the current target
      * configuration.
      */
-    private void cleanupDuplicateAndUnusedConfigs(ServiceSpec targetConfig, UUID targetConfigId)
+    private void cleanupDuplicateAndUnusedConfigs(
+            ServiceSpec targetConfig,
+            UUID targetConfigId)
             throws ConfigStoreException {
         List<Protos.TaskInfo> taskInfosToUpdate = new ArrayList<>();
         Set<UUID> neededConfigs = new HashSet<>();
@@ -242,7 +244,7 @@ public class DefaultConfigurationUpdater implements ConfigurationUpdater<Service
         if (targetSpecOptional.isPresent() && taskSpecOptional.isPresent()) {
             PodSpec targetSpec = targetSpecOptional.get();
             PodSpec taskSpec = taskSpecOptional.get();
-            boolean updateNeeded = areDifferent(targetSpec, taskSpec);
+            boolean updateNeeded = !areMatching(targetSpec, taskSpec);
             LOGGER.info("Compared target: {} to current: {}, update needed: {}", targetSpec, taskSpec, updateNeeded);
             return updateNeeded;
         } else {
@@ -265,16 +267,15 @@ public class DefaultConfigurationUpdater implements ConfigurationUpdater<Service
         }
     }
 
-    private static boolean areDifferent(PodSpec podSpec1, PodSpec podSpec2) {
+    private static boolean areMatching(PodSpec podSpec1, PodSpec podSpec2) {
         if (podSpec1.equals(podSpec2)) {
-            return false;
+            return true;
         }
 
         // Make counts equal, as only a difference in count should not effect an individual tasks.
         podSpec1 = DefaultPodSpec.newBuilder(podSpec1).count(0).build();
         podSpec2 = DefaultPodSpec.newBuilder(podSpec2).count(0).build();
-
-        return !podSpec1.equals(podSpec2);
+        return podSpec1.equals(podSpec2);
     }
 
     /**

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/DefaultScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/DefaultScheduler.java
@@ -90,6 +90,7 @@ public class DefaultScheduler implements Scheduler, Observer {
     protected final AtomicBoolean isAlreadyRegistered = new AtomicBoolean(false);
 
     protected final ServiceSpec serviceSpec;
+    protected final SchedulerFlags schedulerFlags;
     protected final Collection<Plan> plans;
     protected final StateStore stateStore;
     protected final ConfigStore<ServiceSpec> configStore;
@@ -120,6 +121,7 @@ public class DefaultScheduler implements Scheduler, Observer {
      */
     public static class Builder {
         private final ServiceSpec serviceSpec;
+        private final SchedulerFlags schedulerFlags;
 
         // When these optionals are unset, we use default values:
         private Optional<StateStore> stateStoreOptional = Optional.empty();
@@ -135,8 +137,9 @@ public class DefaultScheduler implements Scheduler, Observer {
         private RecoveryPlanManagerFactory recoveryPlanManagerFactory;
         private Collection<Object> resources = new ArrayList<>();
 
-        private Builder(ServiceSpec serviceSpec) {
+        private Builder(ServiceSpec serviceSpec, SchedulerFlags schedulerFlags) {
             this.serviceSpec = serviceSpec;
+            this.schedulerFlags = schedulerFlags;
         }
 
         /**
@@ -156,18 +159,19 @@ public class DefaultScheduler implements Scheduler, Observer {
          *     {@link #setStateStore(StateStore)} or to {@link #getStateStore()}
          */
         public Builder setStateStore(StateStore stateStore) {
-            if (this.stateStoreOptional.isPresent()) {
+            if (stateStoreOptional.isPresent()) {
                 // Any customization of the state store must be applied BEFORE getStateStore() is ever called.
                 throw new IllegalStateException("State store is already set. Was getStateStore() invoked before this?");
             }
-            this.stateStoreOptional = Optional.of(stateStore);
+            stateStoreOptional = Optional.of(stateStore);
             return this;
         }
 
         /**
-         * Specifies the resources which should be exposed through the scheduler's API server.
+         * Specifies custom endpoint resources which should be exposed through the scheduler's API server, in addition
+         * to the defaults.
          */
-        public Builder setResources(Collection<Object> resources) {
+        public Builder setCustomResources(Collection<Object> resources) {
             this.resources = resources;
             return this;
         }
@@ -181,9 +185,16 @@ public class DefaultScheduler implements Scheduler, Observer {
          */
         public StateStore getStateStore() {
             if (!stateStoreOptional.isPresent()) {
-                setStateStore(createStateStore(serviceSpec));
+                setStateStore(createStateStore(serviceSpec, getSchedulerFlags()));
             }
             return stateStoreOptional.get();
+        }
+
+        /**
+         * Returns the {@link SchedulerFlags} object to be used for the scheduler instance.
+         */
+        public SchedulerFlags getSchedulerFlags() {
+            return schedulerFlags;
         }
 
         /**
@@ -318,6 +329,7 @@ public class DefaultScheduler implements Scheduler, Observer {
             // Update/validate config as needed to reflect the new service spec:
             final ConfigurationUpdater.UpdateResult configUpdateResult = updateConfig(
                     serviceSpec,
+                    schedulerFlags,
                     stateStore,
                     configStore,
                     configValidatorsOptional.orElse(defaultConfigValidators()));
@@ -344,11 +356,13 @@ public class DefaultScheduler implements Scheduler, Observer {
 
             return new DefaultScheduler(
                     serviceSpec,
+                    getSchedulerFlags(),
                     resources,
                     plans,
                     stateStore,
                     configStore,
-                    new DefaultOfferRequirementProvider(stateStore, serviceSpec.getName(), configUpdateResult.targetId),
+                    new DefaultOfferRequirementProvider(
+                            stateStore, serviceSpec.getName(), configUpdateResult.targetId, getSchedulerFlags()),
                     endpointProducers,
                     restartHookOptional,
                     Optional.ofNullable(recoveryPlanManagerFactory));
@@ -360,8 +374,8 @@ public class DefaultScheduler implements Scheduler, Observer {
      * details such as the service name, the pods/tasks to be deployed, and the plans describing how the deployment
      * should be organized.
      */
-    public static Builder newBuilder(ServiceSpec serviceSpec) {
-        return new Builder(serviceSpec);
+    public static Builder newBuilder(ServiceSpec serviceSpec, SchedulerFlags schedulerFlags) {
+        return new Builder(serviceSpec, schedulerFlags);
     }
 
     /**
@@ -374,12 +388,13 @@ public class DefaultScheduler implements Scheduler, Observer {
      *
      * @param zkConnectionString the zookeeper connection string to be passed to curator (host:port)
      */
-    public static StateStore createStateStore(ServiceSpec serviceSpec, String zkConnectionString) {
+    public static StateStore createStateStore(
+            ServiceSpec serviceSpec, SchedulerFlags schedulerFlags, String zkConnectionString) {
         StateStore stateStore = new CuratorStateStore(serviceSpec.getName(), zkConnectionString);
-        if (System.getenv(Constants.DISABLE_STATE_CACHE_SCHEDENV) != null) {
-            return stateStore;
-        } else {
+        if (schedulerFlags.isStateCacheEnabled()) {
             return StateStoreCache.getInstance(stateStore);
+        } else {
+            return stateStore;
         }
     }
 
@@ -389,8 +404,8 @@ public class DefaultScheduler implements Scheduler, Observer {
      *
      * @see DcosConstants#MESOS_MASTER_ZK_CONNECTION_STRING
      */
-    public static StateStore createStateStore(ServiceSpec serviceSpec) {
-        return createStateStore(serviceSpec, DcosConstants.MESOS_MASTER_ZK_CONNECTION_STRING);
+    public static StateStore createStateStore(ServiceSpec serviceSpec, SchedulerFlags schedulerFlags) {
+        return createStateStore(serviceSpec, schedulerFlags, DcosConstants.MESOS_MASTER_ZK_CONNECTION_STRING);
     }
 
     /**
@@ -470,6 +485,7 @@ public class DefaultScheduler implements Scheduler, Observer {
      */
     public static ConfigurationUpdater.UpdateResult updateConfig(
             ServiceSpec serviceSpec,
+            SchedulerFlags schedulerFlags,
             StateStore stateStore,
             ConfigStore<ServiceSpec> configStore,
             Collection<ConfigValidator<ServiceSpec>> configValidators) {
@@ -489,6 +505,7 @@ public class DefaultScheduler implements Scheduler, Observer {
      */
     protected DefaultScheduler(
             ServiceSpec serviceSpec,
+            SchedulerFlags schedulerFlags,
             Collection<Object> resources,
             Collection<Plan> plans,
             StateStore stateStore,
@@ -498,6 +515,7 @@ public class DefaultScheduler implements Scheduler, Observer {
             Optional<RestartHook> restartHookOptional,
             Optional<RecoveryPlanManagerFactory> recoveryPlanManagerFactoryOptional) {
         this.serviceSpec = serviceSpec;
+        this.schedulerFlags = schedulerFlags;
         this.resources = resources;
         this.plans = plans;
         this.stateStore = stateStore;
@@ -728,12 +746,12 @@ public class DefaultScheduler implements Scheduler, Observer {
 
         if (serverStarted) {
             apiServerStopwatch.reset();
-        } else if (
-                apiServerStopwatch.elapsed(TimeUnit.MILLISECONDS) > SchedulerFlags.getApiServerTimeout().toMillis()) {
-            LOGGER.error(
-                    "API Server failed to start within {} seconds.",
-                    SchedulerFlags.getApiServerTimeout().getSeconds());
-            SchedulerUtils.hardExit(SchedulerErrorCode.API_SERVER_TIMEOUT);
+        } else {
+            Duration initTimeout = schedulerFlags.getApiServerInitTimeout();
+            if (apiServerStopwatch.elapsed(TimeUnit.MILLISECONDS) > initTimeout.toMillis()) {
+                LOGGER.error("API Server failed to start within {} seconds.", initTimeout.getSeconds());
+                SchedulerUtils.hardExit(SchedulerErrorCode.API_SERVER_TIMEOUT);
+            }
         }
 
         return serverStarted;

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerDriverFactory.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerDriverFactory.java
@@ -16,15 +16,7 @@ import org.slf4j.LoggerFactory;
  */
 public class SchedulerDriverFactory {
 
-    private static final Logger LOGGER =
-        LoggerFactory.getLogger(SchedulerDriverFactory.class);
-
-    /**
-     * If this environment variable is present in the scheduler environment, the master is using
-     * some form of sidechannel auth. When this environment variable is present, we should always
-     * provide a {@link Credential} with (only) the principal set.
-     */
-    private static final String SIDECHANNEL_AUTH_ENV_NAME = "DCOS_SERVICE_ACCOUNT_CREDENTIAL";
+    private static final Logger LOGGER = LoggerFactory.getLogger(SchedulerDriverFactory.class);
 
     /**
      * Creates and returns a new {@link SchedulerDriver} without a credential secret.
@@ -39,8 +31,8 @@ public class SchedulerDriverFactory {
      *     authentication is needed
      */
     public SchedulerDriver create(
-            final Scheduler scheduler, final FrameworkInfo frameworkInfo, final String masterUrl) {
-        return create(scheduler, frameworkInfo, masterUrl, null /* credentialSecret */);
+            Scheduler scheduler, FrameworkInfo frameworkInfo, String masterUrl, SchedulerFlags schedulerFlags) {
+        return create(scheduler, frameworkInfo, masterUrl, schedulerFlags, null /* credentialSecret */);
     }
 
     /**
@@ -61,6 +53,7 @@ public class SchedulerDriverFactory {
             final Scheduler scheduler,
             final FrameworkInfo frameworkInfo,
             final String masterUrl,
+            final SchedulerFlags schedulerFlags,
             final byte[] credentialSecret) {
         Credential credential;
         if (credentialSecret != null && credentialSecret.length > 0) {
@@ -73,7 +66,7 @@ public class SchedulerDriverFactory {
                     .setPrincipal(getPrincipal(frameworkInfo, "secret"))
                     .setSecretBytes(ByteString.copyFrom(credentialSecret))
                     .build();
-        } else if (isSideChannelActive()) {
+        } else if (schedulerFlags.isSideChannelActive()) {
             // Sidechannel auth is enabled. Provide a Credential with only the Principal set.
             LOGGER.info("Creating sidechannel authenticated MesosSchedulerDriver for "
                     + "scheduler[{}], frameworkInfo[{}], masterUrl[{}]",
@@ -104,16 +97,6 @@ public class SchedulerDriverFactory {
         } else {
             return new MesosToSchedulerDriverAdapter(scheduler, frameworkInfo, masterUrl, true, credential);
         }
-    }
-
-    /**
-     * Returns whether it appears that side channel auth should be used when creating the
-     * SchedulerDriver. Side channel auth may take the form of Bouncer-based framework authentication
-     * or potentially other methods in the future (eg Kerberos). Broken out into a separate function
-     * to allow easy customization in tests.
-     */
-    protected boolean isSideChannelActive() {
-        return System.getenv(SIDECHANNEL_AUTH_ENV_NAME) != null;
     }
 
     /**

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerFlags.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerFlags.java
@@ -1,21 +1,200 @@
 package com.mesosphere.sdk.scheduler;
 
 import java.time.Duration;
+import java.util.Map;
+
+import org.apache.mesos.Protos.Credential;
 
 /**
- * This class encapuslates global Scheduler settings retrieved from the environment.
+ * This class encapuslates global Scheduler settings retrieved from the environment. Presented as a non-static object
+ * to simplify scheduler tests, and to make it painfully obvious when global settings are being used in awkward places.
  */
 public class SchedulerFlags {
-    public static final String API_SERVER_TIMEOUT_S = "API_SERVER_TIMEOUT_S";
-    public static final String DEFAULT_API_SERVER_TIMEOUT_S = "600";
 
-    public static Duration getApiServerTimeout() {
-        String apiServerTimeoutSecs = getEnvDefault(API_SERVER_TIMEOUT_S, DEFAULT_API_SERVER_TIMEOUT_S);
-        return Duration.ofSeconds(Integer.parseInt(apiServerTimeoutSecs));
+    /**
+     * Exception which is thrown when failing to retrieve or parse a given flag value.
+     */
+    public static class FlagException extends RuntimeException {
+
+        /**
+         * A machine-accessible error type.
+         */
+        public enum Type {
+            UNKNOWN,
+            NOT_FOUND,
+            INVALID_VALUE
+        }
+
+        public static FlagException notFound(String message) {
+            return new FlagException(Type.NOT_FOUND, message);
+        }
+
+        public static FlagException invalidValue(String message) {
+            return new FlagException(Type.INVALID_VALUE, message);
+        }
+
+        private final Type type;
+
+        private FlagException(Type type, String message) {
+            super(message);
+            this.type = type;
+        }
+
+        public Type getType() {
+            return type;
+        }
+
+        @Override
+        public String getMessage() {
+            return String.format("%s (errtype: %s)", super.getMessage(), type);
+        }
     }
 
-    private static String getEnvDefault(String envKey, String dflt) {
-        String value = System.getenv(envKey);
-        return (value == null) ? dflt : value;
+    /** Envvar to specify a custom amount of time to wait for the Scheduler API to come up during startup. */
+    private static final String API_SERVER_TIMEOUT_S_ENV = "API_SERVER_TIMEOUT_S";
+    /** The default number of seconds to wait for the Scheduler API to come up during startup. */
+    private static final int DEFAULT_API_SERVER_TIMEOUT_S = 600;
+
+    /** Specifies the URI of the executor artifact to be used when launching tasks. */
+    private static final String EXECUTOR_URI_ENV = "EXECUTOR_URI";
+    /** Specifies the URI of the libmesos package used by the scheduler itself. */
+    private static final String LIBMESOS_URI_ENV = "LIBMESOS_URI";
+    /** Specifies the Java URI to be used when launching tasks. */
+    private static final String JAVA_URI_ENV = "JAVA_URI";
+    /** Standard Java envvar pointing to the JRE location on disk. */
+    private static final String JAVA_HOME_ENV = "JAVA_HOME";
+
+    /**
+     * Controls whether the {@link StateStoreCache} is disabled (enabled by default).
+     * If this envvar is set (to anything at all), the cache is disabled.
+     */
+    private static final String DISABLE_STATE_CACHE_ENV = "DISABLE_STATE_CACHE";
+
+    /**
+     * When a port named {@code api} is added to the Marathon app definition for the scheduler, marathon should create
+     * an envvar with this name in the scheduler env. This is preferred over using e.g. the {@code PORT0} envvar which
+     * is against the index of the port in the list.
+     */
+    private static final String MARATHON_API_PORT_ENV = "PORT_API";
+
+    /**
+     * If this environment variable is present in the scheduler environment, the master is using
+     * some form of sidechannel auth. When this environment variable is present, we should always
+     * provide a {@link Credential} with (only) the principal set.
+     */
+    private static final String SIDECHANNEL_AUTH_ENV_NAME = "DCOS_SERVICE_ACCOUNT_CREDENTIAL";
+
+    /**
+     * Returns a new {@link SchedulerFlags} instance which is based off the process environment.
+     */
+    public static SchedulerFlags fromEnv() {
+        return fromMap(System.getenv());
+    }
+
+    /**
+     * Returns a new {@link SchedulerFlags} instance which is based off the provided custom environment map.
+     */
+    public static SchedulerFlags fromMap(Map<String, String> map) {
+        return new SchedulerFlags(map);
+    }
+
+    private final FlagStore flagStore;
+
+    private SchedulerFlags(Map<String, String> flagMap) {
+        this.flagStore = new FlagStore(flagMap);
+    }
+
+    /**
+     * Returns the configured time to wait for the API server to come up during scheduler initialization.
+     */
+    public Duration getApiServerInitTimeout() {
+        return Duration.ofSeconds(flagStore.getOptionalInt(API_SERVER_TIMEOUT_S_ENV, DEFAULT_API_SERVER_TIMEOUT_S));
+    }
+
+    /**
+     * Returns the configured API port, or throws {@link FlagException} if the environment lacked the required
+     * information.
+     */
+    public int getApiServerPort() {
+        return flagStore.getRequiredInt(MARATHON_API_PORT_ENV);
+    }
+
+    public String getExecutorURI() {
+        return flagStore.getRequired(EXECUTOR_URI_ENV);
+    }
+
+    public String getLibMesosURI() {
+        return flagStore.getRequired(LIBMESOS_URI_ENV);
+    }
+
+    public String getJavaURI() {
+        return flagStore.getRequired(JAVA_URI_ENV);
+    }
+
+    public String getJavaHome() {
+        return flagStore.getRequired(JAVA_HOME_ENV);
+    }
+
+    public boolean isStateCacheEnabled() {
+        return !flagStore.isPresent(DISABLE_STATE_CACHE_ENV);
+    }
+
+    /**
+     * Returns whether it appears that side channel auth should be used when creating the SchedulerDriver. Side channel
+     * auth may take the form of Bouncer-based framework authentication or potentially other methods in the future (e.g.
+     * Kerberos).
+     */
+    public boolean isSideChannelActive() {
+        return flagStore.isPresent(SIDECHANNEL_AUTH_ENV_NAME);
+    }
+
+    /**
+     * Internal utility class for grabbing values from a mapping of flag values (typically the process env).
+     */
+    private static class FlagStore {
+
+        private final Map<String, String> flagMap;
+
+        private FlagStore(Map<String, String> flagMap) {
+            this.flagMap = flagMap;
+        }
+
+        private int getOptionalInt(String envKey, int dflt) {
+            return toInt(envKey, getOptional(envKey, String.valueOf(dflt)));
+        }
+
+        private int getRequiredInt(String envKey) {
+            return toInt(envKey, getRequired(envKey));
+        }
+
+        private String getOptional(String envKey, String dflt) {
+            String value = flagMap.get(envKey);
+            return (value == null) ? dflt : value;
+        }
+
+        private String getRequired(String envKey) {
+            String value = flagMap.get(envKey);
+            if (value == null) {
+                throw FlagException.notFound(String.format("Missing required environment variable: %s", envKey));
+            }
+            return value;
+        }
+
+        private boolean isPresent(String envKey) {
+            return flagMap.containsKey(envKey);
+        }
+
+        /**
+         * If the value cannot be parsed as an int, this points to the source envKey, and ensures that
+         * {@link SchedulerFlags} calls only throw {@link FlagException}.
+         */
+        private static int toInt(String envKey, String envVal) {
+            try {
+                return Integer.parseInt(envVal);
+            } catch (NumberFormatException e) {
+                throw FlagException.invalidValue(String.format(
+                        "Failed to parse configured environment variable '%s' as an integer: %s", envKey, envVal));
+            }
+        }
     }
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerUtils.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerUtils.java
@@ -13,13 +13,6 @@ public class SchedulerUtils {
     private static final String ZK_HOST = "master.mesos:2181";
 
     /**
-     * When a port named {@code api} is added to the Marathon app definition for the scheduler, marathon should create
-     * an envvar with this name in the scheduler env. This is preferred over using e.g. the {@code PORT0} envvar which
-     * is against the index of the port in the list.
-     */
-    private static final String MARATHON_API_PORT_ENV = "PORT_API";
-
-    /**
      * Returns the default role to use for a service named {@code frameworkName}.
      */
     public static String nameToRole(String frameworkName) {
@@ -38,20 +31,6 @@ public class SchedulerUtils {
      */
     public static String defaultZkHost() {
         return ZK_HOST;
-    }
-
-    /**
-     * Returns the env-configured API port, or throws {@link IllegalStateException} if the environment lacked the
-     * required information.
-     */
-    public static int apiPort() {
-        String envPort = System.getenv(MARATHON_API_PORT_ENV);
-        if (envPort == null) {
-            throw new IllegalStateException(String.format(
-                    "Missing environment variable %s. Either this or an explicit apiPort must be provided.",
-                    MARATHON_API_PORT_ENV));
-        }
-        return Integer.parseInt(envPort);
     }
 
     /**

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/recovery/monitor/TestingFailureMonitor.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/recovery/monitor/TestingFailureMonitor.java
@@ -30,8 +30,6 @@ public class TestingFailureMonitor implements FailureMonitor {
 
     @Override
     public boolean hasFailed(TaskInfo task) {
-        System.out.println("looking at " + task);
-        System.out.println("have " + failedList);
         return failedList.stream().anyMatch(task::equals);
     }
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultService.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultService.java
@@ -5,6 +5,7 @@ import com.mesosphere.sdk.dcos.DcosCertInstaller;
 import com.mesosphere.sdk.scheduler.DefaultScheduler;
 import com.mesosphere.sdk.scheduler.SchedulerDriverFactory;
 import com.mesosphere.sdk.scheduler.SchedulerErrorCode;
+import com.mesosphere.sdk.scheduler.SchedulerFlags;
 import com.mesosphere.sdk.scheduler.SchedulerUtils;
 import com.mesosphere.sdk.scheduler.plan.Plan;
 
@@ -50,21 +51,26 @@ public class DefaultService implements Service {
         //No initialization needed
     }
 
-    public DefaultService(String yamlSpecification) throws Exception {
-        this(YAMLServiceSpecFactory.generateRawSpecFromYAML(yamlSpecification));
+    public DefaultService(String yamlSpecification, SchedulerFlags schedulerFlags) throws Exception {
+        this(YAMLServiceSpecFactory.generateRawSpecFromYAML(yamlSpecification), schedulerFlags);
     }
 
-    public DefaultService(File pathToYamlSpecification) throws Exception {
-        this(YAMLServiceSpecFactory.generateRawSpecFromYAML(pathToYamlSpecification));
+    public DefaultService(File pathToYamlSpecification, SchedulerFlags schedulerFlags) throws Exception {
+        this(YAMLServiceSpecFactory.generateRawSpecFromYAML(pathToYamlSpecification), schedulerFlags);
     }
 
-    public DefaultService(RawServiceSpec rawServiceSpec) throws Exception {
-        this(DefaultScheduler.newBuilder(YAMLServiceSpecFactory.generateServiceSpec(rawServiceSpec))
+    public DefaultService(RawServiceSpec rawServiceSpec, SchedulerFlags schedulerFlags) throws Exception {
+        this(DefaultScheduler.newBuilder(
+                YAMLServiceSpecFactory.generateServiceSpec(rawServiceSpec, schedulerFlags), schedulerFlags)
                 .setPlansFrom(rawServiceSpec));
     }
 
-    public DefaultService(ServiceSpec serviceSpecification, Collection<Plan> plans) throws Exception {
-        this(DefaultScheduler.newBuilder(serviceSpecification).setPlans(plans));
+    public DefaultService(
+            ServiceSpec serviceSpecification,
+            SchedulerFlags schedulerFlags,
+            Collection<Plan> plans) throws Exception {
+        this(DefaultScheduler.newBuilder(serviceSpecification, schedulerFlags)
+                .setPlans(plans));
     }
 
     public DefaultService(DefaultScheduler.Builder schedulerBuilder) throws Exception {
@@ -79,7 +85,7 @@ public class DefaultService implements Service {
     @Override
     public void run() {
         // Install the certs from "$MESOS_SANDBOX/.ssl" (if present) inside the JRE being used to run the scheduler.
-        DcosCertInstaller.installCertificate(System.getenv("JAVA_HOME"));
+        DcosCertInstaller.installCertificate(schedulerBuilder.getSchedulerFlags().getJavaHome());
 
         CuratorFramework curatorClient = CuratorFrameworkFactory.newClient(
                 schedulerBuilder.getServiceSpec().getZookeeperConnection(), CuratorUtils.getDefaultRetry());
@@ -152,7 +158,8 @@ public class DefaultService implements Service {
         registerAndRunFramework(
                 defaultScheduler,
                 getFrameworkInfo(serviceSpec, schedulerBuilder.getStateStore()),
-                serviceSpec.getZookeeperConnection());
+                serviceSpec.getZookeeperConnection(),
+                schedulerBuilder.getSchedulerFlags());
     }
 
     protected ServiceSpec getServiceSpec() {
@@ -176,9 +183,13 @@ public class DefaultService implements Service {
     private static void registerAndRunFramework(
             Scheduler sched,
             Protos.FrameworkInfo frameworkInfo,
-            String zookeeperHost) {
+            String zookeeperHost,
+            SchedulerFlags schedulerFlags) {
         LOGGER.info("Registering framework: {}", TextFormat.shortDebugString(frameworkInfo));
-        new SchedulerDriverFactory().create(sched, frameworkInfo, String.format("zk://%s/mesos", zookeeperHost)).run();
+        Protos.Status status = new SchedulerDriverFactory().create(
+                sched, frameworkInfo, String.format("zk://%s/mesos", zookeeperHost), schedulerFlags).run();
+        // TODO(nickbp): Exit scheduler process here?
+        LOGGER.error("Scheduler driver exited with status: {}", status);
     }
 
     private Protos.FrameworkInfo getFrameworkInfo(ServiceSpec serviceSpec, StateStore stateStore) {
@@ -199,6 +210,7 @@ public class DefaultService implements Service {
                                                                      .setCheckpoint(true);
 
         // Use provided role if specified, otherwise default to "<svcname>-role".
+        //TODO(nickbp): Use fwkInfoBuilder.addRoles(role) AND fwkInfoBuilder.addCapabilities(MULTI_ROLE)
         if (StringUtils.isEmpty(serviceSpec.getRole())) {
             fwkInfoBuilder.setRole(SchedulerUtils.nameToRole(serviceName));
         } else {

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/YAMLServiceSpecFactory.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/YAMLServiceSpecFactory.java
@@ -7,6 +7,7 @@ import com.google.common.annotations.VisibleForTesting;
 
 import org.apache.commons.io.FileUtils;
 import com.mesosphere.sdk.offer.CommonTaskUtils;
+import com.mesosphere.sdk.scheduler.SchedulerFlags;
 import com.mesosphere.sdk.specification.DefaultServiceSpec;
 import com.mesosphere.sdk.specification.ServiceSpec;
 import org.slf4j.Logger;
@@ -41,7 +42,7 @@ public class YAMLServiceSpecFactory {
     }
 
     public static final RawServiceSpec generateRawSpecFromYAML(File pathToYaml) throws Exception {
-        return generateRawSpecFromYAML(FileUtils.readFileToString(pathToYaml, CHARSET), System.getenv());
+        return generateRawSpecFromYAML(pathToYaml, System.getenv());
     }
 
     public static final RawServiceSpec generateRawSpecFromYAML(File pathToYaml, Map<String, String> env)
@@ -67,10 +68,12 @@ public class YAMLServiceSpecFactory {
      * Converts the provided YAML {@link RawServiceSpec} into a new {@link ServiceSpec}.
      *
      * @param rawServiceSpec the raw service specification representing a YAML file
+     * @param schedulerFlags scheduler flags to use when building the service spec
      * @throws Exception if the conversion fails
      */
-    public static final DefaultServiceSpec generateServiceSpec(RawServiceSpec rawServiceSpec) throws Exception {
-        return generateServiceSpec(rawServiceSpec, new FileReader());
+    public static final DefaultServiceSpec generateServiceSpec(
+            RawServiceSpec rawServiceSpec, SchedulerFlags schedulerFlags) throws Exception {
+        return generateServiceSpec(rawServiceSpec, schedulerFlags, new FileReader());
     }
 
     /**
@@ -78,12 +81,13 @@ public class YAMLServiceSpecFactory {
      * providing a custom file reader for use in testing.
      *
      * @param rawServiceSpec the raw service specification representing a YAML file
+     * @param schedulerFlags scheduler flags to use when building the service spec
      * @param fileReader the file reader to be used for reading template files, allowing overrides for testing
      * @throws Exception if the conversion fails
      */
     @VisibleForTesting
     public static final DefaultServiceSpec generateServiceSpec(
-            RawServiceSpec rawServiceSpec, FileReader fileReader) throws Exception {
-        return YAMLToInternalMappers.from(rawServiceSpec, fileReader);
+            RawServiceSpec rawServiceSpec, SchedulerFlags schedulerFlags, FileReader fileReader) throws Exception {
+        return YAMLToInternalMappers.from(rawServiceSpec, schedulerFlags, fileReader);
     }
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/YAMLToInternalMappers.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/YAMLToInternalMappers.java
@@ -10,6 +10,7 @@ import com.mesosphere.sdk.offer.Constants;
 import com.mesosphere.sdk.offer.evaluate.placement.MarathonConstraintParser;
 import com.mesosphere.sdk.offer.evaluate.placement.PassthroughRule;
 import com.mesosphere.sdk.offer.evaluate.placement.PlacementRule;
+import com.mesosphere.sdk.scheduler.SchedulerFlags;
 import com.mesosphere.sdk.scheduler.SchedulerUtils;
 import com.mesosphere.sdk.specification.*;
 import com.mesosphere.sdk.specification.util.RLimit;
@@ -38,7 +39,9 @@ public class YAMLToInternalMappers {
      * @throws Exception if the conversion fails
      */
     static DefaultServiceSpec from(
-            RawServiceSpec rawSvcSpec, YAMLServiceSpecFactory.FileReader fileReader) throws Exception {
+            RawServiceSpec rawSvcSpec,
+            SchedulerFlags schedulerFlags,
+            YAMLServiceSpecFactory.FileReader fileReader) throws Exception {
         RawScheduler rawScheduler = rawSvcSpec.getScheduler();
         String role = null;
         String principal = null;
@@ -59,7 +62,7 @@ public class YAMLToInternalMappers {
             principal = SchedulerUtils.nameToPrincipal(rawSvcSpec.getName());
         }
         if (apiPort == null) {
-            apiPort = SchedulerUtils.apiPort();
+            apiPort = schedulerFlags.getApiServerPort();
         }
         if (StringUtils.isEmpty(zookeeper)) {
             zookeeper = SchedulerUtils.defaultZkHost();
@@ -86,7 +89,8 @@ public class YAMLToInternalMappers {
                     entry.getKey(),
                     taskConfigRouter.getConfig(entry.getKey()),
                     role,
-                    principal));
+                    principal,
+                    schedulerFlags.getExecutorURI()));
 
         }
         builder.pods(pods);
@@ -150,8 +154,9 @@ public class YAMLToInternalMappers {
             String podName,
             ConfigNamespace configNamespace,
             String role,
-            String principal) throws Exception {
-        DefaultPodSpec.Builder builder = DefaultPodSpec.newBuilder()
+            String principal,
+            String executorUri) throws Exception {
+        DefaultPodSpec.Builder builder = DefaultPodSpec.newBuilder(executorUri)
                 .count(rawPod.getCount())
                 .type(podName)
                 .user(rawPod.getUser());

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/config/ConfigurationUpdaterTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/config/ConfigurationUpdaterTest.java
@@ -1,13 +1,10 @@
 package com.mesosphere.sdk.config;
 
-import com.mesosphere.sdk.offer.Constants;
 import com.mesosphere.sdk.scheduler.DefaultScheduler;
 import com.mesosphere.sdk.specification.*;
 import com.mesosphere.sdk.state.StateStore;
-import com.mesosphere.sdk.testutils.OfferRequirementTestUtils;
 import com.mesosphere.sdk.testutils.TestConstants;
 import org.junit.*;
-import org.junit.contrib.java.lang.system.EnvironmentVariables;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -19,7 +16,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class ConfigurationUpdaterTest {
-    @ClassRule public static final EnvironmentVariables environmentVariables = OfferRequirementTestUtils.getApiPortEnvironment();
     private static final UUID TARGET_ID = UUID.randomUUID();
     private static final UUID NEW_ID = UUID.randomUUID();
     private static final UUID UNKNOWN_ID = UUID.randomUUID();
@@ -44,10 +40,6 @@ public class ConfigurationUpdaterTest {
 
     public static class UnknownConfig implements Configuration {
 
-    }
-
-    static {
-        environmentVariables.set(Constants.EXECUTOR_URI_SCHEDENV, "executor-test-uri");
     }
 
     private static final PodSpec podA = TestPodFactory.getPodSpec(

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/config/DefaultTaskConfigRouterTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/config/DefaultTaskConfigRouterTest.java
@@ -1,15 +1,10 @@
 package com.mesosphere.sdk.config;
 
 import com.google.common.collect.ImmutableMap;
-import com.mesosphere.sdk.offer.Constants;
 import com.mesosphere.sdk.specification.DefaultPodSpec;
 import com.mesosphere.sdk.specification.PodSpec;
 import com.mesosphere.sdk.specification.TaskSpec;
-import com.mesosphere.sdk.testutils.OfferRequirementTestUtils;
-import org.junit.ClassRule;
 import org.junit.Test;
-import org.junit.contrib.java.lang.system.EnvironmentVariables;
-
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -24,31 +19,30 @@ import static org.mockito.Mockito.when;
  * Tests for {@link DefaultTaskConfigRouter}.
  */
 public class DefaultTaskConfigRouterTest {
-    @ClassRule public static final EnvironmentVariables environmentVariables = OfferRequirementTestUtils.getApiPortEnvironment();
+    private static final String EXECUTOR_URI = "executor-test-uri";
     private static TaskSpec mockTaskSpec = mock(TaskSpec.class);
     private static List<TaskSpec> taskSpecs = Arrays.asList(mockTaskSpec);
 
     static {
-        environmentVariables.set(Constants.EXECUTOR_URI_SCHEDENV, "executor-test-uri");
         when(mockTaskSpec.getName()).thenReturn("mockTask");
     }
 
-    private static final PodSpec TASK_SET_A = DefaultPodSpec.newBuilder()
+    private static final PodSpec TASK_SET_A = DefaultPodSpec.newBuilder(EXECUTOR_URI)
             .type("a")
             .count(0)
             .tasks(taskSpecs)
             .build();
-    private static final PodSpec TASK_SET_B = DefaultPodSpec.newBuilder()
+    private static final PodSpec TASK_SET_B = DefaultPodSpec.newBuilder(EXECUTOR_URI)
             .type("b")
             .count(0)
             .tasks(taskSpecs)
             .build();
-    private static final PodSpec TASK_SET_C = DefaultPodSpec.newBuilder()
+    private static final PodSpec TASK_SET_C = DefaultPodSpec.newBuilder(EXECUTOR_URI)
             .type("c")
             .count(0)
             .tasks(taskSpecs)
             .build();
-    private static final PodSpec TASK_SET_D = DefaultPodSpec.newBuilder()
+    private static final PodSpec TASK_SET_D = DefaultPodSpec.newBuilder(EXECUTOR_URI)
             .type("d")
             .count(0)
             .tasks(taskSpecs)

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/DefaultOfferRequirementProviderTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/DefaultOfferRequirementProviderTest.java
@@ -2,6 +2,7 @@ package com.mesosphere.sdk.offer;
 
 import com.mesosphere.sdk.offer.evaluate.EvaluationOutcome;
 import com.mesosphere.sdk.offer.evaluate.placement.PlacementRule;
+import com.mesosphere.sdk.scheduler.SchedulerFlags;
 import com.mesosphere.sdk.scheduler.plan.DefaultPodInstance;
 import com.mesosphere.sdk.scheduler.plan.PodInstanceRequirement;
 import com.mesosphere.sdk.specification.*;
@@ -14,9 +15,7 @@ import org.apache.mesos.Protos.Offer;
 import org.apache.mesos.Protos.TaskInfo;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.ClassRule;
 import org.junit.Test;
-import org.junit.contrib.java.lang.system.EnvironmentVariables;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -30,6 +29,7 @@ import static org.mockito.Mockito.when;
  * This class tests the DefaultOfferRequirementProvider.
  */
 public class DefaultOfferRequirementProviderTest {
+    private static final SchedulerFlags flags = OfferRequirementTestUtils.getTestSchedulerFlags();
     private static final double CPU = 1.0;
     private static final PlacementRule ALLOW_ALL = new PlacementRule() {
         @Override
@@ -37,10 +37,6 @@ public class DefaultOfferRequirementProviderTest {
             return EvaluationOutcome.pass(this, "pass for test");
         }
     };
-
-    @ClassRule
-    public static final EnvironmentVariables environmentVariables =
-            OfferRequirementTestUtils.getOfferRequirementProviderEnvironment();
 
     private DefaultOfferRequirementProvider provider;
 
@@ -58,11 +54,12 @@ public class DefaultOfferRequirementProviderTest {
         podInstance = getPodInstance("valid-minimal-health-configfile.yml");
 
         uuid = UUID.randomUUID();
-        provider = new DefaultOfferRequirementProvider(stateStore, TestConstants.SERVICE_NAME, uuid);
+        provider = new DefaultOfferRequirementProvider(stateStore, TestConstants.SERVICE_NAME, uuid, flags);
     }
 
     private DefaultPodInstance getPodInstance(String serviceSpecFileName) throws Exception {
-        DefaultServiceSpec serviceSpec = ServiceSpecTestUtils.getPodInstance(serviceSpecFileName, mockFileReader);
+        DefaultServiceSpec serviceSpec =
+                ServiceSpecTestUtils.getPodInstance(serviceSpecFileName, mockFileReader, flags);
 
         PodSpec podSpec = DefaultPodSpec.newBuilder(serviceSpec.getPods().get(0))
                 .placementRule(ALLOW_ALL)
@@ -124,7 +121,7 @@ public class DefaultOfferRequirementProviderTest {
         Assert.assertEquals(5, uris.size());
         Assert.assertEquals("test-executor-uri", uris.get(2).getValue());
         Assert.assertEquals("test-libmesos-uri", uris.get(0).getValue());
-        Assert.assertEquals("https://downloads.mesosphere.com/java/jre-8u112-linux-x64-jce-unlimited.tar.gz", uris.get(1).getValue());
+        Assert.assertEquals("test-java-uri", uris.get(1).getValue());
         String artifactDirUrl = String.format("http://api.%s.marathon.%s/v1/artifacts/template/%s/%s/%s/",
                 TestConstants.SERVICE_NAME,
                 ResourceUtils.VIP_HOST_TLD,

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/TaskUtilsTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/TaskUtilsTest.java
@@ -2,15 +2,13 @@ package com.mesosphere.sdk.offer;
 
 import com.mesosphere.sdk.specification.TaskSpec;
 import com.mesosphere.sdk.specification.TestPodFactory;
-import com.mesosphere.sdk.testutils.OfferRequirementTestUtils;
 import org.apache.mesos.Protos;
+
 import com.mesosphere.sdk.specification.DefaultConfigFileSpec;
 import com.mesosphere.sdk.specification.DefaultResourceSet;
 import com.mesosphere.sdk.testutils.TestConstants;
 import org.junit.Assert;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.contrib.java.lang.system.EnvironmentVariables;
 
 import java.util.*;
 
@@ -20,9 +18,6 @@ import javax.validation.ValidationException;
  * This class tests the TaskUtils class.
  */
 public class TaskUtilsTest {
-    @Rule
-    public final EnvironmentVariables environmentVariables = OfferRequirementTestUtils.getApiPortEnvironment();
-
     private static final String testTaskName = "test-task-name";
     private static final String testTaskId = "test-task-id";
     private static final String testAgentId = "test-agent-id";

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluatorTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluatorTest.java
@@ -852,7 +852,7 @@ public class OfferEvaluatorTest extends OfferEvaluatorTestBase {
         ClassLoader classLoader = getClass().getClassLoader();
         File file = new File(classLoader.getResource("resource-set-seq.yml").getFile());
         RawServiceSpec rawServiceSpec = YAMLServiceSpecFactory.generateRawSpecFromYAML(file);
-        DefaultServiceSpec serviceSpec = YAMLServiceSpecFactory.generateServiceSpec(rawServiceSpec);
+        DefaultServiceSpec serviceSpec = YAMLServiceSpecFactory.generateServiceSpec(rawServiceSpec, flags);
 
         PodSpec podSpec = serviceSpec.getPods().get(0);
         PodInstance podInstance = new DefaultPodInstance(podSpec, 0);
@@ -917,7 +917,7 @@ public class OfferEvaluatorTest extends OfferEvaluatorTestBase {
         ClassLoader classLoader = getClass().getClassLoader();
         File file = new File(classLoader.getResource("resource-set-seq.yml").getFile());
         RawServiceSpec rawServiceSpec = YAMLServiceSpecFactory.generateRawSpecFromYAML(file);
-        DefaultServiceSpec serviceSpec = YAMLServiceSpecFactory.generateServiceSpec(rawServiceSpec);
+        DefaultServiceSpec serviceSpec = YAMLServiceSpecFactory.generateServiceSpec(rawServiceSpec, flags);
 
         PodSpec podSpec = serviceSpec.getPods().get(0);
         PodInstance podInstance = new DefaultPodInstance(podSpec, 0);
@@ -987,7 +987,7 @@ public class OfferEvaluatorTest extends OfferEvaluatorTestBase {
         ClassLoader classLoader = getClass().getClassLoader();
         File file = new File(classLoader.getResource("valid-minimal-volume.yml").getFile());
         RawServiceSpec rawServiceSpec = YAMLServiceSpecFactory.generateRawSpecFromYAML(file);
-        DefaultServiceSpec serviceSpec = YAMLServiceSpecFactory.generateServiceSpec(rawServiceSpec);
+        DefaultServiceSpec serviceSpec = YAMLServiceSpecFactory.generateServiceSpec(rawServiceSpec, flags);
 
         PodSpec podSpec = serviceSpec.getPods().get(0);
         PodInstance podInstance = new DefaultPodInstance(podSpec, 0);

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluatorTestBase.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluatorTestBase.java
@@ -3,6 +3,7 @@ package com.mesosphere.sdk.offer.evaluate;
 import com.mesosphere.sdk.curator.CuratorStateStore;
 import com.mesosphere.sdk.offer.DefaultOfferRequirementProvider;
 import com.mesosphere.sdk.offer.OfferRequirementProvider;
+import com.mesosphere.sdk.scheduler.SchedulerFlags;
 import com.mesosphere.sdk.state.StateStore;
 import com.mesosphere.sdk.testutils.CuratorTestUtils;
 import com.mesosphere.sdk.testutils.OfferRequirementTestUtils;
@@ -12,7 +13,6 @@ import org.apache.mesos.Protos.Label;
 import org.apache.mesos.Protos.Resource;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.contrib.java.lang.system.EnvironmentVariables;
 import org.mockito.MockitoAnnotations;
 
 import java.util.UUID;
@@ -21,8 +21,7 @@ import java.util.UUID;
  * A BaseTest for use in writing offer evaluation tests.
  */
 public class OfferEvaluatorTestBase {
-    public static final EnvironmentVariables ENVIRONMENT_VARIABLES =
-            OfferRequirementTestUtils.getOfferRequirementProviderEnvironment();
+    protected static final SchedulerFlags flags = OfferRequirementTestUtils.getTestSchedulerFlags();
 
     protected static final String ROOT_ZK_PATH = "/test-root-path";
     static TestingServer testZk; // Findbugs wants this to be package-protected for some reason
@@ -42,7 +41,7 @@ public class OfferEvaluatorTestBase {
         MockitoAnnotations.initMocks(this);
         stateStore = new CuratorStateStore(ROOT_ZK_PATH, testZk.getConnectString());
         offerRequirementProvider =
-                new DefaultOfferRequirementProvider(stateStore, TestConstants.SERVICE_NAME, UUID.randomUUID());
+                new DefaultOfferRequirementProvider(stateStore, TestConstants.SERVICE_NAME, UUID.randomUUID(), flags);
         evaluator = new OfferEvaluator(stateStore, offerRequirementProvider);
     }
 

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluatorVolumesTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluatorVolumesTest.java
@@ -40,8 +40,6 @@ public class OfferEvaluatorVolumesTest extends OfferEvaluatorTestBase {
         Assert.assertEquals(Operation.Type.CREATE, recommendations.get(3).getOperation().getType());
         Assert.assertEquals(Operation.Type.LAUNCH, recommendations.get(4).getOperation().getType());
 
-        System.out.println(recommendations.get(4).getOperation());
-
         // Validate Create Operation
         Operation createOperation = recommendations.get(1).getOperation();
         Assert.assertEquals("pv0", createOperation.getCreate().getVolumes(0).getDisk().getVolume().getContainerPath());

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/PortEvaluationStageTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/PortEvaluationStageTest.java
@@ -1,6 +1,7 @@
 package com.mesosphere.sdk.offer.evaluate;
 
 import com.mesosphere.sdk.offer.*;
+import com.mesosphere.sdk.scheduler.SchedulerFlags;
 import com.mesosphere.sdk.scheduler.plan.DefaultPodInstance;
 import com.mesosphere.sdk.scheduler.plan.PodInstanceRequirement;
 import com.mesosphere.sdk.specification.DefaultPodSpec;
@@ -10,9 +11,7 @@ import com.mesosphere.sdk.state.StateStore;
 import com.mesosphere.sdk.testutils.*;
 import org.apache.mesos.Protos;
 import org.junit.Assert;
-import org.junit.ClassRule;
 import org.junit.Test;
-import org.junit.contrib.java.lang.system.EnvironmentVariables;
 import org.mockito.Mockito;
 
 import java.util.Arrays;
@@ -21,9 +20,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 public class PortEvaluationStageTest {
-    @ClassRule
-    public static final EnvironmentVariables environmentVariables =
-            OfferRequirementTestUtils.getOfferRequirementProviderEnvironment();
+    private static final SchedulerFlags flags = OfferRequirementTestUtils.getTestSchedulerFlags();
 
     @Test
     public void testReserveDynamicPort() throws Exception {
@@ -153,7 +150,7 @@ public class PortEvaluationStageTest {
         DefaultPodInstance podInstance = getPodInstance("valid-port-healthcheck.yml");
         StateStore stateStore = Mockito.mock(StateStore.class);
         DefaultOfferRequirementProvider provider =
-                new DefaultOfferRequirementProvider(stateStore, TestConstants.SERVICE_NAME, UUID.randomUUID());
+                new DefaultOfferRequirementProvider(stateStore, TestConstants.SERVICE_NAME, UUID.randomUUID(), flags);
         OfferRequirement offerRequirement = provider.getNewOfferRequirement(
                 PodInstanceRequirement.create(podInstance, TaskUtils.getTaskNames(podInstance)));
         PodInfoBuilder podInfoBuilder = new PodInfoBuilder(offerRequirement);
@@ -203,7 +200,7 @@ public class PortEvaluationStageTest {
         DefaultPodInstance podInstance = getPodInstance("valid-port-readinesscheck.yml");
         StateStore stateStore = Mockito.mock(StateStore.class);
         DefaultOfferRequirementProvider provider =
-                new DefaultOfferRequirementProvider(stateStore, TestConstants.SERVICE_NAME, UUID.randomUUID());
+                new DefaultOfferRequirementProvider(stateStore, TestConstants.SERVICE_NAME, UUID.randomUUID(), flags);
         OfferRequirement offerRequirement = provider.getNewOfferRequirement(
                 PodInstanceRequirement.create(podInstance, TaskUtils.getTaskNames(podInstance)));
         PodInfoBuilder podInfoBuilder = new PodInfoBuilder(offerRequirement);
@@ -250,7 +247,7 @@ public class PortEvaluationStageTest {
     }
 
     private DefaultPodInstance getPodInstance(String serviceSpecFileName) throws Exception {
-        DefaultServiceSpec serviceSpec = ServiceSpecTestUtils.getPodInstance(serviceSpecFileName);
+        DefaultServiceSpec serviceSpec = ServiceSpecTestUtils.getPodInstance(serviceSpecFileName, flags);
 
         PodSpec podSpec = DefaultPodSpec.newBuilder(serviceSpec.getPods().get(0))
                 .placementRule((offer, offerRequirement, taskInfos) -> EvaluationOutcome.pass(this, "pass for test"))

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/DefaultSchedulerTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/DefaultSchedulerTest.java
@@ -33,7 +33,6 @@ import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.junit.*;
-import org.junit.contrib.java.lang.system.EnvironmentVariables;
 import org.junit.contrib.java.lang.system.ExpectedSystemExit;
 import org.junit.rules.DisableOnDebug;
 import org.junit.rules.TestRule;
@@ -64,16 +63,15 @@ public class DefaultSchedulerTest {
     public TestRule globalTimeout = new DisableOnDebug(new Timeout(30, TimeUnit.SECONDS));
     @Rule
     public final ExpectedSystemExit exit = ExpectedSystemExit.none();
-    @ClassRule
-    public static final EnvironmentVariables environmentVariables =
-            OfferRequirementTestUtils.getOfferRequirementProviderEnvironment();
     @Mock
     private SchedulerDriver mockSchedulerDriver;
+    @Mock
+    private SchedulerFlags mockSchedulerFlags;
     @Captor
     private ArgumentCaptor<Collection<Protos.Offer.Operation>> operationsCaptor;
     @Captor
     private ArgumentCaptor<Collection<Protos.Offer.Operation>> operationsCaptor2;
-    private static final EnvironmentVariables ENV_VARS = new EnvironmentVariables();
+    public static final SchedulerFlags flags = OfferRequirementTestUtils.getTestSchedulerFlags();
 
     private static final String SERVICE_NAME = "test-service";
     private static final int TASK_A_COUNT = 1;
@@ -194,14 +192,15 @@ public class DefaultSchedulerTest {
     @Before
     public void beforeEach() throws Exception {
         MockitoAnnotations.initMocks(this);
-        ENV_VARS.set(SchedulerFlags.API_SERVER_TIMEOUT_S, SchedulerFlags.DEFAULT_API_SERVER_TIMEOUT_S);
 
         CuratorTestUtils.clear(testingServer);
 
         StateStoreCache.resetInstanceForTests();
-        stateStore = DefaultScheduler.createStateStore(SERVICE_SPECIFICATION, testingServer.getConnectString());
+        when(mockSchedulerFlags.isStateCacheEnabled()).thenReturn(true);
+        stateStore = DefaultScheduler.createStateStore(
+                SERVICE_SPECIFICATION, mockSchedulerFlags, testingServer.getConnectString());
         configStore = DefaultScheduler.createConfigStore(SERVICE_SPECIFICATION, testingServer.getConnectString());
-        defaultScheduler = DefaultScheduler.newBuilder(SERVICE_SPECIFICATION)
+        defaultScheduler = DefaultScheduler.newBuilder(SERVICE_SPECIFICATION, flags)
                 .setStateStore(stateStore)
                 .setConfigStore(configStore)
                 .setCapabilities(getCapabilitiesWithDefaultGpuSupport())
@@ -312,7 +311,7 @@ public class DefaultSchedulerTest {
         // Launch A and B in original configuration
         testLaunchB();
         defaultScheduler.awaitTermination();
-        defaultScheduler = DefaultScheduler.newBuilder(UPDATED_POD_A_SERVICE_SPECIFICATION)
+        defaultScheduler = DefaultScheduler.newBuilder(UPDATED_POD_A_SERVICE_SPECIFICATION, flags)
                 .setStateStore(stateStore)
                 .setConfigStore(configStore)
                 .setCapabilities(getCapabilitiesWithDefaultGpuSupport())
@@ -328,7 +327,7 @@ public class DefaultSchedulerTest {
         // Launch A and B in original configuration
         testLaunchB();
         defaultScheduler.awaitTermination();
-        defaultScheduler = DefaultScheduler.newBuilder(UPDATED_POD_B_SERVICE_SPECIFICATION)
+        defaultScheduler = DefaultScheduler.newBuilder(UPDATED_POD_B_SERVICE_SPECIFICATION, flags)
                 .setStateStore(stateStore)
                 .setConfigStore(configStore)
                 .setCapabilities(getCapabilitiesWithDefaultGpuSupport())
@@ -345,7 +344,7 @@ public class DefaultSchedulerTest {
         testLaunchB();
         defaultScheduler.awaitTermination();
 
-        defaultScheduler = DefaultScheduler.newBuilder(SCALED_POD_A_SERVICE_SPECIFICATION)
+        defaultScheduler = DefaultScheduler.newBuilder(SCALED_POD_A_SERVICE_SPECIFICATION, flags)
                 .setStateStore(stateStore)
                 .setConfigStore(configStore)
                 .setCapabilities(getCapabilitiesWithDefaultGpuSupport())
@@ -353,7 +352,9 @@ public class DefaultSchedulerTest {
         register();
 
         Plan plan = defaultScheduler.deploymentPlanManager.getPlan();
-        Assert.assertEquals(Arrays.asList(Status.COMPLETE, Status.PENDING, Status.COMPLETE, Status.PENDING), getStepStatuses(plan));
+        Assert.assertEquals(
+                Arrays.asList(Status.COMPLETE, Status.PENDING, Status.COMPLETE, Status.PENDING),
+                getStepStatuses(plan));
     }
 
     @Test
@@ -514,7 +515,7 @@ public class DefaultSchedulerTest {
         Assert.assertTrue(defaultScheduler.recoveryPlanManager.getPlan().getChildren().get(0).getChildren().isEmpty());
 
         // Perform Configuration Update
-        defaultScheduler = DefaultScheduler.newBuilder(UPDATED_POD_A_SERVICE_SPECIFICATION)
+        defaultScheduler = DefaultScheduler.newBuilder(UPDATED_POD_A_SERVICE_SPECIFICATION, flags)
                 .setStateStore(stateStore)
                 .setConfigStore(configStore)
                 .setCapabilities(getCapabilitiesWithDefaultGpuSupport())
@@ -569,7 +570,7 @@ public class DefaultSchedulerTest {
         UUID targetConfigId = configStore.getTargetConfig();
 
         // Build new scheduler with invalid config (shrinking task count)
-        defaultScheduler = DefaultScheduler.newBuilder(INVALID_POD_B_SERVICE_SPECIFICATION)
+        defaultScheduler = DefaultScheduler.newBuilder(INVALID_POD_B_SERVICE_SPECIFICATION, flags)
                 .setStateStore(stateStore)
                 .setConfigStore(configStore)
                 .setCapabilities(getCapabilitiesWithDefaultGpuSupport())
@@ -676,15 +677,15 @@ public class DefaultSchedulerTest {
 
     @Test
     public void testApiServerTimeout() throws Exception {
-        int timeoutSec = 1;
-        defaultScheduler = DefaultScheduler.newBuilder(UPDATED_POD_A_SERVICE_SPECIFICATION)
+        int timeoutMillis = 100;
+        when(mockSchedulerFlags.getApiServerInitTimeout()).thenReturn(java.time.Duration.ofMillis(timeoutMillis));
+        defaultScheduler = DefaultScheduler.newBuilder(UPDATED_POD_A_SERVICE_SPECIFICATION, mockSchedulerFlags)
                 .setStateStore(stateStore)
                 .setConfigStore(configStore)
                 .setCapabilities(getCapabilitiesWithDefaultGpuSupport())
                 .build();
-        ENV_VARS.set(SchedulerFlags.API_SERVER_TIMEOUT_S, String.valueOf(timeoutSec));
         Assert.assertFalse(defaultScheduler.apiServerReady());
-        Thread.sleep(timeoutSec * 2000);
+        Thread.sleep(timeoutMillis * 10);
         exit.expectSystemExitWithStatus(SchedulerErrorCode.API_SERVER_TIMEOUT.getValue());
         defaultScheduler.apiServerReady();
     }
@@ -897,6 +898,7 @@ public class DefaultSchedulerTest {
         public TestScheduler(DefaultScheduler defaultScheduler, boolean apiServerReady) {
             super(
                     defaultScheduler.serviceSpec,
+                    flags,
                     defaultScheduler.resources,
                     defaultScheduler.plans,
                     defaultScheduler.stateStore,

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/plan/DefaultPlanCoordinatorTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/plan/DefaultPlanCoordinatorTest.java
@@ -6,6 +6,7 @@ import com.mesosphere.sdk.offer.DefaultOfferRequirementProvider;
 import com.mesosphere.sdk.offer.OfferAccepter;
 import com.mesosphere.sdk.offer.evaluate.OfferEvaluator;
 import com.mesosphere.sdk.scheduler.DefaultTaskKiller;
+import com.mesosphere.sdk.scheduler.SchedulerFlags;
 import com.mesosphere.sdk.scheduler.TaskKiller;
 import com.mesosphere.sdk.scheduler.recovery.TaskFailureListener;
 import com.mesosphere.sdk.specification.DefaultServiceSpec;
@@ -22,7 +23,6 @@ import org.apache.curator.test.TestingServer;
 import org.apache.mesos.Protos;
 import org.apache.mesos.SchedulerDriver;
 import org.junit.*;
-import org.junit.contrib.java.lang.system.EnvironmentVariables;
 import org.mockito.MockitoAnnotations;
 
 import java.util.*;
@@ -35,9 +35,7 @@ import static org.mockito.Mockito.spy;
  */
 public class DefaultPlanCoordinatorTest {
 
-    @ClassRule
-    public static final EnvironmentVariables environmentVariables =
-            OfferRequirementTestUtils.getOfferRequirementProviderEnvironment();
+    private static final SchedulerFlags flags = OfferRequirementTestUtils.getTestSchedulerFlags();
 
     private static final String SERVICE_NAME = "test-service-name";
     public static final int SUFFICIENT_CPUS = 2;
@@ -121,7 +119,8 @@ public class DefaultPlanCoordinatorTest {
         phaseFactory = new DefaultPhaseFactory(stepFactory);
         taskKiller = new DefaultTaskKiller(taskFailureListener, schedulerDriver);
 
-        provider = new DefaultOfferRequirementProvider(stateStore, serviceSpecification.getName(), UUID.randomUUID());
+        provider = new DefaultOfferRequirementProvider(
+                stateStore, serviceSpecification.getName(), UUID.randomUUID(), flags);
         planScheduler = new DefaultPlanScheduler(
                 offerAccepter, new OfferEvaluator(stateStore, provider), stateStore, taskKiller);
         serviceSpecificationB = DefaultServiceSpec.newBuilder()

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/plan/DefaultPlanSchedulerTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/plan/DefaultPlanSchedulerTest.java
@@ -2,6 +2,7 @@ package com.mesosphere.sdk.scheduler.plan;
 
 import com.mesosphere.sdk.offer.*;
 import com.mesosphere.sdk.offer.evaluate.OfferEvaluator;
+import com.mesosphere.sdk.scheduler.SchedulerFlags;
 import com.mesosphere.sdk.scheduler.TaskKiller;
 import com.mesosphere.sdk.specification.DefaultServiceSpec;
 import com.mesosphere.sdk.specification.PodInstance;
@@ -13,9 +14,7 @@ import com.mesosphere.sdk.testutils.OfferRequirementTestUtils;
 import org.apache.mesos.Protos.*;
 import org.apache.mesos.SchedulerDriver;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.contrib.java.lang.system.EnvironmentVariables;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -38,9 +37,7 @@ public class DefaultPlanSchedulerTest {
             .build());
     private static final List<OfferID> ACCEPTED_IDS =
             Arrays.asList(OfferID.newBuilder().setValue("offer").build());
-
-    @Rule
-    public final EnvironmentVariables environmentVariables = OfferRequirementTestUtils.getApiPortEnvironment();
+    private static final SchedulerFlags flags = OfferRequirementTestUtils.getTestSchedulerFlags();
 
     @Mock private OfferAccepter mockOfferAccepter;
     @Mock private OfferEvaluator mockOfferEvaluator;
@@ -61,8 +58,8 @@ public class DefaultPlanSchedulerTest {
 
         ClassLoader classLoader = getClass().getClassLoader();
         File file = new File(classLoader.getResource("valid-minimal.yml").getFile());
-        DefaultServiceSpec serviceSpec = YAMLServiceSpecFactory
-                .generateServiceSpec(YAMLServiceSpecFactory.generateRawSpecFromYAML(file));
+        DefaultServiceSpec serviceSpec = YAMLServiceSpecFactory.generateServiceSpec(
+                YAMLServiceSpecFactory.generateRawSpecFromYAML(file), flags);
 
         PodSpec podSpec = serviceSpec.getPods().get(0);
         PodInstance podInstance = new DefaultPodInstance(podSpec, 0);

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/plan/DefaultStepFactoryTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/plan/DefaultStepFactoryTest.java
@@ -4,6 +4,7 @@ import org.apache.curator.test.TestingServer;
 import com.mesosphere.sdk.config.ConfigStore;
 import com.mesosphere.sdk.curator.CuratorStateStore;
 import com.mesosphere.sdk.scheduler.DefaultScheduler;
+import com.mesosphere.sdk.scheduler.SchedulerFlags;
 import com.mesosphere.sdk.specification.*;
 import com.mesosphere.sdk.state.StateStore;
 import com.mesosphere.sdk.testutils.CuratorTestUtils;
@@ -11,9 +12,7 @@ import com.mesosphere.sdk.testutils.OfferRequirementTestUtils;
 import com.mesosphere.sdk.testutils.TestConstants;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Test;
-import org.junit.contrib.java.lang.system.EnvironmentVariables;
 
 import java.util.Arrays;
 import java.util.List;
@@ -25,9 +24,7 @@ import java.util.stream.Collectors;
  */
 public class DefaultStepFactoryTest {
 
-    @ClassRule
-    public static final EnvironmentVariables environmentVariables =
-            OfferRequirementTestUtils.getOfferRequirementProviderEnvironment();
+    private static final SchedulerFlags flags = OfferRequirementTestUtils.getTestSchedulerFlags();
 
     private static TestingServer testingServer;
 
@@ -69,7 +66,7 @@ public class DefaultStepFactoryTest {
                 TestPodFactory.getTaskSpec(TestConstants.TASK_NAME + 0, TestConstants.RESOURCE_SET_ID);
         TaskSpec taskSpec1 =
                 TestPodFactory.getTaskSpec(TestConstants.TASK_NAME + 1, TestConstants.RESOURCE_SET_ID);
-        PodSpec podSpec = DefaultPodSpec.newBuilder()
+        PodSpec podSpec = DefaultPodSpec.newBuilder(flags.getExecutorURI())
                 .type(TestConstants.POD_TYPE)
                 .count(1)
                 .tasks(Arrays.asList(taskSpec0, taskSpec1))
@@ -108,7 +105,7 @@ public class DefaultStepFactoryTest {
         TaskSpec taskSpec1 =
                 TestPodFactory.getTaskSpec(
                         TestConstants.TASK_NAME + 1, TestConstants.RESOURCE_SET_ID + 1, TestConstants.TASK_DNS_PREFIX);
-        PodSpec podSpec = DefaultPodSpec.newBuilder()
+        PodSpec podSpec = DefaultPodSpec.newBuilder(flags.getExecutorURI())
                 .type(TestConstants.POD_TYPE)
                 .count(1)
                 .tasks(Arrays.asList(taskSpec0, taskSpec1))

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/recovery/DefaultRecoveryPlanManagerTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/recovery/DefaultRecoveryPlanManagerTest.java
@@ -6,6 +6,7 @@ import com.mesosphere.sdk.offer.*;
 import com.mesosphere.sdk.offer.evaluate.OfferEvaluator;
 import com.mesosphere.sdk.scheduler.DefaultScheduler;
 import com.mesosphere.sdk.scheduler.DefaultTaskKiller;
+import com.mesosphere.sdk.scheduler.SchedulerFlags;
 import com.mesosphere.sdk.scheduler.plan.*;
 import com.mesosphere.sdk.scheduler.recovery.constrain.TestingLaunchConstrainer;
 import com.mesosphere.sdk.scheduler.recovery.monitor.TestingFailureMonitor;
@@ -29,9 +30,7 @@ import org.apache.mesos.Protos.TaskInfo;
 import org.apache.mesos.SchedulerDriver;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Test;
-import org.junit.contrib.java.lang.system.EnvironmentVariables;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.MockitoAnnotations;
@@ -57,9 +56,7 @@ import static org.mockito.Mockito.*;
  * </ul>
  */
 public class DefaultRecoveryPlanManagerTest {
-    @ClassRule
-    public static final EnvironmentVariables environmentVariables =
-            OfferRequirementTestUtils.getOfferRequirementProviderEnvironment();
+    private static final SchedulerFlags flags = OfferRequirementTestUtils.getTestSchedulerFlags();
 
     private static final List<Resource> resources = Arrays.asList(
             ResourceTestUtils.getDesiredCpu(TestPodFactory.CPU),
@@ -112,9 +109,9 @@ public class DefaultRecoveryPlanManagerTest {
         offerAccepter = mock(OfferAccepter.class);
         stateStore = new CuratorStateStore(TestConstants.SERVICE_NAME, testingServer.getConnectString());
 
-        serviceSpec = YAMLServiceSpecFactory.generateServiceSpec(YAMLServiceSpecFactory
-                .generateRawSpecFromYAML(new File(getClass()
-                        .getClassLoader().getResource("recovery-plan-manager-test.yml").getPath())));
+        serviceSpec = YAMLServiceSpecFactory.generateServiceSpec(
+                YAMLServiceSpecFactory.generateRawSpecFromYAML(new File(getClass()
+                        .getClassLoader().getResource("recovery-plan-manager-test.yml").getPath())), flags);
 
         configStore = DefaultScheduler.createConfigStore(serviceSpec, testingServer.getConnectString());
         UUID configTarget = configStore.store(serviceSpec);
@@ -138,7 +135,7 @@ public class DefaultRecoveryPlanManagerTest {
         final Plan mockDeployPlan = mock(Plan.class);
         when(mockDeployManager.getPlan()).thenReturn(mockDeployPlan);
         offerRequirementProvider = new DefaultOfferRequirementProvider(
-                stateStore, TestConstants.SERVICE_NAME, UUID.randomUUID());
+                stateStore, TestConstants.SERVICE_NAME, UUID.randomUUID(), flags);
         final DefaultPlanScheduler planScheduler = new DefaultPlanScheduler(
                 offerAccepter,
                 new OfferEvaluator(stateStore, offerRequirementProvider),

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/specification/DefaultPlanGeneratorTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/specification/DefaultPlanGeneratorTest.java
@@ -2,6 +2,7 @@ package com.mesosphere.sdk.specification;
 
 import com.mesosphere.sdk.config.ConfigStore;
 import com.mesosphere.sdk.scheduler.DefaultScheduler;
+import com.mesosphere.sdk.scheduler.SchedulerFlags;
 import com.mesosphere.sdk.scheduler.plan.Phase;
 import com.mesosphere.sdk.scheduler.plan.Plan;
 import com.mesosphere.sdk.scheduler.plan.PodInstanceRequirement;
@@ -14,7 +15,6 @@ import com.mesosphere.sdk.testutils.CuratorTestUtils;
 import com.mesosphere.sdk.testutils.OfferRequirementTestUtils;
 import org.apache.curator.test.TestingServer;
 import org.junit.*;
-import org.junit.contrib.java.lang.system.EnvironmentVariables;
 import org.mockito.MockitoAnnotations;
 
 import java.io.File;
@@ -28,9 +28,7 @@ import java.util.Map;
  */
 public class DefaultPlanGeneratorTest {
 
-    @ClassRule
-    public static final EnvironmentVariables environmentVariables =
-            OfferRequirementTestUtils.getOfferRequirementProviderEnvironment();
+    private static final SchedulerFlags flags = OfferRequirementTestUtils.getTestSchedulerFlags();
 
     private static TestingServer testingServer;
 
@@ -55,11 +53,9 @@ public class DefaultPlanGeneratorTest {
         ClassLoader classLoader = getClass().getClassLoader();
         File file = new File(classLoader.getResource("custom-phases.yml").getFile());
         RawServiceSpec rawServiceSpec = YAMLServiceSpecFactory.generateRawSpecFromYAML(file);
-        DefaultServiceSpec serviceSpec = YAMLServiceSpecFactory.generateServiceSpec(rawServiceSpec);
+        DefaultServiceSpec serviceSpec = YAMLServiceSpecFactory.generateServiceSpec(rawServiceSpec, flags);
 
-        stateStore = DefaultScheduler.createStateStore(
-                serviceSpec,
-                testingServer.getConnectString());
+        stateStore = DefaultScheduler.createStateStore(serviceSpec, flags, testingServer.getConnectString());
         configStore = DefaultScheduler.createConfigStore(serviceSpec, testingServer.getConnectString());
 
         Assert.assertNotNull(serviceSpec);

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/specification/TestPodFactory.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/specification/TestPodFactory.java
@@ -127,7 +127,7 @@ public class TestPodFactory {
     }
 
     public static PodSpec getPodSpec(String type, int count, List<TaskSpec> taskSpecs) {
-        return DefaultPodSpec.newBuilder()
+        return DefaultPodSpec.newBuilder("test-executor")
                 .type(type)
                 .count(count)
                 .tasks(taskSpecs)

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/specification/validation/CapabilityValidatorTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/specification/validation/CapabilityValidatorTest.java
@@ -27,7 +27,6 @@ public class CapabilityValidatorTest {
     @Before
     public void beforeEach() {
         MockitoAnnotations.initMocks(this);
-        environmentVariables.set("EXECUTOR_URI", "");
     }
 
     @Test

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/specification/validation/CapabilityValidatorTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/specification/validation/CapabilityValidatorTest.java
@@ -1,12 +1,12 @@
 package com.mesosphere.sdk.specification.validation;
 
 import com.mesosphere.sdk.dcos.Capabilities;
+import com.mesosphere.sdk.scheduler.SchedulerFlags;
 import com.mesosphere.sdk.specification.DefaultServiceSpec;
 import com.mesosphere.sdk.testutils.OfferRequirementTestUtils;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.contrib.java.lang.system.EnvironmentVariables;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -19,7 +19,7 @@ import static org.mockito.Mockito.when;
  * This class tests {@link CapabilityValidator}.
  */
 public class CapabilityValidatorTest {
-    public final EnvironmentVariables environmentVariables = OfferRequirementTestUtils.getApiPortEnvironment();
+    private static final SchedulerFlags flags = OfferRequirementTestUtils.getTestSchedulerFlags();
 
     @Mock private Capabilities mockCapabilities;
     @Mock private FileReader mockFileReader;
@@ -36,7 +36,7 @@ public class CapabilityValidatorTest {
         CapabilityValidator capabilityValidator = new CapabilityValidator(mockCapabilities);
 
         File file = new File(getClass().getClassLoader().getResource("valid-minimal.yml").getFile());
-        DefaultServiceSpec serviceSpec = generateServiceSpec(generateRawSpecFromYAML(file));
+        DefaultServiceSpec serviceSpec = generateServiceSpec(generateRawSpecFromYAML(file), flags);
 
         capabilityValidator.validate(serviceSpec);
     }
@@ -53,7 +53,7 @@ public class CapabilityValidatorTest {
         when(mockFileReader.read("config-three.conf.mustache")).thenReturn("hi");
 
         File file = new File(getClass().getClassLoader().getResource("valid-exhaustive.yml").getFile());
-        DefaultServiceSpec serviceSpec = generateServiceSpec(generateRawSpecFromYAML(file), mockFileReader);
+        DefaultServiceSpec serviceSpec = generateServiceSpec(generateRawSpecFromYAML(file), flags, mockFileReader);
 
         capabilityValidator.validate(serviceSpec);
     }
@@ -69,7 +69,7 @@ public class CapabilityValidatorTest {
         when(mockFileReader.read("config-three.conf.mustache")).thenReturn("hi");
 
         File file = new File(getClass().getClassLoader().getResource("valid-exhaustive.yml").getFile());
-        DefaultServiceSpec serviceSpec = generateServiceSpec(generateRawSpecFromYAML(file), mockFileReader);
+        DefaultServiceSpec serviceSpec = generateServiceSpec(generateRawSpecFromYAML(file), flags, mockFileReader);
 
         capabilityValidator.validate(serviceSpec);
     }
@@ -86,12 +86,12 @@ public class CapabilityValidatorTest {
 
         // check that it works when GPUs are specified at the task level
         File file = new File(getClass().getClassLoader().getResource("valid-gpu-resource.yml").getFile());
-        DefaultServiceSpec serviceSpec = generateServiceSpec(generateRawSpecFromYAML(file), mockFileReader);
+        DefaultServiceSpec serviceSpec = generateServiceSpec(generateRawSpecFromYAML(file), flags, mockFileReader);
         capabilityValidator.validate(serviceSpec);
 
         // check that it works when GPUs are specified at the resourceSet level
         file = new File(getClass().getClassLoader().getResource("valid-gpu-resourceset.yml").getFile());
-        serviceSpec = generateServiceSpec(generateRawSpecFromYAML(file), mockFileReader);
+        serviceSpec = generateServiceSpec(generateRawSpecFromYAML(file), flags, mockFileReader);
         capabilityValidator.validate(serviceSpec);
     }
 
@@ -105,14 +105,14 @@ public class CapabilityValidatorTest {
         when(mockFileReader.read("config-three.conf.mustache")).thenReturn("hi");
 
         File file = new File(getClass().getClassLoader().getResource("valid-gpu-resource.yml").getFile());
-        DefaultServiceSpec serviceSpec = generateServiceSpec(generateRawSpecFromYAML(file), mockFileReader);
+        DefaultServiceSpec serviceSpec = generateServiceSpec(generateRawSpecFromYAML(file), flags, mockFileReader);
 
         capabilityValidator.validate(serviceSpec);
 
         when(mockCapabilities.supportsRLimits()).thenReturn(true);
         when(mockCapabilities.supportCniPortMapping()).thenReturn(true);
         File file2 = new File(getClass().getClassLoader().getResource("valid-exhaustive.yml").getFile());
-        serviceSpec = generateServiceSpec(generateRawSpecFromYAML(file2), mockFileReader);
+        serviceSpec = generateServiceSpec(generateRawSpecFromYAML(file2), flags, mockFileReader);
 
         capabilityValidator.validate(serviceSpec);
     }
@@ -129,7 +129,7 @@ public class CapabilityValidatorTest {
         when(mockFileReader.read("config-three.conf.mustache")).thenReturn("hi");
 
         File file2 = new File(getClass().getClassLoader().getResource("valid-exhaustive.yml").getFile());
-        DefaultServiceSpec serviceSpec = generateServiceSpec(generateRawSpecFromYAML(file2), mockFileReader);
+        DefaultServiceSpec serviceSpec = generateServiceSpec(generateRawSpecFromYAML(file2), flags, mockFileReader);
         capabilityValidator.validate(serviceSpec);
     }
 }

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/state/PersistentLaunchRecorderTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/state/PersistentLaunchRecorderTest.java
@@ -34,7 +34,7 @@ public class PersistentLaunchRecorderTest extends OfferEvaluatorTestBase {
         ClassLoader classLoader = PersistentLaunchRecorderTest.class.getClassLoader();
         File file = new File(classLoader.getResource("shared-resource-set.yml").getFile());
         RawServiceSpec rawServiceSpec = YAMLServiceSpecFactory.generateRawSpecFromYAML(file);
-        serviceSpec = YAMLServiceSpecFactory.generateServiceSpec(rawServiceSpec);
+        serviceSpec = YAMLServiceSpecFactory.generateServiceSpec(rawServiceSpec, flags);
     }
 
     @Before

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/testutils/OfferRequirementTestUtils.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/testutils/OfferRequirementTestUtils.java
@@ -10,11 +10,11 @@ import com.mesosphere.sdk.offer.TaskRequirement;
 import com.mesosphere.sdk.offer.VolumeRequirement;
 import com.mesosphere.sdk.offer.evaluate.PortsRequirement;
 import org.apache.mesos.Protos;
-import org.junit.contrib.java.lang.system.EnvironmentVariables;
 
 import com.mesosphere.sdk.offer.InvalidRequirementException;
 import com.mesosphere.sdk.offer.OfferRequirement;
 import com.mesosphere.sdk.offer.evaluate.placement.PlacementRule;
+import com.mesosphere.sdk.scheduler.SchedulerFlags;
 
 import java.util.*;
 
@@ -151,32 +151,12 @@ public class OfferRequirementTestUtils {
         return index == 0 ? baseName : baseName + index;
     }
 
-    public static final EnvironmentVariables getApiPortEnvironment() {
-        EnvironmentVariables env = new EnvironmentVariables();
-        for (Map.Entry<String, String> entry : getApiPortMap().entrySet()) {
-            env.set(entry.getKey(), entry.getValue());
-        }
-        return env;
-    }
-
-    public static EnvironmentVariables getOfferRequirementProviderEnvironment() {
-        EnvironmentVariables env = new EnvironmentVariables();
-        for (Map.Entry<String, String> entry : getOfferRequirementProviderMap().entrySet()) {
-            env.set(entry.getKey(), entry.getValue());
-        }
-        return env;
-    }
-
-    public static final Map<String, String> getApiPortMap() {
-        Map<String, String> env = new HashMap<>();
-        env.put("PORT_API", String.valueOf(TestConstants.PORT_API_VALUE));
-        return env;
-    }
-
-    public static Map<String, String> getOfferRequirementProviderMap() {
-        Map<String, String> env = getApiPortMap();
-        env.put("EXECUTOR_URI", "test-executor-uri");
-        env.put("LIBMESOS_URI", "test-libmesos-uri");
-        return env;
+    public static SchedulerFlags getTestSchedulerFlags() {
+        Map<String, String> map = new HashMap<>();
+        map.put("PORT_API", String.valueOf(TestConstants.PORT_API_VALUE));
+        map.put("EXECUTOR_URI", "test-executor-uri");
+        map.put("JAVA_URI", "test-java-uri");
+        map.put("LIBMESOS_URI", "test-libmesos-uri");
+        return SchedulerFlags.fromMap(map);
     }
 }

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/testutils/ServiceSpecTestUtils.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/testutils/ServiceSpecTestUtils.java
@@ -1,5 +1,6 @@
 package com.mesosphere.sdk.testutils;
 
+import com.mesosphere.sdk.scheduler.SchedulerFlags;
 import com.mesosphere.sdk.specification.DefaultServiceSpec;
 import com.mesosphere.sdk.specification.yaml.YAMLServiceSpecFactory;
 
@@ -10,15 +11,16 @@ import java.io.File;
  */
 public class ServiceSpecTestUtils {
 
-    public static DefaultServiceSpec getPodInstance(String serviceSpecFileName) throws Exception {
-        return getPodInstance(serviceSpecFileName, new YAMLServiceSpecFactory.FileReader());
+    public static DefaultServiceSpec getPodInstance(String serviceSpecFileName, SchedulerFlags flags) throws Exception {
+        return getPodInstance(serviceSpecFileName, new YAMLServiceSpecFactory.FileReader(), flags);
     }
 
     public static DefaultServiceSpec getPodInstance(
-            String serviceSpecFileName, YAMLServiceSpecFactory.FileReader fileReader) throws Exception {
+            String serviceSpecFileName, YAMLServiceSpecFactory.FileReader fileReader, SchedulerFlags flags)
+                    throws Exception {
         ClassLoader classLoader = ServiceSpecTestUtils.class.getClassLoader();
         File file = new File(classLoader.getResource(serviceSpecFileName).getFile());
         return YAMLServiceSpecFactory.generateServiceSpec(
-                YAMLServiceSpecFactory.generateRawSpecFromYAML(file), fileReader);
+                YAMLServiceSpecFactory.generateRawSpecFromYAML(file), flags, fileReader);
     }
 }

--- a/tools/launch_ccm_cluster.py
+++ b/tools/launch_ccm_cluster.py
@@ -342,7 +342,7 @@ class StartConfig(object):
             start_timeout_mins = CCMLauncher.DEFAULT_TIMEOUT_MINS,
             public_agents = 0,
             private_agents = 1,
-            aws_region = 'eu-central-1',
+            aws_region = 'us-west-2',
             admin_location = '0.0.0.0/0',
             cloud_provider = '0', # https://mesosphere.atlassian.net/browse/TEST-231
             mount_volumes = False):


### PR DESCRIPTION
Replaces direct in-scheduler env access with an explicit Flags object.
    
A non-static flags object is used for two reasons:
- support easy mocking in tests
- make it painfully obvious when low-level code is reaching out into the system env