### PR TITLE
Update tooling to use drop-in stub universe json format

### DIFF
--- a/tools/publish_aws.py
+++ b/tools/publish_aws.py
@@ -90,14 +90,15 @@ class AWSPublisher(object):
             self._artifact_paths.append(artifact_path)
 
 
-    def _upload_artifact(self, filepath):
+    def _upload_artifact(self, filepath, content_type=None):
         filename = os.path.basename(filepath)
+        cmd = 'aws s3'
         if self._aws_region:
-            cmd = 'aws s3 --region={} cp --acl public-read {} {}/{} 1>&2'.format(
-                self._aws_region, filepath, self._s3_directory, filename)
-        else:
-            cmd = 'aws s3 cp --acl public-read {} {}/{} 1>&2'.format(
-                filepath, self._s3_directory, filename)
+            cmd += ' --region={}'.format(self._aws_region)
+        cmd += ' cp --acl public-read'
+        if content_type:
+            cmd += ' --content-type "{}"'.format(content_type)
+        cmd += ' {} {}/{} 1>&2'.format(filepath, self._s3_directory, filename)
         if self._dry_run:
             logger.info('[DRY RUN] {}'.format(cmd))
             ret = 0
@@ -140,17 +141,18 @@ class AWSPublisher(object):
 
     def upload(self):
         '''generates a unique directory, then uploads artifacts and a new stub universe to that directory'''
+        builder = universe_builder.UniversePackageBuilder(
+            self._pkg_name, self._pkg_version,
+            self._input_dir_path, self._http_directory, self._artifact_paths)
         try:
-            universe_path = universe_builder.UniversePackageBuilder(
-                self._pkg_name, self._pkg_version,
-                self._input_dir_path, self._http_directory, self._artifact_paths).build_zip()
+            universe_path = builder.build_package()
         except Exception as e:
             err = 'Failed to create stub universe: {}'.format(str(e))
             self._github_updater.update('error', err)
             raise
 
         # print universe url early
-        universe_url = self._upload_artifact(universe_path)
+        universe_url = self._upload_artifact(universe_path, content_type=builder.content_type())
         logger.info('---')
         logger.info('Uploading {} artifacts:'.format(len(self._artifact_paths)))
 

--- a/tools/publish_aws.py
+++ b/tools/publish_aws.py
@@ -92,13 +92,14 @@ class AWSPublisher(object):
 
     def _upload_artifact(self, filepath, content_type=None):
         filename = os.path.basename(filepath)
-        cmd = 'aws s3'
+        cmdlist = ['aws s3']
         if self._aws_region:
-            cmd += ' --region={}'.format(self._aws_region)
-        cmd += ' cp --acl public-read'
+            cmdlist.append('--region={}'.format(self._aws_region))
+        cmdlist.append('cp --acl public-read')
         if content_type:
-            cmd += ' --content-type "{}"'.format(content_type)
-        cmd += ' {} {}/{} 1>&2'.format(filepath, self._s3_directory, filename)
+            cmdlist.append('--content-type "{}"'.format(content_type))
+        cmdlist.append('{} {}/{} 1>&2'.format(filepath, self._s3_directory, filename))
+        cmd = ' '.join(cmdlist)
         if self._dry_run:
             logger.info('[DRY RUN] {}'.format(cmd))
             ret = 0

--- a/tools/release_builder.py
+++ b/tools/release_builder.py
@@ -2,7 +2,6 @@
 
 import base64
 import difflib
-import http.client
 import json
 import logging
 import os
@@ -15,6 +14,7 @@ import tempfile
 import urllib.request
 import zipfile
 from collections import OrderedDict
+import http.client
 
 
 logger = logging.getLogger(__name__)
@@ -24,19 +24,19 @@ logging.basicConfig(level=logging.DEBUG, format="%(message)s")
 class UniverseReleaseBuilder(object):
 
     def __init__(self, package_version, stub_universe_url,
-                 commit_desc = '',
-                 min_dcos_release_version = os.environ.get('MIN_DCOS_RELEASE_VERSION', '1.8'),
-                 http_release_server = os.environ.get('HTTP_RELEASE_SERVER', 'https://downloads.mesosphere.com'),
-                 s3_release_bucket = os.environ.get('S3_RELEASE_BUCKET', 'downloads.mesosphere.io'),
-                 release_docker_image = os.environ.get('RELEASE_DOCKER_IMAGE'),
-                 release_dir_path = os.environ.get('RELEASE_DIR_PATH', ''),
-                 beta_release = os.environ.get('BETA', 'False')):
+                 commit_desc='',
+                 min_dcos_release_version=os.environ.get('MIN_DCOS_RELEASE_VERSION', '1.8'),
+                 http_release_server=os.environ.get('HTTP_RELEASE_SERVER', 'https://downloads.mesosphere.com'),
+                 s3_release_bucket=os.environ.get('S3_RELEASE_BUCKET', 'downloads.mesosphere.io'),
+                 release_docker_image=os.environ.get('RELEASE_DOCKER_IMAGE'),
+                 release_dir_path=os.environ.get('RELEASE_DIR_PATH', ''),
+                 beta_release=os.environ.get('BETA', 'False')):
         self._dry_run = os.environ.get('DRY_RUN', '')
