### PR TITLE
Template framework needs better templating

### DIFF
--- a/frameworks/template/build.gradle
+++ b/frameworks/template/build.gradle
@@ -31,9 +31,9 @@ distZip.finalizedBy copyExecutor
 
 distributions {
     main {
-        baseName = 'template-scheduler'
+        baseName = '{{template}}-scheduler'
         version = ''
     }
 }
 
-mainClassName = 'com.mesosphere.sdk.template.scheduler.Main'
+mainClassName = 'com.mesosphere.sdk.{{template}}.scheduler.Main'

--- a/frameworks/template/build.sh
+++ b/frameworks/template/build.sh
@@ -9,7 +9,7 @@ ROOT_DIR="$(dirname "$(dirname $FRAMEWORK_DIR)")"
 export TOOLS_DIR=${ROOT_DIR}/tools
 BUILD_DIR=$FRAMEWORK_DIR/build/distributions
 PUBLISH_STEP=${1-none}
-${ROOT_DIR}/tools/build_framework.sh $PUBLISH_STEP template $FRAMEWORK_DIR $BUILD_DIR/executor.zip $BUILD_DIR/template-scheduler.zip
+${ROOT_DIR}/tools/build_framework.sh $PUBLISH_STEP {{template}} $FRAMEWORK_DIR $BUILD_DIR/executor.zip $BUILD_DIR/{{template}}-scheduler.zip
 
 # capture anonymous metrics for reporting
 curl https://mesosphere.com/wp-content/themes/mesosphere/library/images/assets/sdk/build-sh-finish.png >/dev/null 2>&1

