### PR TITLE
[INFINITY-1352] Dont fail tests on CCM teardown fail.

### DIFF
--- a/test.py
+++ b/test.py
@@ -317,7 +317,10 @@ def setup_clusters(run_attrs):
 
 def teardown_clusters():
     logger.info("Shutting down all clusters.")
-    clustinfo.shutdown_clusters()
+    try:
+        clustinfo.shutdown_clusters()
+    except Exception as e:
+        logger.exception("Cluster teardown did not run correctly, ignoring.")
 
 def _one_cluster_linear_tests(run_attrs, repo_root):
     if run_attrs.cluster_url and run_attrs.cluster_token:


### PR DESCRIPTION
Sometimes CCM fails to accept the trigger-stop http request.  This has occurred due to CCM bugs as well as network connectivity problems.  We don't care about either.