-        self._force_upload = bool(os.environ.get('FORCE_ARTIFACT_UPLOAD', 'false'))
-        name_match = re.match('.+/stub-universe-(.+).zip$', stub_universe_url)
+        self._force_upload = bool(os.environ.get('FORCE_ARTIFACT_UPLOAD', ''))
+        name_match = re.match('.+/stub-universe-(.+).(zip|json)$', stub_universe_url)
         if not name_match:
             raise Exception('Unable to extract package name from stub universe URL. ' +
-                            'Expected filename of form \'stub-universe-[pkgname].zip\'')
+                            'Expected filename of form \'stub-universe-[pkgname].zip\' or \'stub-universe-[pkgname].json\'')
         self._pkg_name = name_match.group(1)
         if not release_dir_path:
             release_dir_path = self._pkg_name + '/assets'
@@ -56,13 +56,13 @@ class UniverseReleaseBuilder(object):
 
         # complain early about any missing envvars...
         # avoid uploading a bunch of stuff to prod just to error out later:
-        if not 'GITHUB_TOKEN' in os.environ:
+        if 'GITHUB_TOKEN' not in os.environ:
             raise Exception('GITHUB_TOKEN is required: Credential to create a PR against Universe')
         encoded_tok = base64.encodestring(os.environ['GITHUB_TOKEN'].encode('utf-8'))
         self._github_token = encoded_tok.decode('utf-8').rstrip('\n')
 
 
-    def _run_cmd(self, cmd, exit_on_fail=True, dry_run_return = 0):
+    def _run_cmd(self, cmd, exit_on_fail=True, dry_run_return=0):
         if self._dry_run:
             logger.info('[DRY RUN] {}'.format(cmd))
             return dry_run_return
@@ -74,33 +74,81 @@ class UniverseReleaseBuilder(object):
             return ret
 
     def _download_unpack_stub_universe(self, scratchdir):
