### PR TITLE
[SPARK-448] Shotgun approach to spark venvutil problem; logging + attempted workaround.

### DIFF
--- a/tools/configure_test_cluster.py
+++ b/tools/configure_test_cluster.py
@@ -105,7 +105,7 @@ class ClusterInitializer(object):
         import modify_master
         modify_master.set_local_infinity_defaults()
 
-    def apply_default_config(self):
+    def apply_default_config(self, initmaster=True):
         saved_env = os.environ.copy()
         try:
             # TODO; track a cluster-specific working dir, and keep this in
@@ -126,12 +126,13 @@ class ClusterInitializer(object):
                     os.dup2(sys.stderr.fileno(), stdout_fd)
 
                     self.create_service_account()
-                    # currently, the create_service_account.sh script sets up the
-                    # cli itself so we initialize it in the style that test logic
-                    # expects after.
-                    # in the shiny future, set up the CLI once for the whole run.
-                    self._initialize_dcos_cli()
-                    self.configure_master_settings()
+                    if initmaster:
+                        # currently, the create_service_account.sh script sets up the
+                        # cli itself so we initialize it in the style that test logic
+                        # expects after.
+                        # in the shiny future, set up the CLI once for the whole run.
+                        self._initialize_dcos_cli()
+                        self.configure_master_settings()
                 finally:
                     sys.stdout.flush()
                     os.dup2(stdout_back, stdout_fd)

--- a/tools/launch_ccm_cluster.py
+++ b/tools/launch_ccm_cluster.py
@@ -303,7 +303,8 @@ class CCMLauncher(object):
             if config.mount_volumes:
                 clustinit.create_mount_volumes()
 
-        return { 'id': cluster_id,
+        return {
+            'id': cluster_id,
             'url': dcos_url,
             'auth_token': auth_token
         }

--- a/tools/launch_ccm_cluster.py
+++ b/tools/launch_ccm_cluster.py
@@ -443,7 +443,7 @@ def parse_args(argv):
         help='What configuration steps to use to set up the cluster [%(default)s]')
 
     parser.add_argument("--output",
-        metavar="filename"
+        metavar="filename",
         help='Write the cluster info to this filename, in addition to standard out')
 
     subparsers = parser.add_subparsers(
@@ -456,6 +456,10 @@ def parse_args(argv):
         choices=('default', 'nomaster', 'none'),
         default='default',
         help='What configuration steps to use to set up the cluster [%(default)s]')
+
+    start_parser.add_argument("--output",
+        metavar="filename",
+        help='Write the cluster info to this filename, in addition to standard out')
 
     msg='ask CCM to stop a cluster and block until this completes'
     stop_parser = subparsers.add_parser('stop',

--- a/tools/launch_ccm_cluster.py
+++ b/tools/launch_ccm_cluster.py
@@ -14,6 +14,7 @@
 #
 # Configuration: Mostly through env vars. See README.md.
 
+import argparse
 import http.client
 import json
 import logging
@@ -288,21 +289,24 @@ class CCMLauncher(object):
         dcos_url = 'https://' + dns_address
         auth_token = dcos_login.DCOSLogin(dcos_url).get_acs_token()
 
-        is_enterprise = config.cf_template.startswith('ee.')
-        clustinit = configure_test_cluster.ClusterInitializer(cluster_id,
-                stack_id, auth_token, dns_address, is_enterprise,
-                config.security_mode)
-        clustinit.apply_default_config()
 
-        if config.mount_volumes:
-            clustinit.create_mount_volumes()
+        if config.postlaunch_steps != 'none':
+            is_enterprise = config.cf_template.startswith('ee.')
+            clustinit = configure_test_cluster.ClusterInitializer(cluster_id,
+                    stack_id, auth_token, dns_address, is_enterprise,
+                    config.security_mode)
+            initmaster = True
+            if config.postlaunch_steps == 'nomaster':
+                initmaster = False
+            clustinit.apply_default_config(initmaster=initmaster)
 
-        return {
-            'id': cluster_id,
+            if config.mount_volumes:
+                clustinit.create_mount_volumes()
+
+        return { 'id': cluster_id,
             'url': dcos_url,
             'auth_token': auth_token
         }
-
 
     def stop(self, config, attempts = DEFAULT_ATTEMPTS):
         return self._retry(attempts, self._stop, config, 'shutdown')
@@ -345,7 +349,8 @@ class StartConfig(object):
             aws_region = 'us-west-2',
             admin_location = '0.0.0.0/0',
             cloud_provider = '0', # https://mesosphere.atlassian.net/browse/TEST-231
-            mount_volumes = False):
+            mount_volumes = False,
+            postlaunch_steps='default'):
         self.name_prefix = name_prefix
         self.duration_mins = int(os.environ.get('CCM_DURATION_MINS', duration_mins))
         self.ccm_channel = os.environ.get('CCM_CHANNEL', ccm_channel)
