### PR TITLE
[SDK] Set Xms/Xmx options before launching custom executor

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/DefaultOfferRequirementProvider.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/DefaultOfferRequirementProvider.java
@@ -647,6 +647,8 @@ public class DefaultOfferRequirementProvider implements OfferRequirementProvider
                 "export LD_LIBRARY_PATH=$MESOS_SANDBOX/libmesos-bundle/lib:$LD_LIBRARY_PATH && " +
                 "export MESOS_NATIVE_JAVA_LIBRARY=$(ls $MESOS_SANDBOX/libmesos-bundle/lib/libmesos-*.so) && " +
                 "export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jre*/) && " +
+         // Remove Xms/Xmx if +UseCGroupMemoryLimitForHeap or equivalent detects cgroups memory limit
+                "export JAVA_OPTS=\"-Xms128M -Xmx128M\" && " +
                 "$MESOS_SANDBOX/executor/bin/executor");
 
         if (podSpec.getUser().isPresent()) {


### PR DESCRIPTION
 Xmx and Xms are set to 128M for custom executor.  