-        '''Returns the path to the directory in the stub universe.'''
-        local_zip_path = os.path.join(scratchdir, self._stub_universe_url.split('/')[-1])
-        result = urllib.request.urlopen(self._stub_universe_url)
-        dlfile = open(local_zip_path, 'wb')
-        dlfile.write(result.read())
-        dlfile.flush()
-        dlfile.close()
-        zipin = zipfile.ZipFile(local_zip_path, 'r')
-        badfile = zipin.testzip()
-        if badfile:
-            raise Exception('Bad file {} in downloaded {} => {}'.format(
-                badfile, self._stub_universe_url, local_zip_path))
-        zipin.extractall(scratchdir)
-        # check for stub-universe-pkgname/repo/packages/P/pkgname/0/:
-        pkgdir_path = os.path.join(
-            scratchdir,
-            'stub-universe-{}'.format(self._pkg_name),
-            'repo',
-            'packages',
-            self._pkg_name[0].upper(),
-            self._pkg_name,
-            '0')
-        if not os.path.isdir(pkgdir_path):
-            raise Exception('Didn\'t find expected path {} after unzipping {}'.format(
-                pkgdir_path, local_zip_path))
-        os.unlink(local_zip_path)
-        return pkgdir_path
+        '''Returns the path to the package directory in the stub universe.'''
+        stub_universe_file = urllib.request.urlopen(self._stub_universe_url)
+
+        stub_universe_extension = os.path.splitext(self._stub_universe_url)[1]
+        if stub_universe_extension == '.zip':
+            # stub universe zip package (universe 2.x only)
+            zipin = zipfile.ZipFile(stub_universe_file, 'r')
+            badfile = zipin.testzip()
+            if badfile:
+                raise Exception('Failed to unpack {} in downloaded {}'.format(
+                    badfile, self._stub_universe_url))
+            zipin.extractall(scratchdir)
+            # check for (and return) path to stub-universe-pkgname/repo/packages/P/pkgname/0/:
+            pkgdir_path = os.path.join(
+                scratchdir,
+                'stub-universe-{}'.format(self._pkg_name),
+                'repo',
+                'packages',
+                self._pkg_name[0].upper(),
+                self._pkg_name,
+                '0')
+            if not os.path.isdir(pkgdir_path):
+                raise Exception('Didn\'t find expected path {} after unzipping {}'.format(
+                    pkgdir_path, self._stub_universe_url))
+            return pkgdir_path
+        elif stub_universe_extension == '.json':
+            # stub universe json file (universe 3.x+ only)
+            stub_universe_json = json.loads(stub_universe_file.read().decode('utf-8'), object_pairs_hook=OrderedDict)
+
+            # put package files into a subdir of scratchdir: avoids conflicts with reuse of scratchdir elsewhere
+            pkgdir = os.path.join(scratchdir, 'stub-universe-{}'.format(self._pkg_name))
+            os.makedirs(pkgdir)
+
+            if 'packages' not in stub_universe_json:
+                raise Exception('Expected "packages" key in root of stub universe JSON: {}'.format(
+                    self._stub_universe_url))
+            if len(stub_universe_json['packages']) != 1:
+                raise Exception('Expected single "packages" entry in stub universe JSON: {}'.format(
+                    self._stub_universe_url))
+
+            package_json = stub_universe_json['packages'][0]
+
+            def extract_json_file(package_dict, name):
+                file_dict = package_dict.get(name, None)
+                if file_dict is not None:
+                    del package_dict[name]
+                    # ensure that the file has a trailing newline (json.dump() doesn't!)
+                    fileref = open(os.path.join(pkgdir, name + '.json'), 'w')
+                    content = json.dumps(file_dict, indent=2)
+                    fileref.write(content)
+                    if not content.endswith('\n'):
+                        fileref.write('\n')
+                    fileref.flush()
+                    fileref.close()
+            extract_json_file(package_json, 'command')
+            extract_json_file(package_json, 'config')
+            extract_json_file(package_json, 'resource')
+
+            marathon_json = package_json.get('marathon', {}).get('v2AppMustacheTemplate', None)
+            if marathon_json is not None:
+                del package_json['marathon']
+                marathon_file = open(os.path.join(pkgdir, 'marathon.json.mustache'), 'w')
+                marathon_file.write(base64.standard_b64decode(marathon_json).decode())
+                marathon_file.flush()
+                marathon_file.close()
+
+            if 'releaseVersion' in package_json:
+                del package_json['releaseVersion']
+
+            json.dump(package_json, open(os.path.join(pkgdir, 'package.json'), 'w'), indent=2)
+
+            return pkgdir
+        else:
+            raise Exception('Expected .zip or .json extension for stub universe: {}'.format(
+                self._stub_universe_url))
 
 
     def _update_file_content(self, path, orig_content, new_content, showdiff=True):
@@ -146,7 +194,7 @@ class UniverseReleaseBuilder(object):
         # don't bother showing diff, things get rearranged..
         self._update_file_content(path, orig_content, new_content, showdiff=False)
 
-        # we expect the artifacts to share the same directory prefix as the stub universe zip itself:
+        # we expect the artifacts to share the same directory prefix as the stub universe file itself:
         original_artifact_prefix = '/'.join(self._stub_universe_url.split('/')[:-1])
         logger.info('[2/2] Replacing artifact prefix {} with {}'.format(
             original_artifact_prefix, self._release_artifact_http_dir))
@@ -167,13 +215,17 @@ class UniverseReleaseBuilder(object):
         # manually delete the destination directory first. (and redirect stdout to stderr)
         cmd = 'aws s3 ls --recursive {} 1>&2'.format(self._release_artifact_s3_dir)
         ret = self._run_cmd(cmd, False, 1)
-        if ret == 0 and not self._force_upload:
-            raise Exception('Release artifact destination already exists. ' +
-                            'Refusing to continue until destination has been manually removed:\n' +
-                            'Do this: aws s3 rm --dryrun --recursive {}'.format(self._release_artifact_s3_dir))
+        if ret == 0:
+            if self._force_upload:
+                logger.info('Destination {} exists but force upload is configured, proceeding...'.format(self._release_artifact_s3_dir))
+            else:
+                raise Exception('Release artifact destination already exists. ' +
+                                'Refusing to continue until destination has been manually removed:\n' +
+                                'Do this: aws s3 rm --dryrun --recursive {}'.format(self._release_artifact_s3_dir))
         elif ret > 256:
             raise Exception('Failed to check artifact destination presence (code {}). Bad AWS credentials? Exiting early.'.format(ret))
