### PR TITLE
HDFS: Don't manually provide FRAMEWORK_NAME envvar

### DIFF
--- a/frameworks/hdfs/src/main/java/com/mesosphere/sdk/hdfs/scheduler/Main.java
+++ b/frameworks/hdfs/src/main/java/com/mesosphere/sdk/hdfs/scheduler/Main.java
@@ -4,7 +4,6 @@ import com.mesosphere.sdk.api.types.EndpointProducer;
 import com.mesosphere.sdk.config.DefaultTaskConfigRouter;
 import com.mesosphere.sdk.offer.evaluate.placement.AndRule;
 import com.mesosphere.sdk.offer.evaluate.placement.TaskTypeRule;
-import com.mesosphere.sdk.offer.taskdata.EnvConstants;
 import com.mesosphere.sdk.scheduler.DefaultScheduler;
 import com.mesosphere.sdk.scheduler.SchedulerFlags;
 import com.mesosphere.sdk.specification.*;
@@ -74,7 +73,6 @@ public class Main {
         }
 
         Map<String, String> env = new HashMap<>(new DefaultTaskConfigRouter().getConfig("ALL").getAllEnv());
-        env.put(EnvConstants.FRAMEWORK_NAME_TASKENV, System.getenv(EnvConstants.FRAMEWORK_NAME_TASKENV));
 
         String fileStr = new String(bytes, Charset.defaultCharset());
         return TemplateUtils.applyEnvToMustache(fileStr, env);

--- a/frameworks/hdfs/src/test/java/com/mesosphere/sdk/hdfs/scheduler/ServiceSpecTest.java
+++ b/frameworks/hdfs/src/test/java/com/mesosphere/sdk/hdfs/scheduler/ServiceSpecTest.java
@@ -2,7 +2,6 @@ package com.mesosphere.sdk.hdfs.scheduler;
 
 import com.google.common.collect.ImmutableMap;
 import com.mesosphere.sdk.config.DefaultTaskConfigRouter;
-import com.mesosphere.sdk.offer.taskdata.EnvConstants;
 import com.mesosphere.sdk.specification.yaml.TemplateUtils;
 import com.mesosphere.sdk.testing.BaseServiceSpecTest;
 import org.junit.Assert;
@@ -102,7 +101,6 @@ public class ServiceSpecTest extends BaseServiceSpecTest {
         String fileStr = new String(bytes, Charset.defaultCharset());
         ImmutableMap<String, String> allEnv = new DefaultTaskConfigRouter().getConfig("ALL").getAllEnv();
         Map<String, String> updatedEnv = new HashMap<>(allEnv);
-        updatedEnv.put(EnvConstants.FRAMEWORK_NAME_TASKENV, System.getenv(EnvConstants.FRAMEWORK_NAME_TASKENV));
 
         String renderedFileStr = TemplateUtils.applyEnvToMustache(fileStr, updatedEnv);
         Assert.assertEquals(-1, renderedFileStr.indexOf("<value></value>"));


### PR DESCRIPTION
This envvar is already included automatically in all tasks