### PR TITLE
Add tests for remaining cassandra sidecar plans

### DIFF
--- a/frameworks/cassandra/src/main/dist/svc.yml
+++ b/frameworks/cassandra/src/main/dist/svc.yml
@@ -76,11 +76,11 @@ pods:
           timeout: 60
       repair:
         goal: FINISHED
-        cmd: ./apache-cassandra-{{CASSANDRA_VERSION}}/bin/nodetool repair -pr -p {{TASKCFG_ALL_JMX_PORT}} -- $CASSANDRA_KEYSPACE_TABLES
+        cmd: ./apache-cassandra-{{CASSANDRA_VERSION}}/bin/nodetool repair -pr -p {{TASKCFG_ALL_JMX_PORT}} -- $(eval "echo $CASSANDRA_KEYSPACES")
         resource-set: sidecar-resources
       cleanup:
         goal: FINISHED
-        cmd: ./apache-cassandra-{{CASSANDRA_VERSION}}/bin/nodetool cleanup -p {{TASKCFG_ALL_JMX_PORT}} -- $CASSANDRA_KEYSPACE_TABLES
+        cmd: ./apache-cassandra-{{CASSANDRA_VERSION}}/bin/nodetool cleanup -p {{TASKCFG_ALL_JMX_PORT}} -- $(eval "echo $CASSANDRA_KEYSPACES")
         resource-set: sidecar-resources
       backup-schema:
         goal: FINISHED
@@ -163,7 +163,7 @@ pods:
         resource-set: sidecar-resources
       upgradesstables:
         goal: FINISHED
-        cmd: ./apache-cassandra-{{CASSANDRA_VERSION}}/bin/nodetool upgradesstables -a -p {{TASKCFG_ALL_JMX_PORT}} -- $CASSANDRA_KEYSPACE_TABLES
+        cmd: ./apache-cassandra-{{CASSANDRA_VERSION}}/bin/nodetool upgradesstables -a -p {{TASKCFG_ALL_JMX_PORT}} -- $(eval "echo $CASSANDRA_KEYSPACES")
         resource-set: sidecar-resources
 plans:
   deploy:

--- a/frameworks/cassandra/src/main/dist/svc.yml
+++ b/frameworks/cassandra/src/main/dist/svc.yml
@@ -76,11 +76,11 @@ pods:
           timeout: 60
       repair:
         goal: FINISHED
-        cmd: ./apache-cassandra-{{CASSANDRA_VERSION}}/bin/nodetool repair -pr -p {{TASKCFG_ALL_JMX_PORT}} -- $(eval "echo $CASSANDRA_KEYSPACES")
+        cmd: ./apache-cassandra-{{CASSANDRA_VERSION}}/bin/nodetool repair -pr -p {{TASKCFG_ALL_JMX_PORT}} -- $CASSANDRA_KEYSPACE
         resource-set: sidecar-resources
       cleanup:
         goal: FINISHED
-        cmd: ./apache-cassandra-{{CASSANDRA_VERSION}}/bin/nodetool cleanup -p {{TASKCFG_ALL_JMX_PORT}} -- $(eval "echo $CASSANDRA_KEYSPACES")
+        cmd: ./apache-cassandra-{{CASSANDRA_VERSION}}/bin/nodetool cleanup -p {{TASKCFG_ALL_JMX_PORT}} -- $CASSANDRA_KEYSPACE
         resource-set: sidecar-resources
       backup-schema:
         goal: FINISHED
@@ -163,7 +163,7 @@ pods:
         resource-set: sidecar-resources
       upgradesstables:
         goal: FINISHED
-        cmd: ./apache-cassandra-{{CASSANDRA_VERSION}}/bin/nodetool upgradesstables -a -p {{TASKCFG_ALL_JMX_PORT}} -- $(eval "echo $CASSANDRA_KEYSPACES")
+        cmd: ./apache-cassandra-{{CASSANDRA_VERSION}}/bin/nodetool upgradesstables -a -p {{TASKCFG_ALL_JMX_PORT}} -- $CASSANDRA_KEYSPACE
         resource-set: sidecar-resources
 plans:
   deploy:

--- a/frameworks/cassandra/tests/config.py
+++ b/frameworks/cassandra/tests/config.py
@@ -1,4 +1,10 @@
+import os
+
 import shakedown