-        logger.info('Destination {} doesnt exist, proceeding...'.format(self._release_artifact_s3_dir))
+        else:
+            logger.info('Destination {} doesnt exist, proceeding...'.format(self._release_artifact_s3_dir))
 
         for i in range(len(original_artifact_urls)):
             progress = '[{}/{}]'.format(i + 1, len(original_artifact_urls))
@@ -182,9 +234,6 @@ class UniverseReleaseBuilder(object):
 
             local_path = os.path.join(scratchdir, filename)
             dest_s3_url = '{}/{}'.format(self._release_artifact_s3_dir, filename)
-
-            # TODO: this currently downloads the file via http, then uploads it via 'aws s3 cp'.
-            # copy directly from src bucket to dest bucket via 'aws s3 cp'? problem: different credentials
 
             # download the artifact (dev s3, via http)
             if self._dry_run:
@@ -205,7 +254,7 @@ class UniverseReleaseBuilder(object):
                 logger.info('{} Uploading {} to {}'.format(progress, local_path, dest_s3_url))
                 ret = os.system('aws s3 cp --acl public-read {} {} 1>&2'.format(
                     local_path, dest_s3_url))
-            if not ret == 0:
+            if ret != 0:
                 raise Exception(
                     'Failed to upload {} to {}. '.format(local_path, dest_s3_url) +
                     'Partial release directory may need to be cleared manually before retrying. Exiting early.')
@@ -224,7 +273,7 @@ class UniverseReleaseBuilder(object):
             'git config --local user.email jenkins@mesosphere.com',
             'git config --local user.name release_builder.py',
             'git checkout -b {}'.format(branch)]))
-        if not ret == 0:
+        if ret != 0:
             raise Exception(
                 'Failed to create local Universe git branch {}. '.format(branch) +
                 'Note that any release artifacts were already uploaded to {}, which must be manually deleted before retrying.'.format(self._release_artifact_s3_dir))
@@ -311,7 +360,7 @@ class UniverseReleaseBuilder(object):
         else:
             cmds.append('git push origin {}'.format(branch))
         ret = os.system(' && '.join(cmds))
-        if not ret == 0:
+        if ret != 0:
             raise Exception(
                 'Failed to push git branch {} to Universe. '.format(branch) +
                 'Note that any release artifacts were already uploaded to {}, which must be manually deleted before retrying.'.format(self._release_artifact_s3_dir))
@@ -336,8 +385,8 @@ class UniverseReleaseBuilder(object):
         conn.request(
             'POST',
             '/repos/mesosphere/universe/pulls',
-            body = json.dumps(payload).encode('utf-8'),
-            headers = headers)
+            body=json.dumps(payload).encode('utf-8'),
+            headers=headers)
         return conn.getresponse()
 
 
@@ -417,7 +466,7 @@ class UniverseReleaseBuilder(object):
         return beta_pkg_dir
 
 
-    def release_zip(self):
+    def release_package(self):
         scratchdir = tempfile.mkdtemp(prefix='stub-universe-tmp')
         pkgdir = self._download_unpack_stub_universe(scratchdir)
         if self._beta_release:
@@ -436,7 +485,7 @@ class UniverseReleaseBuilder(object):
 
 def print_help(argv):
     logger.info('Syntax: {} <package-version> <stub-universe-url> [commit message]'.format(argv[0]))
-    logger.info('  Example: $ {} 1.2.3-4.5.6 https://example.com/path/to/stub-universe-kafka.zip'.format(argv[0]))
+    logger.info('  Example: $ {} 1.2.3-4.5.6 https://example.com/path/to/stub-universe-kafka.json'.format(argv[0]))
     logger.info('Required credentials in env:')
     logger.info('- AWS S3: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY')
     logger.info('- Github (Personal Access Token): GITHUB_TOKEN')
@@ -467,7 +516,7 @@ Universe URL:    {}{}
 ###'''.format(package_version, stub_universe_url, comment_info))
 
     builder = UniverseReleaseBuilder(package_version, stub_universe_url, commit_desc)
-    response = builder.release_zip()
+    response = builder.release_package()
     if not response:
         # print the PR location as stdout for use upstream (the rest is all stderr):
         print('[DRY RUN] The pull request URL would appear here.')

