### PR TITLE
[Infinity-1311] test output stderr

### DIFF
--- a/frameworks/cassandra/tests/test_recovery_shutdown.py
+++ b/frameworks/cassandra/tests/test_recovery_shutdown.py
@@ -2,7 +2,7 @@ import pytest
 from tests.config import *
 import sdk_install as install
 import sdk_tasks as tasks
-import sdk_utils as utils
+import sdk_utils
 import json
 import shakedown
 import time
@@ -11,7 +11,7 @@ import sdk_cmd as cmd
 
 def setup_module(module):
     install.uninstall(PACKAGE_NAME)
-    utils.gc_frameworks()
+    sdk_utils.gc_frameworks()
 
     # check_suppression=False due to https://jira.mesosphere.com/browse/CASSANDRA-568
     install.install(PACKAGE_NAME, DEFAULT_TASK_COUNT, check_suppression=False)
@@ -31,7 +31,7 @@ def teardown_module(module):
 def test_shutdown_host_test():
 
     service_ip = shakedown.get_service_ips(PACKAGE_NAME).pop()
-    print('marathon ip = {}'.format(service_ip))
+    sdk_utils.out('marathon ip = {}'.format(service_ip))
 
     node_ip = 0
     for pod_id in range(0, DEFAULT_TASK_COUNT):
@@ -43,13 +43,13 @@ def test_shutdown_host_test():
         assert Fail, 'could not find a node to shutdown'
 
     old_agent = get_pod_agent(pod_id)
-    print('pod id = {},  node_ip = {}, agent = {}'.format(pod_id, node_ip, old_agent))
+    sdk_utils.out('pod id = {},  node_ip = {}, agent = {}'.format(pod_id, node_ip, old_agent))
 
     task_ids = tasks.get_task_ids(PACKAGE_NAME, 'node-{}'.format(pod_id))
 
     # instead of partition/reconnect, we shutdown host permanently
     status, stdout = shakedown.run_command_on_agent(node_ip, 'sudo shutdown -h +1')
-    print('shutdown agent {}: [{}] {}'.format(node_ip, status, stdout))
+    sdk_utils.out('shutdown agent {}: [{}] {}'.format(node_ip, status, stdout))
     assert status is True
     time.sleep(100)
 

--- a/frameworks/elastic/tests/config.py
+++ b/frameworks/elastic/tests/config.py
@@ -65,7 +65,7 @@ def expected_nodes_success_predicate():
     if result is None:
         return False
     node_count = result["number_of_nodes"]
-    sdk_utils.test_output('Waiting for {} healthy nodes, got {}'.format(DEFAULT_NODE_COUNT, node_count))
+    sdk_utils.out('Waiting for {} healthy nodes, got {}'.format(DEFAULT_NODE_COUNT, node_count))
     return node_count == DEFAULT_NODE_COUNT
 
 

--- a/frameworks/elastic/tests/config.py
+++ b/frameworks/elastic/tests/config.py
@@ -2,6 +2,7 @@ import json
 from functools import wraps
 
 import shakedown
+import sdk_utils
 
 PACKAGE_NAME = 'elastic'
 DEFAULT_TASK_COUNT = 9
@@ -64,7 +65,7 @@ def expected_nodes_success_predicate():
     if result is None:
         return False
     node_count = result["number_of_nodes"]
-    print('Waiting for {} healthy nodes, got {}'.format(DEFAULT_NODE_COUNT, node_count))
+    sdk_utils.test_output('Waiting for {} healthy nodes, got {}'.format(DEFAULT_NODE_COUNT, node_count))
     return node_count == DEFAULT_NODE_COUNT
 
 

--- a/frameworks/hdfs/tests/test_shakedown.py
+++ b/frameworks/hdfs/tests/test_shakedown.py
@@ -201,7 +201,7 @@ def test_install():
 def test_bump_journal_cpus():
     check_healthy()
     journal_ids = tasks.get_task_ids(PACKAGE_NAME, 'journal')
-    sdk_utils.test_output('journal ids: ' + str(journal_ids))
+    sdk_utils.out('journal ids: ' + str(journal_ids))
 
     marathon.bump_cpu_count_config(PACKAGE_NAME, 'JOURNAL_CPUS')
 
@@ -214,7 +214,7 @@ def test_bump_data_nodes():
     check_healthy()
 
     data_ids = tasks.get_task_ids(PACKAGE_NAME, 'data')
-    sdk_utils.test_output('data ids: ' + str(data_ids))
+    sdk_utils.out('data ids: ' + str(data_ids))
 
     marathon.bump_task_count_config(PACKAGE_NAME, 'DATA_COUNT')
 
@@ -231,14 +231,14 @@ def test_modify_app_config():
     name_ids = tasks.get_task_ids(PACKAGE_NAME, 'name')
     zkfc_ids = tasks.get_task_ids(PACKAGE_NAME, 'zkfc')
     data_ids = tasks.get_task_ids(PACKAGE_NAME, 'data')
-    sdk_utils.test_output('journal ids: ' + str(journal_ids))
-    sdk_utils.test_output('name ids: ' + str(name_ids))
-    sdk_utils.test_output('zkfc ids: ' + str(zkfc_ids))
-    sdk_utils.test_output('data ids: ' + str(data_ids))
+    sdk_utils.out('journal ids: ' + str(journal_ids))
+    sdk_utils.out('name ids: ' + str(name_ids))
+    sdk_utils.out('zkfc ids: ' + str(zkfc_ids))
+    sdk_utils.out('data ids: ' + str(data_ids))
 
     config = marathon.get_config(PACKAGE_NAME)
-    sdk_utils.test_output('marathon config: ')
-    sdk_utils.test_output(config)
+    sdk_utils.out('marathon config: ')
+    sdk_utils.out(config)
     expiry_ms = int(config['env'][app_config_field])
     config['env'][app_config_field] = str(expiry_ms + 1)
     marathon.update_app(PACKAGE_NAME, config)
@@ -261,17 +261,17 @@ def test_modify_app_config_rollback():
     name_ids = tasks.get_task_ids(PACKAGE_NAME, 'name')
     zkfc_ids = tasks.get_task_ids(PACKAGE_NAME, 'zkfc')
     data_ids = tasks.get_task_ids(PACKAGE_NAME, 'data')
-    sdk_utils.test_output('journal ids: ' + str(journal_ids))
-    sdk_utils.test_output('name ids: ' + str(name_ids))
-    sdk_utils.test_output('zkfc ids: ' + str(zkfc_ids))
-    sdk_utils.test_output('data ids: ' + str(data_ids))
+    sdk_utils.out('journal ids: ' + str(journal_ids))
+    sdk_utils.out('name ids: ' + str(name_ids))
+    sdk_utils.out('zkfc ids: ' + str(zkfc_ids))
+    sdk_utils.out('data ids: ' + str(data_ids))
 
     old_config = marathon.get_config(PACKAGE_NAME)
     config = marathon.get_config(PACKAGE_NAME)
-    sdk_utils.test_output('marathon config: ')
-    sdk_utils.test_output(config)
+    sdk_utils.out('marathon config: ')
+    sdk_utils.out(config)
     expiry_ms = int(config['env'][app_config_field])
-    sdk_utils.test_output('expiry ms: ' + str(expiry_ms))
+    sdk_utils.out('expiry ms: ' + str(expiry_ms))
     config['env'][app_config_field] = str(expiry_ms + 1)
     marathon.update_app(PACKAGE_NAME, config)
 
@@ -279,8 +279,8 @@ def test_modify_app_config_rollback():
     tasks.check_tasks_updated(PACKAGE_NAME, 'journal', journal_ids)
     journal_ids = tasks.get_task_ids(PACKAGE_NAME, 'journal')
 
-    sdk_utils.test_output('old config: ')
-    sdk_utils.test_output(old_config)
+    sdk_utils.out('old config: ')
+    sdk_utils.out(old_config)
     # Put the old config back (rollback)
     marathon.update_app(PACKAGE_NAME, old_config)
 
@@ -362,7 +362,7 @@ def find_java_home(host):
     rc, output = shakedown.run_command_on_agent(host, java_home_cmd)
     assert rc
     java_home = output.rstrip()
-    sdk_utils.test_output("java_home: {}".format(java_home))
+    sdk_utils.out("java_home: {}".format(java_home))
     return java_home
     
     
@@ -376,16 +376,16 @@ def service_plan_complete(plan_name):
     def fun():
         try:
             pl = service_cli('plan show {}'.format(plan_name))
-            sdk_utils.test_output('Running service_plan_complete for plan {}'.format(plan_name))
-            sdk_utils.test_output(pl)
-            sdk_utils.test_output('status = {}'.format(pl['status']))
+            sdk_utils.out('Running service_plan_complete for plan {}'.format(plan_name))
+            sdk_utils.out(pl)
+            sdk_utils.out('status = {}'.format(pl['status']))
             if pl['status'] == 'COMPLETE':
                 return True
         except:
             tb = traceback.format_exc()
-            sdk_utils.test_output(tb)
+            sdk_utils.out(tb)
             return False
-        sdk_utils.test_output('Plan {} is not complete ({})'.format(plan_name, pl['status']))
+        sdk_utils.out('Plan {} is not complete ({})'.format(plan_name, pl['status']))
         return False
 
     return spin.time_wait_return(fun)

