### PR TITLE
[SDK] Revive on registration always

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/DefaultScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/DefaultScheduler.java
@@ -920,7 +920,7 @@ public class DefaultScheduler implements Scheduler, Observer {
     private void postRegister() {
         reconciler.start();
         reconciler.reconcile(driver);
-        suppressOrRevive();
+        revive();
     }
 
     @Override


### PR DESCRIPTION
Always reviving after a registration event, guarantees we can force revival by restarting the scheduler.  It also makes the suppressed property set once a Scheduler is active to avoid a 404 when checking the suppressed property.