### PR TITLE
[INFINITY-1321] Drop requirements.txt because the toolszip doesn't handle it, it's also weird where it is

### DIFF
--- a/docs/pages/developer-guide.md
+++ b/docs/pages/developer-guide.md
@@ -887,9 +887,8 @@ installed the
 Here's an example of running the tests for the `helloworld` framework:
 
 ```bash
-$ virtualenv -p python3 venv
+$ tools/venvutil.py create venv
 $ source venv/bin/activate
-$ pip install -r tools/requirements.txt
 $ py.test frameworks/helloworld/
 ```
 

--- a/tools/configure_test_cluster.py
+++ b/tools/configure_test_cluster.py
@@ -98,23 +98,12 @@ class ClusterInitializer(object):
     def configure_master_settings(self):
         logger.info("Live-customizing mesos master")
         venv_path = venvutil.shared_tools_venv()
-        requirements_file = os.path.join(_tools_dir(), 'requirements.txt')
-        # needs shakedown, so needs python3
-        if sys.version_info < (3,4):
-            venvutil.create_venv(venv_path, py3=True)
-            venvutil.pip_install(venv_path, requirements_file)
+        venvutil.create_dcoscommons_venv(venv_path)
+        venvutil.activate_venv(venv_path)
 
-            script = os.path.join(_tools_dir(), 'modify_master.py')
-            configure_cmd = ['python', script]
-            venvutil.run_cmd(venv_path, configure_cmd)
-        else:
-            venvutil.create_venv(venv_path)
-            venvutil.pip_install(venv_path, requirements_file)
-            venvutil.activate_venv(venv_path)
-
-            # import delayed until dependencies exist
-            import modify_master
-            modify_master.set_local_infinity_defaults()
+        # import delayed until dependencies exist
+        import modify_master
+        modify_master.set_local_infinity_defaults()
 
     def apply_default_config(self):
         saved_env = os.environ.copy()

--- a/tools/launch_ccm_cluster.py
+++ b/tools/launch_ccm_cluster.py
@@ -342,7 +342,7 @@ class StartConfig(object):
             start_timeout_mins = CCMLauncher.DEFAULT_TIMEOUT_MINS,
             public_agents = 0,
             private_agents = 1,
-            aws_region = 'eu-central-1',
+            aws_region = 'us-west-2',
             admin_location = '0.0.0.0/0',
             cloud_provider = '0', # https://mesosphere.atlassian.net/browse/TEST-231
             mount_volumes = False):

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,1 +1,0 @@
--e git+https://github.com/dcos/shakedown.git@master#egg=shakedown

--- a/tools/venvutil.py
+++ b/tools/venvutil.py
@@ -5,7 +5,7 @@ import os
 import os.path
 import subprocess
 import sys
-# requires python3.3 or later
+import tempfile
 import venv
 
 logger = logging.getLogger(__name__)
@@ -88,3 +88,28 @@ def run_py(path, func, *args, **kwargs):
     # theoretically save and restore is possible, but probably not a good idea
     raise NotImplementedError
 
+def create_default_requirementsfile(filename):
+    with open(filename, 'w') as reqfile:
+        reqfile.write('''
+requests==2.10.0
+
+-e git+https://github.com/dcos/shakedown.git@master#egg=shakedown
+''')
+
+def create_dcoscommons_venv(path):
+    create_venv(path)
+    req_filename = os.path.join(path, 'requirements.txt')
+    create_default_requirementsfile(req_filename)
+    pip_install(path, req_filename)
+
+
+
+if __name__ == "__main__":
+    # only creating default venv so far
+    if len(sys.argv) < 3:
+        sys.exit("Too few arguments\nusage: venvutil.py create <dir>")
+    if sys.argv[1] != "create":
+        sys.exit("Unknown command {}\nusage: venvutil.py create <dir>".format(sys.argv))
+    venv_tgt_dir = sys.argv[2]
+    os.makedirs(venv_tgt_dir)
+    create_dcoscommons_venv(venv_tgt_dir)


### PR DESCRIPTION
The nightly external repo tests are broken due to a lack of this change, so I'd like to merge it tonight or at least tomorrow (the alternative is to back out @benclarkwood s mesos master configuration again)

I'll be changing run_tests.py to use venvutil.py to remove the redundancy asap.