### PR TITLE
Add volumes to executor

### DIFF
--- a/docs/pages/developer-guide.md
+++ b/docs/pages/developer-guide.md
@@ -995,6 +995,25 @@ pods:
 
 In this case, the resources are declared separately from the server task in a resource set named `hello-resources`. They are referenced by a `resource-set` element in the task definition. A task continues to be defined as the combination of a process to run and resources to consume. This alternate formulation provides you with increased  flexibility:  you can now define multiple processes that can consume the same resources.
 
+Pods can also define volumes at the pod level, allowing volumes to be shared between every task in a pod. Although volumes defined on individual tasks are currently visible between tasks in a pod, this will change with the introduction of pods based on [Mesos Task Groups](https://github.com/apache/mesos/blob/master/docs/nested-container-and-task-group.md). Once this change is made, pods will need to define volumes at the pod level if they are intended to be shared across tasks, as in the following example:
+
+```yaml
+name: "hello-world"
+pods:
+  hello:
+    count: 1
+    volumes:
+      path: "shared-container-path"
+      type: ROOT
+      size: 50
+    tasks:
+      server:
+        goal: RUNNING
+        cmd: "echo hello >> shared-container-path/output && sleep 1000"
+        cpus: 1.0
+        memory: 256
+```
+
 **Important:** At any given point in time, only a single process may be consuming a given set of resources. **Resources may never be shared simultaneously by multiple tasks**.  Any attempt to launch a task consuming an already consumed resource-set will result in the killing of the task which is currently running and the launch of the new task.
 
 This alternative formulation of tasks is useful when several tasks should be sequenced in the same container and have a cumulative effect on data in a volume. For example, if you want to initialize something before running the long running server task, you could write the following:

--- a/docs/pages/yaml-reference.md
+++ b/docs/pages/yaml-reference.md
@@ -105,6 +105,10 @@ This documentation effectively reflects the Java object tree under [RawServiceSp
 
     If you wish to use `configs` in your tasks, this needs to include a URI to download the `bootstrap` executable.
 
+  * `volume`/`volumes`
+
+    One or more persistent volumes to be mounted into the pod environment. These behave the same as volumes on a task or resource set, but are guaranteed to be shared between tasks in a pod. Although volumes defined on a task currently behave the same way, individual tasks will not be able to access volumes defined by another task in the future.
+
   * `tasks`
 
     This section lists the tasks which run within a given pod. All tasks share the same pod environment and resources. Resources may be more granularly allocated on a per-task basis in the future.

--- a/frameworks/helloworld/src/main/dist/examples/executor_volume.yml
+++ b/frameworks/helloworld/src/main/dist/examples/executor_volume.yml
@@ -1,0 +1,68 @@
+name: "hello-world"
+pods:
+  hello:
+    count: 2
+    volume:
+      path: "hello-container-path"
+      type: ROOT
+      size: 1024
+    tasks:
+      server:
+        goal: RUNNING
+        cmd: "echo $TASK_NAME >> hello-container-path/output && sleep $SLEEP_DURATION"
+        cpus: 0.1
+        memory: 256
+        env:
+          SLEEP_DURATION: 1000
+      sidecar:
+        goal: FINISHED
+        cmd: "echo 'sidecar' >> hello-container-path/output"
+        cpus: 0.1
+        memory: 256
+  world:
+    count: 1
+    volumes:
+      world-volume:
+        path: "world-container-path"
+        type: ROOT
+        size: 1024
+    tasks:
+      server:
+        goal: RUNNING
+        cmd: "echo $TASK_NAME >> world-container-path/output && sleep $SLEEP_DURATION"
+        cpus: 0.1
+        memory: 256
+        env:
+          SLEEP_DURATION: 1000
+      once:
+        goal: RUNNING
+        cmd: "echo $TASK_NAME >> world-container-path/output"
+        cpus: 0.1
+        memory: 256
+plans:
+  deploy:
+    strategy: serial
+    phases:
+      hello-deploy:
+        strategy: parallel
+        pod: hello
+        steps:
+          - default: [[server]]
+      world-server-deploy:
+        strategy: parallel
+        pod: world
+        steps:
+          - default: [[server]]
+      world-once-deploy:
+        strategy: parallel
+        pod: world
+        steps:
+          - default: [[once]]
+  sidecar:
+    strategy: serial
+    phases:
+      sidecar-deploy:
+        strategy: parallel
+        pod: hello
+        steps:
+          - default: [[sidecar]]

--- a/frameworks/helloworld/src/main/dist/examples/executor_volume.yml
+++ b/frameworks/helloworld/src/main/dist/examples/executor_volume.yml
@@ -35,7 +35,7 @@ pods:
         env:
           SLEEP_DURATION: 1000
       once:
-        goal: RUNNING
+        goal: FINISHED
         cmd: "echo $TASK_NAME >> world-container-path/output"
         cpus: 0.1
         memory: 256

--- a/frameworks/helloworld/src/main/resources/examples/executor_volume.yml
+++ b/frameworks/helloworld/src/main/resources/examples/executor_volume.yml
@@ -1,0 +1,1 @@
+../../dist/examples/executor_volume.yml

--- a/frameworks/helloworld/tests/test_executor_volumes.py
+++ b/frameworks/helloworld/tests/test_executor_volumes.py
@@ -1,0 +1,53 @@
+import pytest
+
+import sdk_install as install
+import sdk_plan as plan
+import sdk_spin as spin
+import sdk_utils
+
+from tests.config import (
+    PACKAGE_NAME
+)
+
+
+def setup_module(module):
+    install.uninstall(PACKAGE_NAME)
+    options = {
+        "service": {
+            "spec_file": "examples/executor_volume.yml"
+        }
+    }
+
+    install.install(PACKAGE_NAME, 3, additional_options=options)
+
+
+def teardown_module(module):
+    install.uninstall(PACKAGE_NAME)
+
+
+@pytest.mark.sanity
+def test_deploy():
+    deployment_plan = plan.get_deployment_plan(PACKAGE_NAME).json()
+    sdk_utils.out("deployment_plan: " + str(deployment_plan))
+
+    assert(len(deployment_plan['phases']) == 3)
+    assert(deployment_plan['phases'][0]['name'] == 'hello-deploy')
+    assert(deployment_plan['phases'][1]['name'] == 'world-server-deploy')
+    assert(deployment_plan['phases'][2]['name'] == 'world-once-deploy')
+    assert(len(deployment_plan['phases'][0]['steps']) == 2)
+    assert(len(deployment_plan['phases'][1]['steps']) == 1)
+    assert(len(deployment_plan['phases'][2]['steps']) == 1)
+
+
+@pytest.mark.sanity
+def test_sidecar():
+    plan.start_sidecar_plan(PACKAGE_NAME)
+    sidecar_plan = plan.get_sidecar_plan(PACKAGE_NAME).json()
+    sdk_utils.out("sidecar_plan: " + str(sidecar_plan))
+
+    assert(len(sidecar_plan['phases']) == 1)
+    assert(sidecar_plan['phases'][0]['name'] == 'sidecar-deploy')
+    assert(len(sidecar_plan['phases'][0]['steps']) == 2)
+
+    spin.time_wait_noisy(lambda: (
+        plan.get_sidecar_plan(PACKAGE_NAME).json()['status'] == 'COMPLETE'))

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/DefaultOfferRequirementProvider.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/DefaultOfferRequirementProvider.java
@@ -187,15 +187,15 @@ public class DefaultOfferRequirementProvider implements OfferRequirementProvider
             }
         }
 