--- a/frameworks/hdfs/tests/test_shakedown.py
+++ b/frameworks/hdfs/tests/test_shakedown.py
@@ -10,7 +10,7 @@ import sdk_install as install
 import sdk_marathon as marathon
 import sdk_spin as spin
 import sdk_tasks as tasks
-import sdk_utils as utils
+import sdk_utils
 from tests.config import (
     PACKAGE_NAME,
     DEFAULT_TASK_COUNT
@@ -26,7 +26,7 @@ HDFS_POD_TYPES = {"journal", "name", "data"}
 
 def setup_module(module):
     install.uninstall(PACKAGE_NAME)
-    utils.gc_frameworks()
+    sdk_utils.gc_frameworks()
     install.install(PACKAGE_NAME, DEFAULT_TASK_COUNT)
 
 
@@ -201,7 +201,7 @@ def test_install():
 def test_bump_journal_cpus():
     check_healthy()
     journal_ids = tasks.get_task_ids(PACKAGE_NAME, 'journal')
-    print('journal ids: ' + str(journal_ids))
+    sdk_utils.test_output('journal ids: ' + str(journal_ids))
 
     marathon.bump_cpu_count_config(PACKAGE_NAME, 'JOURNAL_CPUS')
 
@@ -214,7 +214,7 @@ def test_bump_data_nodes():
     check_healthy()
 
     data_ids = tasks.get_task_ids(PACKAGE_NAME, 'data')
-    print('data ids: ' + str(data_ids))
+    sdk_utils.test_output('data ids: ' + str(data_ids))
 
     marathon.bump_task_count_config(PACKAGE_NAME, 'DATA_COUNT')
 
@@ -231,14 +231,14 @@ def test_modify_app_config():
     name_ids = tasks.get_task_ids(PACKAGE_NAME, 'name')
     zkfc_ids = tasks.get_task_ids(PACKAGE_NAME, 'zkfc')
     data_ids = tasks.get_task_ids(PACKAGE_NAME, 'data')
-    print('journal ids: ' + str(journal_ids))
-    print('name ids: ' + str(name_ids))
-    print('zkfc ids: ' + str(zkfc_ids))
-    print('data ids: ' + str(data_ids))
+    sdk_utils.test_output('journal ids: ' + str(journal_ids))
+    sdk_utils.test_output('name ids: ' + str(name_ids))
+    sdk_utils.test_output('zkfc ids: ' + str(zkfc_ids))
+    sdk_utils.test_output('data ids: ' + str(data_ids))
 
     config = marathon.get_config(PACKAGE_NAME)
-    print('marathon config: ')
-    print(config)
+    sdk_utils.test_output('marathon config: ')
+    sdk_utils.test_output(config)
     expiry_ms = int(config['env'][app_config_field])
     config['env'][app_config_field] = str(expiry_ms + 1)
     marathon.update_app(PACKAGE_NAME, config)
@@ -261,17 +261,17 @@ def test_modify_app_config_rollback():
     name_ids = tasks.get_task_ids(PACKAGE_NAME, 'name')
     zkfc_ids = tasks.get_task_ids(PACKAGE_NAME, 'zkfc')
     data_ids = tasks.get_task_ids(PACKAGE_NAME, 'data')
-    print('journal ids: ' + str(journal_ids))
-    print('name ids: ' + str(name_ids))
-    print('zkfc ids: ' + str(zkfc_ids))
-    print('data ids: ' + str(data_ids))
+    sdk_utils.test_output('journal ids: ' + str(journal_ids))
+    sdk_utils.test_output('name ids: ' + str(name_ids))
+    sdk_utils.test_output('zkfc ids: ' + str(zkfc_ids))
+    sdk_utils.test_output('data ids: ' + str(data_ids))
 
     old_config = marathon.get_config(PACKAGE_NAME)
     config = marathon.get_config(PACKAGE_NAME)
-    print('marathon config: ')
-    print(config)
+    sdk_utils.test_output('marathon config: ')
+    sdk_utils.test_output(config)
     expiry_ms = int(config['env'][app_config_field])
-    print('expiry ms: ' + str(expiry_ms))
+    sdk_utils.test_output('expiry ms: ' + str(expiry_ms))
     config['env'][app_config_field] = str(expiry_ms + 1)
     marathon.update_app(PACKAGE_NAME, config)
 
@@ -279,8 +279,8 @@ def test_modify_app_config_rollback():
     tasks.check_tasks_updated(PACKAGE_NAME, 'journal', journal_ids)
     journal_ids = tasks.get_task_ids(PACKAGE_NAME, 'journal')
 
-    print('old config: ')
-    print(old_config)
+    sdk_utils.test_output('old config: ')
+    sdk_utils.test_output(old_config)
     # Put the old config back (rollback)
     marathon.update_app(PACKAGE_NAME, old_config)
 
@@ -362,7 +362,7 @@ def find_java_home(host):
     rc, output = shakedown.run_command_on_agent(host, java_home_cmd)
     assert rc
     java_home = output.rstrip()
-    print("java_home: {}".format(java_home))
+    sdk_utils.test_output("java_home: {}".format(java_home))
     return java_home
     
     
@@ -376,15 +376,16 @@ def service_plan_complete(plan_name):
     def fun():
         try:
             pl = service_cli('plan show {}'.format(plan_name))
-            print('Running service_plan_complete for plan {}'.format(plan_name))
-            print(pl)
-            print('status = {}'.format(pl['status']))
+            sdk_utils.test_output('Running service_plan_complete for plan {}'.format(plan_name))
+            sdk_utils.test_output(pl)
+            sdk_utils.test_output('status = {}'.format(pl['status']))
             if pl['status'] == 'COMPLETE':
                 return True
         except:
-            traceback.print_exc()
+            tb = traceback.format_exc()
+            sdk_utils.test_output(tb)
             return False
-        print('Plan {} is not complete ({})'.format(plan_name, pl['status']))
+        sdk_utils.test_output('Plan {} is not complete ({})'.format(plan_name, pl['status']))
         return False
 
     return spin.time_wait_return(fun)

--- a/frameworks/helloworld/tests/test_networking.py
+++ b/frameworks/helloworld/tests/test_networking.py
@@ -32,7 +32,7 @@ def teardown_module(module):
 def test_deploy():
     """Verify that the current deploy plan matches the expected plan from the spec."""
     deployment_plan = plan.get_deployment_plan(PACKAGE_NAME).json()
-    print("deployment_plan: " + str(deployment_plan))
+    utils.test_output("deployment_plan: " + str(deployment_plan))
 
     # deploy two pods serially
     assert(len(deployment_plan['phases']) == 2)

--- a/frameworks/helloworld/tests/test_networking.py
+++ b/frameworks/helloworld/tests/test_networking.py
@@ -32,7 +32,7 @@ def teardown_module(module):
 def test_deploy():
     """Verify that the current deploy plan matches the expected plan from the spec."""
     deployment_plan = plan.get_deployment_plan(PACKAGE_NAME).json()
-    utils.test_output("deployment_plan: " + str(deployment_plan))
+    utils.out("deployment_plan: " + str(deployment_plan))
 
     # deploy two pods serially
     assert(len(deployment_plan['phases']) == 2)

--- a/frameworks/helloworld/tests/test_parameterized_plan.py
+++ b/frameworks/helloworld/tests/test_parameterized_plan.py
@@ -3,6 +3,7 @@ import pytest
 import sdk_install as install
 import sdk_plan as plan
 import sdk_spin as spin
+import sdk_utils
 
 from tests.config import (
     PACKAGE_NAME
@@ -28,7 +29,7 @@ def teardown_module(module):
 @pytest.mark.sanity
 def test_deploy():
     deployment_plan = plan.get_deployment_plan(PACKAGE_NAME).json()
-    print("deployment_plan: " + str(deployment_plan))
+    sdk_utils.test_output("deployment_plan: " + str(deployment_plan))
 
     assert(len(deployment_plan['phases']) == 2)
     assert(deployment_plan['phases'][0]['name'] == 'server-deploy')
@@ -41,7 +42,7 @@ def test_deploy():
 def test_sidecar():
     plan.start_sidecar_plan(PACKAGE_NAME, {'PLAN_PARAMETER': 'parameterized'})
     sidecar_plan = plan.get_sidecar_plan(PACKAGE_NAME).json()
-    print("sidecar_plan: " + str(sidecar_plan))
+    sdk_utils.test_output("sidecar_plan: " + str(sidecar_plan))
 
     assert(len(sidecar_plan['phases']) == 1)
     assert(sidecar_plan['phases'][0]['name'] == 'sidecar-deploy')

--- a/frameworks/helloworld/tests/test_parameterized_plan.py
+++ b/frameworks/helloworld/tests/test_parameterized_plan.py
@@ -29,7 +29,7 @@ def teardown_module(module):
 @pytest.mark.sanity
 def test_deploy():
     deployment_plan = plan.get_deployment_plan(PACKAGE_NAME).json()
-    sdk_utils.test_output("deployment_plan: " + str(deployment_plan))
+    sdk_utils.out("deployment_plan: " + str(deployment_plan))
 
     assert(len(deployment_plan['phases']) == 2)
     assert(deployment_plan['phases'][0]['name'] == 'server-deploy')
@@ -42,7 +42,7 @@ def test_deploy():
 def test_sidecar():
     plan.start_sidecar_plan(PACKAGE_NAME, {'PLAN_PARAMETER': 'parameterized'})
     sidecar_plan = plan.get_sidecar_plan(PACKAGE_NAME).json()
-    sdk_utils.test_output("sidecar_plan: " + str(sidecar_plan))
+    sdk_utils.out("sidecar_plan: " + str(sidecar_plan))
 
     assert(len(sidecar_plan['phases']) == 1)
     assert(sidecar_plan['phases'][0]['name'] == 'sidecar-deploy')

--- a/frameworks/helloworld/tests/test_sanity.py
+++ b/frameworks/helloworld/tests/test_sanity.py
@@ -49,7 +49,7 @@ def test_install():
 def test_bump_hello_cpus():
     check_running()
     hello_ids = tasks.get_task_ids(PACKAGE_NAME, 'hello')
-    sdk_utils.test_output('hello ids: ' + str(hello_ids))
+    sdk_utils.out('hello ids: ' + str(hello_ids))
 
     updated_cpus = bump_hello_cpus()
 
@@ -68,7 +68,7 @@ def test_bump_hello_cpus():
 def test_bump_world_cpus():
     check_running()
     world_ids = tasks.get_task_ids(PACKAGE_NAME, 'world')
-    sdk_utils.test_output('world ids: ' + str(world_ids))
+    sdk_utils.out('world ids: ' + str(world_ids))
 
     updated_cpus = bump_world_cpus()
 
@@ -88,7 +88,7 @@ def test_bump_hello_nodes():
     check_running()
 
     hello_ids = tasks.get_task_ids(PACKAGE_NAME, 'hello')
-    sdk_utils.test_output('hello ids: ' + str(hello_ids))
+    sdk_utils.out('hello ids: ' + str(hello_ids))
 
     marathon.bump_task_count_config(PACKAGE_NAME, 'HELLO_COUNT')
 

--- a/frameworks/helloworld/tests/test_sanity.py
+++ b/frameworks/helloworld/tests/test_sanity.py
@@ -11,6 +11,7 @@ import sdk_marathon as marathon
 import sdk_spin as spin
 import sdk_tasks as tasks
 import sdk_test_upgrade
+import sdk_utils
 from tests.config import (
     PACKAGE_NAME,
     DEFAULT_TASK_COUNT,
@@ -48,7 +49,7 @@ def test_install():
 def test_bump_hello_cpus():
     check_running()
     hello_ids = tasks.get_task_ids(PACKAGE_NAME, 'hello')
-    print('hello ids: ' + str(hello_ids))
+    sdk_utils.test_output('hello ids: ' + str(hello_ids))
 
     updated_cpus = bump_hello_cpus()
 
@@ -67,7 +68,7 @@ def test_bump_hello_cpus():
 def test_bump_world_cpus():
     check_running()
     world_ids = tasks.get_task_ids(PACKAGE_NAME, 'world')
-    print('world ids: ' + str(world_ids))
+    sdk_utils.test_output('world ids: ' + str(world_ids))
 
     updated_cpus = bump_world_cpus()
 
@@ -87,7 +88,7 @@ def test_bump_hello_nodes():
     check_running()
 
     hello_ids = tasks.get_task_ids(PACKAGE_NAME, 'hello')
-    print('hello ids: ' + str(hello_ids))
+    sdk_utils.test_output('hello ids: ' + str(hello_ids))
 
     marathon.bump_task_count_config(PACKAGE_NAME, 'HELLO_COUNT')
 

--- a/frameworks/helloworld/tests/test_sidecar.py
+++ b/frameworks/helloworld/tests/test_sidecar.py
@@ -2,6 +2,7 @@ import pytest
 
 import sdk_install as install
 import sdk_plan as plan
+import sdk_utils
 
 from tests.config import (
     PACKAGE_NAME
@@ -27,7 +28,7 @@ def teardown_module(module):
 @pytest.mark.sanity
 def test_deploy():
     deployment_plan = plan.get_deployment_plan(PACKAGE_NAME).json()
-    print("deployment_plan: " + str(deployment_plan))
+    sdk_utils.test_output("deployment_plan: " + str(deployment_plan))
 
     assert(len(deployment_plan['phases']) == 2)
     assert(deployment_plan['phases'][0]['name'] == 'server-deploy')
@@ -40,7 +41,7 @@ def test_deploy():
 def test_sidecar():
     plan.start_sidecar_plan(PACKAGE_NAME)
     sidecar_plan = plan.get_sidecar_plan(PACKAGE_NAME).json()
-    print("sidecar_plan: " + str(sidecar_plan))
+    sdk_utils.test_output("sidecar_plan: " + str(sidecar_plan))
 
     assert(len(sidecar_plan['phases']) == 1)
     assert(sidecar_plan['phases'][0]['name'] == 'sidecar-deploy')

--- a/frameworks/helloworld/tests/test_sidecar.py
+++ b/frameworks/helloworld/tests/test_sidecar.py
@@ -28,7 +28,7 @@ def teardown_module(module):
 @pytest.mark.sanity
 def test_deploy():
     deployment_plan = plan.get_deployment_plan(PACKAGE_NAME).json()
-    sdk_utils.test_output("deployment_plan: " + str(deployment_plan))
+    sdk_utils.out("deployment_plan: " + str(deployment_plan))
 
     assert(len(deployment_plan['phases']) == 2)
     assert(deployment_plan['phases'][0]['name'] == 'server-deploy')
@@ -41,7 +41,7 @@ def test_deploy():
 def test_sidecar():
     plan.start_sidecar_plan(PACKAGE_NAME)
     sidecar_plan = plan.get_sidecar_plan(PACKAGE_NAME).json()
-    sdk_utils.test_output("sidecar_plan: " + str(sidecar_plan))
+    sdk_utils.out("sidecar_plan: " + str(sidecar_plan))
 
     assert(len(sidecar_plan['phases']) == 1)
     assert(sidecar_plan['phases'][0]['name'] == 'sidecar-deploy')

--- a/frameworks/helloworld/tests/test_taskcfg.py
+++ b/frameworks/helloworld/tests/test_taskcfg.py
@@ -5,6 +5,7 @@ import sdk_cmd as cmd
 import sdk_install as install
 import sdk_marathon as marathon
 import sdk_spin as spin
+import sdk_utils
 
 from tests.config import (
     PACKAGE_NAME,
@@ -28,7 +29,7 @@ def test_deploy():
     wait_time = 30
     # taskcfg.yml will initially fail to deploy because several options are missing in the default
     # marathon.json.mustache. verify that tasks are failing for 30s before continuing.
-    print('Checking that tasks are failing to launch for at least {}s'.format(wait_time))
+    sdk_utils.test_output('Checking that tasks are failing to launch for at least {}s'.format(wait_time))
 
     # we can get brief blips of TASK_RUNNING but they shouldnt last more than 2-3s:
     consecutive_task_running = 0
@@ -36,7 +37,7 @@ def test_deploy():
         nonlocal consecutive_task_running
         svc_tasks = shakedown.get_service_tasks(PACKAGE_NAME)
         states = [t['state'] for t in svc_tasks]
-        print('Task states: {}'.format(states))
+        sdk_utils.test_output('Task states: {}'.format(states))
         if 'TASK_RUNNING' in states:
             consecutive_task_running += 1
             assert consecutive_task_running <= 3
@@ -47,7 +48,7 @@ def test_deploy():
     try:
         spin.time_wait_noisy(lambda: fn(), timeout_seconds=wait_time)
     except shakedown.TimeoutExpired:
-        print('Timeout reached as expected')
+        sdk_utils.test_output('Timeout reached as expected')
 
     # add the needed envvars in marathon and confirm that the deployment succeeds:
     config = marathon.get_config(PACKAGE_NAME)

--- a/frameworks/helloworld/tests/test_taskcfg.py
+++ b/frameworks/helloworld/tests/test_taskcfg.py
@@ -29,7 +29,7 @@ def test_deploy():
     wait_time = 30
     # taskcfg.yml will initially fail to deploy because several options are missing in the default
     # marathon.json.mustache. verify that tasks are failing for 30s before continuing.
-    sdk_utils.test_output('Checking that tasks are failing to launch for at least {}s'.format(wait_time))
+    sdk_utils.out('Checking that tasks are failing to launch for at least {}s'.format(wait_time))
 
     # we can get brief blips of TASK_RUNNING but they shouldnt last more than 2-3s:
     consecutive_task_running = 0
@@ -37,7 +37,7 @@ def test_deploy():
         nonlocal consecutive_task_running
         svc_tasks = shakedown.get_service_tasks(PACKAGE_NAME)
         states = [t['state'] for t in svc_tasks]
-        sdk_utils.test_output('Task states: {}'.format(states))
+        sdk_utils.out('Task states: {}'.format(states))
         if 'TASK_RUNNING' in states:
             consecutive_task_running += 1
             assert consecutive_task_running <= 3
@@ -48,7 +48,7 @@ def test_deploy():
     try:
         spin.time_wait_noisy(lambda: fn(), timeout_seconds=wait_time)
     except shakedown.TimeoutExpired:
-        sdk_utils.test_output('Timeout reached as expected')
+        sdk_utils.out('Timeout reached as expected')
 
     # add the needed envvars in marathon and confirm that the deployment succeeds:
     config = marathon.get_config(PACKAGE_NAME)

--- a/frameworks/helloworld/tests/test_web_url.py
+++ b/frameworks/helloworld/tests/test_web_url.py
@@ -2,6 +2,7 @@ import pytest
 
 import sdk_install as install
 import sdk_plan as plan
+import sdk_utils
 
 from tests.config import (
     PACKAGE_NAME
@@ -27,7 +28,7 @@ def teardown_module(module):
 @pytest.mark.sanity
 def test_deploy():
     deployment_plan = plan.get_deployment_plan(PACKAGE_NAME).json()
-    print("deployment_plan: " + str(deployment_plan))
+    sdk_utils.test_output("deployment_plan: " + str(deployment_plan))
 
     assert(len(deployment_plan['phases']) == 1)
     assert(deployment_plan['phases'][0]['name'] == 'hello')

--- a/frameworks/helloworld/tests/test_web_url.py
+++ b/frameworks/helloworld/tests/test_web_url.py
@@ -28,7 +28,7 @@ def teardown_module(module):
 @pytest.mark.sanity
 def test_deploy():
     deployment_plan = plan.get_deployment_plan(PACKAGE_NAME).json()
-    sdk_utils.test_output("deployment_plan: " + str(deployment_plan))
+    sdk_utils.out("deployment_plan: " + str(deployment_plan))
 
     assert(len(deployment_plan['phases']) == 1)
     assert(deployment_plan['phases'][0]['name'] == 'hello')

--- a/frameworks/kafka/tests/test_shakedown_basics.py
+++ b/frameworks/kafka/tests/test_shakedown_basics.py
@@ -115,7 +115,7 @@ def test_topic_create():
     create_info = service_cli(
         'topic create {}'.format(EPHEMERAL_TOPIC_NAME)
     )
-    utils.test_output(create_info)
+    utils.out(create_info)
     assert ('Created topic "%s".\n' % EPHEMERAL_TOPIC_NAME in create_info['message'])
     assert ("topics with a period ('.') or underscore ('_') could collide." in create_info['message'])
     topic_list_info = service_cli('topic list')

--- a/frameworks/kafka/tests/test_shakedown_basics.py
+++ b/frameworks/kafka/tests/test_shakedown_basics.py
@@ -115,7 +115,7 @@ def test_topic_create():
     create_info = service_cli(
         'topic create {}'.format(EPHEMERAL_TOPIC_NAME)
     )
-    print(create_info)
+    utils.test_output(create_info)
     assert ('Created topic "%s".\n' % EPHEMERAL_TOPIC_NAME in create_info['message'])
     assert ("topics with a period ('.') or underscore ('_') could collide." in create_info['message'])
     topic_list_info = service_cli('topic list')

--- a/frameworks/kafka/tests/test_shakedown_endpoint_port.py
+++ b/frameworks/kafka/tests/test_shakedown_endpoint_port.py
@@ -62,7 +62,7 @@ def test_port_static_to_static_port():
     broker_ids = tasks.get_task_ids(SERVICE_NAME, '{}-'.format(DEFAULT_POD_TYPE))
 
     config = marathon.get_config(SERVICE_NAME)
-    utils.test_output('Old Config :{}'.format(config))
+    utils.out('Old Config :{}'.format(config))
 
     for broker_id in range(DEFAULT_BROKER_COUNT):
         result = service_cli('broker get {}'.format(broker_id))
@@ -79,7 +79,7 @@ def test_port_static_to_static_port():
 
     config['env']['BROKER_PORT'] = '9095'
     marathon.update_app(SERVICE_NAME, config)
-    utils.test_output('New Config :{}'.format(config))
+    utils.out('New Config :{}'.format(config))
 
     tasks.check_tasks_updated(SERVICE_NAME, '{}-'.format(DEFAULT_POD_TYPE), broker_ids)
     # all tasks are running

--- a/frameworks/kafka/tests/test_shakedown_endpoint_port.py
+++ b/frameworks/kafka/tests/test_shakedown_endpoint_port.py
@@ -62,7 +62,7 @@ def test_port_static_to_static_port():
     broker_ids = tasks.get_task_ids(SERVICE_NAME, '{}-'.format(DEFAULT_POD_TYPE))
 
     config = marathon.get_config(SERVICE_NAME)
-    print('Old Config :{}'.format(config))
+    utils.test_output('Old Config :{}'.format(config))
 
     for broker_id in range(DEFAULT_BROKER_COUNT):
         result = service_cli('broker get {}'.format(broker_id))
@@ -79,7 +79,7 @@ def test_port_static_to_static_port():
 
     config['env']['BROKER_PORT'] = '9095'
     marathon.update_app(SERVICE_NAME, config)
-    print('New Config :{}'.format(config))
+    utils.test_output('New Config :{}'.format(config))
 
     tasks.check_tasks_updated(SERVICE_NAME, '{}-'.format(DEFAULT_POD_TYPE), broker_ids)
     # all tasks are running

--- a/frameworks/kafka/tests/test_shakedown_port.py
+++ b/frameworks/kafka/tests/test_shakedown_port.py
@@ -61,7 +61,7 @@ def test_port_static_to_static_port():
     broker_ids = tasks.get_task_ids(SERVICE_NAME, '{}-'.format(DEFAULT_POD_TYPE))
 
     config = marathon.get_config(SERVICE_NAME)
-    print('Old Config :{}'.format(config))
+    utils.test_output('Old Config :{}'.format(config))
 
     for broker_id in range(DEFAULT_BROKER_COUNT):
         result = service_cli('broker get {}'.format(broker_id))
@@ -69,7 +69,7 @@ def test_port_static_to_static_port():
 
     config['env']['BROKER_PORT'] = '9095'
     marathon.update_app(SERVICE_NAME, config)
-    print('New Config :{}'.format(config))
+    utils.test_output('New Config :{}'.format(config))
 
     tasks.check_tasks_updated(SERVICE_NAME, '{}-'.format(DEFAULT_POD_TYPE), broker_ids)
     # all tasks are running

--- a/frameworks/kafka/tests/test_shakedown_port.py
+++ b/frameworks/kafka/tests/test_shakedown_port.py
@@ -61,7 +61,7 @@ def test_port_static_to_static_port():
     broker_ids = tasks.get_task_ids(SERVICE_NAME, '{}-'.format(DEFAULT_POD_TYPE))
 
     config = marathon.get_config(SERVICE_NAME)
-    utils.test_output('Old Config :{}'.format(config))
+    utils.out('Old Config :{}'.format(config))
 
     for broker_id in range(DEFAULT_BROKER_COUNT):
         result = service_cli('broker get {}'.format(broker_id))
@@ -69,7 +69,7 @@ def test_port_static_to_static_port():
 
     config['env']['BROKER_PORT'] = '9095'
     marathon.update_app(SERVICE_NAME, config)
-    utils.test_output('New Config :{}'.format(config))
+    utils.out('New Config :{}'.format(config))
 
     tasks.check_tasks_updated(SERVICE_NAME, '{}-'.format(DEFAULT_POD_TYPE), broker_ids)
     # all tasks are running

--- a/frameworks/kafka/tests/test_shakedown_upgrade.py
+++ b/frameworks/kafka/tests/test_shakedown_upgrade.py
@@ -33,13 +33,13 @@ def teardown_module(module):
 def test_upgrade():
 
     test_version = upgrade.get_pkg_version(PACKAGE_NAME)
-    print('Found test version: {}'.format(test_version))
+    utils.test_output('Found test version: {}'.format(test_version))
 
     repositories = json.loads(cmd.run_cli('package repo list --json'))['repositories']
-    print("Repositories: " + str(repositories))
+    utils.test_output("Repositories: " + str(repositories))
 
     if len(repositories) < 2:
-        print("There is only one version in the repository. Skipping upgrade test!")
+        utils.test_output("There is only one version in the repository. Skipping upgrade test!")
         assert repo[0]['name'] == 'Universe'
         return
 
@@ -50,30 +50,30 @@ def test_upgrade():
             shakedown.remove_package_repo(repo['name'])
 
     universe_version = upgrade.get_pkg_version(PACKAGE_NAME)
-    print('Found Universe version: {}'.format(universe_version))
+    utils.test_output('Found Universe version: {}'.format(universe_version))
 
-    print('Installing Universe version: {}'.format(universe_version))
+    utils.test_output('Installing Universe version: {}'.format(universe_version))
     install.install(PACKAGE_NAME, DEFAULT_BROKER_COUNT)
-    print('Installation complete for Universe version: {}'.format(universe_version))
+    utils.test_output('Installation complete for Universe version: {}'.format(universe_version))
 
     tasks.check_running(SERVICE_NAME, DEFAULT_BROKER_COUNT)
     broker_ids = tasks.get_task_ids(SERVICE_NAME, 'broker-')
 
-    print('Adding test version to repository with name: {} and url: {}'.format(test_repo_name, test_repo_url))
+    utils.test_output('Adding test version to repository with name: {} and url: {}'.format(test_repo_name, test_repo_url))
     upgrade.add_repo(test_repo_name, test_repo_url, universe_version, 0, PACKAGE_NAME)
 
-    print('Upgrading to test version: {}'.format(test_version))
+    utils.test_output('Upgrading to test version: {}'.format(test_version))
     marathon.destroy_app(SERVICE_NAME)
 
-    print('Installing test version: {}'.format(test_version))
+    utils.test_output('Installing test version: {}'.format(test_version))
 
     # installation will return with old tasks because they are still running
     install.install(PACKAGE_NAME, DEFAULT_BROKER_COUNT)
-    print('Installation complete for test version: {}'.format(test_version))
+    utils.test_output('Installation complete for test version: {}'.format(test_version))
 
     # wait till tasks are restarted
     tasks.check_tasks_updated(SERVICE_NAME, '{}-'.format(DEFAULT_POD_TYPE), broker_ids)
-    print('All task are restarted')
+    utils.test_output('All task are restarted')
     # all tasks are running
     tasks.check_running(SERVICE_NAME, DEFAULT_BROKER_COUNT)
      

--- a/frameworks/kafka/tests/test_shakedown_upgrade.py
+++ b/frameworks/kafka/tests/test_shakedown_upgrade.py
@@ -33,13 +33,13 @@ def teardown_module(module):
 def test_upgrade():
 
     test_version = upgrade.get_pkg_version(PACKAGE_NAME)
-    utils.test_output('Found test version: {}'.format(test_version))
+    utils.out('Found test version: {}'.format(test_version))
 
     repositories = json.loads(cmd.run_cli('package repo list --json'))['repositories']
-    utils.test_output("Repositories: " + str(repositories))
+    utils.out("Repositories: " + str(repositories))
 
     if len(repositories) < 2:
-        utils.test_output("There is only one version in the repository. Skipping upgrade test!")
+        utils.out("There is only one version in the repository. Skipping upgrade test!")
         assert repo[0]['name'] == 'Universe'
         return
 
@@ -50,30 +50,30 @@ def test_upgrade():
             shakedown.remove_package_repo(repo['name'])
 
     universe_version = upgrade.get_pkg_version(PACKAGE_NAME)
-    utils.test_output('Found Universe version: {}'.format(universe_version))
+    utils.out('Found Universe version: {}'.format(universe_version))
 
-    utils.test_output('Installing Universe version: {}'.format(universe_version))
+    utils.out('Installing Universe version: {}'.format(universe_version))
     install.install(PACKAGE_NAME, DEFAULT_BROKER_COUNT)
-    utils.test_output('Installation complete for Universe version: {}'.format(universe_version))
+    utils.out('Installation complete for Universe version: {}'.format(universe_version))
 
     tasks.check_running(SERVICE_NAME, DEFAULT_BROKER_COUNT)
     broker_ids = tasks.get_task_ids(SERVICE_NAME, 'broker-')
 
-    utils.test_output('Adding test version to repository with name: {} and url: {}'.format(test_repo_name, test_repo_url))
+    utils.out('Adding test version to repository with name: {} and url: {}'.format(test_repo_name, test_repo_url))
     upgrade.add_repo(test_repo_name, test_repo_url, universe_version, 0, PACKAGE_NAME)
 
-    utils.test_output('Upgrading to test version: {}'.format(test_version))
+    utils.out('Upgrading to test version: {}'.format(test_version))
     marathon.destroy_app(SERVICE_NAME)
 
-    utils.test_output('Installing test version: {}'.format(test_version))
+    utils.out('Installing test version: {}'.format(test_version))
 
     # installation will return with old tasks because they are still running
     install.install(PACKAGE_NAME, DEFAULT_BROKER_COUNT)
-    utils.test_output('Installation complete for test version: {}'.format(test_version))
+    utils.out('Installation complete for test version: {}'.format(test_version))
 
     # wait till tasks are restarted
     tasks.check_tasks_updated(SERVICE_NAME, '{}-'.format(DEFAULT_POD_TYPE), broker_ids)
-    utils.test_output('All task are restarted')
+    utils.out('All task are restarted')
     # all tasks are running
     tasks.check_running(SERVICE_NAME, DEFAULT_BROKER_COUNT)
      

--- a/test.py
+++ b/test.py
@@ -511,7 +511,8 @@ def start_test_background(framework, cluster, repo_root):
     _setup_strict(framework, cluster, repo_root)
 
     logger.info("Launching shakedown in background for %s", framework.name)
-    logger.debug("stub_universe:{framework.stub_universe_url} cluster_url:{cluster.url} authtoken:{cluster.auth_token}".format(locals()))
+    logger.debug("stub_universe:%s cluster_url:%s authtoken:%s",
+            framework.stub_universe_url, cluster.url, cluster.auth_token))
 
     custom_env = os.environ.copy()
     custom_env['TEST_GITHUB_LABEL'] = framework.name
@@ -543,7 +544,8 @@ def run_test(framework, cluster, repo_root):
     _setup_strict(framework, cluster, repo_root)
 
     logger.info("Launching shakedown for %s", framework.name)
-    logger.debug("stub_universe:%s cluster_url:%s authtoken:%s" % (framework.stub_universe_url, cluster.url, cluster.auth_token))
+    logger.debug("stub_universe:%s cluster_url:%s authtoken:%s",
+            framework.stub_universe_url, cluster.url, cluster.auth_token))
     custom_env = os.environ.copy()
     custom_env['STUB_UNIVERSE_URL'] = framework.stub_universe_url
     custom_env['TEST_GITHUB_LABEL'] = framework.name

--- a/test.py
+++ b/test.py
@@ -60,7 +60,12 @@ def parse_args(args=sys.argv):
             'For "success-only", test failures will leave the cluster running.')
     parser.add_argument("test", nargs="*", help="Test or tests to run.  "
             "If no args provided, run all.")
-    return parser.parse_args()
+    run_attrs = parser.parse_args()
+    if (run_attrs.cluster_url or run_attrs.cluster_token) and not (
+            run_attrs.cluster_url and run_attrs.cluster_token):
+        raise Exception("Currently cluster url and token must be used together.")
+    return run_attrs
+
 
 class TestRequirementsNotMet(Exception):
     pass
@@ -68,7 +73,7 @@ class TestRequirementsNotMet(Exception):
 class CommandFailure(Exception):
     pass
 
-def detect_requirements():
+def detect_requirements(run_attrs):
     "Log all requirements met or not met, then throw exception if any not met"
     logger.info("Checking requirements")
     def have_command(cmd):
@@ -315,7 +320,7 @@ def teardown_clusters():
     clustinfo.shutdown_clusters()
 
 def _one_cluster_linear_tests(run_attrs, repo_root):
-    if run_attrs.cluster_url:
+    if run_attrs.cluster_url and run_attrs.cluster_token:
         clustinfo.add_running_cluster(run_attrs.cluster_url,
                                       run_attrs.cluster_token)
     else:
@@ -505,7 +510,8 @@ def start_test_background(framework, cluster, repo_root):
                 framework.name)
     _setup_strict(framework, cluster, repo_root)
 
-    logger.info("Launching shakedown for %s", framework.name)
+    logger.info("Launching shakedown in background for %s", framework.name)
+    logger.debug("stub_universe:{framework.stub_universe_url} cluster_url:{cluster.url} authtoken:{cluster.auth_token}".format(locals()))
 
     custom_env = os.environ.copy()
     custom_env['TEST_GITHUB_LABEL'] = framework.name
@@ -536,7 +542,8 @@ def run_test(framework, cluster, repo_root):
     logger.info("Starting cluster configure & test run for %s", framework.name)
     _setup_strict(framework, cluster, repo_root)
 
-    logger.info("launching shakedown for %s", framework.name)
+    logger.info("Launching shakedown for %s", framework.name)
+    logger.debug("stub_universe:%s cluster_url:%s authtoken:%s" % (framework.stub_universe_url, cluster.url, cluster.auth_token))
     custom_env = os.environ.copy()
     custom_env['STUB_UNIVERSE_URL'] = framework.stub_universe_url
     custom_env['TEST_GITHUB_LABEL'] = framework.name
@@ -566,7 +573,7 @@ def report_failed_actions():
 def main():
     run_attrs = parse_args()
     try:
-        detect_requirements()
+        detect_requirements(run_attrs)
     except TestRequirementsNotMet:
         logger.error("Aborting run.")
         return False

--- a/test.py
+++ b/test.py
@@ -512,7 +512,7 @@ def start_test_background(framework, cluster, repo_root):
 
     logger.info("Launching shakedown in background for %s", framework.name)
     logger.debug("stub_universe:%s cluster_url:%s authtoken:%s",
-            framework.stub_universe_url, cluster.url, cluster.auth_token))
+            framework.stub_universe_url, cluster.url, cluster.auth_token)
 
     custom_env = os.environ.copy()
     custom_env['TEST_GITHUB_LABEL'] = framework.name
