### PR TITLE
[INFINITY-1380] Fix cleaning of resources for permanently failed tasks.

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/ResourceCleaner.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/ResourceCleaner.java
@@ -8,6 +8,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import com.mesosphere.sdk.scheduler.recovery.FailureUtils;
 import org.apache.mesos.Protos;
 import org.apache.mesos.Protos.Offer;
 import org.apache.mesos.Protos.Resource;
@@ -105,7 +106,11 @@ public class ResourceCleaner {
         Collection<Resource> resources = new ArrayList<>();
 
         for (Protos.TaskInfo taskInfo : stateStore.fetchTasks()) {
-            // get all resources from both the task level and the executor level
+            if (FailureUtils.isLabeledAsFailed(taskInfo)) {
+                continue;
+            }
+
+            // Get all resources from both the task level and the executor level
             resources.addAll(taskInfo.getResourcesList());
             if (taskInfo.hasExecutor()) {
                 resources.addAll(taskInfo.getExecutor().getResourcesList());


### PR DESCRIPTION
If a task is permanently failed, it's resources should not be considered "expected," so they can be cleaned up.