### PR TITLE
Use version 0.15.0 in standalone service generation script.

### DIFF
--- a/new-standalone-service.sh
+++ b/new-standalone-service.sh
@@ -3,7 +3,7 @@
 set -e
 
 CLEANUP_PATH=`pwd`
-VERSION="0.12.0"
+VERSION="0.15.0"
 
 cleanup() {
     debug "Cleaning up"


### PR DESCRIPTION
It's using 0.12.0 as we speak.