### PR TITLE
[HDFS-447] Restoring the HDFS preInstallNotes to the exact wording as in Universe

### DIFF
--- a/frameworks/hdfs/universe/package.json
+++ b/frameworks/hdfs/universe/package.json
@@ -9,5 +9,5 @@
   "tags": ["hdfs", "hadoop"],
   "postInstallNotes": "DC/OS Apache HDFS Service is being installed.\n\n\tDocumentation: https://docs.mesosphere.com/current/usage/service-guides/hdfs/\n\tIssues: https://jira.dcos.io/projects/DCOS_HDFS",
   "postUninstallNotes": "DC/OS Apache HDFS Service has been uninstalled.\nPlease follow the instructions at http://docs.mesosphere.com/current/usage/service-guides/hdfs/#uninstall to remove any persistent state if required.",
-  "preInstallNotes": "This DC/OS Service is currently in preview. In order for HDFS to start successfully, it requires a minimum of five nodes; each with at least 2 CPU shares and 8GB of RAM available for use by the HDFS Service.\nNote that the service is considered Preview and there may be bugs, missing features or documentation, and should be tested thoroughly before being put into production."
+  "preInstallNotes": "This DC/OS Service is currently in preview. Note that the service is considered Preview and there may be bugs, missing features or documentation, and should be tested thoroughly before being put into production.\nIn order for HDFS to start successfully, it requires a minimum of five nodes; each with at least 2 CPU shares and 8GB of RAM available for use by the HDFS Service."
 }

--- a/frameworks/hdfs/universe/package.json
+++ b/frameworks/hdfs/universe/package.json
@@ -9,5 +9,5 @@
   "tags": ["hdfs", "hadoop"],
   "postInstallNotes": "DC/OS Apache HDFS Service is being installed.\n\n\tDocumentation: https://docs.mesosphere.com/current/usage/service-guides/hdfs/\n\tIssues: https://jira.dcos.io/projects/DCOS_HDFS",
   "postUninstallNotes": "DC/OS Apache HDFS Service has been uninstalled.\nPlease follow the instructions at http://docs.mesosphere.com/current/usage/service-guides/hdfs/#uninstall to remove any persistent state if required.",
-  "preInstallNotes": "In order for HDFS to start successfully, it requires a minimum of five nodes; each with at least 2 CPU shares and 8GB of RAM available for use by the HDFS Service.\nNote that the service is considered Preview and there may be bugs, missing features or documentation, and should be tested thoroughly before being put into production."
+  "preInstallNotes": "This DC/OS Service is currently in preview. In order for HDFS to start successfully, it requires a minimum of five nodes; each with at least 2 CPU shares and 8GB of RAM available for use by the HDFS Service.\nNote that the service is considered Preview and there may be bugs, missing features or documentation, and should be tested thoroughly before being put into production."
 }

--- a/frameworks/hdfs/universe/package.json
+++ b/frameworks/hdfs/universe/package.json
@@ -9,5 +9,5 @@
   "tags": ["hdfs", "hadoop"],
   "postInstallNotes": "DC/OS Apache HDFS Service is being installed.\n\n\tDocumentation: https://docs.mesosphere.com/current/usage/service-guides/hdfs/\n\tIssues: https://jira.dcos.io/projects/DCOS_HDFS",
   "postUninstallNotes": "DC/OS Apache HDFS Service has been uninstalled.\nPlease follow the instructions at http://docs.mesosphere.com/current/usage/service-guides/hdfs/#uninstall to remove any persistent state if required.",
-  "preInstallNotes": "This DC/OS Service is currently in preview. Note that the service is considered Preview and there may be bugs, missing features or documentation, and should be tested thoroughly before being put into production.\nIn order for HDFS to start successfully, it requires a minimum of five nodes; each with at least 2 CPU shares and 8GB of RAM available for use by the HDFS Service."
+  "preInstallNotes": "The HDFS service is currently in preview: there may be bugs, missing features, or missing documentation. Test HDFS thoroughly before putting it into production. \n HDFS requires a minimum of five nodes, each with at least 2 CPU shares and 8GB of RAM available to the HDFS service."
 }


### PR DESCRIPTION
Restoring the HDFS preInstallNotes to the exact wording and ordering as currently appears in Universe.
See Ravi's comment's here: https://github.com/mesosphere/universe/pull/1062
