### PR TITLE
[INFINITY-1370] Download cli once and only once in test.sh & test.py

### DIFF
--- a/frameworks/kafka/universe/config.json
+++ b/frameworks/kafka/universe/config.json
@@ -57,7 +57,7 @@
           "mem":{
             "description":"Broker mem requirements",
             "type":"integer",
-            "default":2304
+            "default":2048
           },
           "heap":{
             "description":"The Kafka process JVM heap configuration object",
@@ -66,7 +66,7 @@
               "size": {
                 "type":"integer",
                 "description":"The amount of JVM heap, in MB, allocated to the Kafka broker process.",
-                "default": 2048
+                "default":512
               }
             },
             "additionalProperties": false,

--- a/test.py
+++ b/test.py
@@ -414,7 +414,7 @@ def _multicluster_linear_per_cluster(run_attrs, repo_root):
                     start_config = launch_ccm_cluster.StartConfig(private_agents=6)
                     avail_cluster = clustinfo.start_cluster(start_config,
                             reporting_name="Cluster %s" % human_count)
-                    avail_cluster.ensure_cli_downloaded(cluster.url, get_work_dir())
+                    cli_install.ensure_cli_downloaded(avial_cluster.url, get_work_dir())
                 elif not avail_cluster:
                     # We're not supposed to start more clusters, so wait, and
                     # check for test completion.

--- a/test.py
+++ b/test.py
@@ -16,25 +16,26 @@ logger = logging.getLogger("dcos-commons-test")
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(name)s %(message)s")
 
 sys.path.append(os.path.join(get_repo_root(), 'tools'))
+import cli_install
 import clustinfo
 import fwinfo
 import launch_ccm_cluster
 
 
 work_dir = None
-def get_work_dir():
+def set_work_dir(location):
+    """Create and remember a directory for storing changing files modified by
+    the test run"""
     global work_dir
-    if not work_dir:
-        work_dir = tempfile.mkdtemp(prefix='test_workdir_', dir=get_repo_root())
-        logger.info("Using %s for test run files", work_dir)
-    return work_dir
-
-work_dir = None
-def get_work_dir():
-    global work_dir
-    if not work_dir:
+    assert not work_dir
+    assert location in ('tmp', 'repo_root')
+    if location == 'tmp':
+        work_dir = tempfile.mkdtemp(prefix='test_workdir')
+    else:
         work_dir = tempfile.mkdtemp(prefix='test_workdir', dir=get_repo_root())
-        logger.info("Using %s for test run files", work_dir)
+    logger.info("Using %s for test run files", work_dir)
+
+def get_work_dir():
     return work_dir
 
 def parse_args(args=sys.argv):
@@ -58,6 +59,9 @@ def parse_args(args=sys.argv):
             default='success-only',
             help="On test completion, shut down any cluster(s) automatically created.  "
             'For "success-only", test failures will leave the cluster running.')
+    parser.add_argument("--keep-workdir", action='store_true',
+            help="place the working directory in the source repo, and do not "
+            "delete on completion")
     parser.add_argument("test", nargs="*", help="Test or tests to run.  "
             "If no args provided, run all.")
     run_attrs = parser.parse_args()
@@ -308,12 +312,17 @@ def setup_clusters(run_attrs):
     if count == 1 and run_attrs.cluster_url and run_attrs.cluster_token:
         clustinfo.add_running_cluster(run_attrs.cluster_url,
                 run_attrs.cluster_token)
+        cli_install.ensure_cli_downloaded(run_attrs.cluster_url,
+                                          get_work_dir())
         return
     elif count > 1 and (run_attrs.cluster_url):
         sys.exit("Sorry, no support for multiple externally set up clusters yet.")
     for i in range(count):
         human_count = i+1
-        clustinfo.start_cluster(reporting_name="cluster number %s" % human_count)
+        cluster = clustinfo.start_cluster(reporting_name="cluster number %s" % human_count)
+        # ensure_cli_downloaded only actually does anything the first time
+        cli_install.ensure_cli_downloaded(cluster.url, get_work_dir())
+
 
 def teardown_clusters():
     logger.info("Shutting down all clusters.")
@@ -328,6 +337,7 @@ def _one_cluster_linear_tests(run_attrs, repo_root):
         clustinfo.start_cluster(start_config)
 
     cluster = clustinfo._clusters[0]
