### PR TITLE
[INFINITY-1319] Replace pods immediately.

### DIFF
--- a/frameworks/helloworld/tests/test_recovery.py
+++ b/frameworks/helloworld/tests/test_recovery.py
@@ -89,6 +89,7 @@ def test_pods_replace():
 
 @pytest.mark.sanity
 @pytest.mark.recovery
+@pytest.mark.shutdown_node
 def test_pods_replace_dead_agent():
     # Find a pod that is on a different agent than the scheduler.
     scheduler_ip = shakedown.get_service_ips('marathon', PACKAGE_NAME).pop()
@@ -109,7 +110,7 @@ def test_pods_replace_dead_agent():
     # Initial task id
     task_ids = tasks.get_task_ids(PACKAGE_NAME, 'world-{}'.format(pod_id))
     stdout = cmd.run_cli('{} state property suppressed'.format(PACKAGE_NAME))
-    assert stdout == 'true' # make sure we're already suppressed.
+    assert stdout.rstrip('\n') == 'true' # make sure we're already suppressed.
 
     # Don't use `shutdown now` so that SSH command completes successfully.
     status, stdout = shakedown.run_command_on_agent(agent_to_kill, 'sudo shutdown -h +1')
@@ -120,7 +121,7 @@ def test_pods_replace_dead_agent():
     cmd.run_cli('{} replace pod world-{}'.format(PACKAGE_NAME, pod_id))
     time.sleep(5)
     stdout = cmd.run_cli('{} state property suppressed'.format(PACKAGE_NAME))
-    assert stdout == 'false' # make sure we've revived.
+    assert stdout.rstrip('\n') == 'false' # make sure we've revived.
 
     tasks.check_tasks_updated(PACKAGE_NAME, 'node', task_ids)
 

--- a/frameworks/helloworld/tests/test_recovery.py
+++ b/frameworks/helloworld/tests/test_recovery.py
@@ -2,11 +2,13 @@ import json
 
 import pytest
 import shakedown
+import time
 
 import sdk_cmd as cmd
 import sdk_install as install
 import sdk_marathon as marathon
 import sdk_tasks as tasks
+import sdk_utils
 from tests.config import (
     PACKAGE_NAME,
     DEFAULT_TASK_COUNT,
@@ -83,6 +85,44 @@ def test_pods_replace():
     new_agent = json.loads(stdout)[0]['info']['slaveId']['value']
     # TODO: enable assert if/when agent is guaranteed to change (may randomly move back to old agent)
     # assert old_agent != new_agent
+
+
+@pytest.mark.sanity
+@pytest.mark.recovery
+def test_pods_replace_dead_agent():
+    # Find a pod that is on a different agent than the scheduler.
+    scheduler_ip = shakedown.get_service_ips('marathon', PACKAGE_NAME).pop()
+    sdk_utils.out('marathon ip = {}'.format(scheduler_ip))
+
+    agent_to_kill = None
+    for pod_id in range(0, DEFAULT_TASK_COUNT):
+        task = 'world-{}-server'.format(pod_id)
+        task_ip = shakedown.get_service_ips(PACKAGE_NAME, task_name=task)
+        if task_ip != scheduler_ip:
+            agent_to_kill = task_ip
+            break
+
+    if agent_to_kill is None:
+        sdk_utils.out("Failed to find an agent to kill. All world tasks are on scheduler agent.")
+        raise
+
+    # Initial task id
+    task_ids = tasks.get_task_ids(PACKAGE_NAME, 'world-{}'.format(pod_id))
+    stdout = cmd.run_cli('{} state property suppressed'.format(PACKAGE_NAME))
+    assert stdout == 'true' # make sure we're already suppressed.
+
+    # Don't use `shutdown now` so that SSH command completes successfully.
+    status, stdout = shakedown.run_command_on_agent(agent_to_kill, 'sudo shutdown -h +1')
+    sdk_utils.out('shutdown agent {}: [{}] {}'.format(agent_to_kill, status, stdout))
+    assert status is True
+    time.sleep(100) # Make sure agent is shutdown.
+
+    cmd.run_cli('{} replace pod world-{}'.format(PACKAGE_NAME, pod_id))
+    time.sleep(5)
+    stdout = cmd.run_cli('{} state property suppressed'.format(PACKAGE_NAME))
+    assert stdout == 'false' # make sure we've revived.
+
+    tasks.check_tasks_updated(PACKAGE_NAME, 'node', task_ids)
 
 
 @pytest.mark.recovery

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/api/TaskStatusResource.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/api/TaskStatusResource.java
@@ -1,0 +1,58 @@
+package com.mesosphere.sdk.api;
+
+import com.mesosphere.sdk.scheduler.TaskStatusWriter;
+import com.mesosphere.sdk.state.StateStore;
+import org.apache.mesos.Protos;
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.*;
+import javax.ws.rs.core.Response;
+import java.util.Optional;
+
+/**
+ * Basic API to directly modify the TaskStatus of a Task.
+ */
+@Path("/v1/taskstatus")
+public class TaskStatusResource {
+    private final Logger LOGGER = LoggerFactory.getLogger(getClass());
+
+    private final TaskStatusWriter taskStatusWriter;
+    private final StateStore stateStore;
+
+    public TaskStatusResource(TaskStatusWriter taskStatusWriter, StateStore stateStore) {
+        this.taskStatusWriter = taskStatusWriter;
+        this.stateStore = stateStore;
+    }
+
+    @POST
+    @Path("/{name}")
+    public Response updateState(@PathParam("name") String taskname,
+                                 @QueryParam("targetState") Protos.TaskState targetState) throws Exception {
+        LOGGER.info("Trying to update state of task {} to new desired state {}", taskname, targetState);
+        Optional<Protos.TaskStatus> possibleTask = stateStore.fetchStatus(taskname);
+        if (!possibleTask.isPresent()) {
+            LOGGER.error("No task found for name {}", taskname);
+            return ResponseUtils.plainResponse(String.format("No task with name %s", taskname),
+                    Response.Status.NOT_FOUND);
+        }
+
+        Protos.TaskStatus taskStatus = possibleTask.get();
+        LOGGER.info("Task {} found. currently={} desired={}", taskname,
+                taskStatus.getState(),
+                targetState);
+        try {
+            taskStatusWriter.writeTaskStatus(taskStatus.getTaskId(),
+                    targetState,
+                    "Task state manually overridden by API call");
+        } catch (Exception e) {
+            LOGGER.error(String.format("Failed to write new state %s for task %s", targetState, taskname), e);
+            return Response.serverError().build();
+        }
+
+        JSONObject result = new JSONObject().put("newState", targetState.toString())
+                .put("oldState", taskStatus.getState().toString());
+        return ResponseUtils.jsonOkResponse(result);
+    }
+}

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/DefaultScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/DefaultScheduler.java
@@ -655,11 +655,13 @@ public class DefaultScheduler implements Scheduler, Observer {
         }
         resources.add(endpointsResource);
         resources.add(new PlansResource(planCoordinator));
+        TaskStatusWriter taskStatusWriter = new TaskStatusWriter(this, driver);
         if (customRestartHook.isPresent()) {
-            resources.add(new PodsResource(taskKiller, stateStore, customRestartHook.get()));
+            resources.add(new PodsResource(taskKiller, taskStatusWriter, stateStore, customRestartHook.get()));
         } else {
-            resources.add(new PodsResource(taskKiller, stateStore));
+            resources.add(new PodsResource(taskKiller, taskStatusWriter, stateStore));
         }
+        resources.add(new TaskStatusResource(taskStatusWriter, stateStore));
         resources.add(new StateResource(stateStore, new StringPropertyDeserializer()));
         resources.add(new TaskResource(stateStore, taskKiller, serviceSpec.getName()));
     }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/DefaultTaskKiller.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/DefaultTaskKiller.java
