### PR TITLE
Fix release_builder.py package name in beta packages

### DIFF
--- a/tools/release_builder.py
+++ b/tools/release_builder.py
@@ -462,12 +462,13 @@ class UniverseReleaseBuilder(object):
         with open(package_file_name, 'w') as f:
             json.dump(package_json, f, indent=4)
 
+        self._pkg_name = package_json['name']
+
         # Rename the directory structure
         parts = pkgdir.split('/')
         parts[-2] = 'beta-' + parts[-2]
         parts[-3] = 'B'
         beta_pkg_dir = '/'.join(parts)
-        self._pkg_name = parts[-2]
         shutil.copytree(pkgdir, beta_pkg_dir)
         shutil.rmtree(pkgdir)
         return beta_pkg_dir


### PR DESCRIPTION
The package name in beta packages was incorrect because it was derived from the directory path. Fixed by getting it from `package.json` instead.

Dry run output looks correct now (for fake version 1.2.3):

`
    Switched to a new branch 'automated/release_beta-kafka_1.2.3-4.5.6-beta_IjbnzQ'
    commit bc17a039130df1c26775cb5491bee1a7394d5cde
    Author: release_builder.py <jenkins@mesosphere.com>
    Date:   Tue May 16 08:48:57 2017 -0700
    
    Release kafka 1.2.3-4.5.6-beta (automated commit)
    
    Changes since revision 1:
    0 files added: []
    0 files removed: []
    4 files changed:
`