@@ -368,6 +373,7 @@ class StartConfig(object):
             description = 'A test cluster with {} private/{} public agents'.format(
                 self.private_agents, self.public_agents)
         self.description = description
+        self.postlaunch_steps = postlaunch_steps
 
 
 
@@ -427,6 +433,61 @@ def _start_cluster(launcher, github_label, start_stop_attempts, config):
         raise
     return cluster_info
 
+def parse_args(argv):
+    parser = argparse.ArgumentParser(prog='launch_ccm_cluster.py',
+        description="create and manage cloud cluster manager clusters")
+
+    parser.add_argument("--configure",
+        choices=('default', 'nomaster', 'none'),
+        default='default',
+        help='What configuration steps to use to set up the cluster [%(default)s]')
+
+    parser.add_argument("--output",
+        metavar="filename"
+        help='Write the cluster info to this filename, in addition to standard out')
+
+    subparsers = parser.add_subparsers(
+        help='An action other than the default start', dest='command')
+
+    start_parser = subparsers.add_parser('start',
+        help='launch a new cluster (this happens with no command as well)')
+
+    start_parser.add_argument("--configure",
+        choices=('default', 'nomaster', 'none'),
+        default='default',
+        help='What configuration steps to use to set up the cluster [%(default)s]')
+
+    msg='ask CCM to stop a cluster and block until this completes'
+    stop_parser = subparsers.add_parser('stop',
+        help=msg, description=msg)
+
+    stop_parser.add_argument('ccm_id', help='the cluster id to stop')
+
+    msg='ask CCM to stop a cluster without blocking'
+    trigstop_parser = subparsers.add_parser('trigger-stop',
+        help=msg, description=msg)
+
+    trigstop_parser.add_argument('ccm_id', help='the cluster id to stop')
+
+    msg = 'wait for a CCM cluster to transition from one state to another'
+    statuses = CCMLauncher._CCM_STATUSES.values()
+    wait_parser = subparsers.add_parser('wait',
+        help=msg,
+        description=msg + "; valid states are ({})".format(", ".join(statuses)))
+
+    wait_parser.add_argument('ccm_id', help='the cluster id to stop.')
+
+    wait_parser.add_argument('current_state',
+        choices=statuses,
+        metavar='current_state',
+        help='state to consider valid while waiting')
+    wait_parser.add_argument('new_state',
+        choices=statuses,
+        metavar='new_state',
+        help='state to wait for')
+    return parser.parse_args(argv[1:])
+
+
 def main(argv):
     ccm_token = os.environ.get('CCM_AUTH_TOKEN', '')
     if not ccm_token:
@@ -439,43 +500,30 @@ def main(argv):
     start_stop_attempts = int(os.environ.get('CCM_ATTEMPTS', CCMLauncher.DEFAULT_ATTEMPTS))
 
     launcher = CCMLauncher(ccm_token, github_label)
