### PR TITLE
[KAFKA] Change heap default to 512MB

### DIFF
--- a/frameworks/kafka/universe/config.json
+++ b/frameworks/kafka/universe/config.json
@@ -57,7 +57,7 @@
           "mem":{
             "description":"Broker mem requirements",
             "type":"integer",
-            "default":2304
+            "default":2048
           },
           "heap":{
             "description":"The Kafka process JVM heap configuration object",
@@ -66,7 +66,7 @@
               "size": {
                 "type":"integer",
                 "description":"The amount of JVM heap, in MB, allocated to the Kafka broker process.",
-                "default": 2048
+                "default":512
               }
             },
             "additionalProperties": false,


### PR DESCRIPTION
From Confluent documentation and best practices with Kafka:  What I get is that Kafka uses heap very efficiently. Kafka also likes page cache. For example recommendation for a 32G machine is 5G heap max. I would say one should not set more than 4G heap anyway. Here we set defaults. User should change those options in config.json. If you have bigger messages, you may need more heap. You may want to use more memory to benefit from page cache, etc. 