@@ -15,7 +15,8 @@ public class DefaultTaskKiller implements TaskKiller {
     private final TaskFailureListener taskFailureListener;
     private final SchedulerDriver driver;
 
-    public DefaultTaskKiller(TaskFailureListener taskFailureListener, SchedulerDriver driver) {
+    public DefaultTaskKiller(TaskFailureListener taskFailureListener,
+                             SchedulerDriver driver) {
         this.taskFailureListener = taskFailureListener;
         this.driver = driver;
     }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/TaskStatusWriter.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/TaskStatusWriter.java
@@ -1,0 +1,55 @@
+package com.mesosphere.sdk.scheduler;
+
+import org.apache.mesos.Protos;
+import org.apache.mesos.Scheduler;
+import org.apache.mesos.SchedulerDriver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Simple writer to manipulate the TaskStatus of a Mesos task (as far as our Scheduler
+ * is concerned).
+ */
+public class TaskStatusWriter {
+    private final Logger LOGGER = LoggerFactory.getLogger(this.getClass());
+    private final Scheduler scheduler;
+    private final SchedulerDriver schedulerDriver;
+
+    public TaskStatusWriter(Scheduler scheduler,
+                            SchedulerDriver schedulerDriver) {
+        this.scheduler = scheduler;
+        this.schedulerDriver = schedulerDriver;
+    }
+
+    /**
+     * Constructs a TaskStatus from the supplied parameters and sends
+     * it to the Scheduler by calling statusUpdate()
+     * @param taskID
+     * @param taskState
+     * @param message
+     * @throws Exception
+     */
+    public void writeTaskStatus(Protos.TaskID taskID,
+                                Protos.TaskState taskState,
+                                String message)  throws Exception {
+        writeTaskStatus(Protos.TaskStatus.newBuilder()
+                .setTaskId(taskID)
+                .setState(taskState)
+                .setMessage(message)
+                .build());
+    }
+
+    /**
+     * Sends the specified TaskStatus to the Scheduler by calling statusUpdate()
+     * @param status
+     * @throws Exception
+     */
+    public void writeTaskStatus(Protos.TaskStatus status) throws Exception {
+        LOGGER.info("Writing new status for taskId={} state={} message='{}'",
+                status.getTaskId().getValue(),
+                status.getState().toString(),
+                status.getMessage());
+        scheduler.statusUpdate(schedulerDriver, status);
+    }
+
+}

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/recovery/DefaultRecoveryPlanManager.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/recovery/DefaultRecoveryPlanManager.java
@@ -89,7 +89,7 @@ public class DefaultRecoveryPlanManager extends ChainedObserver implements PlanM
      * <p>
      * 1. Updates existing steps.
      * 2. If the needs recovery and doesn't yet have a step in the plan, removes any COMPLETED steps for this task
-     * (at most one step for a given task can exist) and creates a new PENDING step.
+     * (at most one step for a given taskd can exist) and creates a new PENDING step.
      *
      * @param status task status
      */

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/api/TaskStatusResourceTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/api/TaskStatusResourceTest.java
@@ -1,0 +1,68 @@
+package com.mesosphere.sdk.api;
+
+import com.mesosphere.sdk.scheduler.TaskStatusWriter;
+import com.mesosphere.sdk.state.StateStore;
+import org.apache.mesos.Protos;
+import org.json.JSONObject;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import javax.ws.rs.core.Response;
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+
+public class TaskStatusResourceTest {
+
+    @Mock
+    private TaskStatusWriter mockTaskStatusWriter;
+    @Mock
+    private StateStore mockStateStore;
+
+    private TaskStatusResource taskStatusResource;
+
+    @Before
+    public void beforeEach() {
+        MockitoAnnotations.initMocks(this);
+        taskStatusResource = new TaskStatusResource(mockTaskStatusWriter, mockStateStore);
+    }
+
+    @Test
+    public void updateStateSuccess() throws Exception {
+        Protos.TaskStatus taskStatus = Protos.TaskStatus.newBuilder()
+                .setTaskId(Protos.TaskID.newBuilder().setValue("task-id").build())
+                .setState(Protos.TaskState.TASK_RUNNING)
+                .build();
+        when(mockStateStore.fetchStatus("test-task")).thenReturn(Optional.of(taskStatus));
+        Response response = taskStatusResource.updateState("test-task", Protos.TaskState.TASK_DROPPED);
+        JSONObject result = new JSONObject(response.getEntity().toString());
+        assertEquals("TASK_RUNNING", result.getString("oldState"));
+        assertEquals("TASK_DROPPED", result.getString("newState"));
+    }
+
+    @Test
+    public void updateStateTaskNotFound() throws Exception {
+        when(mockStateStore.fetchStatus("test-task")).thenReturn(Optional.empty());
+        Response response = taskStatusResource.updateState("test-task", Protos.TaskState.TASK_DROPPED);
+        assertEquals(Response.Status.NOT_FOUND.getStatusCode(), response.getStatus());
+    }
+
+    @Test
+    public void updateStateWriteTaskStatusFail() throws Exception {
+        Protos.TaskStatus taskStatus = Protos.TaskStatus.newBuilder()
+                .setTaskId(Protos.TaskID.newBuilder().setValue("task-id").build())
+                .setState(Protos.TaskState.TASK_RUNNING)
+                .build();
+        when(mockStateStore.fetchStatus("test-task")).thenReturn(Optional.of(taskStatus));
+        doThrow(new Exception()).when(mockTaskStatusWriter).writeTaskStatus(Protos.TaskID.newBuilder().setValue("task-id").build(),
+                Protos.TaskState.TASK_DROPPED,
+                "Task state manually overridden by API call");
+        Response response = taskStatusResource.updateState("test-task", Protos.TaskState.TASK_DROPPED);
+        assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
+
+    }
+}

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/TaskStatusWriterTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/TaskStatusWriterTest.java
@@ -1,0 +1,41 @@
+package com.mesosphere.sdk.scheduler;
+
+import org.apache.mesos.Protos;
+import org.apache.mesos.Scheduler;
+import org.apache.mesos.SchedulerDriver;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+public class TaskStatusWriterTest {
+
+    @Mock
+    Scheduler mockScheduler;
+    @Mock
+    SchedulerDriver mockSchedulerDriver;
+
+    @Before
+    public void beforeEach() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void writeStatusTest() throws Exception {
+        TaskStatusWriter taskStatusWriter = new TaskStatusWriter(mockScheduler, mockSchedulerDriver);
+        taskStatusWriter.writeTaskStatus(Protos.TaskID.newBuilder().setValue("testid").build(),
+                Protos.TaskState.TASK_KILLED,
+                "This is a test.");
+
+        verify(mockScheduler).statusUpdate(mockSchedulerDriver, Protos.TaskStatus.newBuilder()
+            .setTaskId(Protos.TaskID.newBuilder().setValue("testid").build())
+            .setState(Protos.TaskState.TASK_KILLED)
+            .setMessage("This is a test.")
+            .build());
+        verifyNoMoreInteractions(mockScheduler);
+    }
+
+}


### PR DESCRIPTION
Right now, we wait for Mesos to kill all of a pod's tasks before we revive and try to replace it.

Instead, immediately "kill" the task as far as the scheduler is concerned (via TaskStatusWriter), and then tell Mesos to kill it as well. 

This insulates us from agent failure delaying replaces (and agent failure is one of the few times you'll really want to do replace).