-    if len(argv) >= 2:
-        if argv[1] == 'stop':
-            if len(argv) >= 3:
-                launcher.stop(StopConfig(argv[2]), start_stop_attempts)
-                return 0
-            else:
-                logger.info('Usage: {} stop <ccm_id>'.format(argv[0]))
-                return 1
-        if argv[1] == 'trigger-stop':
-            if len(argv) >= 3:
-                launcher.trigger_stop(StopConfig(argv[2]))
-                return 0
-            else:
-                logger.info('Usage: {} trigger-stop <ccm_id>'.format(argv[0]))
-                return 1
-        if argv[1] == 'wait':
-            if len(argv) >= 5:
-                # piggy-back off of StopConfig's env handling:
-                stop_config = StopConfig(argv[2])
-                cluster_info = launcher.wait_for_status(
-                    stop_config.cluster_id,
-                    [argv[3]],
-                    argv[4],
-                    stop_config.stop_timeout_mins)
-                if not cluster_info:
-                    return 1
-                # print to stdout (the rest of this script only writes to stderr):
-                print(pprint.pformat(cluster_info))
-                return 0
-            else:
-                logger.info('Usage: {} wait <ccm_id> <current_state> <new_state>'.format(argv[0]))
-                return 1
-        else:
-            logger.info('Usage: {} [stop <ccm_id>|trigger-stop <ccm_id>|wait <ccm_id> <current_state> <new_state>]'.format(argv[0]))
-            return
-
-    _start_cluster(launcher, github_label, start_stop_attempts, StartConfig())
+    args = parse_args(argv)
+    if args.command == 'stop':
+        launcher.stop(StopConfig(args.ccm_id), start_stop_attempts)
+    elif args.command == 'trigger-stop':
+        launcher.trigger_stop(StopConfig(args.ccm_id))
+    elif args.command == 'wait':
+        # piggy-back off of StopConfig's env handling:
+        stop_config = StopConfig(args.ccm_id)
+        cluster_info = launcher.wait_for_status(
+            stop_config.cluster_id,
+            [args.current_state],
+            args.new_state,
+            stop_config.stop_timeout_mins)
+        if not cluster_info:
+            return 1
+        # print to stdout (the rest of this script only writes to stderr):
+        print(pprint.pformat(cluster_info))
+        if args.output:
+            with open(args.output, "w") as output_f:
+                out_s = json.dumps(cluster_info)
+                output_f.write(out_s)
+    else:  # 'start' or no command
+        _start_cluster(launcher, github_label, start_stop_attempts,
+                StartConfig(postlaunch_steps=args.configure))
     return 0
 
 

--- a/tools/launch_ccm_cluster.py
+++ b/tools/launch_ccm_cluster.py
@@ -492,6 +492,10 @@ def parse_args(argv):
         help='state to wait for')
     return parser.parse_args(argv[1:])
 
+def write_clustinfo(cluster_info, filename):
+    with open(filename, "w") as output_f:
+        out_s = json.dumps(cluster_info)
+        output_f.write(out_s)
 
 def main(argv):
     ccm_token = os.environ.get('CCM_AUTH_TOKEN', '')
@@ -506,6 +510,7 @@ def main(argv):
 
     launcher = CCMLauncher(ccm_token, github_label)
     args = parse_args(argv)
+    print(args)
     if args.command == 'stop':
         launcher.stop(StopConfig(args.ccm_id), start_stop_attempts)
     elif args.command == 'trigger-stop':
@@ -523,12 +528,13 @@ def main(argv):
         # print to stdout (the rest of this script only writes to stderr):
         print(pprint.pformat(cluster_info))
         if args.output:
-            with open(args.output, "w") as output_f:
-                out_s = json.dumps(cluster_info)
-                output_f.write(out_s)
+            write_clustinfo(cluster_info, args.output)
     else:  # 'start' or no command