+
+import sdk_cmd as cmd
+import sdk_spin as spin
+
 
 PACKAGE_NAME = 'cassandra'
 DEFAULT_TASK_COUNT = 3
@@ -12,6 +18,42 @@ REQUEST_HEADERS = {
     'authorization': 'token=%s' % DCOS_TOKEN
 }
 
+WRITE_DATA_JOB = 'write-data'
+VERIFY_DATA_JOB = 'verify-data'
+DELETE_DATA_JOB = 'delete-data'
+VERIFY_DELETION_JOB = 'verify-deletion'
+TEST_JOBS = (
+    WRITE_DATA_JOB, VERIFY_DATA_JOB, DELETE_DATA_JOB, VERIFY_DELETION_JOB
+)
+
 
 def check_dcos_service_health():
     return shakedown.service_healthy(PACKAGE_NAME)
+
+
+def qualified_job_name(job_name):
+    return 'test.cassandra.{}'.format(job_name)
+
+
+def install_cassandra_jobs():
+    jobs_folder = os.path.join(
+        os.path.dirname(os.path.realpath(__file__)), 'jobs'
+    )
+    for job in TEST_JOBS:
+        cmd.run_cli('job add {}'.format(
+            os.path.join(jobs_folder, '{}.json'.format(job))
+        ))
+
+
+def launch_and_verify_job(job_name, expected_successes=1):
+    cmd.run_cli('job run {}'.format(qualified_job_name(job_name)))
+
+    spin.time_wait_noisy(lambda: (
+        'Successful runs: {}'.format(expected_successes) in
+        cmd.run_cli('job history {}'.format(qualified_job_name(job_name)))
+    ))
+
+
+def remove_cassandra_jobs():
+    for job in TEST_JOBS:
+        cmd.run_cli('job remove {}'.format(qualified_job_name(job)))

--- a/frameworks/cassandra/tests/test_backup.py
+++ b/frameworks/cassandra/tests/test_backup.py
@@ -13,15 +13,6 @@ import sdk_tasks as tasks
 import sdk_utils as utils
 
 
-WRITE_DATA_JOB = 'write-data'
-VERIFY_DATA_JOB = 'verify-data'
-DELETE_DATA_JOB = 'delete-data'
-VERIFY_DELETION_JOB = 'verify-deletion'
-TEST_JOBS = (
-    WRITE_DATA_JOB, VERIFY_DATA_JOB, DELETE_DATA_JOB, VERIFY_DELETION_JOB
-)
-
-
 def setup_module(module):
     install.uninstall(PACKAGE_NAME)
     utils.gc_frameworks()
@@ -29,13 +20,7 @@ def setup_module(module):
     # check_suppression=False due to https://jira.mesosphere.com/browse/CASSANDRA-568
     install.install(PACKAGE_NAME, DEFAULT_TASK_COUNT, check_suppression=False)
 
-    jobs_folder = os.path.join(
-        os.path.dirname(os.path.realpath(__file__)), 'jobs'
-    )
-    for job in TEST_JOBS:
-        cmd.run_cli('job add {}'.format(
-            os.path.join(jobs_folder, '{}.json'.format(job))
-        ))
+    install_cassandra_jobs()
 
 
 def setup_function(function):
@@ -45,21 +30,7 @@ def setup_function(function):
 def teardown_module(module):
     install.uninstall(PACKAGE_NAME)
 
-    for job in TEST_JOBS:
-        cmd.run_cli('job remove {}'.format(qualified_job_name(job)))
-
-
-def qualified_job_name(job_name):
-    return 'test.cassandra.{}'.format(job_name)
-
-
-def launch_and_verify_job(job_name, expected_successes=1):
-    cmd.run_cli('job run {}'.format(qualified_job_name(job_name)))
-
-    spin.time_wait_noisy(lambda: (
-        'Successful runs: {}'.format(expected_successes) in
-        cmd.run_cli('job history {}'.format(qualified_job_name(job_name)))
-    ))
+    remove_cassandra_jobs()
 
 
 @pytest.mark.sanity

--- a/frameworks/cassandra/tests/test_maintenance_plans.py
+++ b/frameworks/cassandra/tests/test_maintenance_plans.py
@@ -34,6 +34,7 @@ def teardown_module(module):
     remove_cassandra_jobs()
 
 
