### PR TITLE
[HDFS-441] Warn on offer rescind instead of exit

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/DefaultScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/DefaultScheduler.java
@@ -797,8 +797,7 @@ public class DefaultScheduler implements Scheduler, Observer {
 
     @Override
     public void offerRescinded(SchedulerDriver driver, Protos.OfferID offerId) {
-        LOGGER.error("Rescinding offers is not supported.");
-        SchedulerUtils.hardExit(SchedulerErrorCode.OFFER_RESCINDED);
+        LOGGER.warn("Ignoring rescinded Offer: {}.", offerId.getValue());
     }
 
     @Override


### PR DESCRIPTION
[Scheduler documentation](http://mesos.apache.org/documentation/latest/app-framework-development-guide/)

```
/*
 * Invoked when an offer is no longer valid (e.g., the slave was
 * lost or another framework used resources in the offer). If for
 * whatever reason an offer is never rescinded (e.g., dropped
 * message, failing over framework, etc.), a framework that attempts
 * to launch tasks using an invalid offer will receive TASK_LOST
 * status updates for those tasks (see Scheduler::resourceOffers).
 */
virtual void offerRescinded(SchedulerDriver* driver, const OfferID& offerId);
```
There is one case in which attempting to launch a Task and receiving a `TASK_LOST` is a problem.  That is the very first launch of a Task.  This is already a problem for us in the case where we generate a set of initial operations (`RESERVE`, `CREATE`, `LAUNCH`) to launch a Task which is not perfect.

We do not automatically recover from this case and require `dcos <service> pods replace <pod>` to be entered by a human.  We have never seen an instance of this race failure occur.  It's possible that ignoring rescinds will increase this frequency.  If we start to see instances of hitting this race, we should invest time and energy fixing the race.  In the mean time the frequency of scheduler crashes is more disruptive than avoiding the extremely rare and never encountered race condition.