### PR TITLE
Use repeated -p parameter for specifying plan envvars

### DIFF
--- a/cli/commands.go
+++ b/cli/commands.go
@@ -31,15 +31,15 @@ func GetArguments() []string {
 	return os.Args[2:]
 }
 
-func GetPlanParameterPayload(parameters string) (string, error) {
+func GetPlanParameterPayload(parameters []string) (string, error) {
 	envPairs := make(map[string]string)
-	for _, pair := range strings.Split(parameters, ",") {
+	for _, pair := range parameters {
 		elements := strings.Split(pair, "=")
-		if len(elements) != 2 {
+		if len(elements) < 2 {
 			return "", errors.New(fmt.Sprintf(
 				"Must have one variable name and one variable value per definition"))
 		}
-		envPairs[elements[0]] = elements[1]
+		envPairs[elements[0]] = strings.Join(elements[1:], "=")
 	}
 
 	jsonVal, err := json.Marshal(envPairs)
@@ -203,7 +203,7 @@ func HandleEndpointsSection(app *kingpin.Application) {
 
 type PlanHandler struct {
 	PlanName   string
-	Parameters string
+	Parameters []string
 	Phase      string
 	Step       string
 }
@@ -299,7 +299,7 @@ func HandlePlanSection(app *kingpin.Application) {
 
 	start := plan.Command("start", "Start the plan with the provided name, with optional envvars to supply to task").Action(cmd.RunStart)
 	start.Arg("plan", "Name of the plan to start").Required().StringVar(&cmd.PlanName)
-	start.Arg("params", "Comma-separated list of VAR=value pairs").StringVar(&cmd.Parameters)
+	start.Flag("params", "Envvar definition in VAR=value form; can be repeated for multiple variables").Short('p').StringsVar(&cmd.Parameters)
 
 	stop := plan.Command("stop", "Stop the plan with the provided name").Action(cmd.RunStop)
 	stop.Arg("plan", "Name of the plan to stop").Required().StringVar(&cmd.PlanName)

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -31,15 +31,24 @@ func GetArguments() []string {
 	return os.Args[2:]
 }
 
+func GetVariablePair(pairString string) ([]string, error) {
+	elements := strings.Split(pairString, "=")
+	if len(elements) < 2 {
+		return nil, errors.New(fmt.Sprintf(
+			"Must have one variable name and one variable value per definition"))
+	}
+
+	return []string{elements[0], strings.Join(elements[1:], "=")}, nil
+}
+
 func GetPlanParameterPayload(parameters []string) (string, error) {
 	envPairs := make(map[string]string)
-	for _, pair := range parameters {
-		elements := strings.Split(pair, "=")
-		if len(elements) < 2 {
-			return "", errors.New(fmt.Sprintf(
-				"Must have one variable name and one variable value per definition"))
+	for _, pairString := range parameters {
+		pair, err := GetVariablePair(pairString)
+		if err != nil {
+			return "", err
 		}
-		envPairs[elements[0]] = strings.Join(elements[1:], "=")
+		envPairs[pair[0]] = pair[1]
 	}
 
 	jsonVal, err := json.Marshal(envPairs)

--- a/cli/commands_test.go
+++ b/cli/commands_test.go
@@ -1,0 +1,90 @@
+package cli
+
+import (
+	"testing"
+	"reflect"
+	"encoding/json"
+)
+
+func TestGetVariablePairParsesVariable(t *testing.T) {
+	pairString := "var=value"
+	pair, err := GetVariablePair(pairString)
+
+	if err != nil {
+		t.Error("Got error: ", err)
+	}
+
+	if !reflect.DeepEqual(pair, []string{"var", "value"}) {
+		t.Error("Expected [\"var\", \"value\"], got ", pair)
+	}
+}
+
+func TestGetVariablePairParsesVariableWithEqualsSign(t *testing.T) {
+	pairString := "var=value=more"
+	pair, err := GetVariablePair(pairString)
+
+	if err != nil {
+		t.Error("Got error: ", err)
+	}
+
+	if !reflect.DeepEqual(pair, []string{"var", "value=more"}) {
+		t.Error("Expected [\"var\", \"value=more\"], got ", pair)
+	}
+}
+
+func TestGetVariablePairParsesVariableWithSpace(t *testing.T) {
+	pairString := "var=value more"
+	pair, err := GetVariablePair(pairString)
+
+	if err != nil {
+		t.Error("Got error: ", err)
+	}
+
+	if !reflect.DeepEqual(pair, []string{"var", "value more"}) {
+		t.Error("Expected [\"var\", \"value more\"], got ", pair)
+	}
+}
+
+func TestGetVariablePairFailsWhenEqualsSignNotPresent(t *testing.T) {
+	pairString := "var value"
+	_, err := GetVariablePair(pairString)
+
+	if err == nil {
+		t.Error("Parsing for \"var value\" should have failed without an equals sign present")
+	}
+}
+
+func TestSingleVariableIsMarshaledToJSON(t *testing.T) {
+	parameters := []string{"var=value"}
+	expectedParameters, _ := json.Marshal(map[string]string{
+		"var": "value",
+	})
+
+	result, err := GetPlanParameterPayload(parameters)
+
+	if err != nil {
+		t.Error("Got error: ", err)
+	}
+
+	if string(expectedParameters) != result {
+		t.Error("Expected ", string(expectedParameters), ", got ", result)
+	}
+}
+
+func TestMultipleVariablesAreMarshaledToJSON(t *testing.T) {
+	parameters := []string{"var=value", "var2=value2"}
+	expectedParameters, _ := json.Marshal(map[string]string{
+		"var": "value",
+		"var2": "value2",
+	})
+
+	result, err := GetPlanParameterPayload(parameters)
+
+	if err != nil {
+		t.Error("Got error: ", err)
+	}
+
+	if string(expectedParameters) != result {
+		t.Error("Expected ", string(expectedParameters), ", got ", result)
+	}
+}

--- a/docs/pages/developer-guide.md
+++ b/docs/pages/developer-guide.md
@@ -1115,7 +1115,7 @@ $ curl -k -X POST -H "Authorization: token=$AUTH_TOKEN" -H "Content-Type: applic
 
 You can also use the DC/OS CLI:
 ```bash
-$ dcos $FRAMEWORK_NAME plan start sidecar-example PLAN_PARAMETER1=sidecar,PLAN_PARAMETER2=plan
+$ dcos $FRAMEWORK_NAME plan start sidecar-example -p PLAN_PARAMETER1=sidecar -p PLAN_PARAMETER2=plan
 ```
 
 When no parameters are specified, the body of the POST request must be an empty JSON object (`{}`). Supply default values with standard Bash syntax. In the above case, you can declare the default value of `PLAN_PARAMETER1` to be `sidecar` by changing the task's command string to `echo ${PLAN_PARAMETER1:-sidecar} >> output`.

--- a/frameworks/cassandra/build.sh
+++ b/frameworks/cassandra/build.sh
@@ -12,5 +12,9 @@ PUBLISH_STEP=${1-none}
 ${ROOT_DIR}/gradlew distZip -p ${ROOT_DIR}/sdk/executor
 ${ROOT_DIR}/tools/build_framework.sh $PUBLISH_STEP cassandra $FRAMEWORK_DIR $BUILD_DIR/executor.zip $BUILD_DIR/cassandra-scheduler.zip
 
+# run CLI unit tests
+cd ${ROOT_DIR}/cli
+go test
+
 # capture anonymous metrics for reporting
 curl https://mesosphere.com/wp-content/themes/mesosphere/library/images/assets/sdk/build-sh-finish.png >/dev/null 2>&1


### PR DESCRIPTION
Manually verified that this works as expected with single and multi-parameter plans.