### PR TITLE
[TESTS][INFINITY-1238] Added upgrade-downgrade tests to run in soak cluster

### DIFF
--- a/frameworks/elastic/tests/test_soak.py
+++ b/frameworks/elastic/tests/test_soak.py
@@ -1,0 +1,16 @@
+import json
+import pytest
+import sdk_test_upgrade
+from tests.config import (
+    PACKAGE_NAME,
+    DEFAULT_TASK_COUNT,
+)
+
+
+@pytest.mark.soak_upgrade
+def test_soak_upgrade_downgrade():
+    """ Assumes that the install options file is placed in the repo root directory by the user.
+    """
+    with open('elastic.json') as options_file:
+        install_options = json.load(options_file)
+    sdk_test_upgrade.soak_upgrade_downgrade(PACKAGE_NAME, DEFAULT_TASK_COUNT, install_options)

--- a/frameworks/helloworld/tests/test_soak.py
+++ b/frameworks/helloworld/tests/test_soak.py
@@ -1,0 +1,11 @@
+import pytest
+import sdk_test_upgrade
+from tests.config import (
+    PACKAGE_NAME,
+    DEFAULT_TASK_COUNT,
+)
+
+
+@pytest.mark.soak_upgrade
+def test_soak_upgrade_downgrade():
+    sdk_test_upgrade.soak_upgrade_downgrade(PACKAGE_NAME, DEFAULT_TASK_COUNT)

--- a/testing/sdk_test_upgrade.py
+++ b/testing/sdk_test_upgrade.py
@@ -65,7 +65,7 @@ def upgrade_downgrade(package_name, running_task_count, additional_options={}):
 
 
 # In the soak cluster, we assume that the Universe version of the framework is already installed.
-# Also, we assume that the Universe is the default repo and the stub repos are already in place,
+# Also, we assume that the Universe is the default repo (at --index=0) and the stub repos are already in place,
 # so we don't need to add or remove any repos.
 #
 # (1) Upgrades to test version of framework.
@@ -74,7 +74,8 @@ def soak_upgrade_downgrade(package_name, running_task_count, install_options={})
     print('Upgrading to test version')
     upgrade_or_downgrade(package_name, running_task_count, install_options, 'stub-universe')
 
-    print('Downgrading to master version')
+    print('Downgrading to Universe version')
+    # Default Universe is at --index=0
     upgrade_or_downgrade(package_name, running_task_count, install_options)
 
 

--- a/testing/sdk_test_upgrade.py
+++ b/testing/sdk_test_upgrade.py
@@ -64,10 +64,29 @@ def upgrade_downgrade(package_name, running_task_count, additional_options={}):
     upgrade_or_downgrade(package_name, running_task_count, additional_options)
 
 
-def upgrade_or_downgrade(package_name, running_task_count, additional_options):
+# In the soak cluster, we assume that the Universe version of the framework is already installed.
+# Also, we assume that the Universe is the default repo and the stub repos are already in place,
+# so we don't need to add or remove any repos.
+#
+# (1) Upgrades to test version of framework.
+# (2) Downgrades to Universe version.
+def soak_upgrade_downgrade(package_name, running_task_count, install_options={}):
+    print('Upgrading to test version')
+    upgrade_or_downgrade(package_name, running_task_count, install_options, 'stub-universe')
+
+    print('Downgrading to master version')
+    upgrade_or_downgrade(package_name, running_task_count, install_options)
+
+
+def upgrade_or_downgrade(package_name, running_task_count, additional_options, package_version=None):
     task_ids = tasks.get_task_ids(package_name, '')
     marathon.destroy_app(package_name)
-    install.install(package_name, running_task_count, check_suppression=False, additional_options=additional_options)
+    install.install(
+        package_name,
+        running_task_count,
+        additional_options=additional_options,
+        package_version=package_version,
+        check_suppression=False)
     sdk_utils.out('Waiting for upgrade / downgrade deployment to complete')
     spin.time_wait_noisy(lambda: (
         plan.get_deployment_plan(package_name).json()['status'] == 'COMPLETE'))


### PR DESCRIPTION
Added upgrade-downgrade tests to run in soak cluster, for hello-world and Elastic.

Differences from the CI upgrade-downgrade test:

- In the soak cluster, we assume that the Universe version of the framework is already installed.
- Also, we assume that the Universe is the default repo and the stub repos are already in place,
so we don't need to add or remove any repos.

These tests run in a metronome job inside the soak cluster. For metronome job config, see: https://github.com/mesosphere/soak-cluster-configurations/pull/71