--- a/tools/universe_builder.py
+++ b/tools/universe_builder.py
@@ -1,102 +1,71 @@
 #!/usr/bin/env python3
 
+import base64
 import difflib
 import hashlib
+import json
 import logging
 import os
 import os.path
 import re
-import shutil
 import sys
 import tempfile
-import time
-import zipfile
+from collections import OrderedDict
+
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.DEBUG, format="%(message)s")
 
-jre_url = 'https://downloads.mesosphere.com/java/jre-8u121-linux-x64.tar.gz'
-jre_jce_unlimited_url = 'https://downloads.mesosphere.com/java/jre-8u112-linux-x64-jce-unlimited.tar.gz'
-libmesos_bundle_url = 'https://downloads.mesosphere.com/libmesos-bundle/libmesos-bundle-1.9.0-rc2-1.2.0-rc2-1.tar.gz'
+_jre_url = 'https://downloads.mesosphere.com/java/jre-8u121-linux-x64.tar.gz'
+_jre_jce_unlimited_url = 'https://downloads.mesosphere.com/java/jre-8u112-linux-x64-jce-unlimited.tar.gz'
+_libmesos_bundle_url = 'https://downloads.mesosphere.com/libmesos-bundle/libmesos-bundle-1.9.0-rc2-1.2.0-rc2-1.tar.gz'
+
+_command_json_filename = 'command.json'
+_config_json_filename = 'config.json'
+_marathon_json_filename = 'marathon.json.mustache'
+_package_json_filename = 'package.json'
+_resource_json_filename = 'resource.json'
+_expected_package_filenames = [
+    _command_json_filename,
+    _config_json_filename,
+    _marathon_json_filename,
+    _package_json_filename,
+    _resource_json_filename]
+
 
 class UniversePackageBuilder(object):
 
-    def __init__(self, package_name, package_version, input_dir_path, upload_dir_url, artifact_paths):
+    def __init__(self, package_name, package_version, input_dir_path, upload_dir_url, artifact_paths, packaging_version=3):
+        self._cosmos_packaging_version = packaging_version
         self._pkg_name = package_name
         self._pkg_version = package_version
-        self._input_dir_path = input_dir_path
         self._upload_dir_url = upload_dir_url
 
         if not os.path.isdir(input_dir_path):
             raise Exception('Provided package path is not a directory: {}'.format(input_dir_path))
+        self._input_dir_path = input_dir_path
 
-        self._artifact_files = {}
+        self._artifact_file_paths = {}
         for artifact_path in artifact_paths:
             if not os.path.isfile(artifact_path):
                 raise Exception('Provided package path is not a file: {} (full list: {})'.format(artifact_path, artifact_paths))
-            prior_path = self._artifact_files.get(os.path.basename(artifact_path), '')
+            prior_path = self._artifact_file_paths.get(os.path.basename(artifact_path), '')
             if prior_path:
                 raise Exception('Duplicate filename between "{}" and "{}". Artifact filenames must be unique.'.format(prior_path, artifact_path))
-            self._artifact_files[os.path.basename(artifact_path)] = artifact_path
+            self._artifact_file_paths[os.path.basename(artifact_path)] = artifact_path
 
 
-    def _create_version_json(self, metadir):
-        version = open(os.path.join(metadir, 'version.json'), 'w')
-        version.write('''{
-  "version": "2.0.0"
-}
-''')
-        version.flush()
-        version.close()
-
-
-    def _create_index_json(self, metadir):
-        index = open(os.path.join(metadir, 'index.json'), 'w')
-        template = '''{
-  "packages":[ {
-    "name": "%(name)s",
-    "description": "Test package for %(name)s, generated %(time)s",
-    "currentVersion": "%(ver)s",
-    "versions": { "%(ver)s":"0" },
-    "tags": [ ],
-    "framework": true,
-    "selected": false
-  } ],
-  "version":"2.0.0"
-}
-'''
-        # "".format() is confused by all the {}'s, so use % for formatting:
-        index.write(template % {
-            'ver': self._pkg_version,
-            'name': self._pkg_name,
-            'time': time.ctime()})
-        index.flush()
-        index.close()
-
-
-    def _create_tree(self, scratchdir):
-        treedir = os.path.join(scratchdir, 'stub-universe-{}'.format(self._pkg_name))
-        # create stub-universe-PKG/scripts/.stub_dir
-        scriptsdir = os.path.join(treedir, 'scripts')
-        os.makedirs(scriptsdir)
-        stubfile = open(os.path.join(scriptsdir, '.stub_dir'), 'w')
-        stubfile.write('this a stub directory, install will fail without it.')
-        stubfile.flush()
-        stubfile.close()
-        # create stub-universe-PKG/repo/meta/[version.json|index.json]
-        metadir = os.path.join(treedir, 'repo', 'meta')
-        os.makedirs(metadir)
-        self._create_version_json(metadir)
-        self._create_index_json(metadir)
-        # create stub-universe/repo/packages/P/package/0/[*.json*]
-        pkgdir = os.path.join(treedir, 'repo', 'packages', self._pkg_name[0].upper(), self._pkg_name, '0')
-        os.makedirs(pkgdir)
-        for pkgfile in os.listdir(self._input_dir_path):
-            # Don't copy in .dotfiles; editor temps etc
-            if pkgfile.startswith('.'):
+    def _iterate_package_files(self):
+        for package_filename in os.listdir(self._input_dir_path):
+            package_filepath = os.path.join(self._input_dir_path, package_filename)
+            if os.stat(package_filepath).st_size > (1024 * 1024):
+                logger.warning('Ignoring package file larger than 1MB: {}'.format(package_filepath))
                 continue