-        _start_cluster(launcher, github_label, start_stop_attempts,
+        cluster_info = _start_cluster(launcher, github_label, start_stop_attempts,
                 StartConfig(postlaunch_steps=args.configure))
+        if args.output:
+            write_clustinfo(cluster_info, args.output)
+
     return 0
 
 

--- a/tools/venvutil.py
+++ b/tools/venvutil.py
@@ -86,11 +86,8 @@ def activate_venv(path):
 
 def pip_install(path, requirements_filepath):
     "Populate a venv with given requirements"
-    #pip_bin = os.path.join(path, 'bin', 'pip')
-    #run_cmd(path, [pip_bin, 'install', '-r', requirements_filepath])
-    pip_bin = 'pip3'
-    run_cmd(path, [pip_bin, 'install', '-r', requirements_filepath, 
-                   '--root', path])
+    pip_bin = os.path.join(path, 'bin', 'pip')
+    run_cmd(path, [pip_bin, 'install', '-r', requirements_filepath])
 
 def run_cmd(path, cmd, *args, **kwargs):
     "Run an external command with a particular venv"

--- a/tools/venvutil.py
+++ b/tools/venvutil.py
@@ -21,15 +21,34 @@ def venv_exists(path):
     return os.path.isfile(path, 'bin', 'python')
 
 
-def create_venv(path, with_pip=True, symlinks=True, py3=False):
+def create_venv(path, with_pip=True, symlinks=True):
     "Create, but do not activate, a virtual env"
-    # ignoring py3; if we're already running py3, always py3
     path = os.path.abspath(path)
+    logger.info("using venv module at path %s", venv.__file__)
     builder = venv.EnvBuilder(with_pip=with_pip, symlinks=symlinks)
 
-    logger.info("Creating venv at {}".format(path))
-    builder.create(path)
-    logger.info("Files in {}:\n{}\n".format(path, "\n".join(os.listdir(os.path.join(path, 'bin')))))
+
+    logger.info("Creating venv at %s", path)
+    logger.info("current environment is: %s", os.environ)
+    #builder.create(path)
+    context = builder.ensure_directories(path)
+    logger.info("venv context: %s", context)
+    logger.info("venv listing: %s", ", ".join(os.listdir(path)))
+    builder.create_configuration(context)
+    cfg_file = os.path.join(path, 'pyvenv.cfg')
+    with open(cfg_file) as f:
+        logger.info("venv pyvenv.cfg: %s", f.read())
+
+    builder.setup_python(context)
+    bin_dir = os.path.join(path, 'bin')
+    dirents1 =  os.listdir(bin_dir)
+    logger.info("After setup_python, files in %s: %s", bin_dir, ", ".join(dirents1))
+
+    builder._setup_pip(context)
+    dirents2 =  os.listdir(bin_dir)
+    logger.info("After _setup_pip, files in %s: %s", bin_dir, ", ".join(dirents2))
+
+
 
 def activate_venv(path):
     "Activate a given venv for the current python process."
@@ -67,8 +86,11 @@ def activate_venv(path):
 
 def pip_install(path, requirements_filepath):
     "Populate a venv with given requirements"
-    pip_bin = os.path.join(path, 'bin', 'pip')
-    run_cmd(path, [pip_bin, 'install', '-r', requirements_filepath])
+    #pip_bin = os.path.join(path, 'bin', 'pip')
+    #run_cmd(path, [pip_bin, 'install', '-r', requirements_filepath])
+    pip_bin = 'pip3'
+    run_cmd(path, [pip_bin, 'install', '-r', requirements_filepath, 
+                   '--root', path])
 
 def run_cmd(path, cmd, *args, **kwargs):
     "Run an external command with a particular venv"


### PR DESCRIPTION
I have a theory, mentioned in the jira, that this is a known problem with ensurepip, that it can shortcircuit with "I already have pip!"   Indeed, the spark job is different in that it explicitly downloads pip before launch_ccm_cluster.py ever runs.

This suggests a few possible workarounds.

1 - update the spark code that explicitly downloads a fairly old version of pip for python2 to use python3 and/or venvutil (not certain to work)
2 - drop the downloaded pip off the path before invoking launch_ccm_cluster
3 - have venvutil sniff for pip on the PATH and editing it out if present (seems wrong)
4 - explicitly tell pip to install the packages into the venvutil (what I'm trying here).

Also in this change I'm including a bunch of logging to try to find out if I'm wrong.

-----

Update: what i'm trying is: don't do an unnecessary step (create virtualenv, launch shakedown) in the middle of launching the cluster.