### PR TITLE
Fix intermittent HDFS shakedown test failure

### DIFF
--- a/testing/sdk_plan.py
+++ b/testing/sdk_plan.py
@@ -8,7 +8,6 @@ import shakedown
 
 
 def get_deployment_plan(service_name):
-    sdk_utils.out("Waiting for deploy plan to complete...")
     return get_plan(service_name, "deploy")
 
 
@@ -26,6 +25,8 @@ def start_plan(service_name, plan, parameters=None):
 
 
 def get_plan(service_name, plan):
+    sdk_utils.out("Waiting for {} plan to complete...".format(service_name))
+
     def fn():
         return sdk_api.get(service_name, "/v1/plans/{}".format(plan))
     return sdk_spin.time_wait_return(fn)
@@ -37,9 +38,21 @@ def wait_for_completed_deployment(service_name):
     return sdk_spin.time_wait_return(fn)
 
 
+def wait_for_completed_recovery(service_name):
+    def fn():
+        return recovery_plan_is_finished(service_name)
+    return sdk_spin.time_wait_return(fn)
+
+
 def deployment_plan_is_finished(service_name):
     finished = plan_is_finished(service_name, 'deploy')
     sdk_utils.out("Deployment plan for {} is finished: {}".format(service_name, finished))
+    return finished
+
+
+def recovery_plan_is_finished(service_name):
+    finished = plan_is_finished(service_name, 'recovery')
+    sdk_utils.out("Recovery plan for {} is finished: {}".format(service_name, finished))
     return finished
 
 

--- a/testing/sdk_tasks.py
+++ b/testing/sdk_tasks.py
@@ -68,11 +68,11 @@ def check_tasks_updated(service_name, prefix, old_task_ids, timeout_seconds=-1):
 
 def check_tasks_not_updated(service_name, prefix, old_task_ids):
     sdk_plan.wait_for_completed_deployment(service_name)
+    sdk_plan.wait_for_completed_recovery(service_name)
     task_ids = get_task_ids(service_name, prefix)
-    msg = 'Checking tasks starting with "{}" have not been updated:\n- Old tasks: {}\n- Current tasks: {}'.format(
-        prefix, old_task_ids, task_ids)
-    sdk_utils.out(msg)
-    assert set(old_task_ids).issubset(set(task_ids)), "Tasks got updated"
+    task_sets = "\n- Old tasks: {}\n- Current tasks: {}".format(old_task_ids, task_ids)
+    sdk_utils.out('Checking tasks starting with "{}" have not been updated:{}'.format(prefix, task_sets))
+    assert set(old_task_ids).issubset(set(task_ids)), "Tasks got updated:{}".format(task_sets)
 
 
 def kill_task_with_pattern(pattern, host=None):


### PR DESCRIPTION
Fix intermittent failure in test_kill_all_journalnodes()

- NN's actually do fail when JN's are restarted (https://community.cloudera.com/t5/Storage-Random-Access-HDFS/Namenode-failovered-when-a-JournalNode-restart/m-p/51177)
- Ensure deploy/recovery plans are COMPLETE before querying for updated task IDs
- Remove unneeded checks around zkfc_ids (there are none)
- Replaced `service_plan_complete()/service_cli()` methods with calls to helpers in `sdk_plan`
- Added `get_recovery_plan()` helper to `sdk_plan`
- Included old/current task lists in assertion failure message in `check_tasks_not_updated()`
- DRY up calls to `check_healthy()`