@@ -545,7 +545,7 @@ def run_test(framework, cluster, repo_root):
 
     logger.info("Launching shakedown for %s", framework.name)
     logger.debug("stub_universe:%s cluster_url:%s authtoken:%s",
-            framework.stub_universe_url, cluster.url, cluster.auth_token))
+            framework.stub_universe_url, cluster.url, cluster.auth_token)
     custom_env = os.environ.copy()
     custom_env['STUB_UNIVERSE_URL'] = framework.stub_universe_url
     custom_env['TEST_GITHUB_LABEL'] = framework.name

--- a/testing/sdk_cmd.py
+++ b/testing/sdk_cmd.py
@@ -2,13 +2,14 @@
 
 import dcos.http
 import sdk_spin
+import sdk_utils
 import shakedown
 
 
 def request(method, url, retry=True, **kwargs):
     def fn():
         response = dcos.http.request(method, url, **kwargs)
-        print('Got {} for {} {} (args: {})'.format(
+        sdk_utils.test_output('Got {} for {} {} (args: {})'.format(
             response.status_code, method.upper(), url, kwargs))
         response.raise_for_status()
         return response
@@ -23,6 +24,6 @@ def run_cli(cmd):
     if ret != 0:
         err = 'Got error code {} when running command "dcos {}":\nstdout: "{}"\nstderr: "{}"'.format(
             ret, cmd, stdout, stderr)
-        print(err)
+        sdk_utils.test_output(err)
         raise Exception(err)
     return stdout

--- a/testing/sdk_cmd.py
+++ b/testing/sdk_cmd.py
@@ -9,7 +9,7 @@ import shakedown
 def request(method, url, retry=True, **kwargs):
     def fn():
         response = dcos.http.request(method, url, **kwargs)
-        sdk_utils.test_output('Got {} for {} {} (args: {})'.format(
+        sdk_utils.out('Got {} for {} {} (args: {})'.format(
             response.status_code, method.upper(), url, kwargs))
         response.raise_for_status()
         return response
@@ -24,6 +24,6 @@ def run_cli(cmd):
     if ret != 0:
         err = 'Got error code {} when running command "dcos {}":\nstdout: "{}"\nstderr: "{}"'.format(
             ret, cmd, stdout, stderr)
-        sdk_utils.test_output(err)
+        sdk_utils.out(err)
         raise Exception(err)
     return stdout

--- a/testing/sdk_install.py
+++ b/testing/sdk_install.py
@@ -6,6 +6,7 @@ import dcos.marathon
 import sdk_api
 import sdk_spin
 import sdk_tasks
+import sdk_utils
 import shakedown
 
 import os
@@ -24,7 +25,7 @@ def install(
     start = time.time()
     merged_options = get_package_options(additional_options)
 
-    print('Installing {} with options={} version={}'.format(
+    sdk_utils.test_output('Installing {} with options={} version={}'.format(
         package_name, merged_options, package_version))
 
     # install_package_and_wait silently waits for all marathon deployments to clear.
@@ -36,7 +37,7 @@ def install(
         options_json=merged_options)
 
     # 2. wait for expected tasks to come up
-    print("Waiting for expected tasks to come up...")
+    sdk_utils.test_output("Waiting for expected tasks to come up...")
     sdk_tasks.check_running(service_name, running_task_count)
 
     # 3. check service health
@@ -45,17 +46,17 @@ def install(
         # TODO(nickbp): upstream fix to shakedown, which currently checks for ANY deployments rather
         #               than the one we care about
         deploying_apps = set([])
-        print("Getting deployments")
+        sdk_utils.test_output("Getting deployments")
         deployments = marathon_client.get_deployments()
-        print("Found {} deployments".format(len(deployments)))
+        sdk_utils.test_output("Found {} deployments".format(len(deployments)))
         for deployment in deployments:
-            print("Deployment: {}".format(deployment))
+            sdk_utils.test_output("Deployment: {}".format(deployment))
             for app in deployment.get('affectedApps', []):
-                print("Adding {}".format(app))
+                sdk_utils.test_output("Adding {}".format(app))
                 deploying_apps.add(app)
-        print('Checking that deployment of {} has ended:\n- Deploying apps: {}'.format(service_name, deploying_apps))
+        sdk_utils.test_output('Checking that deployment of {} has ended:\n- Deploying apps: {}'.format(service_name, deploying_apps))
         return not '/{}'.format(service_name) in deploying_apps
-    print("Waiting for marathon deployment to finish...")
+    sdk_utils.test_output("Waiting for marathon deployment to finish...")
     sdk_spin.time_wait_noisy(is_deployment_finished, timeout_seconds=30)
 
     # 4. Ensure the framework is suppressed.
@@ -66,11 +67,11 @@ def install(
     # Universe.  It can be removed once all frameworks rely on
     # dcos-commons >= 0.13.
     if check_suppression:
-        print("Waiting for framework to be suppressed...")
+        sdk_utils.test_output("Waiting for framework to be suppressed...")
         sdk_spin.time_wait_noisy(
             lambda: sdk_api.is_suppressed(service_name))
 
-    print('Install done after {}'.format(sdk_spin.pretty_time(time.time() - start)))
+    sdk_utils.test_output('Install done after {}'.format(sdk_spin.pretty_time(time.time() - start)))
 
 
 def uninstall(service_name, package_name=None):
@@ -78,11 +79,11 @@ def uninstall(service_name, package_name=None):
 
     if package_name is None:
         package_name = service_name
-    print('Uninstalling/janitoring {}'.format(service_name))
+    sdk_utils.test_output('Uninstalling/janitoring {}'.format(service_name))
     try:
         shakedown.uninstall_package_and_wait(package_name, service_name=service_name)
     except (dcos.errors.DCOSException, ValueError) as e:
-        print('Got exception when uninstalling package, ' +
+        sdk_utils.test_output('Got exception when uninstalling package, ' +
               'continuing with janitor anyway: {}'.format(e))
 
     janitor_start = time.time()
@@ -96,7 +97,7 @@ def uninstall(service_name, package_name=None):
 
     finish = time.time()
 
-    print('Uninstall done after pkg({}) + janitor({}) = total({})'.format(
+    sdk_utils.test_output('Uninstall done after pkg({}) + janitor({}) = total({})'.format(
         sdk_spin.pretty_time(janitor_start - start),
         sdk_spin.pretty_time(finish - janitor_start),
         sdk_spin.pretty_time(finish - start)))

--- a/testing/sdk_install.py
+++ b/testing/sdk_install.py
@@ -25,7 +25,7 @@ def install(
     start = time.time()
     merged_options = get_package_options(additional_options)
 
-    sdk_utils.test_output('Installing {} with options={} version={}'.format(
+    sdk_utils.out('Installing {} with options={} version={}'.format(
         package_name, merged_options, package_version))
 
     # install_package_and_wait silently waits for all marathon deployments to clear.
@@ -37,7 +37,7 @@ def install(
         options_json=merged_options)
 
     # 2. wait for expected tasks to come up
-    sdk_utils.test_output("Waiting for expected tasks to come up...")
+    sdk_utils.out("Waiting for expected tasks to come up...")
     sdk_tasks.check_running(service_name, running_task_count)
 
     # 3. check service health
@@ -46,17 +46,17 @@ def install(
         # TODO(nickbp): upstream fix to shakedown, which currently checks for ANY deployments rather
         #               than the one we care about
         deploying_apps = set([])
-        sdk_utils.test_output("Getting deployments")
+        sdk_utils.out("Getting deployments")
         deployments = marathon_client.get_deployments()
-        sdk_utils.test_output("Found {} deployments".format(len(deployments)))
+        sdk_utils.out("Found {} deployments".format(len(deployments)))
         for deployment in deployments:
-            sdk_utils.test_output("Deployment: {}".format(deployment))
+            sdk_utils.out("Deployment: {}".format(deployment))
             for app in deployment.get('affectedApps', []):
-                sdk_utils.test_output("Adding {}".format(app))
+                sdk_utils.out("Adding {}".format(app))
                 deploying_apps.add(app)
-        sdk_utils.test_output('Checking that deployment of {} has ended:\n- Deploying apps: {}'.format(service_name, deploying_apps))
+        sdk_utils.out('Checking that deployment of {} has ended:\n- Deploying apps: {}'.format(service_name, deploying_apps))
         return not '/{}'.format(service_name) in deploying_apps
-    sdk_utils.test_output("Waiting for marathon deployment to finish...")
+    sdk_utils.out("Waiting for marathon deployment to finish...")
     sdk_spin.time_wait_noisy(is_deployment_finished, timeout_seconds=30)
 
     # 4. Ensure the framework is suppressed.
@@ -67,11 +67,11 @@ def install(
     # Universe.  It can be removed once all frameworks rely on
     # dcos-commons >= 0.13.
     if check_suppression:
-        sdk_utils.test_output("Waiting for framework to be suppressed...")
+        sdk_utils.out("Waiting for framework to be suppressed...")
         sdk_spin.time_wait_noisy(
             lambda: sdk_api.is_suppressed(service_name))
 
-    sdk_utils.test_output('Install done after {}'.format(sdk_spin.pretty_time(time.time() - start)))
+    sdk_utils.out('Install done after {}'.format(sdk_spin.pretty_time(time.time() - start)))
 
 
 def uninstall(service_name, package_name=None):
@@ -79,11 +79,11 @@ def uninstall(service_name, package_name=None):
 
     if package_name is None:
         package_name = service_name
-    sdk_utils.test_output('Uninstalling/janitoring {}'.format(service_name))
+    sdk_utils.out('Uninstalling/janitoring {}'.format(service_name))
     try:
         shakedown.uninstall_package_and_wait(package_name, service_name=service_name)
     except (dcos.errors.DCOSException, ValueError) as e:
-        sdk_utils.test_output('Got exception when uninstalling package, ' +
+        sdk_utils.out('Got exception when uninstalling package, ' +
               'continuing with janitor anyway: {}'.format(e))
 
     janitor_start = time.time()
@@ -97,7 +97,7 @@ def uninstall(service_name, package_name=None):
 
     finish = time.time()
 
-    sdk_utils.test_output('Uninstall done after pkg({}) + janitor({}) = total({})'.format(
+    sdk_utils.out('Uninstall done after pkg({}) + janitor({}) = total({})'.format(
         sdk_spin.pretty_time(janitor_start - start),
         sdk_spin.pretty_time(finish - janitor_start),
         sdk_spin.pretty_time(finish - start)))

--- a/testing/sdk_spin.py
+++ b/testing/sdk_spin.py
@@ -1,5 +1,6 @@
 '''Utilities relating to waiting for an operation to complete'''
 
+import sdk_utils
 import shakedown
 
 import time
@@ -24,7 +25,8 @@ def time_wait_return(predicate, timeout_seconds=DEFAULT_TIMEOUT, ignore_exceptio
                 return False
         except Exception as e:
             if ignore_exceptions:
-                traceback.print_exc()
+                tb = traceback.format_exc()
+                sdk_utils.test_output(tb)
             else:
                 raise
     time_wait_noisy(
@@ -40,12 +42,13 @@ def time_wait_noisy(predicate, timeout_seconds=DEFAULT_TIMEOUT, ignore_exception
             result = predicate()
         except Exception as e:
             if ignore_exceptions:
-                traceback.print_exc()
+                tb = traceback.format_exc()
+                sdk_utils.test_output(tb)
                 return False
             else:
                 raise
         if not result:
-            print('[{}/{}] Waiting...'.format(
+            sdk_utils.test_output('[{}/{}] Waiting...'.format(
                 pretty_time(time.time() - start),
                 pretty_time(timeout_seconds)))
         return result

--- a/testing/sdk_spin.py
+++ b/testing/sdk_spin.py
@@ -26,7 +26,7 @@ def time_wait_return(predicate, timeout_seconds=DEFAULT_TIMEOUT, ignore_exceptio
         except Exception as e:
             if ignore_exceptions:
                 tb = traceback.format_exc()
-                sdk_utils.test_output(tb)
+                sdk_utils.out(tb)
             else:
                 raise
     time_wait_noisy(
@@ -43,12 +43,12 @@ def time_wait_noisy(predicate, timeout_seconds=DEFAULT_TIMEOUT, ignore_exception
         except Exception as e:
             if ignore_exceptions:
                 tb = traceback.format_exc()
-                sdk_utils.test_output(tb)
+                sdk_utils.out(tb)
                 return False
             else:
                 raise
         if not result:
-            sdk_utils.test_output('[{}/{}] Waiting...'.format(
+            sdk_utils.out('[{}/{}] Waiting...'.format(
                 pretty_time(time.time() - start),
                 pretty_time(timeout_seconds)))
         return result

--- a/testing/sdk_tasks.py
+++ b/testing/sdk_tasks.py
@@ -2,6 +2,7 @@
 
 import dcos.errors
 import sdk_spin
+import sdk_utils
 import shakedown
 
 
@@ -10,7 +11,7 @@ def check_running(service_name, expected_task_count, timeout_seconds=-1):
         try:
             tasks = shakedown.get_service_tasks(service_name)
         except dcos.errors.DCOSHTTPException:
-            print('Failed to get tasks for service {}'.format(service_name))
+            sdk_utils.test_output('Failed to get tasks for service {}'.format(service_name))
             tasks = []
         running_task_names = []
         other_tasks = []
@@ -19,11 +20,12 @@ def check_running(service_name, expected_task_count, timeout_seconds=-1):
                 running_task_names.append(t['name'])
             else:
                 other_tasks.append('{}={}'.format(t['name'], t['state']))
-        print('Waiting for {} running tasks, got {} running/{} total:\n- running: {}\n- other: {}'.format(
+        msg = 'Waiting for {} running tasks, got {} running/{} total:\n- running: {}\n- other: {}'.format(
             expected_task_count,
             len(running_task_names), len(tasks),
             running_task_names,
-            other_tasks))
+            other_tasks)
+        sdk_utils.test_output(msg)
         return len(running_task_names) >= expected_task_count
 
     if timeout_seconds <= 0:
@@ -43,11 +45,12 @@ def check_tasks_updated(service_name, prefix, old_task_ids, timeout_seconds=-1):
         try:
             task_ids = get_task_ids(service_name, prefix)
         except dcos.errors.DCOSHTTPException:
-            print('Failed to get task ids for service {}'.format(service_name))
+            sdk_utils.test_output('Failed to get task ids for service {}'.format(service_name))
             task_ids = []
 
-        print('Waiting for tasks starting with "{}" to be updated:\n- Old tasks: {}\n- Current tasks: {}'.format(
-            prefix, old_task_ids, task_ids))
+        msg = 'Waiting for tasks starting with "{}" to be updated:\n- Old tasks: {}\n- Current tasks: {}'.format(
+            prefix, old_task_ids, task_ids)
+        sdk_utils.test_output(msg)
         all_updated = True
         for id in task_ids:
             if id in old_task_ids:
@@ -67,11 +70,12 @@ def check_tasks_not_updated(service_name, prefix, old_task_ids):
         try:
             task_ids = get_task_ids(service_name, prefix)
         except dcos.errors.DCOSHTTPException:
-            print('Failed to get task ids for service {}'.format(service_name))
+            sdk_utils.test_output('Failed to get task ids for service {}'.format(service_name))
             task_ids = []
 
-        print('Checking prior tasks starting with "{}" are undisturbed:\n- Old tasks: {}\n- Current tasks: {}'.format(
+        msg = ('Checking prior tasks starting with "{}" are undisturbed:\n- Old tasks: {}\n- Current tasks: {}'.format(
             prefix, old_task_ids, task_ids))
+        sdk_utils.test_output(msg)
         for task_id in task_ids:
             if task_id not in old_task_ids:
                 return False
@@ -80,7 +84,7 @@ def check_tasks_not_updated(service_name, prefix, old_task_ids):
     try:
         sdk_spin.time_wait_noisy(lambda: fn(), timeout_seconds=60)
     except shakedown.TimeoutExpired:
-        print('Timeout reached as expected')
+        sdk_utils.test_output('Timeout reached as expected')
 
 
 def kill_task_with_pattern(pattern, host=None):

--- a/testing/sdk_tasks.py
+++ b/testing/sdk_tasks.py
@@ -11,7 +11,7 @@ def check_running(service_name, expected_task_count, timeout_seconds=-1):
         try:
             tasks = shakedown.get_service_tasks(service_name)
         except dcos.errors.DCOSHTTPException:
-            sdk_utils.test_output('Failed to get tasks for service {}'.format(service_name))
+            sdk_utils.out('Failed to get tasks for service {}'.format(service_name))
             tasks = []
         running_task_names = []
         other_tasks = []
@@ -25,7 +25,7 @@ def check_running(service_name, expected_task_count, timeout_seconds=-1):
             len(running_task_names), len(tasks),
             running_task_names,
             other_tasks)
-        sdk_utils.test_output(msg)
+        sdk_utils.out(msg)
         return len(running_task_names) >= expected_task_count
 
     if timeout_seconds <= 0:
@@ -45,12 +45,12 @@ def check_tasks_updated(service_name, prefix, old_task_ids, timeout_seconds=-1):
         try:
             task_ids = get_task_ids(service_name, prefix)
         except dcos.errors.DCOSHTTPException:
-            sdk_utils.test_output('Failed to get task ids for service {}'.format(service_name))
+            sdk_utils.out('Failed to get task ids for service {}'.format(service_name))
             task_ids = []
 
         msg = 'Waiting for tasks starting with "{}" to be updated:\n- Old tasks: {}\n- Current tasks: {}'.format(
             prefix, old_task_ids, task_ids)
-        sdk_utils.test_output(msg)
+        sdk_utils.out(msg)
         all_updated = True
         for id in task_ids:
             if id in old_task_ids:
@@ -70,12 +70,12 @@ def check_tasks_not_updated(service_name, prefix, old_task_ids):
         try:
             task_ids = get_task_ids(service_name, prefix)
         except dcos.errors.DCOSHTTPException:
-            sdk_utils.test_output('Failed to get task ids for service {}'.format(service_name))
+            sdk_utils.out('Failed to get task ids for service {}'.format(service_name))
             task_ids = []
 
         msg = ('Checking prior tasks starting with "{}" are undisturbed:\n- Old tasks: {}\n- Current tasks: {}'.format(
             prefix, old_task_ids, task_ids))
-        sdk_utils.test_output(msg)
+        sdk_utils.out(msg)
         for task_id in task_ids:
             if task_id not in old_task_ids:
                 return False
@@ -84,7 +84,7 @@ def check_tasks_not_updated(service_name, prefix, old_task_ids):
     try:
         sdk_spin.time_wait_noisy(lambda: fn(), timeout_seconds=60)
     except shakedown.TimeoutExpired:
-        sdk_utils.test_output('Timeout reached as expected')
+        sdk_utils.out('Timeout reached as expected')
 
 
 def kill_task_with_pattern(pattern, host=None):

--- a/testing/sdk_test_upgrade.py
+++ b/testing/sdk_test_upgrade.py
@@ -19,10 +19,10 @@ def upgrade_downgrade(package_name, running_task_count):
     install.uninstall(package_name)
 
     test_version = get_pkg_version(package_name)
-    sdk_utils.test_output('Found test version: {}'.format(test_version))
+    sdk_utils.out('Found test version: {}'.format(test_version))
 
     repositories = json.loads(cmd.run_cli('package repo list --json'))['repositories']
-    sdk_utils.test_output("Repositories: " + str(repositories))
+    sdk_utils.out("Repositories: " + str(repositories))
     universe_url = "fail"
     for repo in repositories:
         if repo['name'] == 'Universe':
@@ -30,37 +30,37 @@ def upgrade_downgrade(package_name, running_task_count):
             break
 
     assert "fail" != universe_url
-    sdk_utils.test_output("Universe URL: " + universe_url)
+    sdk_utils.out("Universe URL: " + universe_url)
 
     # Move the Universe repo to the top of the repo list
     shakedown.remove_package_repo('Universe')
     add_repo('Universe', universe_url, test_version, 0, package_name)
 
     universe_version = get_pkg_version(package_name)
-    sdk_utils.test_output('Found Universe version: {}'.format(universe_version))
+    sdk_utils.out('Found Universe version: {}'.format(universe_version))
 
-    sdk_utils.test_output('Installing Universe version')
+    sdk_utils.out('Installing Universe version')
     install.install(package_name, running_task_count, check_suppression=False)
 
     # Move the Universe repo to the bottom of the repo list
     shakedown.remove_package_repo('Universe')
     add_last_repo('Universe', universe_url, universe_version, package_name)
 
-    sdk_utils.test_output('Upgrading to test version')
+    sdk_utils.out('Upgrading to test version')
     upgrade_or_downgrade(package_name, running_task_count)
 
     # Move the Universe repo to the top of the repo list
     shakedown.remove_package_repo('Universe')
     add_repo('Universe', universe_url, test_version, 0, package_name)
 
-    sdk_utils.test_output('Downgrading to master version')
+    sdk_utils.out('Downgrading to master version')
     upgrade_or_downgrade(package_name, running_task_count)
 
     # Move the Universe repo to the bottom of the repo list
     shakedown.remove_package_repo('Universe')
     add_last_repo('Universe', universe_url, universe_version, package_name)
 
-    sdk_utils.test_output('Upgrading to test version')
+    sdk_utils.out('Upgrading to test version')
     upgrade_or_downgrade(package_name, running_task_count)
 
 
@@ -68,10 +68,10 @@ def upgrade_or_downgrade(package_name, running_task_count):
     task_ids = tasks.get_task_ids(package_name, '')
     marathon.destroy_app(package_name)
     install.install(package_name, running_task_count, check_suppression=False)
-    sdk_utils.test_output('Waiting for upgrade / downgrade deployment to complete')
+    sdk_utils.out('Waiting for upgrade / downgrade deployment to complete')
     spin.time_wait_noisy(lambda: (
         plan.get_deployment_plan(package_name).json()['status'] == 'COMPLETE'))
-    sdk_utils.test_output('Checking that all tasks have restarted')
+    sdk_utils.out('Checking that all tasks have restarted')
     tasks.check_tasks_updated(package_name, '', task_ids)
 
 

--- a/testing/sdk_test_upgrade.py
+++ b/testing/sdk_test_upgrade.py
@@ -8,6 +8,7 @@ import sdk_marathon as marathon
 import sdk_plan as plan
 import sdk_spin as spin
 import sdk_tasks as tasks
+import sdk_utils
 
 
 # (1) Installs Universe version of framework.
@@ -18,10 +19,10 @@ def upgrade_downgrade(package_name, running_task_count):
     install.uninstall(package_name)
 
     test_version = get_pkg_version(package_name)
-    print('Found test version: {}'.format(test_version))
+    sdk_utils.test_output('Found test version: {}'.format(test_version))
 
     repositories = json.loads(cmd.run_cli('package repo list --json'))['repositories']
-    print("Repositories: " + str(repositories))
+    sdk_utils.test_output("Repositories: " + str(repositories))
     universe_url = "fail"
     for repo in repositories:
         if repo['name'] == 'Universe':
@@ -29,37 +30,37 @@ def upgrade_downgrade(package_name, running_task_count):
             break
 
     assert "fail" != universe_url
-    print("Universe URL: " + universe_url)
+    sdk_utils.test_output("Universe URL: " + universe_url)
 
     # Move the Universe repo to the top of the repo list
     shakedown.remove_package_repo('Universe')
     add_repo('Universe', universe_url, test_version, 0, package_name)
 
     universe_version = get_pkg_version(package_name)
-    print('Found Universe version: {}'.format(universe_version))
+    sdk_utils.test_output('Found Universe version: {}'.format(universe_version))
 
-    print('Installing Universe version')
+    sdk_utils.test_output('Installing Universe version')
     install.install(package_name, running_task_count, check_suppression=False)
 
     # Move the Universe repo to the bottom of the repo list
     shakedown.remove_package_repo('Universe')
     add_last_repo('Universe', universe_url, universe_version, package_name)
 
-    print('Upgrading to test version')
+    sdk_utils.test_output('Upgrading to test version')
     upgrade_or_downgrade(package_name, running_task_count)
 
     # Move the Universe repo to the top of the repo list
     shakedown.remove_package_repo('Universe')
     add_repo('Universe', universe_url, test_version, 0, package_name)
 
-    print('Downgrading to master version')
+    sdk_utils.test_output('Downgrading to master version')
     upgrade_or_downgrade(package_name, running_task_count)
 
     # Move the Universe repo to the bottom of the repo list
     shakedown.remove_package_repo('Universe')
     add_last_repo('Universe', universe_url, universe_version, package_name)
 
-    print('Upgrading to test version')
+    sdk_utils.test_output('Upgrading to test version')
     upgrade_or_downgrade(package_name, running_task_count)
 
 
@@ -67,10 +68,10 @@ def upgrade_or_downgrade(package_name, running_task_count):
     task_ids = tasks.get_task_ids(package_name, '')
     marathon.destroy_app(package_name)
     install.install(package_name, running_task_count, check_suppression=False)
-    print('Waiting for upgrade / downgrade deployment to complete')
+    sdk_utils.test_output('Waiting for upgrade / downgrade deployment to complete')
     spin.time_wait_noisy(lambda: (
         plan.get_deployment_plan(package_name).json()['status'] == 'COMPLETE'))
-    print('Checking that all tasks have restarted')
+    sdk_utils.test_output('Checking that all tasks have restarted')
     tasks.check_tasks_updated(package_name, '', task_ids)
 
 

--- a/testing/sdk_utils.py
+++ b/testing/sdk_utils.py
@@ -1,8 +1,14 @@
-'''Utilities relating to reclaiming private agent disk space consumed by Mesos but not yet garbage collected'''
 
 import shakedown
+import logging
 
+
+def test_output(msg):
+    '''Emit an informational message on test progress during test runs'''
+    logger = logging.getLogger(__name__)
+    logger.info(msg)
 
 def gc_frameworks():
+    '''Reeclaims private agent disk space consumed by Mesos but not yet garbage collected'''
     for host in shakedown.get_private_agents():
         shakedown.run_command(host, "sudo rm -rf /var/lib/mesos/slave/slaves/*/frameworks/*")

--- a/testing/sdk_utils.py
+++ b/testing/sdk_utils.py
@@ -3,7 +3,7 @@ import sys
 import shakedown
 
 
-def test_output(msg):
+def out(msg):
     '''Emit an informational message on test progress during test runs'''
     print(msg, file=sys.stderr)
 

--- a/testing/sdk_utils.py
+++ b/testing/sdk_utils.py
@@ -30,6 +30,6 @@ def test_output(msg):
 
 
 def gc_frameworks():
-    '''Reeclaims private agent disk space consumed by Mesos but not yet garbage collected'''
+    '''Reclaims private agent disk space consumed by Mesos but not yet garbage collected'''
     for host in shakedown.get_private_agents():
         shakedown.run_command(host, "sudo rm -rf /var/lib/mesos/slave/slaves/*/frameworks/*")

--- a/testing/sdk_utils.py
+++ b/testing/sdk_utils.py
@@ -1,12 +1,33 @@
+import sys
 
 import shakedown
-import logging
 
 
 def test_output(msg):
     '''Emit an informational message on test progress during test runs'''
-    logger = logging.getLogger(__name__)
-    logger.info(msg)
+    print(msg, file=sys.stderr)
+
+    # I'd much rather the latter, but it is super confusing intermingled with
+    # shakedown output.
+
+    ## pytest is awful; hack around its inability to provide a sanely
+    ## configurable logging environment
+    #current_time = datetime.datetime.now()
+    #frames = inspect.getouterframes(inspect.currentframe())
+    #try:
+    #    parent = frames[1]
+    #finally:
+    #    del frames
+    #try:
+    #    parent_filename = parent[1]
+    #finally:
+    #    del parent
+    #name = inspect.getmodulename(parent_filename)
+    #out = "{current_time} {name} {msg}\n".format(current_time=current_time,
+    #                                             name=name,
+    #                                             msg=msg)
+    #sys.stderr.write(out)
+
 
 def gc_frameworks():
     '''Reeclaims private agent disk space consumed by Mesos but not yet garbage collected'''

--- a/tools/run_tests.py
+++ b/tools/run_tests.py
@@ -32,6 +32,9 @@ class CITester(object):
         if not self._sandbox_path:
             self._sandbox_path = tempfile.mkdtemp(prefix='ci-test-')
         custom_env = {}
+        # ask for unbuffered stdout, since test output randomly uses stdout
+        # vs stderr
+        custom_env['PYTHONUNBUFFERED'] = "yes"
         # must be custom for CLI to behave properly:
         custom_env['HOME'] = self._sandbox_path
         # prepend HOME (where CLI binary is downloaded) to PATH:


### PR DESCRIPTION
After a few failed experiments, the working pattern is to just ask python not to buffer output.  Since test.py is already running run_tests.py with the same file as fd 1 and 2, this should provide a reliable linear stream of events.   That's a very small change.

The much larger linecount change is the move from print to a dedicated "this is test output" function.  I'm not married this.  But I wanted to move away from print inline everywhere since that's a growing problem.  

I can also decouple the test.py fix, though given the pace of my reviews and merges I'm not excited about it.