### PR TITLE
[INFINITY-1318] Fix UNRESERVE of MOUNT volume disk resource

### DIFF
--- a/frameworks/helloworld/src/main/dist/svc.yml
+++ b/frameworks/helloworld/src/main/dist/svc.yml
@@ -1,7 +1,11 @@
 name: hello-world
+scheduler:
+  principal: {{SERVICE_PRINCIPAL}}
+  user: {{SERVICE_USER}}
 pods:
   hello:
-    count: 3
+    count: {{HELLO_COUNT}}
+    placement: {{HELLO_PLACEMENT}}
     tasks:
       server:
         goal: RUNNING
@@ -10,7 +14,42 @@ pods:
         memory: {{HELLO_MEM}}
         volume:
           path: hello-container-path
-          type: MOUNT
-          size: 10
+          type: ROOT
+          size: {{HELLO_DISK}}
         env:
           SLEEP_DURATION: {{SLEEP_DURATION}}
+        health-check:
+          cmd: stat hello-container-path/output
+          interval: 5
+          grace-period: 30
+          delay: 0
+          timeout: 10
+          max-consecutive-failures: 3
+  world:
+    count: {{WORLD_COUNT}}
+    placement: {{WORLD_PLACEMENT}}
+    tasks:
+      server:
+        goal: RUNNING
+        cmd: >
+               echo world1 >> world-container-path1/output &&
+               echo world2 >> world-container-path2/output &&
+               sleep $SLEEP_DURATION
+        cpus: {{WORLD_CPUS}}
+        memory: {{WORLD_MEM}}
+        volumes:
+          vol1:
+            path: world-container-path1
+            type: ROOT
+            size: {{HELLO_DISK}}
+          vol2:
+            path: world-container-path2
+            type: ROOT
+            size: {{HELLO_DISK}}
+        env:
+          SLEEP_DURATION: {{SLEEP_DURATION}}
+        readiness-check:
+          cmd: BYTES="$(wc -c world-container-path2/output | awk '{print $1;}')" && [ $BYTES -gt 0 ]
+          interval: 5
+          delay: 0
+          timeout: 10

--- a/frameworks/helloworld/src/main/dist/svc.yml
+++ b/frameworks/helloworld/src/main/dist/svc.yml
@@ -1,11 +1,7 @@
 name: hello-world
-scheduler:
-  principal: {{SERVICE_PRINCIPAL}}
-  user: {{SERVICE_USER}}
 pods:
   hello:
-    count: {{HELLO_COUNT}}
-    placement: {{HELLO_PLACEMENT}}
+    count: 3
     tasks:
       server:
         goal: RUNNING
@@ -14,42 +10,7 @@ pods:
         memory: {{HELLO_MEM}}
         volume:
           path: hello-container-path
-          type: ROOT
-          size: {{HELLO_DISK}}
+          type: MOUNT
+          size: 10
         env:
           SLEEP_DURATION: {{SLEEP_DURATION}}