-            shutil.copyfile(os.path.join(self._input_dir_path, pkgfile), os.path.join(pkgdir, pkgfile))
-        return treedir
+            if package_filename not in _expected_package_filenames:
+                logger.warning('Ignoring unrecognized package file: {} (expected one of: {})'.format(
+                    package_filepath, ', '.join(_expected_package_filenames)))
+                continue
+            yield package_filename, open(package_filepath).read()
 
 
     def _calculate_sha256(self, filepath):
@@ -110,7 +79,7 @@ class UniversePackageBuilder(object):
         return hasher.hexdigest()
 
 
-    def _get_file_template_mapping(self, filepath):
+    def _get_template_mapping_for_content(self, orig_content):
         '''Returns a template mapping (dict) for the following cases:
         - Default params like '{{package-version}}' and '{{artifact-dir}}'
         - SHA256 params like '{{sha256:artifact.zip}}' (requires user-provided paths to artifact files)
@@ -120,53 +89,41 @@ class UniversePackageBuilder(object):
         template_mapping = {
             'package-version': self._pkg_version,
             'artifact-dir': self._upload_dir_url,
-            'jre-url': jre_url,
-            'jre-jce-unlimited-url': jre_jce_unlimited_url,
-            'libmesos-bundle-url': libmesos_bundle_url}
+            'jre-url': _jre_url,
+            'jre-jce-unlimited-url': _jre_jce_unlimited_url,
+            'libmesos-bundle-url': _libmesos_bundle_url}
 
         # look for any 'sha256:filename' template params, and get shas for those.
         # this avoids calculating shas unless they're requested by the template.
-        orig_content = open(filepath, 'r').read()
         for shafilename in re.findall('{{sha256:(.+?)}}', orig_content):
             # somefile.txt => sha256:somefile.txt
-            shafilepath = self._artifact_files.get(shafilename, '')
+            shafilepath = self._artifact_file_paths.get(shafilename, '')
             if not shafilepath:
                 raise Exception(
                     'Missing path for artifact file named \'{}\' (to calculate sha256). '.format(shafilename) +
-                    'Please provide the full path to this artifact (known artifacts: {})'.format(self._artifact_files))
+                    'Please provide the full path to this artifact (known artifacts: {})'.format(self._artifact_file_paths))
             template_mapping['sha256:{}'.format(shafilename)] = self._calculate_sha256(shafilepath)
 
         # import any custom TEMPLATE_SOME_PARAM environment variables:
         for env_key, env_val in os.environ.items():
             if env_key.startswith('TEMPLATE_'):
                 # 'TEMPLATE_SOME_KEY' => 'some-key'
-                template_mapping[env_key[9:].lower().replace('_','-')] = env_val
+                template_mapping[env_key[9:].lower().replace('_', '-')] = env_val
 
         return template_mapping
 
 
-    def _apply_templating_file(self, filepath):
-        # basic checks to avoid files that we shouldn't edit:
-        if not filepath.endswith('.json'):
-            logger.warning('')
-            logger.warning('Ignoring non-json file: {}'.format(filepath))
-            return
-        if os.stat(filepath).st_size > (1024 * 1024):
-            logger.warning('')
-            logger.warning('Ignoring file larger than 1MB: {}'.format(filepath))
-            return
-
-        template_mapping = self._get_file_template_mapping(filepath)
-        orig_content = open(filepath, 'r').read()
+    def _apply_templating_to_file(self, filename, orig_content):
+        template_mapping = self._get_template_mapping_for_content(orig_content)
         new_content = orig_content
         for template_key, template_val in template_mapping.items():
             new_content = new_content.replace('{{%s}}' % template_key, template_val)
         if orig_content == new_content:
             logger.info('')
-            logger.info('No templating detected in {}, leaving file as-is'.format(filepath))
-            return
+            logger.info('No templating detected in {}, leaving file as-is'.format(filename))
+            return orig_content
         logger.info('')
-        logger.info('Applied templating changes to {}:'.format(filepath))
+        logger.info('Applied templating changes to {}:'.format(filename))
         logger.info('Template params used:')
         template_keys = list(template_mapping.keys())
         template_keys.sort()
@@ -174,49 +131,54 @@ class UniversePackageBuilder(object):
             logger.info('  {{%s}} => %s' % (key, template_mapping[key]))
         logger.info('Resulting diff:')
         logger.info('\n'.join(difflib.ndiff(orig_content.split('\n'), new_content.split('\n'))))
-        rewrite = open(filepath, 'w')
-        rewrite.write(new_content)
-        rewrite.flush()
-        rewrite.close()
+        return new_content
 
 
-    def _apply_templating_tree(self, scratchdir):
-        for root, dirs, files in os.walk(scratchdir):
-            files.sort() # nice to have: process in consistent order
-            for f in files:
-                self._apply_templating_file(os.path.join(root, f))
+    def _generate_packages_dict(self, package_files):
+        package_json = json.loads(package_files[_package_json_filename], object_pairs_hook=OrderedDict)
+        package_json['releaseVersion'] = 0
+        package_json['packagingVersion'] = '{}.0'.format(self._cosmos_packaging_version)
+
+        command_json = package_files.get(_command_json_filename, None)
+        if command_json is not None:
+            package_json['command'] = json.loads(command_json, object_pairs_hook=OrderedDict)
+
+        config_json = package_files.get(_config_json_filename, None)
+        if config_json is not None:
+            package_json['config'] = json.loads(config_json, object_pairs_hook=OrderedDict)
+
+        marathon_json = package_files.get(_marathon_json_filename, None)
+        if marathon_json is not None:
+            package_json['marathon'] = {
+                'v2AppMustacheTemplate': base64.standard_b64encode(bytearray(marathon_json, 'utf-8')).decode()}
+
+        resource_json = package_files.get(_resource_json_filename, None)
+        if resource_json is not None:
+            package_json['resource'] = json.loads(resource_json, object_pairs_hook=OrderedDict)
+
+        return {'packages': [package_json]}
 
 
-    def _create_zip(self, scratchdir):
-        # if compression is enabled, cosmos returns 'invalid stored block lengths'.
-        # this only happens with python-generated files, mutual format incompatibility?:
-        zippath = os.path.join(scratchdir, 'stub-universe-{}.zip'.format(self._pkg_name))
-        zipout = zipfile.ZipFile(zippath, 'w', zipfile.ZIP_STORED)
-        for root, dirs, files in os.walk(scratchdir):
-            destroot = root[len(scratchdir):]
-            logger.info('  adding: {}/ => {}/'.format(root, destroot))
-            # cosmos requires a preceding explicit directory entry:
-            zipout.write(root, destroot)
-            files.sort() # nice to have: process in consistent order
-            for f in files:
-                srcpath = os.path.join(root, f)
-                if srcpath == zippath:
-                    # don't include the (newly created) zipfile itself!
-                    continue
-                destpath = srcpath[len(scratchdir):]
-                logger.info('  adding: {} => {}'.format(srcpath, destpath))
-                zipout.write(srcpath, destpath)
-        return zippath
+    def build_package(self):
+        '''builds a stub universe json package and returns its location on disk'''
 
-
-    def build_zip(self):
-        '''builds a universe zip and returns its location on disk'''
+        # read files into memory and apply templating to files:
+        updated_package_files = {}
+        for filename, content in self._iterate_package_files():
+            updated_package_files[filename] = self._apply_templating_to_file(filename, content)
         scratchdir = tempfile.mkdtemp(prefix='stub-universe-tmp')
-        treedir = self._create_tree(scratchdir)
-        self._apply_templating_tree(scratchdir)
-        zippath = self._create_zip(scratchdir)
-        shutil.rmtree(treedir)
-        return zippath
+        jsonpath = os.path.join(scratchdir, 'stub-universe-{}.json'.format(self._pkg_name))
+        jsonfile = open(jsonpath, 'w')
+        jsonfile.write(json.dumps(self._generate_packages_dict(updated_package_files), indent=2))
+        jsonfile.flush()
+        jsonfile.close()
+        return jsonpath
+
+
+    def content_type(self):
+        '''returns the content type that Cosmos requires for stub universes generated by this class'''
+        return 'application/vnd.dcos.universe.repo+json;charset=utf-8;version=v{}'.format(
+            self._cosmos_packaging_version)
 
 
 def print_help(argv):
@@ -246,9 +208,8 @@ Upload base dir: {}
 Artifacts:       {}
 ###'''.format(package_name, package_version, package_dir_path, upload_dir_url, ','.join(artifact_paths)))
 