+    cli_install.ensure_cli_downloaded(cluster.url, get_work_dir())
     for framework in fwinfo.get_frameworks():
         func = run_test
         args = framework, cluster, repo_root
@@ -404,6 +414,7 @@ def _multicluster_linear_per_cluster(run_attrs, repo_root):
                     start_config = launch_ccm_cluster.StartConfig(private_agents=6)
                     avail_cluster = clustinfo.start_cluster(start_config,
                             reporting_name="Cluster %s" % human_count)
+                    avail_cluster.ensure_cli_downloaded(cluster.url, get_work_dir())
                 elif not avail_cluster:
                     # We're not supposed to start more clusters, so wait, and
                     # check for test completion.
@@ -521,6 +532,7 @@ def start_test_background(framework, cluster, repo_root):
     custom_env['STUB_UNIVERSE_URL'] = framework.stub_universe_url
     custom_env['CLUSTER_URL'] = cluster.url
     custom_env['CLUSTER_AUTH_TOKEN'] = cluster.auth_token
+    custom_env['TESTRUN_TEMPDIR'] = get_work_dir()
 
     runtests_script = os.path.join(repo_root, 'tools', 'run_tests.py')
 
@@ -553,6 +565,8 @@ def run_test(framework, cluster, repo_root):
     custom_env['TEST_GITHUB_LABEL'] = framework.name
     custom_env['CLUSTER_URL'] = cluster.url
     custom_env['CLUSTER_AUTH_TOKEN'] = cluster.auth_token
+    custom_env['TESTRUN_TEMPDIR'] = get_work_dir()
+    custom_env['TESTRUN_TEMPDIR'] = get_work_dir()
     runtests_script = os.path.join(repo_root, 'tools', 'run_tests.py')
     # Why this trailing slash here? no idea.
     framework_testdir = os.path.join(framework.dir, 'tests') + "/"
@@ -592,6 +606,12 @@ def main():
             build_and_upload(run_attrs)
 
         if run_attrs.run_tests:
+            if run_attrs.keep_workdir:
+                set_work_dir(location='repo_root')
+                os.envion['KEEP_SANDBOX'] = 'yes'
+            else:
+                set_work_dir(location='tmp')
+
             # if we're only testing, use stub_universes from before (they're
             # normally calculated during the build)
             if not run_attrs.run_build:
@@ -599,6 +619,9 @@ def main():
             run_tests(run_attrs, repo_root)
     finally:
         report_failed_actions()
+        # only created during test
+        if run_attrs.run_tests and not run_attrs.keep_workdir:
+            shutil.rmtree(get_work_dir(), ignore_errors=True)
     return True
 
 if __name__ == "__main__":

--- a/test.py
+++ b/test.py
@@ -566,7 +566,6 @@ def run_test(framework, cluster, repo_root):
     custom_env['CLUSTER_URL'] = cluster.url
     custom_env['CLUSTER_AUTH_TOKEN'] = cluster.auth_token
     custom_env['TESTRUN_TEMPDIR'] = get_work_dir()
-    custom_env['TESTRUN_TEMPDIR'] = get_work_dir()
     runtests_script = os.path.join(repo_root, 'tools', 'run_tests.py')
     # Why this trailing slash here? no idea.
     framework_testdir = os.path.join(framework.dir, 'tests') + "/"
@@ -608,7 +607,7 @@ def main():
         if run_attrs.run_tests:
             if run_attrs.keep_workdir:
                 set_work_dir(location='repo_root')
-                os.envion['KEEP_SANDBOX'] = 'yes'
+                os.environ['KEEP_SANDBOX'] = 'yes'
             else:
                 set_work_dir(location='tmp')
 

--- a/test.sh
+++ b/test.sh
@@ -57,6 +57,12 @@ REPO_ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 cd $REPO_ROOT_DIR
 
+# ensure we have a dcos binary
+TESTRUN_TEMPDIR=$(mktemp -d /tmp/sdktest.XXXXXXXX)
+export TESTRUN_TEMPDIR
+echo "test workdir set to $TESTRUN_TEMPDIR"
+export PATH=$TESTRUN_TEMPDIR:$PATH
+
 # Get a CCM cluster if not already configured (see available settings in dcos-commons/tools/README.md):
 if [ -z "$CLUSTER_URL" ]; then
     echo "CLUSTER_URL is empty/unset, launching new cluster."