--- a/frameworks/template/cli/dcos-template/main.go
+++ b/frameworks/template/cli/dcos-template/main.go
@@ -2,17 +2,18 @@ package main
 
 import (
 	"github.com/mesosphere/dcos-commons/cli"
+	"github.com/mesosphere/dcos-commons/cli/commands"
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 
 func main() {
 	app := cli.New()
 
-	cli.HandleConfigSection(app)
-	cli.HandleEndpointsSection(app)
-	cli.HandlePlanSection(app)
-	cli.HandlePodsSection(app)
-	cli.HandleStateSection(app)
+	commands.HandleConfigSection(app)
+	commands.HandleEndpointsSection(app)
+	commands.HandlePlanSection(app)
+	commands.HandlePodsSection(app)
+	commands.HandleStateSection(app)
 
 	kingpin.MustParse(app.Parse(cli.GetArguments()))
 }

--- a/frameworks/template/src/main/dist/svc.yml
+++ b/frameworks/template/src/main/dist/svc.yml
@@ -3,17 +3,17 @@ scheduler:
   principal: {{FRAMEWORK_PRINCIPAL}}
   user: {{FRAMEWORK_USER}}
 pods:
-  template:
+  {{template}}:
     count: {{NODE_COUNT}}
     placement: {{NODE_PLACEMENT}}
     tasks:
       node:
         goal: RUNNING
-        cmd: "echo template >> template-container-path/output && sleep $SLEEP_DURATION"
+        cmd: "echo {{template}} >> {{template}}-container-path/output && sleep $SLEEP_DURATION"
         cpus: {{NODE_CPUS}}
         memory: {{NODE_MEM}}
         volume:
-          path: "template-container-path"
+          path: "{{template}}-container-path"
           type: {{NODE_DISK_TYPE}}
           size: {{NODE_DISK}}
         env:

--- a/frameworks/template/src/main/java/com/mesosphere/sdk/template/scheduler/Main.java
+++ b/frameworks/template/src/main/java/com/mesosphere/sdk/template/scheduler/Main.java
@@ -1,4 +1,4 @@
-package com.mesosphere.sdk.template.scheduler;
+package com.mesosphere.sdk.{{template}}.scheduler;
 
 import com.mesosphere.sdk.scheduler.SchedulerFlags;
 import com.mesosphere.sdk.specification.*;

--- a/frameworks/template/src/test/java/com/mesosphere/sdk/template/scheduler/ServiceSpecTest.java
+++ b/frameworks/template/src/test/java/com/mesosphere/sdk/template/scheduler/ServiceSpecTest.java
@@ -1,4 +1,4 @@
-package com.mesosphere.sdk.template.scheduler;
+package com.mesosphere.sdk.{{template}}.scheduler;
 
 import com.mesosphere.sdk.testing.BaseServiceSpecTest;
 import org.junit.BeforeClass;
@@ -11,7 +11,7 @@ public class ServiceSpecTest extends BaseServiceSpecTest {
         ENV_VARS.set("EXECUTOR_URI", "");
         ENV_VARS.set("LIBMESOS_URI", "");
         ENV_VARS.set("PORT_API", "8080");
-        ENV_VARS.set("FRAMEWORK_NAME", "template");
+        ENV_VARS.set("FRAMEWORK_NAME", "{{template}}");
 
         ENV_VARS.set("NODE_COUNT", "2");
         ENV_VARS.set("NODE_CPUS", "0.1");

--- a/frameworks/template/tests/config.py
+++ b/frameworks/template/tests/config.py
@@ -1,2 +1,2 @@
-PACKAGE_NAME = 'template'
+PACKAGE_NAME = '{{template}}'
 DEFAULT_TASK_COUNT = 1

--- a/frameworks/template/universe/config.json
+++ b/frameworks/template/universe/config.json
@@ -9,7 +9,7 @@
             "title": "Service name",
             "description": "The name of the service instance",
             "type": "string",
-            "default": "template"
+            "default": "{{template}}"
           },
           "sleep": {
             "description": "The sleep duration in seconds before tasks exit.",

--- a/frameworks/template/universe/marathon.json.mustache
+++ b/frameworks/template/universe/marathon.json.mustache
@@ -3,7 +3,7 @@
   "cpus": 1.0,
   "mem": 1024,
   "instances": 1,
-  "cmd": "export LD_LIBRARY_PATH=$MESOS_SANDBOX/libmesos-bundle/lib:$LD_LIBRARY_PATH; export MESOS_NATIVE_JAVA_LIBRARY=$(ls $MESOS_SANDBOX/libmesos-bundle/lib/libmesos-*.so); export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jre*/); export JAVA_HOME=${JAVA_HOME%/}; export PATH=$(ls -d $JAVA_HOME/bin):$PATH &&  export JAVA_OPTS=\"-Xms256M -Xmx512M -XX:-HeapDumpOnOutOfMemoryError\" &&  ./template-scheduler/bin/template ./template-scheduler/svc.yml",
+  "cmd": "export LD_LIBRARY_PATH=$MESOS_SANDBOX/libmesos-bundle/lib:$LD_LIBRARY_PATH; export MESOS_NATIVE_JAVA_LIBRARY=$(ls $MESOS_SANDBOX/libmesos-bundle/lib/libmesos-*.so); export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jre*/); export JAVA_HOME=${JAVA_HOME%/}; export PATH=$(ls -d $JAVA_HOME/bin):$PATH &&  export JAVA_OPTS=\"-Xms256M -Xmx512M -XX:-HeapDumpOnOutOfMemoryError\" &&  ./{{template}}-scheduler/bin/{{template}} ./{{template}}-scheduler/svc.yml",
   "labels": {
     "DCOS_COMMONS_API_VERSION": "v1",
     "DCOS_COMMONS_UNINSTALL": "true",

--- a/frameworks/template/universe/package.json
+++ b/frameworks/template/universe/package.json
@@ -1,13 +1,13 @@
 {
   "packagingVersion": "2.0",
   "minDcosReleaseVersion": "1.9",
-  "name": "template",
+  "name": "{{template}}",
   "version": "{{package-version}}",
   "maintainer": "support@YOURNAMEHERE.COM",
   "description": "YOURNAMEHERE on DC/OS",
   "selected": false,
   "framework": true,
-  "tags": ["template"],
+  "tags": ["{{template}}"],
   "postInstallNotes": "DC/OS YOURNAMEHERE is being installed!\n\n\tDocumentation: http://YOURNAMEHERE.COM/DOCS\n\tIssues: http://YOURNAMEHERE.COM/SUPPORT",
   "postUninstallNotes": "DC/OS YOURNAMEHERE has been uninstalled."
 }

--- a/frameworks/template/universe/resource.json
+++ b/frameworks/template/universe/resource.json
@@ -3,7 +3,7 @@
     "uris": {
       "jre-tar-gz": "{{jre-url}}",
       "libmesos-bundle-tar-gz": "{{libmesos-bundle-url}}",
-      "scheduler-zip": "{{artifact-dir}}/template-scheduler.zip",
+      "scheduler-zip": "{{artifact-dir}}/{{template}}-scheduler.zip",
       "executor-zip": "{{artifact-dir}}/executor.zip"
     }
   },
@@ -16,23 +16,23 @@
     "binaries":{
       "darwin":{
         "x86-64":{
-          "contentHash":[ { "algo":"sha256", "value":"{{sha256:dcos-template-darwin}}" } ],
+          "contentHash":[ { "algo":"sha256", "value":"{{sha256:dcos-{{template}}-darwin}}" } ],
           "kind":"executable",
-          "url":"{{artifact-dir}}/dcos-template-darwin"
+          "url":"{{artifact-dir}}/dcos-{{template}}-darwin"
         }
       },
       "linux":{
         "x86-64":{
-          "contentHash":[ { "algo":"sha256", "value":"{{sha256:dcos-template-linux}}" } ],
+          "contentHash":[ { "algo":"sha256", "value":"{{sha256:dcos-{{template}}-linux}}" } ],
           "kind":"executable",
-          "url":"{{artifact-dir}}/dcos-template-linux"
+          "url":"{{artifact-dir}}/dcos-{{template}}-linux"
         }
       },
       "windows":{
         "x86-64":{
-          "contentHash":[ { "algo":"sha256", "value":"{{sha256:dcos-template.exe}}" } ],
+          "contentHash":[ { "algo":"sha256", "value":"{{sha256:dcos-{{template}}.exe}}" } ],
           "kind":"executable",
-          "url":"{{artifact-dir}}/dcos-template.exe"
+          "url":"{{artifact-dir}}/dcos-{{template}}.exe"
         }
       }
     }

--- a/frameworks/template/vendor/github.com/mesosphere/dcos-commons/cli/README.md
+++ b/frameworks/template/vendor/github.com/mesosphere/dcos-commons/cli/README.md
@@ -20,41 +20,26 @@ Prerequisites:
 - git
 - [Go 1.5+](https://golang.org/dl/)
 
-First, get the code and set up the environment (edit `/YOUR/CODEPATH` and `/YOUR/GOPATH` as needed):
+First, get the code and set up the environment (edit `/YOUR/GOPATH` as needed):
 
 ```bash
-export CODEPATH=/YOUR/CODEPATH # eg ~/code
 export GOPATH=/YOUR/GOPATH # eg ~/go
 export GO15VENDOREXPERIMENT=1 # only required if using Go 1.5. for Go 1.6+ this step can be skipped
 
-mkdir -p $CODEPATH
-cd $CODEPATH
-
-git clone git@github.com:mesosphere/dcos-commons
-mkdir -p $GOPATH/src/github.com/mesosphere
-ln -s $CODEPATH/dcos-commons $GOPATH/src/github.com/mesosphere/dcos-commons
+git clone git@github.com:mesosphere/dcos-commons && cd dcos-commons
 ```
 
-Assuming the above structure (with `~/code` for where you put your code and `~/go` for your `GOPATH`), the directory structure should look something like the following:
-
-```
-~/
-  code/
-    dcos-commons/
-  go/
-    src/
-      github.com/
-        mesosphere/
-          dcos-commons # symlink to ~/code/dcos-commons
-```
-
-Now you may build the example CLI module for each targeted platform:
+Now you may build the example CLI module for each targeted platform. Run build.sh from the framework root, e.g. for `helloworld`:
 
 ```bash
-cd $GOPATH/src/github.com/mesosphere/dcos-commons/frameworks/helloworld/cli
-go get
-./build-cli.sh # creates dcos-data-store.exe, dcos-data-store-darwin, dcos-data-store-linux
-./dcos-data-store/dcos-data-store-linux data-store -h
+cd frameworks/helloworld
+./build.sh # will build framework including dcos-hello-world.exe, dcos-hello-world-darwin, dcos-hello-world-linux
+```
+
+To run the compiled CLI (the example below uses Linux, pick the correct binary for your platform):
+
+```bash
+./cli/dcos-hello-world/dcos-hello-world-linux hello-world -h
 ```
 
 ## Develop
@@ -62,6 +47,43 @@ go get
 See the [example CLI module](../frameworks/helloworld/cli/) for an example of how your CLI module could be built. The provided example adds a set of custom commands on top of the standard set.
 
 Like the example CLI module, your own code may simply access the CLI libraries provided here by importing `github.com/mesosphere/dcos-commons/cli`. Your CLI module implementation may pick and choose which standard commands should be included, while also implementing its own custom commands.
+
+### Vendoring Dependencies
+
+It is highly recommended that CLIs depending on these library files use [`govendor`](https://github.com/kardianos/govendor). This will allow the projects to be built against a specific, snapshotted version of this library and insulate them from build failures caused by breaking changes in the `master` branch of this repository.
+
+To vendorise a CLI that depends on this project, (e.g. [`helloworld/cli`](/frameworks/helloworld/cli/)):
+
+1. Install [govendor](https://github.com/kardianos/govendor).
+
+1. Ensure the CLI folder is linked into your `$GOPATH`:
+
+    ```bash
+    cd frameworks/helloworld/cli
+    ln -s $(pwd) $GOPATH/src/github.com/mesosphere/dcos-commons/frameworks/helloworld/cli
+    ```
+
+1. Initialise `govendor` metadata:
+
+    ```bash
+    govendor init
+    ```
+
+1. Fetch the CLI dependency (and any subpackages):
+
+    ```bash
+    govendor fetch github.com/mesosphere/dcos-commons/cli/\^
+    ```
+
+When building this project with a go version greater than 1.5 (`go build` must be run from the project's directory within the `$GOPATH`), these dependencies will be picked up automatically.
+
+To later update the version of this dependency, simply run `fetch` again:
+
+    ```bash
+    govendor fetch github.com/mesosphere/dcos-commons/cli/\^
+    ```
+
+(See the [`govendor` README](https://github.com/kardianos/govendor) for further examples, including fetching a specific revision or tag of this code.)
 
 ### Direct execution
 

--- a/frameworks/template/vendor/github.com/mesosphere/dcos-commons/cli/client/dcoscli.go
+++ b/frameworks/template/vendor/github.com/mesosphere/dcos-commons/cli/client/dcoscli.go
@@ -1,6 +1,7 @@
-package cli
+package client
 
 import (
+	"github.com/mesosphere/dcos-commons/cli/config"
 	"log"
 	"os"
 	"os/exec"
@@ -10,7 +11,7 @@ import (
 // TODO(nick): Consider breaking this config retrieval out into a separate independent library?
 
 func RunCLICommand(arg ...string) (string, error) {
-	if Verbose {
+	if config.Verbose {
 		log.Printf("Running DC/OS CLI command: dcos %s", strings.Join(arg, " "))
 	}
 	outBytes, err := exec.Command("dcos", arg...).CombinedOutput()

--- a/frameworks/template/vendor/github.com/mesosphere/dcos-commons/cli/client/http.go
+++ b/frameworks/template/vendor/github.com/mesosphere/dcos-commons/cli/client/http.go
@@ -1,10 +1,11 @@
-package cli
+package client
 
 import (
 	"bytes"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"github.com/mesosphere/dcos-commons/cli/config"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -13,112 +14,93 @@ import (
 	"strings"
 )
 
-type tlsSetting int
-
-const (
-	tlsUnknown tlsSetting = iota
-	tlsUnverified
-	tlsVerified
-	tlsSpecificCert
-)
-
-var (
-	dcosAuthToken string
-	dcosUrl       string
-	ServiceName   string
-
-	tlsForceInsecure bool
-	tlsCliSetting    tlsSetting = tlsUnknown
-	tlsCACertPath    string
-)
-
 func HTTPGet(urlPath string) *http.Response {
 	return CheckHTTPResponse(HTTPQuery(CreateHTTPRequest("GET", urlPath)))
 }
 func HTTPGetQuery(urlPath, urlQuery string) *http.Response {
-	return CheckHTTPResponse(HTTPQuery(CreateHTTPQueryRequest("GET", urlPath, urlQuery)))
+	return CheckHTTPResponse(HTTPQuery(createHTTPQueryRequest("GET", urlPath, urlQuery)))
 }
 func HTTPGetData(urlPath, payload, contentType string) *http.Response {
-	return CheckHTTPResponse(HTTPQuery(CreateHTTPDataRequest("GET", urlPath, payload, contentType)))
+	return CheckHTTPResponse(HTTPQuery(createHTTPDataRequest("GET", urlPath, payload, contentType)))
 }
 func HTTPGetJSON(urlPath, jsonPayload string) *http.Response {
-	return CheckHTTPResponse(HTTPQuery(CreateHTTPJSONRequest("GET", urlPath, jsonPayload)))
+	return CheckHTTPResponse(HTTPQuery(createHTTPJSONRequest("GET", urlPath, jsonPayload)))
 }
 
 func HTTPDelete(urlPath string) *http.Response {
 	return CheckHTTPResponse(HTTPQuery(CreateHTTPRequest("DELETE", urlPath)))
 }
 func HTTPDeleteQuery(urlPath, urlQuery string) *http.Response {
-	return CheckHTTPResponse(HTTPQuery(CreateHTTPQueryRequest("DELETE", urlPath, urlQuery)))
+	return CheckHTTPResponse(HTTPQuery(createHTTPQueryRequest("DELETE", urlPath, urlQuery)))
 }
 func HTTPDeleteData(urlPath, payload, contentType string) *http.Response {
-	return CheckHTTPResponse(HTTPQuery(CreateHTTPDataRequest("DELETE", urlPath, payload, contentType)))
+	return CheckHTTPResponse(HTTPQuery(createHTTPDataRequest("DELETE", urlPath, payload, contentType)))
 }
 func HTTPDeleteJSON(urlPath, jsonPayload string) *http.Response {
-	return CheckHTTPResponse(HTTPQuery(CreateHTTPJSONRequest("DELETE", urlPath, jsonPayload)))
+	return CheckHTTPResponse(HTTPQuery(createHTTPJSONRequest("DELETE", urlPath, jsonPayload)))
 }
 
 func HTTPPost(urlPath string) *http.Response {
 	return CheckHTTPResponse(HTTPQuery(CreateHTTPRequest("POST", urlPath)))
 }
 func HTTPPostQuery(urlPath, urlQuery string) *http.Response {
-	return CheckHTTPResponse(HTTPQuery(CreateHTTPQueryRequest("POST", urlPath, urlQuery)))
+	return CheckHTTPResponse(HTTPQuery(createHTTPQueryRequest("POST", urlPath, urlQuery)))
 }
 func HTTPPostData(urlPath, payload, contentType string) *http.Response {
-	return CheckHTTPResponse(HTTPQuery(CreateHTTPDataRequest("POST", urlPath, payload, contentType)))
+	return CheckHTTPResponse(HTTPQuery(createHTTPDataRequest("POST", urlPath, payload, contentType)))
 }
 func HTTPPostJSON(urlPath, jsonPayload string) *http.Response {
-	return CheckHTTPResponse(HTTPQuery(CreateHTTPJSONRequest("POST", urlPath, jsonPayload)))
+	return CheckHTTPResponse(HTTPQuery(createHTTPJSONRequest("POST", urlPath, jsonPayload)))
 }
 
 func HTTPPut(urlPath string) *http.Response {
 	return CheckHTTPResponse(HTTPQuery(CreateHTTPRequest("PUT", urlPath)))
 }
 func HTTPPutQuery(urlPath, urlQuery string) *http.Response {
-	return CheckHTTPResponse(HTTPQuery(CreateHTTPQueryRequest("PUT", urlPath, urlQuery)))
+	return CheckHTTPResponse(HTTPQuery(createHTTPQueryRequest("PUT", urlPath, urlQuery)))
 }
 func HTTPPutData(urlPath, payload, contentType string) *http.Response {
-	return CheckHTTPResponse(HTTPQuery(CreateHTTPDataRequest("PUT", urlPath, payload, contentType)))
+	return CheckHTTPResponse(HTTPQuery(createHTTPDataRequest("PUT", urlPath, payload, contentType)))
 }
 func HTTPPutJSON(urlPath, jsonPayload string) *http.Response {
-	return CheckHTTPResponse(HTTPQuery(CreateHTTPJSONRequest("PUT", urlPath, jsonPayload)))
+	return CheckHTTPResponse(HTTPQuery(createHTTPJSONRequest("PUT", urlPath, jsonPayload)))
 }
 
 func HTTPQuery(request *http.Request) *http.Response {
-	if tlsForceInsecure { // user override via '--force-insecure'
-		tlsCliSetting = tlsUnverified
+	if config.TlsForceInsecure { // user override via '--force-insecure'
+		config.TlsCliSetting = config.TlsUnverified
 	}
-	if tlsCliSetting == tlsUnknown {
+	if config.TlsCliSetting == config.TlsUnknown {
 		// get CA settings from CLI
 		cliVerifySetting := OptionalCLIConfigValue("core.ssl_verify")
 		if strings.EqualFold(cliVerifySetting, "false") {
 			// 'false': disable cert validation
-			tlsCliSetting = tlsUnverified
+			config.TlsCliSetting = config.TlsUnverified
 		} else if strings.EqualFold(cliVerifySetting, "true") {
 			// 'true': require validation against default CAs
-			tlsCliSetting = tlsVerified
+			config.TlsCliSetting = config.TlsVerified
 		} else if len(cliVerifySetting) != 0 {
 			// '<other string>': path to local/custom cert file
-			if len(tlsCACertPath) == 0 {
-				tlsCACertPath = cliVerifySetting
+			if len(config.TlsCACertPath) == 0 {
+				config.TlsCACertPath = cliVerifySetting
 			}
-			tlsCliSetting = tlsSpecificCert
+			config.TlsCliSetting = config.TlsSpecificCert
 		} else {
 			// this shouldn't happen: 'auth login' requires a non-empty setting.
 			// play it safe and leave cert verification enabled by default.
-			tlsCliSetting = tlsVerified
+			config.TlsCliSetting = config.TlsVerified
 		}
 	}
 
 	// allow unverified certs if user invoked --force-insecure, or if it's configured that way in CLI:
-	tlsConfig := &tls.Config{InsecureSkipVerify: (tlsCliSetting == tlsUnverified)}
+	tlsConfig := &tls.Config{InsecureSkipVerify: (config.TlsCliSetting == config.TlsUnverified)}
 
 	// import custom cert if user manually set the flag, or if it's configured in CLI:
-	if len(tlsCACertPath) != 0 {
+	if len(config.TlsCACertPath) != 0 {
 		// include custom CA cert as verified
-		cert, err := ioutil.ReadFile(tlsCACertPath)
+		cert, err := ioutil.ReadFile(config.TlsCACertPath)
 		if err != nil {
-			log.Fatalf("Unable to read from CA certificate file %s: %s", tlsCACertPath, err)
+			log.Fatalf("Unable to read from CA certificate file %s: %s", config.TlsCACertPath, err)
 		}
 		certPool := x509.NewCertPool()
 		certPool.AppendCertsFromPEM(cert)
@@ -147,7 +129,7 @@ func HTTPQuery(request *http.Request) *http.Response {
 			log.Fatalf("- Is 'core.dcos_acs_token' set correctly? Run 'dcos auth login' to log in.")
 		}
 	}
-	if Verbose {
+	if config.Verbose {
 		log.Printf("Response: %s (%d bytes)", response.Status, response.ContentLength)
 	}
 	return response
@@ -161,7 +143,7 @@ func CheckHTTPResponse(response *http.Response) *http.Response {
 	case response.StatusCode == 500:
 		log.Printf("HTTP %s Query for %s failed: %s",
 			response.Request.Method, response.Request.URL, response.Status)
-		log.Printf("- Did you provide the correct service name? Currently using '%s', specify a different name with '--name=<name>'.", ServiceName)
+		log.Printf("- Did you provide the correct service name? Currently using '%s', specify a different name with '--name=<name>'.", config.ServiceName)
 		log.Fatalf("- Was the service recently installed? It may still be initializing, Wait a bit and try again.")
 	case response.StatusCode < 200 || response.StatusCode >= 300:
 		log.Fatalf("HTTP %s Query for %s failed: %s",
@@ -170,47 +152,47 @@ func CheckHTTPResponse(response *http.Response) *http.Response {
 	return response
 }
 
-func CreateHTTPJSONRequest(method, urlPath, jsonPayload string) *http.Request {
-	return CreateHTTPDataRequest(method, urlPath, jsonPayload, "application/json")
+func createHTTPJSONRequest(method, urlPath, jsonPayload string) *http.Request {
+	return createHTTPDataRequest(method, urlPath, jsonPayload, "application/json")
 }
 
-func CreateHTTPDataRequest(method, urlPath, jsonPayload, contentType string) *http.Request {
-	return CreateHTTPRawRequest(method, urlPath, "", jsonPayload, contentType)
+func createHTTPDataRequest(method, urlPath, jsonPayload, contentType string) *http.Request {
+	return createHTTPRawRequest(method, urlPath, "", jsonPayload, contentType)
 }
 
-func CreateHTTPQueryRequest(method, urlPath, urlQuery string) *http.Request {
-	return CreateHTTPRawRequest(method, urlPath, urlQuery, "", "")
+func createHTTPQueryRequest(method, urlPath, urlQuery string) *http.Request {
+	return createHTTPRawRequest(method, urlPath, urlQuery, "", "")
 }
 
 func CreateHTTPRequest(method, urlPath string) *http.Request {
-	return CreateHTTPRawRequest(method, urlPath, "", "", "")
+	return createHTTPRawRequest(method, urlPath, "", "", "")
 }
 
-func CreateHTTPRawRequest(method, urlPath, urlQuery, payload, contentType string) *http.Request {
-	return CreateHTTPURLRequest(method, CreateURL(urlPath, urlQuery), payload, contentType)
+func createHTTPRawRequest(method, urlPath, urlQuery, payload, contentType string) *http.Request {
+	return createHTTPURLRequest(method, createURL(urlPath, urlQuery), payload, contentType)
 }
 
-func CreateURL(urlPath, urlQuery string) *url.URL {
+func createURL(urlPath, urlQuery string) *url.URL {
 	// get data from CLI, if overrides were not provided by user:
-	if len(dcosUrl) == 0 {
-		dcosUrl = RequiredCLIConfigValue(
+	if len(config.DcosUrl) == 0 {
+		config.DcosUrl = RequiredCLIConfigValue(
 			"core.dcos_url",
 			"DC/OS Cluster URL",
 			"Run 'dcos config set core.dcos_url http://your-cluster.com' to configure.")
 	}
 	// Trim eg "/#/" from copy-pasted Dashboard URL:
-	dcosUrl = strings.TrimRight(dcosUrl, "#/")
-	parsedUrl, err := url.Parse(dcosUrl)
+	config.DcosUrl = strings.TrimRight(config.DcosUrl, "#/")
+	parsedUrl, err := url.Parse(config.DcosUrl)
 	if err != nil {
-		log.Fatalf("Unable to parse DC/OS Cluster URL '%s': %s", dcosUrl, err)
+		log.Fatalf("Unable to parse DC/OS Cluster URL '%s': %s", config.DcosUrl, err)
 	}
-	parsedUrl.Path = path.Join("service", ServiceName, urlPath)
+	parsedUrl.Path = path.Join("service", config.ServiceName, urlPath)
 	parsedUrl.RawQuery = urlQuery
 	return parsedUrl
 }
 
-func CreateHTTPURLRequest(method string, url *url.URL, payload, contentType string) *http.Request {
-	if Verbose {
+func createHTTPURLRequest(method string, url *url.URL, payload, contentType string) *http.Request {
+	if config.Verbose {
 		log.Printf("HTTP Query: %s %s", method, url)
 		if len(payload) != 0 {
 			log.Printf("  Payload: %s", payload)
@@ -220,13 +202,13 @@ func CreateHTTPURLRequest(method string, url *url.URL, payload, contentType stri
 	if err != nil {
 		log.Fatalf("Failed to create HTTP %s request for %s: %s", method, url, err)
 	}
-	if len(dcosAuthToken) == 0 {
+	if len(config.DcosAuthToken) == 0 {
 		// if the token wasnt manually provided by the user, try to fetch it from the main CLI.
 		// this value is optional: clusters can be configured to not require any auth
-		dcosAuthToken = OptionalCLIConfigValue("core.dcos_acs_token")
+		config.DcosAuthToken = OptionalCLIConfigValue("core.dcos_acs_token")
 	}
-	if len(dcosAuthToken) != 0 {
-		request.Header.Set("Authorization", fmt.Sprintf("token=%s", dcosAuthToken))
+	if len(config.DcosAuthToken) != 0 {
+		request.Header.Set("Authorization", fmt.Sprintf("token=%s", config.DcosAuthToken))
 	}
 	if len(contentType) != 0 {
 		request.Header.Set("Content-Type", contentType)

--- a/frameworks/template/vendor/github.com/mesosphere/dcos-commons/cli/client/response.go
+++ b/frameworks/template/vendor/github.com/mesosphere/dcos-commons/cli/client/response.go
@@ -1,4 +1,4 @@
-package cli
+package client
 
 import (
 	"bytes"

--- a/frameworks/template/vendor/github.com/mesosphere/dcos-commons/cli/commands.go
+++ b/frameworks/template/vendor/github.com/mesosphere/dcos-commons/cli/commands.go
@@ -1,18 +1,15 @@
 package cli
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/mesosphere/dcos-commons/cli/commands"
+	"github.com/mesosphere/dcos-commons/cli/config"
+	"github.com/mesosphere/dcos-commons/cli/client"
 	"gopkg.in/alecthomas/kingpin.v2"
 	"log"
-	"net/url"
 	"os"
 	"strings"
-)
-
-var (
-	Verbose bool
 )
 
 func GetModuleName() (string, error) {
@@ -31,39 +28,12 @@ func GetArguments() []string {
 	return os.Args[2:]
 }
 
-func GetVariablePair(pairString string) ([]string, error) {
-	elements := strings.Split(pairString, "=")
-	if len(elements) < 2 {
-		return nil, errors.New(fmt.Sprintf(
-			"Must have one variable name and one variable value per definition"))
-	}
-
-	return []string{elements[0], strings.Join(elements[1:], "=")}, nil
-}
-
-func GetPlanParameterPayload(parameters []string) (string, error) {
-	envPairs := make(map[string]string)
-	for _, pairString := range parameters {
-		pair, err := GetVariablePair(pairString)
-		if err != nil {
-			return "", err
-		}
-		envPairs[pair[0]] = pair[1]
-	}
-
-	jsonVal, err := json.Marshal(envPairs)
-	if err != nil {
-		return "", err
-	}
-
-	return string(jsonVal), nil
-}
-
-//TODO: remove NewApp and HandleCommonFlags (in favor of New()) on or after April 2017
-func NewApp(version string, author string, longDescription string) (*kingpin.Application, error) {
-	return New(), nil
-}
-func HandleCommonFlags(app *kingpin.Application, defaultServiceName string, shortDescription string) {
+func HandleDefaultSections(app *kingpin.Application) {
+	commands.HandleConfigSection(app)
+	commands.HandleEndpointsSection(app)
+	commands.HandlePlanSection(app)
+	commands.HandlePodsSection(app)
+	commands.HandleStateSection(app)
 }
 
 func New() *kingpin.Application {
@@ -75,7 +45,7 @@ func New() *kingpin.Application {
 	app := kingpin.New(fmt.Sprintf("dcos %s", modName), "")
 
 	app.HelpFlag.Short('h') // in addition to default '--help'
-	app.Flag("verbose", "Enable extra logging of requests/responses").Short('v').BoolVar(&Verbose)
+	app.Flag("verbose", "Enable extra logging of requests/responses").Short('v').BoolVar(&config.Verbose)
 
 	// This fulfills an interface that's expected by the main DC/OS CLI:
 	// Prints a description of the module.
@@ -85,338 +55,23 @@ func New() *kingpin.Application {
 		return nil
 	}).Bool()
 
-	app.Flag("force-insecure", "Allow unverified TLS certificates when querying service").BoolVar(&tlsForceInsecure)
+	app.Flag("force-insecure", "Allow unverified TLS certificates when querying service").BoolVar(&config.TlsForceInsecure)
 
 	// Overrides of data that we fetch from DC/OS CLI:
 
 	// Support using "DCOS_AUTH_TOKEN" or "AUTH_TOKEN" when available
-	app.Flag("custom-auth-token", "Custom auth token to use when querying service").Envar("DCOS_AUTH_TOKEN").PlaceHolder("DCOS_AUTH_TOKEN").StringVar(&dcosAuthToken)
+	app.Flag("custom-auth-token", "Custom auth token to use when querying service").Envar("DCOS_AUTH_TOKEN").PlaceHolder("DCOS_AUTH_TOKEN").StringVar(&config.DcosAuthToken)
 	// Support using "DCOS_URI" or "DCOS_URL" when available
-	app.Flag("custom-dcos-url", "Custom cluster URL to use when querying service").Envar("DCOS_URI").Envar("DCOS_URL").PlaceHolder("DCOS_URI/DCOS_URL").StringVar(&dcosUrl)
+	app.Flag("custom-dcos-url", "Custom cluster URL to use when querying service").Envar("DCOS_URI").Envar("DCOS_URL").PlaceHolder("DCOS_URI/DCOS_URL").StringVar(&config.DcosUrl)
 	// Support using "DCOS_CA_PATH" or "DCOS_CERT_PATH" when available
-	app.Flag("custom-cert-path", "Custom TLS CA certificate file to use when querying service").Envar("DCOS_CA_PATH").Envar("DCOS_CERT_PATH").PlaceHolder("DCOS_CA_PATH/DCOS_CERT_PATH").StringVar(&tlsCACertPath)
+	app.Flag("custom-cert-path", "Custom TLS CA certificate file to use when querying service").Envar("DCOS_CA_PATH").Envar("DCOS_CERT_PATH").PlaceHolder("DCOS_CA_PATH/DCOS_CERT_PATH").StringVar(&config.TlsCACertPath)
 
 	// Default to --name <name> : use provided framework name (default to <modulename>.service_name, if available)
-	serviceName := OptionalCLIConfigValue(fmt.Sprintf("%s.service_name", os.Args[1]))
+	serviceName := client.OptionalCLIConfigValue(fmt.Sprintf("%s.service_name", os.Args[1]))
 	if len(serviceName) == 0 {
 		serviceName = modName
 	}
-	app.Flag("name", "Name of the service instance to query").Default(serviceName).StringVar(&ServiceName)
+	app.Flag("name", "Name of the service instance to query").Default(serviceName).StringVar(&config.ServiceName)
 
 	return app
-}
-
-// Config section
-
-type ConfigHandler struct {
-	ShowId string
-}
-
-func (cmd *ConfigHandler) RunList(c *kingpin.ParseContext) error {
-	PrintJSON(HTTPGet("v1/configurations"))
-	return nil
-}
-func (cmd *ConfigHandler) RunShow(c *kingpin.ParseContext) error {
-	PrintJSON(HTTPGet(fmt.Sprintf("v1/configurations/%s", cmd.ShowId)))
-	return nil
-}
-func (cmd *ConfigHandler) RunTarget(c *kingpin.ParseContext) error {
-	PrintJSON(HTTPGet("v1/configurations/target"))
-	return nil
-}
-func (cmd *ConfigHandler) RunTargetId(c *kingpin.ParseContext) error {
-	PrintJSON(HTTPGet("v1/configurations/targetId"))
-	return nil
-}
-
-func HandleConfigSection(app *kingpin.Application) {
-	// config <list, show, target, target_id>
-	cmd := &ConfigHandler{}
-	config := app.Command("config", "View persisted configurations")
-
-	config.Command("list", "List IDs of all available configurations").Action(cmd.RunList)
-
-	show := config.Command("show", "Display a specified configuration").Action(cmd.RunShow)
-	show.Arg("config_id", "ID of the configuration to display").Required().StringVar(&cmd.ShowId)
-
-	config.Command("target", "Display the target configuration").Action(cmd.RunTarget)
-
-	config.Command("target_id", "List ID of the target configuration").Action(cmd.RunTargetId)
-}
-
-// Connection section, manually implemented by some services (DEPRECATED, use common Endpoints)
-
-type ConnectionHandler struct {
-	TypeName string
-}
-
-func (cmd *ConnectionHandler) RunConnection(c *kingpin.ParseContext) error {
-	if len(cmd.TypeName) == 0 {
-		// Root endpoint: Always produce JSON
-		PrintJSON(HTTPGet("v1/connection"))
-	} else {
-		// Any custom type endpoints: May be any format, so just print the raw text
-		PrintText(HTTPGet(fmt.Sprintf("v1/connection/%s", cmd.TypeName)))
-	}
-	return nil
-}
-
-// TODO remove this command once callers have migrated to HandleEndpointsSection().
-func HandleConnectionSection(app *kingpin.Application, connectionTypes []string) {
-	// connection [type]
-	cmd := &ConnectionHandler{}
-	connection := app.Command("connection", fmt.Sprintf("View connection information (custom types: %s)", strings.Join(connectionTypes, ", "))).Action(cmd.RunConnection)
-	if len(connectionTypes) != 0 {
-		connection.Arg("type", fmt.Sprintf("Custom type of the connection data to display (%s)", strings.Join(connectionTypes, ", "))).StringVar(&cmd.TypeName)
-	}
-}
-
-// Endpoints section
-
-type EndpointsHandler struct {
-	Name                  string
-	PrintDeprecatedNotice bool
-}
-
-func (cmd *EndpointsHandler) RunEndpoints(c *kingpin.ParseContext) error {
-	// TODO(nickbp): Remove this after April 2017
-	if cmd.PrintDeprecatedNotice {
-		log.Fatalf("--native is no longer supported. Use 'native' entries in endpoint listing.")
-	}
-
-	path := "v1/endpoints"
-	if len(cmd.Name) != 0 {
-		path += "/" + cmd.Name
-	}
-	response := HTTPGet(path)
-	if len(cmd.Name) == 0 {
-		// Root endpoint: Always produce JSON
-		PrintJSON(response)
-	} else {
-		// Any specific endpoints: May be any format, so just print the raw text
-		PrintText(response)
-	}
-	return nil
-}
-
-func HandleEndpointsSection(app *kingpin.Application) {
-	// endpoints [type]
-	cmd := &EndpointsHandler{}
-	endpoints := app.Command("endpoints", "View client endpoints").Action(cmd.RunEndpoints)
-	// TODO(nickbp): Remove deprecated argument after April 2017:
-	endpoints.Flag("native", "deprecated argument").BoolVar(&cmd.PrintDeprecatedNotice)
-	endpoints.Arg("name", "Name of specific endpoint to be returned").StringVar(&cmd.Name)
-}
-
-// Plan section
-
-type PlanHandler struct {
-	PlanName   string
-	Parameters []string
-	Phase      string
-	Step       string
-}
-
-func GetPlanName(cmd *PlanHandler) string {
-	plan := "deploy"
-	if len(cmd.PlanName) > 0 {
-		plan = cmd.PlanName
-	}
-	return plan
-}
-
-func (cmd *PlanHandler) RunList(c *kingpin.ParseContext) error {
-	response := HTTPGet("/v1/plans")
-	PrintJSON(response)
-	return nil
-}
-
-func (cmd *PlanHandler) RunShow(c *kingpin.ParseContext) error {
-	response := HTTPQuery(CreateHTTPRequest("GET", fmt.Sprintf("v1/plans/%s", GetPlanName(cmd))))
-	CheckHTTPResponse(response)
-	PrintJSON(response)
-	return nil
-}
-
-func (cmd *PlanHandler) RunStart(c *kingpin.ParseContext) error {
-	payload := "{}"
-	if len(cmd.Parameters) > 0 {
-		parameterPayload, err := GetPlanParameterPayload(cmd.Parameters)
-		if err != nil {
-			return err
-		}
-		payload = parameterPayload
-	}
-	response := HTTPPostData(fmt.Sprintf("v1/plans/%s/start", cmd.PlanName), payload, "application/json")
-	PrintJSON(response)
-	return nil
-}
-
-func (cmd *PlanHandler) RunStop(c *kingpin.ParseContext) error {
-	response := HTTPPost(fmt.Sprintf("v1/plans/%s/stop", cmd.PlanName))
-	PrintJSON(response)
-	return nil
-}
-
-func (cmd *PlanHandler) RunContinue(c *kingpin.ParseContext) error {
-	query := url.Values{}
-	if len(cmd.Phase) > 0 {
-		query.Set("phase", cmd.Phase)
-	}
-	response := HTTPPostQuery(fmt.Sprintf("v1/plans/%s/continue", GetPlanName(cmd)), query.Encode())
-	PrintJSON(response)
-	return nil
-}
-
-func (cmd *PlanHandler) RunInterrupt(c *kingpin.ParseContext) error {
-	query := url.Values{}
-	if len(cmd.Phase) > 0 {
-		query.Set("phase", cmd.Phase)
-	}
-	response := HTTPPostQuery(fmt.Sprintf("v1/plans/%s/interrupt", GetPlanName(cmd)), query.Encode())
-	PrintJSON(response)
-	return nil
-}
-
-func (cmd *PlanHandler) RunRestart(c *kingpin.ParseContext) error {
-	query := url.Values{}
-	query.Set("phase", cmd.Phase)
-	query.Set("step", cmd.Step)
-	response := HTTPPostQuery(fmt.Sprintf("v1/plans/%s/restart", GetPlanName(cmd)), query.Encode())
-	PrintJSON(response)
-	return nil
-}
-
-func (cmd *PlanHandler) RunForce(c *kingpin.ParseContext) error {
-	query := url.Values{}
-	query.Set("phase", cmd.Phase)
-	query.Set("step", cmd.Step)
-	response := HTTPPostQuery(fmt.Sprintf("v1/plans/%s/forceComplete", GetPlanName(cmd)), query.Encode())
-	PrintJSON(response)
-	return nil
-}
-
-func HandlePlanSection(app *kingpin.Application) {
-	// plan <active, continue, force, interrupt, restart, show>
-	cmd := &PlanHandler{}
-	plan := app.Command("plan", "Query service plans")
-
-	plan.Command("list", "Show all plans for this service").Action(cmd.RunList)
-
-	show := plan.Command("show", "Display the deploy plan or the plan with the provided name").Action(cmd.RunShow)
-	show.Arg("plan", "Name of the plan to show").StringVar(&cmd.PlanName)
-
-	start := plan.Command("start", "Start the plan with the provided name, with optional envvars to supply to task").Action(cmd.RunStart)
-	start.Arg("plan", "Name of the plan to start").Required().StringVar(&cmd.PlanName)
-	start.Flag("params", "Envvar definition in VAR=value form; can be repeated for multiple variables").Short('p').StringsVar(&cmd.Parameters)
-
-	stop := plan.Command("stop", "Stop the plan with the provided name").Action(cmd.RunStop)
-	stop.Arg("plan", "Name of the plan to stop").Required().StringVar(&cmd.PlanName)
-
-	continueCmd := plan.Command("continue", "Continue the deploy plan, or the plan with the provided name, or a specific phase in that plan with the provided name or UUID").Action(cmd.RunContinue)
-	continueCmd.Arg("plan", "Name of the plan to continue").StringVar(&cmd.PlanName)
-	continueCmd.Arg("phase", "Name or UUID of a specific phase to continue").StringVar(&cmd.Phase)
-
-	interrupt := plan.Command("interrupt", "Interrupt the deploy plan, or the plan with the provided name, or a specific phase in that plan with the provided name or UUID").Action(cmd.RunInterrupt)
-	interrupt.Arg("plan", "Name of the plan to interrupt").StringVar(&cmd.PlanName)
-	interrupt.Arg("phase", "Name or UUID of a specific phase to interrupt").StringVar(&cmd.Phase)
-
-	restart := plan.Command("restart", "Restart the plan with the provided name, or the specific step in the provided phase (each by name or UUID)").Action(cmd.RunRestart)
-	restart.Arg("plan", "Name of the plan to restart").Required().StringVar(&cmd.PlanName)
-	restart.Arg("phase", "Name or UUID of the phase containing the provided step").StringVar(&cmd.Phase) // TODO optional
-	restart.Arg("step", "Name or UUID of step to be restarted").StringVar(&cmd.Step)
-
-	force := plan.Command("force", "Force complete the plan with the provided name").Action(cmd.RunForce)
-	force.Arg("plan", "Name of the plan to force complete").Required().StringVar(&cmd.PlanName)
-	force.Arg("phase", "Name or UUID of the phase containing the provided step").Required().StringVar(&cmd.Phase)
-	force.Arg("step", "Name or UUID of step to be restarted").Required().StringVar(&cmd.Step)
-}
-
-// Pods section
-
-type PodsHandler struct {
-	PodName string
-}
-
-func (cmd *PodsHandler) RunList(c *kingpin.ParseContext) error {
-	PrintJSON(HTTPGet("v1/pods"))
-	return nil
-}
-func (cmd *PodsHandler) RunStatus(c *kingpin.ParseContext) error {
-	if len(cmd.PodName) == 0 {
-		PrintJSON(HTTPGet("v1/pods/status"))
-	} else {
-		PrintJSON(HTTPGet(fmt.Sprintf("v1/pods/%s/status", cmd.PodName)))
-	}
-	return nil
-}
-func (cmd *PodsHandler) RunInfo(c *kingpin.ParseContext) error {
-	PrintJSON(HTTPGet(fmt.Sprintf("v1/pods/%s/info", cmd.PodName)))
-	return nil
-}
-func (cmd *PodsHandler) RunRestart(c *kingpin.ParseContext) error {
-	PrintText(HTTPPost(fmt.Sprintf("v1/pods/%s/restart", cmd.PodName)))
-	return nil
-}
-func (cmd *PodsHandler) RunReplace(c *kingpin.ParseContext) error {
-	PrintText(HTTPPost(fmt.Sprintf("v1/pods/%s/replace", cmd.PodName)))
-	return nil
-}
-
-func HandlePodsSection(app *kingpin.Application) {
-	// pods [status [name], info <name>, restart <name>, replace <name>]
-	cmd := &PodsHandler{}
-	pods := app.Command("pods", "View Pod/Task state")
-
-	pods.Command("list", "Display the list of known pod instances").Action(cmd.RunList)
-
-	status := pods.Command("status", "Display the status for tasks in one pod or all pods").Action(cmd.RunStatus)
-	status.Arg("pod", "Name of a specific pod instance to display").StringVar(&cmd.PodName)
-
-	info := pods.Command("info", "Display the full state information for tasks in a pod").Action(cmd.RunInfo)
-	info.Arg("pod", "Name of the pod instance to display").Required().StringVar(&cmd.PodName)
-
-	restart := pods.Command("restart", "Restarts a given pod without moving it to a new agent").Action(cmd.RunRestart)
-	restart.Arg("pod", "Name of the pod instance to restart").Required().StringVar(&cmd.PodName)
-
-	replace := pods.Command("replace", "Destroys a given pod and moves it to a new agent").Action(cmd.RunReplace)
-	replace.Arg("pod", "Name of the pod instance to replace").Required().StringVar(&cmd.PodName)
-}
-
-// State section
-
-type StateHandler struct {
-	PropertyName string
-}
-
-func (cmd *StateHandler) RunFrameworkId(c *kingpin.ParseContext) error {
-	PrintJSON(HTTPGet("v1/state/frameworkId"))
-	return nil
-}
-func (cmd *StateHandler) RunProperties(c *kingpin.ParseContext) error {
-	PrintJSON(HTTPGet("v1/state/properties"))
-	return nil
-}
-func (cmd *StateHandler) RunProperty(c *kingpin.ParseContext) error {
-	PrintJSON(HTTPGet(fmt.Sprintf("v1/state/properties/%s", cmd.PropertyName)))
-	return nil
-}
-func (cmd *StateHandler) RunRefreshCache(c *kingpin.ParseContext) error {
-	PrintJSON(HTTPPut("v1/state/refresh"))
-	return nil
-}
-
-func HandleStateSection(app *kingpin.Application) {
-	// state <framework_id, status, task, tasks>
-	cmd := &StateHandler{}
-	state := app.Command("state", "View persisted state")
-
-	state.Command("framework_id", "Display the mesos framework ID").Action(cmd.RunFrameworkId)
-
-	state.Command("properties", "List names of all custom properties").Action(cmd.RunProperties)
-
-	task := state.Command("property", "Display the content of a specified property").Action(cmd.RunProperty)
-	task.Arg("name", "Name of the property to display").Required().StringVar(&cmd.PropertyName)
-
-	state.Command("refresh_cache", "Refresh the state cache, used for debugging").Action(cmd.RunRefreshCache)
 }

--- a/frameworks/template/vendor/github.com/mesosphere/dcos-commons/cli/commands/config.go
+++ b/frameworks/template/vendor/github.com/mesosphere/dcos-commons/cli/commands/config.go
@@ -1,0 +1,43 @@
+package commands
+
+import (
+	"fmt"
+	"github.com/mesosphere/dcos-commons/cli/client"
+	"gopkg.in/alecthomas/kingpin.v2"
+)
+
+type ConfigHandler struct {
+	ShowId string
+}
+
+func (cmd *ConfigHandler) RunList(c *kingpin.ParseContext) error {
+	client.PrintJSON(client.HTTPGet("v1/configurations"))
+	return nil
+}
+func (cmd *ConfigHandler) RunShow(c *kingpin.ParseContext) error {
+	client.PrintJSON(client.HTTPGet(fmt.Sprintf("v1/configurations/%s", cmd.ShowId)))
+	return nil
+}
+func (cmd *ConfigHandler) RunTarget(c *kingpin.ParseContext) error {
+	client.PrintJSON(client.HTTPGet("v1/configurations/target"))
+	return nil
+}
+func (cmd *ConfigHandler) RunTargetId(c *kingpin.ParseContext) error {
+	client.PrintJSON(client.HTTPGet("v1/configurations/targetId"))
+	return nil
+}
+
+func HandleConfigSection(app *kingpin.Application) {
+	// config <list, show, target, target_id>
+	cmd := &ConfigHandler{}
+	config := app.Command("config", "View persisted configurations")
+
+	config.Command("list", "List IDs of all available configurations").Action(cmd.RunList)
+
+	show := config.Command("show", "Display a specified configuration").Action(cmd.RunShow)
+	show.Arg("config_id", "ID of the configuration to display").Required().StringVar(&cmd.ShowId)
+
+	config.Command("target", "Display the target configuration").Action(cmd.RunTarget)
+
+	config.Command("target_id", "List ID of the target configuration").Action(cmd.RunTargetId)
+}

--- a/frameworks/template/vendor/github.com/mesosphere/dcos-commons/cli/commands/endpoints.go
+++ b/frameworks/template/vendor/github.com/mesosphere/dcos-commons/cli/commands/endpoints.go
@@ -1,0 +1,42 @@
+package commands
+
+import (
+	"github.com/mesosphere/dcos-commons/cli/client"
+	"gopkg.in/alecthomas/kingpin.v2"
+	"log"
+)
+
+// Endpoints section
+
+type EndpointsHandler struct {
+	Name                  string
+	PrintDeprecatedNotice bool
+}
+
+func (cmd *EndpointsHandler) RunEndpoints(c *kingpin.ParseContext) error {
+	// TODO(nickbp): Remove this after April 2017
+	if cmd.PrintDeprecatedNotice {
+		log.Fatalf("--native is no longer supported. Use 'native' entries in endpoint listing.")
+	}
+
+	path := "v1/endpoints"
+	if len(cmd.Name) != 0 {
+		path += "/" + cmd.Name
+	}
+	response := client.HTTPGet(path)
+	if len(cmd.Name) == 0 {
+		// Root endpoint: Always produce JSON
+		client.PrintJSON(response)
+	} else {
+		// Any specific endpoints: May be any format, so just print the raw text
+		client.PrintText(response)
+	}
+	return nil
+}
+
+func HandleEndpointsSection(app *kingpin.Application) {
+	// endpoints [type]
+	cmd := &EndpointsHandler{}
+	endpoints := app.Command("endpoints", "View client endpoints").Action(cmd.RunEndpoints)
+	endpoints.Arg("name", "Name of specific endpoint to be returned").StringVar(&cmd.Name)
+}

--- a/frameworks/template/vendor/github.com/mesosphere/dcos-commons/cli/commands/plan.go
+++ b/frameworks/template/vendor/github.com/mesosphere/dcos-commons/cli/commands/plan.go
@@ -1,0 +1,163 @@
+package commands
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/mesosphere/dcos-commons/cli/client"
+	"gopkg.in/alecthomas/kingpin.v2"
+	"net/url"
+	"strings"
+)
+
+// Plan section
+
+type PlanHandler struct {
+    PlanName   string
+    Parameters []string
+    Phase      string
+    Step       string
+}
+
+func GetVariablePair(pairString string) ([]string, error) {
+	elements := strings.Split(pairString, "=")
+	if len(elements) < 2 {
+		return nil, errors.New(fmt.Sprintf(
+			"Must have one variable name and one variable value per definition"))
+	}
+
+	return []string{elements[0], strings.Join(elements[1:], "=")}, nil
+}
+
+func GetPlanParameterPayload(parameters []string) (string, error) {
+	envPairs := make(map[string]string)
+	for _, pairString := range parameters {
+		pair, err := GetVariablePair(pairString)
+		if err != nil {
+			return "", err
+		}
+		envPairs[pair[0]] = pair[1]
+	}
+
+	jsonVal, err := json.Marshal(envPairs)
+	if err != nil {
+		return "", err
+	}
+
+	return string(jsonVal), nil
+}
+
+func GetPlanName(cmd *PlanHandler) string {
+	plan := "deploy"
+	if len(cmd.PlanName) > 0 {
+		plan = cmd.PlanName
+	}
+	return plan
+}
+
+func (cmd *PlanHandler) RunList(c *kingpin.ParseContext) error {
+	response := client.HTTPGet("/v1/plans")
+	client.PrintJSON(response)
+	return nil
+}
+
+func (cmd *PlanHandler) RunShow(c *kingpin.ParseContext) error {
+	response := client.HTTPQuery(client.CreateHTTPRequest("GET", fmt.Sprintf("v1/plans/%s", GetPlanName(cmd))))
+	client.CheckHTTPResponse(response)
+	client.PrintJSON(response)
+	return nil
+}
+
+func (cmd *PlanHandler) RunStart(c *kingpin.ParseContext) error {
+	payload := "{}"
+	if len(cmd.Parameters) > 0 {
+		parameterPayload, err := GetPlanParameterPayload(cmd.Parameters)
+		if err != nil {
+			return err
+		}
+		payload = parameterPayload
+	}
+	response := client.HTTPPostData(fmt.Sprintf("v1/plans/%s/start", cmd.PlanName), payload, "application/json")
+	client.PrintJSON(response)
+	return nil
+}
+
+func (cmd *PlanHandler) RunStop(c *kingpin.ParseContext) error {
+	response := client.HTTPPost(fmt.Sprintf("v1/plans/%s/stop", cmd.PlanName))
+	client.PrintJSON(response)
+	return nil
+}
+
+func (cmd *PlanHandler) RunContinue(c *kingpin.ParseContext) error {
+	query := url.Values{}
+	if len(cmd.Phase) > 0 {
+		query.Set("phase", cmd.Phase)
+	}
+	response := client.HTTPPostQuery(fmt.Sprintf("v1/plans/%s/continue", GetPlanName(cmd)), query.Encode())
+	client.PrintJSON(response)
+	return nil
+}
+
+func (cmd *PlanHandler) RunInterrupt(c *kingpin.ParseContext) error {
+	query := url.Values{}
+	if len(cmd.Phase) > 0 {
+		query.Set("phase", cmd.Phase)
+	}
+	response := client.HTTPPostQuery(fmt.Sprintf("v1/plans/%s/interrupt", GetPlanName(cmd)), query.Encode())
+	client.PrintJSON(response)
+	return nil
+}
+
+func (cmd *PlanHandler) RunRestart(c *kingpin.ParseContext) error {
+	query := url.Values{}
+	query.Set("phase", cmd.Phase)
+	query.Set("step", cmd.Step)
+	response := client.HTTPPostQuery(fmt.Sprintf("v1/plans/%s/restart", GetPlanName(cmd)), query.Encode())
+	client.PrintJSON(response)
+	return nil
+}
+
+func (cmd *PlanHandler) RunForce(c *kingpin.ParseContext) error {
+	query := url.Values{}
+	query.Set("phase", cmd.Phase)
+	query.Set("step", cmd.Step)
+	response := client.HTTPPostQuery(fmt.Sprintf("v1/plans/%s/forceComplete", GetPlanName(cmd)), query.Encode())
+	client.PrintJSON(response)
+	return nil
+}
+
+func HandlePlanSection(app *kingpin.Application) {
+	// plan <active, continue, force, interrupt, restart, show>
+	cmd := &PlanHandler{}
+	plan := app.Command("plan", "Query service plans")
+
+	plan.Command("list", "Show all plans for this service").Action(cmd.RunList)
+
+	show := plan.Command("show", "Display the deploy plan or the plan with the provided name").Action(cmd.RunShow)
+	show.Arg("plan", "Name of the plan to show").StringVar(&cmd.PlanName)
+
+    start := plan.Command("start", "Start the plan with the provided name, with optional envvars to supply to task").Action(cmd.RunStart)
+    start.Arg("plan", "Name of the plan to start").Required().StringVar(&cmd.PlanName)
+    start.Flag("params", "Envvar definition in VAR=value form; can be repeated for multiple variables").Short('p').StringsVar(&cmd.Parameters)
+
+	stop := plan.Command("stop", "Stop the plan with the provided name").Action(cmd.RunStop)
+	stop.Arg("plan", "Name of the plan to stop").Required().StringVar(&cmd.PlanName)
+
+	continueCmd := plan.Command("continue", "Continue the deploy plan, or the plan with the provided name, or a specific phase in that plan with the provided name or UUID").Action(cmd.RunContinue)
+	continueCmd.Arg("plan", "Name of the plan to continue").StringVar(&cmd.PlanName)
+	continueCmd.Arg("phase", "Name or UUID of a specific phase to continue").StringVar(&cmd.Phase)
+
+	interrupt := plan.Command("interrupt", "Interrupt the deploy plan, or the plan with the provided name, or a specific phase in that plan with the provided name or UUID").Action(cmd.RunInterrupt)
+	interrupt.Arg("plan", "Name of the plan to interrupt").StringVar(&cmd.PlanName)
+	interrupt.Arg("phase", "Name or UUID of a specific phase to interrupt").StringVar(&cmd.Phase)
+
+	restart := plan.Command("restart", "Restart the plan with the provided name, or the specific step in the provided phase (each by name or UUID)").Action(cmd.RunRestart)
+	restart.Arg("plan", "Name of the plan to restart").Required().StringVar(&cmd.PlanName)
+	restart.Arg("phase", "Name or UUID of the phase containing the provided step").StringVar(&cmd.Phase) // TODO optional
+	restart.Arg("step", "Name or UUID of step to be restarted").StringVar(&cmd.Step)
+
+	force := plan.Command("force", "Force complete the plan with the provided name").Action(cmd.RunForce)
+	force.Arg("plan", "Name of the plan to force complete").Required().StringVar(&cmd.PlanName)
+	force.Arg("phase", "Name or UUID of the phase containing the provided step").Required().StringVar(&cmd.Phase)
+	force.Arg("step", "Name or UUID of step to be restarted").Required().StringVar(&cmd.Step)
+}

--- a/frameworks/template/vendor/github.com/mesosphere/dcos-commons/cli/commands/pods.go
+++ b/frameworks/template/vendor/github.com/mesosphere/dcos-commons/cli/commands/pods.go
@@ -1,0 +1,58 @@
+package commands
+
+import (
+	"fmt"
+	"github.com/mesosphere/dcos-commons/cli/client"
+	"gopkg.in/alecthomas/kingpin.v2"
+)
+
+// Pods section
+
+type PodsHandler struct {
+	PodName string
+}
+
+func (cmd *PodsHandler) RunList(c *kingpin.ParseContext) error {
+	client.PrintJSON(client.HTTPGet("v1/pods"))
+	return nil
+}
+func (cmd *PodsHandler) RunStatus(c *kingpin.ParseContext) error {
+	if len(cmd.PodName) == 0 {
+		client.PrintJSON(client.HTTPGet("v1/pods/status"))
+	} else {
+		client.PrintJSON(client.HTTPGet(fmt.Sprintf("v1/pods/%s/status", cmd.PodName)))
+	}
+	return nil
+}
+func (cmd *PodsHandler) RunInfo(c *kingpin.ParseContext) error {
+	client.PrintJSON(client.HTTPGet(fmt.Sprintf("v1/pods/%s/info", cmd.PodName)))
+	return nil
+}
+func (cmd *PodsHandler) RunRestart(c *kingpin.ParseContext) error {
+	client.PrintText(client.HTTPPost(fmt.Sprintf("v1/pods/%s/restart", cmd.PodName)))
+	return nil
+}
+func (cmd *PodsHandler) RunReplace(c *kingpin.ParseContext) error {
+	client.PrintText(client.HTTPPost(fmt.Sprintf("v1/pods/%s/replace", cmd.PodName)))
+	return nil
+}
+
+func HandlePodsSection(app *kingpin.Application) {
+	// pods [status [name], info <name>, restart <name>, replace <name>]
+	cmd := &PodsHandler{}
+	pods := app.Command("pods", "View Pod/Task state")
+
+	pods.Command("list", "Display the list of known pod instances").Action(cmd.RunList)
+
+	status := pods.Command("status", "Display the status for tasks in one pod or all pods").Action(cmd.RunStatus)
+	status.Arg("pod", "Name of a specific pod instance to display").StringVar(&cmd.PodName)
+
+	info := pods.Command("info", "Display the full state information for tasks in a pod").Action(cmd.RunInfo)
+	info.Arg("pod", "Name of the pod instance to display").Required().StringVar(&cmd.PodName)
+
+	restart := pods.Command("restart", "Restarts a given pod without moving it to a new agent").Action(cmd.RunRestart)
+	restart.Arg("pod", "Name of the pod instance to restart").Required().StringVar(&cmd.PodName)
+
+	replace := pods.Command("replace", "Destroys a given pod and moves it to a new agent").Action(cmd.RunReplace)
+	replace.Arg("pod", "Name of the pod instance to replace").Required().StringVar(&cmd.PodName)
+}

--- a/frameworks/template/vendor/github.com/mesosphere/dcos-commons/cli/commands/state.go
+++ b/frameworks/template/vendor/github.com/mesosphere/dcos-commons/cli/commands/state.go
@@ -1,0 +1,45 @@
+package commands
+
+import (
+	"fmt"
+	"github.com/mesosphere/dcos-commons/cli/client"
+	"gopkg.in/alecthomas/kingpin.v2"
+)
+
+// State section
+
+type StateHandler struct {
+	PropertyName string
+}
+
+func (cmd *StateHandler) RunFrameworkId(c *kingpin.ParseContext) error {
+	client.PrintJSON(client.HTTPGet("v1/state/frameworkId"))
+	return nil
+}
+func (cmd *StateHandler) RunProperties(c *kingpin.ParseContext) error {
+	client.PrintJSON(client.HTTPGet("v1/state/properties"))
+	return nil
+}
+func (cmd *StateHandler) RunProperty(c *kingpin.ParseContext) error {
+	client.PrintJSON(client.HTTPGet(fmt.Sprintf("v1/state/properties/%s", cmd.PropertyName)))
+	return nil
+}
+func (cmd *StateHandler) RunRefreshCache(c *kingpin.ParseContext) error {
+	client.PrintJSON(client.HTTPPut("v1/state/refresh"))
+	return nil
+}
+
+func HandleStateSection(app *kingpin.Application) {
+	// state <framework_id, status, task, tasks>
+	cmd := &StateHandler{}
+	state := app.Command("state", "View persisted state")
+
+	state.Command("framework_id", "Display the mesos framework ID").Action(cmd.RunFrameworkId)
+
+	state.Command("properties", "List names of all custom properties").Action(cmd.RunProperties)
+
+	task := state.Command("property", "Display the content of a specified property").Action(cmd.RunProperty)
+	task.Arg("name", "Name of the property to display").Required().StringVar(&cmd.PropertyName)
+
+	state.Command("refresh_cache", "Refresh the state cache, used for debugging").Action(cmd.RunRefreshCache)
+}

--- a/frameworks/template/vendor/github.com/mesosphere/dcos-commons/cli/config/config.go
+++ b/frameworks/template/vendor/github.com/mesosphere/dcos-commons/cli/config/config.go
@@ -1,0 +1,13 @@
+package config
+
+var (
+	DcosAuthToken string
+	DcosUrl       string
+	ServiceName   string
+
+	TlsForceInsecure bool
+	TlsCliSetting    tlsSetting = TlsUnknown
+	TlsCACertPath    string
+
+	Verbose bool
+)

--- a/frameworks/template/vendor/github.com/mesosphere/dcos-commons/cli/config/tls.go
+++ b/frameworks/template/vendor/github.com/mesosphere/dcos-commons/cli/config/tls.go
@@ -1,0 +1,10 @@
+package config
+
+type tlsSetting int
+
+const (
+	TlsUnknown tlsSetting = iota
+	TlsUnverified
+	TlsVerified
+	TlsSpecificCert
+)

--- a/frameworks/template/vendor/vendor.json
+++ b/frameworks/template/vendor/vendor.json
@@ -21,10 +21,28 @@
 			"revisionTime": "2015-10-22T06:55:26Z"
 		},
 		{
-			"checksumSHA1": "P3iWutRP+oVM/JerQG8PXutteDA=",
+			"checksumSHA1": "3eEVgzEAupeKrgVinZliQ2pQz1k=",
 			"path": "github.com/mesosphere/dcos-commons/cli",
-			"revision": "1d0caf841e5ffa966f102842af69c81200433c29",
-			"revisionTime": "2017-05-03T20:33:53Z"
+			"revision": "715d27f3e43a5e25b8ecb4beed97333b136fdd9a",
+			"revisionTime": "2017-05-12T03:39:39Z"
+		},
+		{
+			"checksumSHA1": "jRAmnN/GQG0aYFGLXFa9kCnbG68=",
+			"path": "github.com/mesosphere/dcos-commons/cli/client",
+			"revision": "715d27f3e43a5e25b8ecb4beed97333b136fdd9a",
+			"revisionTime": "2017-05-12T03:39:39Z"
+		},
+		{
+			"checksumSHA1": "c98dfK76mbphwOxDiEHE5W67res=",
+			"path": "github.com/mesosphere/dcos-commons/cli/commands",
+			"revision": "715d27f3e43a5e25b8ecb4beed97333b136fdd9a",
+			"revisionTime": "2017-05-12T03:39:39Z"
+		},
+		{
+			"checksumSHA1": "ZMlCs+z3SI8W/xiQl8G4i8KzDQo=",
+			"path": "github.com/mesosphere/dcos-commons/cli/config",
+			"revision": "715d27f3e43a5e25b8ecb4beed97333b136fdd9a",
+			"revisionTime": "2017-05-12T03:39:39Z"
 		},
 		{
 			"checksumSHA1": "ZvPW/nSYs/UeoZejaV2ZSm9+2Do=",
@@ -33,5 +51,5 @@
 			"revisionTime": "2017-03-28T23:38:35Z"
 		}
 	],
-	"rootPath": "github.com/mesosphere/dcos-commons/frameworks/template"
+	"rootPath": "github.com/mesosphere/dcos-edge-lb/framework/_build/dcos-commons/frameworks/template"
 }

--- a/frameworks/template/vendor/vendor.json
+++ b/frameworks/template/vendor/vendor.json
@@ -51,5 +51,5 @@
 			"revisionTime": "2017-03-28T23:38:35Z"
 		}
 	],
-	"rootPath": "github.com/mesosphere/dcos-edge-lb/framework/_build/dcos-commons/frameworks/template"
+	"rootPath": "github.com/mesosphere/dcos-commons/frameworks/template"
 }

--- a/new-framework.sh
+++ b/new-framework.sh
@@ -31,7 +31,8 @@ fi
 
 UPPER_CASE_PROJECT_NAME=$(echo $PROJECT_NAME | awk '{print toupper($0)}')
 
-find $1 -type f -exec sed -i.bak "s/template/$PROJECT_NAME/g; s/TEMPLATE/$UPPER_CASE_PROJECT_NAME/g; s/template/$PROJECT_NAME/g" {} \;
+find $1 -type f -exec sed -i.bak "s/{{template}}/$PROJECT_NAME/g; s/{{TEMPLATE}}/$UPPER_CASE_PROJECT_NAME/g" {} \;
+
 sed -i.bak -e '21,$ d' $1/src/main/dist/svc.yml
 find $1 -type f -name *.bak -exec rm {} \;
 

--- a/new-standalone-service.sh
+++ b/new-standalone-service.sh
@@ -117,7 +117,7 @@ mv $PROJECT_PATH/$PROJECT_NAME/src/test/java/com/mesosphere/sdk/template/ $PROJE
 
 UPPER_CASE_PROJECT_NAME=$(echo $PROJECT_NAME | awk '{print toupper($0)}')
 
-find $PROJECT_PATH/$PROJECT_NAME -type f -exec sed -i.bak "s/template/$PROJECT_NAME/g; s/TEMPLATE/$UPPER_CASE_PROJECT_NAME/g; s/template/$PROJECT_NAME/g" {} \;
+find $PROJECT_PATH/$PROJECT_NAME -type f -exec sed -i.bak "s/{{template}}/$PROJECT_NAME/g; s/{{TEMPLATE}}/$UPPER_CASE_PROJECT_NAME/g" {} \;
 sed -i.bak -e '21,$ d' $PROJECT_PATH/$PROJECT_NAME/src/main/dist/svc.yml
 find $PROJECT_PATH/$PROJECT_NAME -type f -name *.bak -exec rm -f {} \;
 


### PR DESCRIPTION
* `new-framework.sh` and `new-standalone-service.sh` both did a replace of the word "template" in `frameworks/template`, but there are legitimate uses of that word in `frameworks/template/vendor`. The proposed solution is to instead use a more template friendly term like `{{template}}` for replacements.
* Also updated the template's cli and vendor dirs with a more recent version of the dcos-commons cli package 

Altenative solution to this problem?
* Remove `frameworks/template/vendor` and instead run `govendor fetch github.com/mesosphere/dcos-commons/cli` once the new framework has been generated