### PR TITLE
Modify the upgrade integration test to work with beta packages

### DIFF
--- a/frameworks/elastic/tests/test_shakedown.py
+++ b/frameworks/elastic/tests/test_shakedown.py
@@ -136,13 +136,13 @@ def test_kibana_proxylite_adminrouter_integration():
 @pytest.mark.upgrade
 @pytest.mark.sanity
 def test_upgrade_downgrade():
-    # Remove this once Universe package version defaults to user `nobody`
     options = {
         "service": {
-            "user": "nobody"
+            "beta-optin": True
         }
     }
-    sdk_test_upgrade.upgrade_downgrade(PACKAGE_NAME, DEFAULT_TASK_COUNT, additional_options=options)
+    sdk_test_upgrade.upgrade_downgrade("beta-{}".format(PACKAGE_NAME), PACKAGE_NAME, DEFAULT_TASK_COUNT,
+                                       additional_options=options)
 
 
 @pytest.mark.recovery

--- a/frameworks/elastic/tests/test_soak.py
+++ b/frameworks/elastic/tests/test_soak.py
@@ -13,4 +13,5 @@ def test_soak_upgrade_downgrade():
     """
     with open('elastic.json') as options_file:
         install_options = json.load(options_file)
-    sdk_test_upgrade.soak_upgrade_downgrade(PACKAGE_NAME, DEFAULT_TASK_COUNT, install_options)
+    sdk_test_upgrade.soak_upgrade_downgrade("beta-{}".format(PACKAGE_NAME), PACKAGE_NAME, PACKAGE_NAME,
+                                            DEFAULT_TASK_COUNT, install_options)

--- a/frameworks/helloworld/tests/test_sanity.py
+++ b/frameworks/helloworld/tests/test_sanity.py
@@ -256,4 +256,4 @@ def test_lock():
 @pytest.mark.upgrade
 @pytest.mark.sanity
 def test_upgrade_downgrade():
-    sdk_test_upgrade.upgrade_downgrade(PACKAGE_NAME, DEFAULT_TASK_COUNT)
+    sdk_test_upgrade.upgrade_downgrade(PACKAGE_NAME, PACKAGE_NAME, DEFAULT_TASK_COUNT)

--- a/frameworks/helloworld/tests/test_soak.py
+++ b/frameworks/helloworld/tests/test_soak.py
@@ -8,4 +8,4 @@ from tests.config import (
 
 @pytest.mark.soak_upgrade
 def test_soak_upgrade_downgrade():
-    sdk_test_upgrade.soak_upgrade_downgrade(PACKAGE_NAME, DEFAULT_TASK_COUNT)
+    sdk_test_upgrade.soak_upgrade_downgrade(PACKAGE_NAME, PACKAGE_NAME, PACKAGE_NAME, DEFAULT_TASK_COUNT)

--- a/testing/sdk_test_upgrade.py
+++ b/testing/sdk_test_upgrade.py
@@ -15,10 +15,13 @@ import sdk_utils
 # (2) Upgrades to test version of framework.
 # (3) Downgrades to Universe version.
 # (4) Upgrades back to test version, as clean up.
-def upgrade_downgrade(package_name, running_task_count, additional_options={}):
-    install.uninstall(package_name)
+#
+# With beta packages, the Universe package name is different from the test package name.
+# We install both with the same service name=test_package_name.
+def upgrade_downgrade(universe_package_name, test_package_name, running_task_count, additional_options={}):
+    install.uninstall(test_package_name)
 
-    test_version = get_pkg_version(package_name)
+    test_version = get_pkg_version(test_package_name)
     sdk_utils.out('Found test version: {}'.format(test_version))
 
     repositories = json.loads(cmd.run_cli('package repo list --json'))['repositories']
@@ -34,34 +37,36 @@ def upgrade_downgrade(package_name, running_task_count, additional_options={}):
 
     # Move the Universe repo to the top of the repo list
     shakedown.remove_package_repo('Universe')
-    add_repo('Universe', universe_url, test_version, 0, package_name)
+    add_repo('Universe', universe_url, test_version, 0, universe_package_name)
 
-    universe_version = get_pkg_version(package_name)
+    universe_version = get_pkg_version(universe_package_name)
     sdk_utils.out('Found Universe version: {}'.format(universe_version))
 
     sdk_utils.out('Installing Universe version')
-    install.install(package_name, running_task_count, check_suppression=False, additional_options=additional_options)
+    # Keep the service name the same throughout the test
+    install.install(universe_package_name, running_task_count, service_name=test_package_name,
+                    check_suppression=False, additional_options=additional_options)
 
     # Move the Universe repo to the bottom of the repo list
     shakedown.remove_package_repo('Universe')
-    add_last_repo('Universe', universe_url, universe_version, package_name)
+    add_last_repo('Universe', universe_url, universe_version, test_package_name)
 
     sdk_utils.out('Upgrading to test version')
-    upgrade_or_downgrade(package_name, running_task_count, additional_options)
+    upgrade_or_downgrade(test_package_name, test_package_name, running_task_count, additional_options)
 
     # Move the Universe repo to the top of the repo list
     shakedown.remove_package_repo('Universe')
-    add_repo('Universe', universe_url, test_version, 0, package_name)
+    add_repo('Universe', universe_url, test_version, 0, universe_package_name)
 
-    sdk_utils.out('Downgrading to master version')
-    upgrade_or_downgrade(package_name, running_task_count, additional_options)
+    sdk_utils.out('Downgrading to Universe version')
+    upgrade_or_downgrade(universe_package_name, test_package_name, running_task_count, additional_options)
 
     # Move the Universe repo to the bottom of the repo list
     shakedown.remove_package_repo('Universe')
-    add_last_repo('Universe', universe_url, universe_version, package_name)
+    add_last_repo('Universe', universe_url, universe_version, test_package_name)
 
     sdk_utils.out('Upgrading to test version')
-    upgrade_or_downgrade(package_name, running_task_count, additional_options)
+    upgrade_or_downgrade(test_package_name, test_package_name, running_task_count, additional_options)
 
 
 # In the soak cluster, we assume that the Universe version of the framework is already installed.
@@ -70,28 +75,30 @@ def upgrade_downgrade(package_name, running_task_count, additional_options={}):
 #
 # (1) Upgrades to test version of framework.
 # (2) Downgrades to Universe version.
-def soak_upgrade_downgrade(package_name, running_task_count, install_options={}):
+def soak_upgrade_downgrade(universe_package_name, test_package_name, service_name, running_task_count,
+                           install_options={}):
     print('Upgrading to test version')
-    upgrade_or_downgrade(package_name, running_task_count, install_options, 'stub-universe')
+    upgrade_or_downgrade(test_package_name, service_name, running_task_count, install_options, 'stub-universe')
 
     print('Downgrading to Universe version')
     # Default Universe is at --index=0
-    upgrade_or_downgrade(package_name, running_task_count, install_options)
+    upgrade_or_downgrade(universe_package_name, service_name, running_task_count, install_options)
 
 
-def upgrade_or_downgrade(package_name, running_task_count, additional_options, package_version=None):
-    task_ids = tasks.get_task_ids(package_name, '')
-    marathon.destroy_app(package_name)
+def upgrade_or_downgrade(package_name, service_name, running_task_count, additional_options, package_version=None):
+    task_ids = tasks.get_task_ids(service_name, '')
+    marathon.destroy_app(service_name)
     install.install(
         package_name,
         running_task_count,
+        service_name=service_name,
         additional_options=additional_options,
         package_version=package_version,
         check_suppression=False)
     sdk_utils.out('Waiting for upgrade / downgrade deployment to complete')
-    plan.wait_for_completed_deployment(package_name)
+    plan.wait_for_completed_deployment(service_name)
     sdk_utils.out('Checking that all tasks have restarted')
-    tasks.check_tasks_updated(package_name, '', task_ids)
+    tasks.check_tasks_updated(service_name, '', task_ids)
 
 
 def get_test_repo_info():
@@ -107,22 +114,23 @@ def get_pkg_version(package_name):
     return match.group(1)
 
 
-def add_repo(repo_name, repo_url, prev_version, index, package_name):
+# Default repo is the one at index=0.
+def add_repo(repo_name, repo_url, prev_version, index, default_repo_package_name):
     assert shakedown.add_package_repo(
         repo_name,
         repo_url,
         index)
-    # Make sure the new repo packages are available
-    new_default_version_available(prev_version, package_name)
+    # Make sure the new default repo packages are available
+    new_default_version_available(prev_version, default_repo_package_name)
 
 
-def add_last_repo(repo_name, repo_url, prev_version, package_name):
+def add_last_repo(repo_name, repo_url, prev_version, default_repo_package_name):
     assert shakedown.add_package_repo(
         repo_name,
         repo_url)
-    # Make sure the new repo packages are available
-    new_default_version_available(prev_version, package_name)
+    # Make sure the new default repo packages are available
+    new_default_version_available(prev_version, default_repo_package_name)
 
 
-def new_default_version_available(prev_version, package_name):
-    spin.time_wait_noisy(lambda: get_pkg_version(package_name) != prev_version)
+def new_default_version_available(prev_version, default_repo_package_name):
+    spin.time_wait_noisy(lambda: get_pkg_version(default_repo_package_name) != prev_version)


### PR DESCRIPTION
Modified the upgrade/downgrade integration test to work with services that have beta packages in the Universe. Now the integration test will install the beta- package, if specified, rather than the non-beta package.
- The main change was to add additional parameters to the upgrade_downgrade() method so that the caller can specify different values for (1) Universe package name, (2) test package name, and (3) service name.
- For example, for Elastic, (1) Universe package name = `beta-elastic`, (2) test package name = `elastic`, and (3) service name = `elastic`.
- Before this change, all three names were always the same value, so there was no need to distinguish.