@@ -71,6 +77,12 @@ if [ -z "$CLUSTER_URL" ]; then
 else
     echo "Using provided CLUSTER_URL as cluster: $CLUSTER_URL"
     CLUSTER_CREATED=""
+fi
+
+# launch_ccm_cluster.py may have fetched already
+if [ ! -f $TESTRUN_TEMPDIR/dcos ]; then
+    echo "Fetching dcos cli"
+    ${REPO_ROOT_DIR}/tools/cli_install.py $CLUSTER_URL $TESTRUN_TEMPDIR
 fi
 
 # A specific framework can be specified to run its tests

--- a/tools/cli_install.py
+++ b/tools/cli_install.py
@@ -85,6 +85,10 @@ def _get_tempfilename(a_dir):
 def _mark_executable(path):
     os.chmod(path, 0o755)
 
+def install_cli_from_dir(src_dir, write_dir):
+    src_file = os.path.join(src_dir, get_cli_filename())
+    install_cli(src_file, write_dir)
+
 def install_cli(src_file, write_dir):
     """Copy an existing cli to a target directory path, updating the target
     atomically."""
@@ -102,6 +106,16 @@ def install_cli(src_file, write_dir):
         if os.path.exists(temp_target):
             os.unlink(temp_target)
     return output_filepath
+
+def ensure_cli_downloaded(dcos_url, write_dir):
+    """If the cli filename is not present in write_dir, download the correct
+    cli version for a given cluster url.
+    No attempt is made to verify it's the correct version, so a per-cluster or
+    per-run dir should be used."""
+    output_filepath = os.path.join(write_dir, get_cli_filename())
+    if os.path.exists(output_filepath):
+        return output_filepath
+    return download_cli(dcos_url, write_dir)
 
 def download_cli(dcos_url, write_dir):
     """Download the correct cli version for a given cluster url, placing it in
@@ -144,21 +158,32 @@ if __name__ == "__main__":
         f.write("usage: cli_install.py <path_to_existing_cli> <target_dir>\n")
         f.write("  OR\n")
         f.write("usage: cli_install.py <cluster_url> <target_dir>\n")
+        f.write("  OR\n")
+        f.write("usage: cli_install.py ensure_installed <cluster_url> <target_dir>\n")
 
 
     if not len(sys.argv) == 3:
         usage()
         sys.exit(1)
 
-    source = sys.argv[1]
-    target_dir = sys.argv[2]
+    args = sys.argv[1:]
+    maybe_install = False
+    if args[0] == "ensure_installed":
+        maybe_install=True
+        args=args[1:]
+
+    source = args[1]
+    target_dir = args[2]
 
     # convenience for command line
     if not os.path.exists(target_dir):
         os.makedirs(target_dir)
 
     if source.startswith('http://') or source.startswith('https://'):
-        download_cli(source, target_dir)
+        if maybe_install:
+            ensure_cli_downloaded(source, target_dir)
+        else:
+            download_cli(source, target_dir)
     elif os.path.isfile(source):
         install_cli(source, target_dir)
     else:

--- a/tools/cli_install.py
+++ b/tools/cli_install.py
@@ -89,7 +89,7 @@ def _mark_executable(path):
 
 def install_cli_from_dir(src_dir, write_dir):
     src_file = os.path.join(src_dir, get_cli_filename())
-    install_cli(src_file, write_dir)
+    return install_cli(src_file, write_dir)
 
 
 def install_cli(src_file, write_dir):

--- a/tools/cli_install.py
+++ b/tools/cli_install.py
@@ -76,6 +76,7 @@ def get_cluster_version(dcos_url):
     ver_s = json.loads(json_s)['version']
     return ver_s
 
+
 def _get_tempfilename(a_dir):
     temp_target_f = tempfile.NamedTemporaryFile(dir=a_dir, delete=False)
     temp_target_f.close()
@@ -85,9 +86,11 @@ def _get_tempfilename(a_dir):
 def _mark_executable(path):
     os.chmod(path, 0o755)
 
+
 def install_cli_from_dir(src_dir, write_dir):
     src_file = os.path.join(src_dir, get_cli_filename())
     install_cli(src_file, write_dir)
+
 
 def install_cli(src_file, write_dir):
     """Copy an existing cli to a target directory path, updating the target
@@ -107,6 +110,7 @@ def install_cli(src_file, write_dir):
             os.unlink(temp_target)
     return output_filepath
 
