### PR TITLE
[INFINITY-1305] Automate SDK releases against tags

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,16 +16,9 @@ allprojects {
 
     apply from: "$rootDir/gradle/quality.gradle"
 
-    // ---
-    // To create a release release:
-    // 1. Merge a PR with "-SNAPSHOT" suffix removed
-    // 2. Merge a second PR which bumps the version with "-SNAPSHOT" suffix added back
-    // For example, given a version of "1.2.3-SNAPSHOT", merge "1.2.3" then "1.2.4-SNAPSHOT".
-    // ---
-    // In general, users of this SDK should NOT depend on "-SNAPSHOT" builds, as they may break
-    // at ANY TIME as changes are merged into master. They represent a fully unstable API.
-    // ---
     group = "mesosphere"
+    // In master, this is ALWAYS a -SNAPSHOT version.
+    // Releases are made FROM TAGS. To create a release, see release.sh.
     version = "0.14.0-SNAPSHOT"
 
     sourceCompatibility = '1.8'

--- a/build.gradle
+++ b/build.gradle
@@ -14,11 +14,25 @@ allprojects {
     apply plugin: 'maven-publish'
     apply plugin: 'com.github.ksoichiro.console.reporter'
 
-    apply from: "$rootDir/gradle/quality.gradle"
+    apply from: '$rootDir/gradle/quality.gradle'
 
-    group = "mesosphere"
-    // In master, this is ALWAYS a -SNAPSHOT version.
-    // Releases are made FROM TAGS. To create a release, see release.sh.
+    group = 'mesosphere'
+    // ---
+    // INFO:
+    //
+    // In general, users of this SDK may use '-SNAPSHOT' builds for testing or development, but
+    // they MUST NOT be used for releases. A given '-SNAPSHOT' build will vary on a per-PR basis
+    // and APIs WILL break at any time. See the tags in this repo for a list of stable releases.
+    //
+    // In repo master, this version MUST ALWAYS be a '-SNAPSHOT' version.
+    // Release versions are ONLY published inside of tags.
+    // --
+    // INSTRUCTIONS: How to cut a release of e.g. '0.10.0', then start the '0.11.0-SNAPSHOT' track:
+    //
+    // 1. Run a CI job which calls './release.sh -r 0.10.0' to create the release tag from current master.
+    // 2. In the GitHub UI, add a Release entry against the tag created in step 1. List any changes in release notes.
+    // 3. Create a PR which bumps this from '0.10.0-SNAPSHOT' to '0.11.0-SNAPSHOT' in master to start the 0.11.0 track.
+    // --
     version = "0.14.0-SNAPSHOT"
 
     sourceCompatibility = '1.8'

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,8 @@ allprojects {
     apply plugin: 'maven-publish'
     apply plugin: 'com.github.ksoichiro.console.reporter'
 
-    apply from: '$rootDir/gradle/quality.gradle'
+    // Double quotes are required for $rootDir to be resolved:
+    apply from: "$rootDir/gradle/quality.gradle"
 
     group = 'mesosphere'
     // ---
@@ -33,7 +34,7 @@ allprojects {
     // 2. In the GitHub UI, add a Release entry against the tag created in step 1. List any changes in release notes.
     // 3. Create a PR which bumps this from '0.10.0-SNAPSHOT' to '0.11.0-SNAPSHOT' in master to start the 0.11.0 track.
     // --
-    version = "0.15.0-SNAPSHOT"
+    version = '0.15.0-SNAPSHOT'
 
     sourceCompatibility = '1.8'
     targetCompatibility = '1.8'
@@ -44,8 +45,8 @@ allprojects {
     }
 
     [compileJava, compileTestJava]*.options*.encoding = 'UTF-8'
-    compileJava.options.compilerArgs << "-Xlint:unchecked" << "-Xlint:deprecation"
-    compileTestJava.options.compilerArgs << "-Xlint:unchecked" << "-Xlint:deprecation"
+    compileJava.options.compilerArgs << '-Xlint:unchecked' << '-Xlint:deprecation'
+    compileTestJava.options.compilerArgs << '-Xlint:unchecked' << '-Xlint:deprecation'
 
     task wrapper(type: Wrapper) {
         gradleVersion = '3.2'
@@ -70,7 +71,7 @@ allprojects {
     // Print results on the fly
     test {
         testLogging {
-            events "passed", "skipped", "failed"
+            events 'passed', 'skipped', 'failed'
         }
     }
 
@@ -83,11 +84,12 @@ allprojects {
 }
 
 ext {
-    mesosVer = "1.2.0-rc1"
+    mesosVer = '1.2.0-rc1'
 }
 
 subprojects {
     dependencies {
+        // Double quotes are required for $mesosVer to be resolved:
         compile "org.apache.mesos:mesos:${mesosVer}"
     }
 }

--- a/release.sh
+++ b/release.sh
@@ -1,16 +1,95 @@
 #!/bin/bash
 
+# Builds and uploads a release, optionally creating a tag for that release.
+# --
+
+syntax() {
+    echo "Syntax: ./release.sh -r <tagname or 'snapshot'> [-f]"
+    echo "Arguments:"
+    echo "  -r: The version string of the SDK to be used in gradle and in the tag name, or '-r snapshot' to publish a snapshot of master."
+    echo "  -f: Force the tag creation if the tag already exists. (not applicable to '-r snapshot')"
+}
+
 # Exit immediately on failure:
 set -e
 
 REPO_ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd $REPO_ROOT_DIR
 
+GRADLE_BUILD_FILE=$REPO_ROOT_DIR/build.gradle
+
+FLAG_RELEASE=""
+FLAG_FORCE="false"
+while getopts "r:f" opt; do
+    case $opt in
+        r)
+            FLAG_RELEASE=${OPTARG,,} # to lowercase
+            ;;
+        f)
+            FLAG_FORCE="true"
+            ;;
+        \?)
+            syntax
+            exit 1
+            ;;
+    esac
+done
+if [ -z "$FLAG_RELEASE" ]; then
+    echo "Missing required tag argument (-r <tagname or 'snapshot'>)"
+    syntax
+    exit 1
+fi
+echo "Settings: tag=$FLAG_RELEASE force=$FLAG_FORCE"
+
+export SDK_VERSION=$(egrep "version = \"(.*)\"" $GRADLE_BUILD_FILE | cut -d '"' -f2)
+if [ -z "$SDK_VERSION" ]; then
+    echo "Unable to extract SDK version from $GRADLE_BUILD_FILE"
+    exit 1
+fi
+echo "Current gradle version: $SDK_VERSION"
+
+if [ "x${FLAG_RELEASE}" = "xsnapshot" ]; then
+    # Sanity check: Validate that build.gradle already has a '-SNAPSHOT' version (case sensitive comparison)
+    if [[ "$SDK_VERSION" != *"-SNAPSHOT"* ]]; then
+        echo "SDK version in $GRADLE_BUILD_FILE doesn't contain '-SNAPSHOT'."
+        echo "The master branch must only have snapshot builds."
+        exit 1
+    fi
+else
+    # Uploading a release: Create and publish the release tag, which contains a commit updating build.gradle.
+    # Sanity check: Tagged releases of snapshots is disallowed (case insensitive comparison)
+    if [[ "${FLAG_RELEASE^^}" = *"SNAPSHOT"* ]]; then
+        echo "Requested tag release version may not contain 'SNAPSHOT'."
+        exit 1
+    fi
+    sed -i "s/version = \\\"${SDK_VERSION}\\\"/version = \\\"${FLAG_RELEASE}\\\"/" $GRADLE_BUILD_FILE
+    export SDK_VERSION=$FLAG_RELEASE
+    git add $GRADLE_BUILD_FILE
+    git ci -m "Automated cut of $FLAG_RELEASE"
+    if [ "x$FLAG_FORCE" = "xtrue" ]; then
+        git tag -f "$FLAG_RELEASE"
+        git push origin -f "$FLAG_RELEASE"
+    else
+        FAILED=""
+        git tag "$FLAG_RELEASE" || FAILED="true"
+        # Jump through hoops to avoid conflicts with 'set -e':
+        if [ -n "$FAILED" ]; then
+            echo "Tag named '$FLAG_RELEASE' already exists locally. Use '-f' to overwrite the current tag."
+            exit 1
+        fi
+        git push origin "$FLAG_RELEASE" || FAILED="true"
+        if [ -n "$FAILED" ]; then
+            echo "Tag named '$FLAG_RELEASE' already exists in remote repo. Use '-f' to overwrite the current tag."
+            exit 1
+        fi
+    fi
+fi
+
 # Build and upload Java library to Maven repo:
 ./build.sh
 ./gradlew publish
 
-# Scripts below expects S3_BUCKET and SDK_VERSION env vars. To be supplied by Jenkins.
+# Scripts below expect an S3_BUCKET env var. To be supplied by Jenkins.
 
 # INFINITY-1208: Disable build and publish for now as it requires changes coming in
 # the self-hosted branch. 3-27-17 bwood

--- a/release.sh
+++ b/release.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-# Builds and uploads a release, optionally creating a tag for that release.
+# --
+# Builds and uploads a release of the SDK against a release-specific tag.
+# This does NOT create releases of individual services in the repo, just the SDK itself.
 # --
 
 syntax() {

--- a/tools/launch_ccm_cluster.py
+++ b/tools/launch_ccm_cluster.py
@@ -342,7 +342,7 @@ class StartConfig(object):
             start_timeout_mins = CCMLauncher.DEFAULT_TIMEOUT_MINS,
             public_agents = 0,
             private_agents = 1,
-            aws_region = 'eu-central-1',
+            aws_region = 'us-west-2',
             admin_location = '0.0.0.0/0',
             cloud_provider = '0', # https://mesosphere.atlassian.net/browse/TEST-231
             mount_volumes = False):


### PR DESCRIPTION
This automates the process for creating a new release of the SDK (jars for now, other bits soon)
- `release.sh -r snapshot`: Publish build of current master (what current release.sh does)
- `release.sh -r 1.2.3`: Create/push 1.2.3 tag (with build.gradle updated), then publish build of 1.2.3
- Escape hatch if a tag already exists (e.g. build flaked after creating the tag on prior attempt): '-f' to force override

Policy changes:
- Master only has SNAPSHOT versions, never release versions.
- Release versions are created against release tags.

TODO:
- Once script is available, create manually-invoked jenkins job with parameters: version string and force checkbox