-    builder = UniversePackageBuilder(
-        package_name, package_version, package_dir_path, upload_dir_url, artifact_paths)
-    package_path = builder.build_zip()
+    package_path = UniversePackageBuilder(
+        package_name, package_version, package_dir_path, upload_dir_url, artifact_paths).build_package()
     if not package_path:
         return -1
     logger.info('---')

--- a/tools/universe_builder.py
+++ b/tools/universe_builder.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import base64
+import collections
 import difflib
 import hashlib
 import json
@@ -10,7 +11,6 @@ import os.path
 import re
 import sys
 import tempfile
-from collections import OrderedDict
 
 
 logger = logging.getLogger(__name__)
@@ -108,7 +108,7 @@ class UniversePackageBuilder(object):
         for env_key, env_val in os.environ.items():
             if env_key.startswith('TEMPLATE_'):
                 # 'TEMPLATE_SOME_KEY' => 'some-key'
-                template_mapping[env_key[9:].lower().replace('_', '-')] = env_val
+                template_mapping[env_key[len('TEMPLATE_'):].lower().replace('_', '-')] = env_val
 
         return template_mapping
 
@@ -135,26 +135,26 @@ class UniversePackageBuilder(object):
 
 
     def _generate_packages_dict(self, package_files):
-        package_json = json.loads(package_files[_package_json_filename], object_pairs_hook=OrderedDict)
+        package_json = json.loads(package_files[_package_json_filename], object_pairs_hook=collections.OrderedDict)
         package_json['releaseVersion'] = 0
         package_json['packagingVersion'] = '{}.0'.format(self._cosmos_packaging_version)
 