+@pytest.mark.sanity
 def test_cleanup_plan_completes():
     cleanup_parameters = {'CASSANDRA_KEYSPACE': 'testspace1'}
 
@@ -46,6 +47,7 @@ def test_cleanup_plan_completes():
     )
 
 
+@pytest.mark.sanity
 def test_repair_plan_completes():
     repair_parameters = {'CASSANDRA_KEYSPACE': 'testspace1'}
 
@@ -58,6 +60,7 @@ def test_repair_plan_completes():
     )
 
 
+@pytest.mark.sanity
 def test_upgrade_sstables_plan_completes():
     upgrade_sstables_parameters = {'CASSANDRA_KEYSPACE': 'testspace1'}
 

--- a/frameworks/cassandra/tests/test_maintenance_plans.py
+++ b/frameworks/cassandra/tests/test_maintenance_plans.py
@@ -1,0 +1,70 @@
+import pytest
+
+from tests.config import *
+import sdk_install as install
+import sdk_plan as plan
+import sdk_spin as spin
+import sdk_tasks as tasks
+import sdk_utils as utils
+
+
+def setup_module(module):
+    install.uninstall(PACKAGE_NAME)
+    utils.gc_frameworks()
+
+    # check_suppression=False due to https://jira.mesosphere.com/browse/CASSANDRA-568
+    install.install(PACKAGE_NAME, DEFAULT_TASK_COUNT, check_suppression=False)
+
+    install_cassandra_jobs()
+    # Write data to Cassandra with a metronome job, then verify it was written
+    launch_and_verify_job(WRITE_DATA_JOB)
+    launch_and_verify_job(VERIFY_DATA_JOB)
+
+
+def setup_function(function):
+    tasks.check_running(PACKAGE_NAME, DEFAULT_TASK_COUNT)
+
+
+def teardown_module(module):
+    install.uninstall(PACKAGE_NAME)
+
+    # Delete Cassandra data, then remove job definitions from metronome
+    launch_and_verify_job(DELETE_DATA_JOB)
+    launch_and_verify_job(VERIFY_DELETION_JOB)
+    remove_cassandra_jobs()
+
+
+def test_cleanup_plan_completes():
+    cleanup_parameters = {'CASSANDRA_KEYSPACE': 'testspace1'}
+
+    plan.start_plan(PACKAGE_NAME, 'cleanup', parameters=cleanup_parameters)
+    spin.time_wait_noisy(
+        lambda: (
+            plan.get_plan(PACKAGE_NAME, 'cleanup').json()['status'] ==
+            'COMPLETE'
+        )
+    )
+
+
+def test_repair_plan_completes():
+    repair_parameters = {'CASSANDRA_KEYSPACE': 'testspace1'}
+
+    plan.start_plan(PACKAGE_NAME, 'repair', parameters=repair_parameters)
+    spin.time_wait_noisy(
+        lambda: (
+            plan.get_plan(PACKAGE_NAME, 'repair').json()['status'] ==
+            'COMPLETE'
+        )
+    )
+
+
+def test_upgrade_sstables_plan_completes():
+    upgrade_sstables_parameters = {'CASSANDRA_KEYSPACE': 'testspace1'}
+
+    plan.start_plan(PACKAGE_NAME, 'upgradesstables', parameters=upgrade_sstables_parameters)
+    spin.time_wait_noisy(
+        lambda: (
+            plan.get_plan(PACKAGE_NAME, 'upgradesstables').json()['status'] ==
+            'COMPLETE'
+        )
+    )

--- a/frameworks/cassandra/tests/test_maintenance_plans.py
+++ b/frameworks/cassandra/tests/test_maintenance_plans.py
@@ -28,9 +28,7 @@ def setup_function(function):
 def teardown_module(module):
     install.uninstall(PACKAGE_NAME)
 
-    # Delete Cassandra data, then remove job definitions from metronome
-    launch_and_verify_job(DELETE_DATA_JOB)
-    launch_and_verify_job(VERIFY_DELETION_JOB)
+    # remove job definitions from metronome
     remove_cassandra_jobs()
 
 


### PR DESCRIPTION
This brings the SDK Cassandra plan coverage up to par with `dcos-cassandra-service`, which tests cleanup and repair plans for successful completion.