### PR TITLE
[INFINITY-1364] toolsreleasesh broken by initpaths

### DIFF
--- a/tools/init_paths.sh
+++ b/tools/init_paths.sh
@@ -8,7 +8,7 @@ if [ -z "$TOOLS_DIR" ]; then
 fi
 
 if [ -z "$REPO_ROOT_DIR" ]; then
-    REPO_ROOT_DIR=$(dirname $TOOLS_DIR)
+    REPO_ROOT_DIR="$(dirname $TOOLS_DIR)"
 fi
 
 if [ -z "$REPO_NAME" ]; then

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -8,7 +8,7 @@ set -e
 
 script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source $script_dir/init_paths.sh
-cd $REPO_ROOT_DIR
+cd "$TOOLS_DIR"
 
 # Upload current tools (with '.commit' file containing the current SHA) to DEV S3.
 # This can be downloaded via: https://infinity-artifacts.s3.amazonaws.com/dcos-commons-tools.tgz

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -1,9 +1,13 @@
 #!/bin/bash
 
+#script to publish the tools dir to s3 for use in other jobs
+
+
 # Exit immediately on failure:
 set -e
 
-source init_paths.sh
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source $script_dir/init_paths.sh
 cd $REPO_ROOT_DIR
 
 # Upload current tools (with '.commit' file containing the current SHA) to DEV S3.


### PR DESCRIPTION
This script always was `cd`ing into dcos-commons/tools, but probably due to copy&paste, claimed to be `cd`ing into the root.  When mohit introduced init_paths.sh, this meant the script no longer worked.  I "fixed" it to not assume init_paths was in the current directory, but that was not the full fix, as now the tools zip contained dcos-commons/*.py and sh, instead of dcos-commons/tools/*.py & sh.

As a bonus, bother to be space-in-path safe in init-paths.sh.  Someone is going to make another jenkins job with a space sooner or later, and there are failures elsewhere, but there's no point in failing here.  (If i was spending more time on this, maybe I'd make a fail-fast on spaces)