-        command_json = package_files.get(_command_json_filename, None)
+        command_json = package_files.get(_command_json_filename)
         if command_json is not None:
-            package_json['command'] = json.loads(command_json, object_pairs_hook=OrderedDict)
+            package_json['command'] = json.loads(command_json, object_pairs_hook=collections.OrderedDict)
 
-        config_json = package_files.get(_config_json_filename, None)
+        config_json = package_files.get(_config_json_filename)
         if config_json is not None:
-            package_json['config'] = json.loads(config_json, object_pairs_hook=OrderedDict)
+            package_json['config'] = json.loads(config_json, object_pairs_hook=collections.OrderedDict)
 
-        marathon_json = package_files.get(_marathon_json_filename, None)
+        marathon_json = package_files.get(_marathon_json_filename)
         if marathon_json is not None:
             package_json['marathon'] = {
                 'v2AppMustacheTemplate': base64.standard_b64encode(bytearray(marathon_json, 'utf-8')).decode()}
 
-        resource_json = package_files.get(_resource_json_filename, None)
+        resource_json = package_files.get(_resource_json_filename)
         if resource_json is not None:
-            package_json['resource'] = json.loads(resource_json, object_pairs_hook=OrderedDict)
+            package_json['resource'] = json.loads(resource_json, object_pairs_hook=collections.OrderedDict)
 
         return {'packages': [package_json]}
 


### PR DESCRIPTION
Code for building stub universes is switched entirely to the json format. The release builder, meanwhile, still supports both old zips and new jsons for now. The json file now being produced is identical in usage to the prior zip file (`dcos package repo add http://arrl.org/foo.json`, etc...)

Other notable changes:
- Fixes a nasty bug in `release_builder` which would allow always overwriting AWS data (bool('false') => True)
- Adds support in `publish_aws` and `publish_http` for the bizarre universe content type that Cosmos requires for these json files.
- Breaks out the universe version in `universe_builder` to allow easier switching to v4 later.
- Misc formatting fixes that pylint complained about