### PR TITLE
[KAF-326] Use new spinner; accept empty 200 success.

### DIFF
--- a/testing/sdk_cmd.py
+++ b/testing/sdk_cmd.py
@@ -14,7 +14,7 @@ def request(method, url, retry=True, **kwargs):
         response.raise_for_status()
         return response
     if retry:
-        return sdk_spin.time_wait_return(lambda: fn())
+        return shakedown.wait_while_exceptions(lambda: fn())
     else:
         return fn()
 


### PR DESCRIPTION
Same as in dcos-kafka-service; an empty response is false, but still OK.  So accept anything that's not an exception.