-        health-check:
-          cmd: stat hello-container-path/output
-          interval: 5
-          grace-period: 30
-          delay: 0
-          timeout: 10
-          max-consecutive-failures: 3
-  world:
-    count: {{WORLD_COUNT}}
-    placement: {{WORLD_PLACEMENT}}
-    tasks:
-      server:
-        goal: RUNNING
-        cmd: >
-               echo world1 >> world-container-path1/output &&
-               echo world2 >> world-container-path2/output &&
-               sleep $SLEEP_DURATION
-        cpus: {{WORLD_CPUS}}
-        memory: {{WORLD_MEM}}
-        volumes:
-          vol1:
-            path: world-container-path1
-            type: ROOT
-            size: {{HELLO_DISK}}
-          vol2:
-            path: world-container-path2
-            type: ROOT
-            size: {{HELLO_DISK}}
-        env:
-          SLEEP_DURATION: {{SLEEP_DURATION}}
-        readiness-check:
-          cmd: BYTES="$(wc -c world-container-path2/output | awk '{print $1;}')" && [ $BYTES -gt 0 ]
-          interval: 5
-          delay: 0
-          timeout: 10

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/UnreserveOfferRecommendation.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/UnreserveOfferRecommendation.java
@@ -16,13 +16,21 @@ public class UnreserveOfferRecommendation implements OfferRecommendation {
 
     public UnreserveOfferRecommendation(Offer offer, Resource resource) {
         this.offer = offer;
+        Resource.Builder resourceBuilder = resource.toBuilder();
+
+        if (resource.hasDisk() && resource.getDisk().hasSource()) {
+            resource = resourceBuilder.setDisk(
+                    Resource.DiskInfo.newBuilder()
+                            .setSource(resource.getDisk().getSource()))
+                    .build();
+        } else {
+            resource = resourceBuilder.clearDisk().clearRevocable().build();
+        }
+
         this.operation = Operation.newBuilder()
                 .setType(Operation.Type.UNRESERVE)
                 .setUnreserve(Operation.Unreserve.newBuilder()
-                        .addAllResources(Arrays.asList(Resource.newBuilder(resource)
-                                .clearDisk()
-                                .clearRevocable()
-                                .build())))
+                        .addAllResources(Arrays.asList(resource)))
                 .build();
     }
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/UnreserveOfferRecommendation.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/UnreserveOfferRecommendation.java
@@ -18,6 +18,7 @@ public class UnreserveOfferRecommendation implements OfferRecommendation {
         this.offer = offer;
         Resource.Builder resourceBuilder = resource.toBuilder();
 
+        // If non-root disk resource, we want to clear ALL fields except for the field indicating the disk source.
         if (resource.hasDisk() && resource.getDisk().hasSource()) {
             resource = resourceBuilder.setDisk(
                     Resource.DiskInfo.newBuilder()

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/UnreserveOfferRecommendationTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/UnreserveOfferRecommendationTest.java
@@ -1,0 +1,53 @@
+package com.mesosphere.sdk.offer;
+
+import com.mesosphere.sdk.testutils.OfferTestUtils;
+import com.mesosphere.sdk.testutils.ResourceTestUtils;
+import org.apache.mesos.Protos;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * This class tests the {@link UnreserveOfferRecommendation} class.
+ */
+public class UnreserveOfferRecommendationTest {
+
+    @Test
+    public void testUnreserveRootDisk() {
+        Protos.Resource resource = ResourceTestUtils.getExpectedRootVolume(1);
+        Protos.Offer offer = OfferTestUtils.getOffer(resource);
+
+        UnreserveOfferRecommendation unreserveOfferRecommendation = new UnreserveOfferRecommendation(offer, resource);
+        Protos.Offer.Operation operation = unreserveOfferRecommendation.getOperation();
+        Assert.assertEquals(1, operation.getUnreserve().getResourcesCount());
+
+        Protos.Resource opResource = operation.getUnreserve().getResources(0);
+
+        Assert.assertFalse(opResource.hasDisk());
+        Assert.assertFalse(opResource.hasRevocable());
+
+        resource = resource.toBuilder().clearDisk().clearRevocable().build();
+        Assert.assertEquals(resource, opResource);
+    }
+
+    @Test
+    public void testUnreserveMountDisk() {
+        Protos.Resource resource = ResourceTestUtils.getExpectedMountVolume(1);
+        Protos.Offer offer = OfferTestUtils.getOffer(resource);
+
+        UnreserveOfferRecommendation unreserveOfferRecommendation = new UnreserveOfferRecommendation(offer, resource);
+        Protos.Offer.Operation operation = unreserveOfferRecommendation.getOperation();
+        Assert.assertEquals(1, operation.getUnreserve().getResourcesCount());
+
+        Protos.Resource opResource = operation.getUnreserve().getResources(0);
+
+        Assert.assertTrue(opResource.hasDisk());
+        Assert.assertTrue(opResource.getDisk().hasSource());
+        Assert.assertFalse(opResource.hasRevocable());
+
+        resource = resource.toBuilder().setDisk(
+                Protos.Resource.DiskInfo.newBuilder()
+                        .setSource(resource.getDisk().getSource()))
+                .build();
+        Assert.assertEquals(resource, opResource);
+    }
+}


### PR DESCRIPTION
1. Deployed `hello-world` with MOUNT volumes with just enough machines for it to fit. 
1. Replaced a node and verified that it couldn't get rescheduled because it was generating an invalid UNRESERVE operation
1. Upgraded to this fix.
1. Success

Also matches code from Marathon now: https://github.com/mesosphere/marathon/blob/9dab2704f27243825cbd252588d3476ce980d9bb/src/main/scala/mesosphere/marathon/core/launcher/InstanceOp.scala#L76