+
 def ensure_cli_downloaded(dcos_url, write_dir):
     """If the cli filename is not present in write_dir, download the correct
     cli version for a given cluster url.
@@ -116,6 +120,7 @@ def ensure_cli_downloaded(dcos_url, write_dir):
     if os.path.exists(output_filepath):
         return output_filepath
     return download_cli(dcos_url, write_dir)
+
 
 def download_cli(dcos_url, write_dir):
     """Download the correct cli version for a given cluster url, placing it in

--- a/tools/configure_test_cluster.py
+++ b/tools/configure_test_cluster.py
@@ -54,8 +54,10 @@ class ClusterInitializer(object):
     def _install_cli(self):
         # create_service_account relies on dcos cli, which we may not have
         # at this point.
-        self.cli_tempdir = tempfile.mkdtemp(prefix="conf_cluster")
-        cli_install.download_cli(self.dcos_url, self.cli_tempdir)
+        self.cli_tempdir = os.environ.get('TESTRUN_TEMPDIR')
+        if not self.cli_tempdir:
+            self.cli_tempdir = tempfile.mkdtemp(prefix="conf_cluster")
+        cli_install.ensure_cli_downloaded(self.dcos_url, self.cli_tempdir)
 
     def _run_shellscript_with_cli(self, script, args):
         custom_env = os.environ.copy()
@@ -64,7 +66,8 @@ class ClusterInitializer(object):
         _run_script(script, args, env=custom_env)
 
     def __del__(self):
-        if self.cli_tempdir:
+        # clean up if we created it.
+        if self.cli_tempdir and not 'TESTRUN_TEMPDIR' in os.environ:
             shutil.rmtree(self.cli_tempdir)
 
     def create_service_account(self):

--- a/tools/run_tests.py
+++ b/tools/run_tests.py
@@ -60,7 +60,7 @@ class CITester(object):
         if not local_path:
             src_tmpdir = os.environ.get('TESTRUN_TEMPDIR')
             if src_tmpdir:
-                cli_install.install_cli_from_dir(src_tmpdir, self._sandbox_path)
+                return cli_install.install_cli_from_dir(src_tmpdir, self._sandbox_path)
         if local_path:
             cli_filepath = cli_install.install_cli(local_path, self._sandbox_path)
         else:

--- a/tools/run_tests.py
+++ b/tools/run_tests.py
@@ -30,7 +30,12 @@ class CITester(object):
 
     def _configure_cli_sandbox(self):
         if not self._sandbox_path:
-            self._sandbox_path = tempfile.mkdtemp(prefix='ci-test-')
+            preexisting_testtmp = os.environ.get('TESTRUN_TEMPDIR')
+            if preexisting_testtmp:
+                self._sandbox_path = tempfile.mkdtemp(prefix='ci-test-',
+                        dir=preexisting_testtmp)
+            else:
+                self._sandbox_path = tempfile.mkdtemp(prefix='ci-test-')
         custom_env = {}
         # ask for unbuffered stdout, since test output randomly uses stdout
         # vs stderr
@@ -52,6 +57,10 @@ class CITester(object):
     def _download_cli_to_sandbox(self):
         # TODO: provide non-env interface to copy a dcos cli
         local_path = os.environ.get('DCOS_CLI_PATH')
+        if not local_path:
+            src_tmpdir = os.environ.get('TESTRUN_TEMPDIR')
+            if src_tmpdir:
+                cli_install.install_cli_from_dir(src_tmpdir, self._sandbox_path)
         if local_path:
             cli_filepath = cli_install.install_cli(local_path, self._sandbox_path)
         else:
@@ -268,10 +277,9 @@ def main(argv):
         else:
             raise Exception('Unsupported test type: {}'.format(test_type))
 
-        tester.delete_sandbox()
-    except:
-        tester.delete_sandbox()
-        raise
+    finally:
+        if not 'KEEP_SANDBOX' in os.environ:
+            tester.delete_sandbox()
     return 0
 
 


### PR DESCRIPTION
This is essentially a step towards cleaning up how temp dirs and the dcos cli are managed across test runs.

Here we have one working dir for the whole run, and download the cli once (though it's copied a few times).  

It's not exciting alone, but it felt like a necessary preamble to gathering diagnostics on test failure; since we have to do that in test.py  (or test.sh) to make it make sense, which means we need the dcos cli ensured available at that level (the alternative is to just increase the undesirable action pile in CI).