### PR TITLE
Fix handling of MOUNT volumes (allow leading slash in spec)

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultVolumeSpec.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultVolumeSpec.java
@@ -23,7 +23,7 @@ public class DefaultVolumeSpec extends DefaultResourceSpec implements VolumeSpec
 
     /** Regexp in @Pattern will detect blank string. No need to use @NotEmpty or @NotBlank. */
     @NotNull
-    @Pattern(regexp = "[a-zA-Z0-9]+([a-zA-Z0-9_-]*[/\\\\]*)*")
+    @Pattern(regexp = "[/\\\\]?[a-zA-Z0-9]+([a-zA-Z0-9_-]*[/\\\\]*)*")
     private final String containerPath;
 
     public DefaultVolumeSpec(

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/config/validate/VerifyVolumePathTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/config/validate/VerifyVolumePathTest.java
@@ -24,12 +24,6 @@ public class VerifyVolumePathTest {
     }
 
     @Test(expected = Exception.class)
-    public void testVolumePathSlash() {
-        new DefaultVolumeSpec(
-                DISK_SIZE_MB, VolumeSpec.Type.MOUNT, "/path/to/volume0", "role", "principal", "VOLUME");
-    }
-
-    @Test(expected = Exception.class)
     public void testVolumePathChar() {
         new DefaultVolumeSpec(
                 DISK_SIZE_MB, VolumeSpec.Type.MOUNT, "@?test", "role", "principal", "VOLUME");
@@ -51,7 +45,7 @@ public class VerifyVolumePathTest {
     @Test
     public void testVolumePathCorrect1() {
         new DefaultVolumeSpec(
-                DISK_SIZE_MB, VolumeSpec.Type.ROOT, "path/path", "role", "principal", "VOLUME");
+                DISK_SIZE_MB, VolumeSpec.Type.ROOT, "/path/path", "role", "principal", "VOLUME");
     }
 
     @Test


### PR DESCRIPTION
To specify MOUNT volume for framework consumption it is needed to allow leading slash in validation.  