-        Map<String, Protos.Resource> volumeMap = new HashMap<>();
         if (executorInfo == null) {
             executorInfo = getNewExecutorInfo(
                     podInstance.getPod(), serviceName, targetConfigurationId, schedulerFlags);
-        } else {
-            volumeMap.putAll(executorInfo.getResourcesList().stream()
-                    .filter(r -> r.hasDisk() && r.getDisk().hasVolume())
-                    .collect(Collectors.toMap(r -> r.getDisk().getVolume().getContainerPath(), Function.identity())));
         }
+
+        Map<String, Protos.Resource> volumeMap = new HashMap<>();
+        volumeMap.putAll(executorInfo.getResourcesList().stream()
+                .filter(r -> r.hasDisk() && r.getDisk().hasVolume())
+                .collect(Collectors.toMap(r -> r.getDisk().getVolume().getContainerPath(), Function.identity())));
 
         List<ResourceRequirement> resourceRequirements = new ArrayList<>();
         for (VolumeSpec v : podInstance.getPod().getVolumes()) {

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/ExecutorRequirement.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/ExecutorRequirement.java
@@ -136,7 +136,7 @@ public class ExecutorRequirement {
 
     public OfferEvaluationStage getEvaluationStage() {
         Protos.ExecutorID executorID = null;
-        if (getExecutorInfo().hasExecutorId() && !getExecutorInfo().getExecutorId().getValue().isEmpty()) {
+        if (ExecutorUtils.hasExecutorId(getExecutorInfo())) {
             executorID = getExecutorInfo().getExecutorId();
         }
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/ExecutorRequirement.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/ExecutorRequirement.java
@@ -17,6 +17,7 @@ import java.util.stream.Collectors;
  */
 public class ExecutorRequirement {
     private ExecutorInfo executorInfo;
+    private Collection<ResourceRequirement> resourceRequirements;
 
     /**
      * This method generates one of two possible Executor requirements.  In the first case, if an empty ExecutorID is
@@ -24,27 +25,34 @@ public class ExecutorRequirement {
      * second case, if an ExecutorInfo with a valid name is presented a requirement indicating use of an already running
      * Executor is generated.
      * @param executorInfo is the ExecutorInfo indicate what requirement should be generated.
+     * @param resourceRequirements the requirements for resources attached to this executor
      * @return an ExecutorRequirement to be used to evaluate Offers by the OfferEvaluator
      * @throws InvalidRequirementException when a malformed ExecutorInfo is presented indicating an invalid
      * ExecutorRequirement.
      */
-    public static ExecutorRequirement create(ExecutorInfo executorInfo)
-        throws InvalidRequirementException {
+    public static ExecutorRequirement create(
+            ExecutorInfo executorInfo,
+            Collection<ResourceRequirement> resourceRequirements) throws InvalidRequirementException {
         if (executorInfo.getExecutorId().getValue().isEmpty()) {
-            return createExecutorRequirement(executorInfo);
+            return createExecutorRequirement(executorInfo, resourceRequirements);
         } else {
             return getExistingExecutorRequirement(executorInfo);
         }
     }
 
-    private static ExecutorRequirement createExecutorRequirement(ExecutorInfo executorInfo)
-            throws InvalidRequirementException{
-        return new ExecutorRequirement(executorInfo);
+    public static ExecutorRequirement create(ExecutorInfo executorInfo) throws InvalidRequirementException {
+        return create(executorInfo, null);
+    }
+
+    private static ExecutorRequirement createExecutorRequirement(
+            ExecutorInfo executorInfo,
+            Collection<ResourceRequirement> resourceRequirements) throws InvalidRequirementException {
+        return new ExecutorRequirement(executorInfo, resourceRequirements);
     }
 
     private static ExecutorRequirement getExistingExecutorRequirement(ExecutorInfo executorInfo)
         throws InvalidRequirementException {
-        ExecutorRequirement executorRequirement = new ExecutorRequirement(executorInfo);
+        ExecutorRequirement executorRequirement = new ExecutorRequirement(executorInfo, null);
 
         if (executorRequirement.desiresResources()) {
             throw new InvalidRequirementException("When using an existing Executor, no new resources may be required.");
@@ -53,10 +61,15 @@ public class ExecutorRequirement {
         }
     }
 
-    private ExecutorRequirement(ExecutorInfo executorInfo)
-            throws InvalidRequirementException {
+    private ExecutorRequirement(
+            ExecutorInfo executorInfo,
+            Collection<ResourceRequirement> resourceRequirements) throws InvalidRequirementException {
         validateExecutorInfo(executorInfo);
         this.executorInfo = executorInfo;
+        this.resourceRequirements = resourceRequirements != null ? resourceRequirements :
+                executorInfo.getResourcesList().stream()
+                        .map(r -> new ResourceRequirement(r))
+                        .collect(Collectors.toList());
     }
 
     public ExecutorInfo getExecutorInfo() {
@@ -64,9 +77,7 @@ public class ExecutorRequirement {
     }
 
     public Collection<ResourceRequirement> getResourceRequirements() {
-        return executorInfo.getResourcesList().stream()
-                .map(r -> new ResourceRequirement(r))
-                .collect(Collectors.toList());
+        return resourceRequirements;
     }
 
     public Collection<String> getResourceIds() {

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/ExecutorRequirement.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/ExecutorRequirement.java
@@ -129,14 +129,18 @@ public class ExecutorRequirement {
             if (!executorName.equals(executorInfo.getName())) {
                 throw new InvalidRequirementException(String.format(
                         "When non-empty, ExecutorInfo.id must align with ExecutorInfo.name. Use "
-                        + "ExecutorUtils.toExecutorId(): %s", executorInfo));
+                        + "CommonIdUtils.toExecutorId(): %s", executorInfo));
             }
         }
     }
 
+    public boolean isRunningExecutor() {
+        return executorInfo.hasExecutorId() && !StringUtils.isEmpty(executorInfo.getExecutorId().getValue());
+    }
+
     public OfferEvaluationStage getEvaluationStage() {
         Protos.ExecutorID executorID = null;
-        if (ExecutorUtils.hasExecutorId(getExecutorInfo())) {
+        if (isRunningExecutor()) {
             executorID = getExecutorInfo().getExecutorId();
         }
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluator.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluator.java
@@ -1,7 +1,6 @@
 package com.mesosphere.sdk.offer.evaluate;
 
 import com.google.inject.Inject;
-import com.mesosphere.sdk.executor.ExecutorUtils;
 import com.mesosphere.sdk.offer.*;
 import com.mesosphere.sdk.specification.PodInstance;
 import com.mesosphere.sdk.state.StateStore;
@@ -90,8 +89,8 @@ public class OfferEvaluator {
         if (offerRequirement.getExecutorRequirementOptional().isPresent()) {
             ExecutorRequirement executorRequirement = offerRequirement.getExecutorRequirementOptional().get();
 
-            // If this executor already has an ID, it's running. Don't attempt to claim its resources again.
-            if (!ExecutorUtils.hasExecutorId(executorRequirement.getExecutorInfo())) {
+            // We don't want to re-reserve resources for an already-running executor.
+            if (!executorRequirement.isRunningExecutor()) {
                 for (ResourceRequirement r : executorRequirement.getResourceRequirements()) {
                     evaluationPipeline.add(r.getEvaluationStage(null));
                 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluator.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluator.java
@@ -87,6 +87,10 @@ public class OfferEvaluator {
 
         evaluationPipeline.add(new PlacementRuleEvaluationStage(stateStore.fetchTasks()));
         if (offerRequirement.getExecutorRequirementOptional().isPresent()) {
+            for (ResourceRequirement r :
+                    offerRequirement.getExecutorRequirementOptional().get().getResourceRequirements()) {
+                evaluationPipeline.add(r.getEvaluationStage(null));
+            }
             evaluationPipeline.add(offerRequirement.getExecutorRequirementOptional().get().getEvaluationStage());
         } else {
             evaluationPipeline.add(new ExecutorEvaluationStage());

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/PodInfoBuilder.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/PodInfoBuilder.java
@@ -1,6 +1,5 @@
 package com.mesosphere.sdk.offer.evaluate;
 
-import com.mesosphere.sdk.executor.ExecutorUtils;
 import com.mesosphere.sdk.offer.ExecutorRequirement;
 import com.mesosphere.sdk.offer.OfferRequirement;
 import org.apache.mesos.Protos;
@@ -34,7 +33,7 @@ public class PodInfoBuilder {
         // If this executor is already running, we won't be claiming any new resources for it, and we want to make sure
         // to provide an identical ExecutorInfo to Mesos for any other tasks that are going to launch in this pod.
         // So don't clear the resources on the existing protobuf, we're just going to pass it as is.
-        if (executorBuilder != null && !ExecutorUtils.hasExecutorId(executorRequirement.get().getExecutorInfo())) {
+        if (executorBuilder != null && !executorRequirement.get().isRunningExecutor()) {
             clearResources(executorBuilder);
         }
     }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/PodInfoBuilder.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/PodInfoBuilder.java
@@ -1,5 +1,7 @@
 package com.mesosphere.sdk.offer.evaluate;
 
+import com.mesosphere.sdk.executor.ExecutorUtils;
+import com.mesosphere.sdk.offer.ExecutorRequirement;
 import com.mesosphere.sdk.offer.OfferRequirement;
 import org.apache.mesos.Protos;
 
@@ -24,9 +26,17 @@ public class PodInfoBuilder {
         taskBuilders = offerRequirement.getTaskRequirements().stream()
                 .map(r -> r.getTaskInfo())
                 .collect(Collectors.toMap(t -> t.getName(), t -> clearResources(t.toBuilder())));
-        executorBuilder = offerRequirement.getExecutorRequirementOptional().isPresent() ?
-                offerRequirement.getExecutorRequirementOptional().get().getExecutorInfo().toBuilder() :
+
+        Optional<ExecutorRequirement> executorRequirement = offerRequirement.getExecutorRequirementOptional();
+        executorBuilder = executorRequirement.isPresent() ?
+                executorRequirement.get().getExecutorInfo().toBuilder() :
                 null;
+        // If this executor is already running, we won't be claiming any new resources for it, and we want to make sure
+        // to provide an identical ExecutorInfo to Mesos for any other tasks that are going to launch in this pod.
+        // So don't clear the resources on the existing protobuf, we're just going to pass it as is.
+        if (executorBuilder != null && !ExecutorUtils.hasExecutorId(executorRequirement.get().getExecutorInfo())) {
+            clearResources(executorBuilder);
+        }
     }
 
     public OfferRequirement getOfferRequirement() {
@@ -49,6 +59,12 @@ public class PodInfoBuilder {
     }
 
     private static Protos.TaskInfo.Builder clearResources(Protos.TaskInfo.Builder builder) {
+        builder.clearResources();
+
+        return builder;
+    }
+
+    private static Protos.ExecutorInfo.Builder clearResources(Protos.ExecutorInfo.Builder builder) {
         builder.clearResources();
 
         return builder;

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultPodSpec.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultPodSpec.java
@@ -48,6 +48,8 @@ public class DefaultPodSpec implements PodSpec {
     private final PlacementRule placementRule;
     @Valid
     private final Collection<URI> uris;
+    @Valid
+    private Collection<VolumeSpec> volumes;
 
     @JsonCreator
     public DefaultPodSpec(
@@ -59,7 +61,8 @@ public class DefaultPodSpec implements PodSpec {
             @JsonProperty("rlimits") Collection<RLimit> rlimits,
             @JsonProperty("uris") Collection<URI> uris,
             @JsonProperty("task-specs") List<TaskSpec> tasks,
-            @JsonProperty("placement-rule") PlacementRule placementRule) {
+            @JsonProperty("placement-rule") PlacementRule placementRule,
+            @JsonProperty("volumes") Collection<VolumeSpec> volumes) {
         this.type = type;
         this.user = user;
         this.count = count;
@@ -69,12 +72,14 @@ public class DefaultPodSpec implements PodSpec {
         this.uris = (uris != null) ? uris : Collections.emptyList();
         this.tasks = tasks;
         this.placementRule = placementRule;
+        this.volumes = (volumes != null) ? volumes : Collections.emptyList();
     }
 
     private DefaultPodSpec(Builder builder) {
         this(builder.type, builder.user, builder.count,
              builder.image, builder.networks, builder.rlimits,
-             builder.uris, builder.tasks, builder.placementRule);
+             builder.uris, builder.tasks, builder.placementRule,
+             builder.volumes);
         ValidationUtils.validate(this);
     }
 
@@ -94,6 +99,7 @@ public class DefaultPodSpec implements PodSpec {
         builder.tasks = new ArrayList<>();
         builder.tasks.addAll(copy.getTasks());
         builder.placementRule = copy.getPlacementRule().isPresent() ? copy.getPlacementRule().get() : null;
+        builder.volumes = copy.getVolumes();
         return builder;
     }
 
@@ -143,6 +149,11 @@ public class DefaultPodSpec implements PodSpec {
     }
 
     @Override
+    public Collection<VolumeSpec> getVolumes() {
+        return volumes;
+    }
+
+    @Override
     public boolean equals(Object o) {
         return EqualsBuilder.reflectionEquals(this, o);
     }
@@ -168,6 +179,7 @@ public class DefaultPodSpec implements PodSpec {
         private Collection<URI> uris;
         private List<TaskSpec> tasks = new ArrayList<>();
         private PlacementRule placementRule;
+        private Collection<VolumeSpec> volumes;
 
         private Builder(Optional<String> executorUri) {
             this.executorUri = executorUri;
@@ -300,6 +312,18 @@ public class DefaultPodSpec implements PodSpec {
          */
         public Builder placementRule(PlacementRule placementRule) {
             this.placementRule = placementRule;
+            return this;
+        }
+
+        /**
+         * Sets the {@code volumes} and returns a reference to this Builder so that the methods can be
+         * chained together.
+         *
+         * @param volumes the {@code volumes} to set
+         * @return a reference to this Builder
+         */
+        public Builder volumes(Collection<VolumeSpec> volumes) {
+            this.volumes = volumes;
             return this;
         }
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/PodSpec.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/PodSpec.java
@@ -43,6 +43,9 @@ public interface PodSpec {
     @JsonProperty("placement-rule")
     Optional<PlacementRule> getPlacementRule();
 
+    @JsonProperty("volumes")
+    Collection<VolumeSpec> getVolumes();
+
     @JsonIgnore
     static String getName(PodSpec podSpec, int index) {
         return podSpec.getType() + "-" + index;

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/RawPod.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/RawPod.java
@@ -23,6 +23,8 @@ public class RawPod implements RawContainerInfoProvider {
     private final Collection<String> uris;
     private final WriteOnceLinkedHashMap<String, RawTask> tasks;
     private final WriteOnceLinkedHashMap<String, RawResourceSet> resourceSets;
+    private final RawVolume volume;
+    private final WriteOnceLinkedHashMap<String, RawVolume> volumes;
 
     private RawPod(
             @JsonProperty("resource-sets") WriteOnceLinkedHashMap<String, RawResourceSet> resourceSets,
@@ -35,7 +37,9 @@ public class RawPod implements RawContainerInfoProvider {
             @JsonProperty("strategy") String strategy,
             @JsonProperty("uris") Collection<String> uris,
             @JsonProperty("tasks") WriteOnceLinkedHashMap<String, RawTask> tasks,
-            @JsonProperty("user") String user) {
+            @JsonProperty("user") String user,
+            @JsonProperty("volume") RawVolume volume,
+            @JsonProperty("volumes") WriteOnceLinkedHashMap<String, RawVolume> volumes) {
         this.placement = placement;
         this.count = count;
         this.container = container;
@@ -47,6 +51,8 @@ public class RawPod implements RawContainerInfoProvider {
         this.uris = uris;
         this.tasks = tasks;
         this.resourceSets = resourceSets;
+        this.volume = volume;
+        this.volumes = volumes == null ? new WriteOnceLinkedHashMap<>() : volumes;
     }
 
     public String getPlacement() {
@@ -91,5 +97,13 @@ public class RawPod implements RawContainerInfoProvider {
 
     public WriteOnceLinkedHashMap<String, RawResourceSet> getResourceSets() {
         return resourceSets;
+    }
+
+    public RawVolume getVolume() {
+        return volume;
+    }
+
+    public WriteOnceLinkedHashMap<String, RawVolume> getVolumes() {
+        return volumes;
     }
 }

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/testutils/OfferRequirementTestUtils.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/testutils/OfferRequirementTestUtils.java
@@ -2,14 +2,17 @@ package com.mesosphere.sdk.testutils;
 
 import com.mesosphere.sdk.offer.CommonIdUtils;
 import com.mesosphere.sdk.offer.Constants;
+import com.mesosphere.sdk.offer.ExecutorRequirement;
 import com.mesosphere.sdk.offer.NamedVIPRequirement;
 import com.mesosphere.sdk.offer.PortRequirement;
 import com.mesosphere.sdk.offer.ResourceRequirement;
 import com.mesosphere.sdk.offer.ResourceUtils;
 import com.mesosphere.sdk.offer.TaskException;
 import com.mesosphere.sdk.offer.TaskRequirement;
+import com.mesosphere.sdk.offer.TaskUtils;
 import com.mesosphere.sdk.offer.VolumeRequirement;
 import com.mesosphere.sdk.offer.evaluate.PortsRequirement;
+import org.apache.commons.lang.StringUtils;
 import org.apache.mesos.Protos;
 import org.apache.mesos.Protos.HealthCheck;
 import org.apache.mesos.Protos.TaskInfo;
@@ -37,6 +40,24 @@ public class OfferRequirementTestUtils {
         } catch (InvalidRequirementException e) {
             throw new IllegalStateException(e);
         }
+    }
+
+    public static OfferRequirement getOfferRequirement(
+            Protos.Resource resource, Protos.Resource executorResource) throws InvalidRequirementException {
+        TaskRequirement taskRequirement = new TaskRequirement(
+                TaskTestUtils.getTaskInfo(Arrays.asList(resource)), getResourceRequirements(Arrays.asList(resource)));
+        ExecutorRequirement executorRequirement = ExecutorRequirement.create(
+                StringUtils.isEmpty(ResourceUtils.getResourceId(executorResource)) ?
+                        TaskTestUtils.getExecutorInfo(executorResource) :
+                        TaskTestUtils.getExistingExecutorInfo(executorResource),
+                getResourceRequirements(Arrays.asList(executorResource)));
+
+        return new OfferRequirement(
+                TestConstants.TASK_TYPE,
+                0,
+                Arrays.asList(taskRequirement),
+                Optional.of(executorRequirement),
+                Optional.empty());
     }
 
     public static OfferRequirement getOfferRequirement(Protos.Resource resource) throws InvalidRequirementException {

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/testutils/OfferRequirementTestUtils.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/testutils/OfferRequirementTestUtils.java
@@ -9,7 +9,6 @@ import com.mesosphere.sdk.offer.ResourceRequirement;
 import com.mesosphere.sdk.offer.ResourceUtils;
 import com.mesosphere.sdk.offer.TaskException;
 import com.mesosphere.sdk.offer.TaskRequirement;
-import com.mesosphere.sdk.offer.TaskUtils;
 import com.mesosphere.sdk.offer.VolumeRequirement;
 import com.mesosphere.sdk.offer.evaluate.PortsRequirement;
 import org.apache.commons.lang.StringUtils;

--- a/sdk/scheduler/src/test/resources/valid-exhaustive.yml
+++ b/sdk/scheduler/src/test/resources/valid-exhaustive.yml
@@ -16,6 +16,11 @@ pods:
       RLIMIT_AS:
         soft: 5
         hard: 10
+    volumes:
+      shared:
+        path: "shared-container-path"
+        type: ROOT
+        size: 3000
     resource-sets:
       meta-data-resources:
         cpus: 0.1


### PR DESCRIPTION
After moving to task groups, volumes defined on individual task groups will not be visible between other task groups in the same pod. This change allows volumes to be defined at the pod level so that they are attached to the `ExecutorInfo` on launch, which is the mandated method for sharing volumes between task groups in the same pod.