### PR TITLE
Fixed JettyApiServerTest use of bind any address as loopback

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/api/JettyApiServer.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/api/JettyApiServer.java
@@ -12,6 +12,10 @@ import java.util.Collection;
 
 /**
  * A JettyApiServer takes a list of POJO JAX-RS Resources and serves them on the indicated port of 0.0.0.0.
+ *
+ * When constructed with a port of zero, an available ephemeral port will be
+ * determined and bound by the JettyApiServer. In this case, call getLocalPort
+ * to obtain the port number.
  */
 public class JettyApiServer {
     private final Server server;
@@ -55,6 +59,9 @@ public class JettyApiServer {
         if (this.port != 0) {
             return this.port;
         }
+        // When constructed w/ port 0, an available ephemeral port will be
+        // bound and this will be on the first and only network interface
+        // (connector) for the Jetty Server.
         NetworkConnector networkConnector = (NetworkConnector) server.getConnectors()[0];
         this.port = networkConnector.getLocalPort();
         return this.port;

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/api/JettyApiServer.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/api/JettyApiServer.java
@@ -1,6 +1,8 @@
 package com.mesosphere.sdk.api;
 
+import org.eclipse.jetty.server.NetworkConnector;
 import org.eclipse.jetty.server.Server;
+
 import org.glassfish.jersey.jetty.JettyHttpContainerFactory;
 import org.glassfish.jersey.server.ResourceConfig;
 
@@ -13,6 +15,7 @@ import java.util.Collection;
  */
 public class JettyApiServer {
     private final Server server;
+    private int port;
 
     public JettyApiServer(int port, Collection<Object> resources) {
         ResourceConfig resourceConfig = new ResourceConfig();
@@ -25,6 +28,9 @@ public class JettyApiServer {
                 .port(port).build();
 
         this.server = JettyHttpContainerFactory.createServer(baseUri, resourceConfig);
+        if (port != 0) {
+            this.port = port;
+        }
     }
 
     public void start() throws Exception {
@@ -43,5 +49,14 @@ public class JettyApiServer {
 
     public boolean isStarted() {
         return server.isStarted();
+    }
+
+    public int getLocalPort() {
+        if (this.port != 0) {
+            return this.port;
+        }
+        NetworkConnector networkConnector = (NetworkConnector) server.getConnectors()[0];
+        this.port = networkConnector.getLocalPort();
+        return this.port;
     }
 }

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/api/JettyApiServerTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/api/JettyApiServerTest.java
@@ -16,7 +16,6 @@ import javax.ws.rs.Path;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.io.IOException;
-import java.net.ServerSocket;
 import java.util.Arrays;
 
 /**
@@ -24,14 +23,37 @@ import java.util.Arrays;
  */
 public class JettyApiServerTest {
     private JettyApiServer jettyApiServer;
-    private int port;
     private static final String TEST = "test";
 
     @Before
     public void beforeEach() throws IOException {
+        final int jettyStartRetries = 10;
+        final int jettyStartRetryDelay = 1000;
         MockitoAnnotations.initMocks(this);
-        port = getRandomPort();
-        jettyApiServer = new JettyApiServer(port, Arrays.asList(new TestPojo()));
+
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                for(int i = 0; i < jettyStartRetries; i++) {
+                    try {
+                        jettyApiServer = new JettyApiServer(0, Arrays.asList(new TestPojo()));
+                        jettyApiServer.start();
+                        break;
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                    }
+
+                    sleep(jettyStartRetryDelay);
+                }
+            }
+        }).start();
+
+        for(int i = 0; i < jettyStartRetries; i++) {
+            if (jettyApiServer != null && jettyApiServer.isStarted()) {
+                break;
+            }
+            sleep(jettyStartRetryDelay);
+        }
     }
 
     @After
@@ -41,30 +63,11 @@ public class JettyApiServerTest {
 
     @Test
     public void testGetRequest() throws Exception {
-        new Thread(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    jettyApiServer.start();
-                } catch (Exception e) {
-                    e.printStackTrace();
-                }
-            }
-        }).start();
-
         HttpClient client = HttpClientBuilder.create().build();
-        HttpGet request = new HttpGet(String.format("http://0.0.0.0:%s/%s", port, TEST));
+        HttpGet request = new HttpGet(String.format("http://127.0.0.1:%s/%s", getJettyApiServerPort(), TEST));
         HttpEntity entity = client.execute(request).getEntity();
         String responseString = EntityUtils.toString(entity, "UTF-8");
-
         Assert.assertEquals(TEST, responseString);
-    }
-
-    private static int getRandomPort() throws IOException {
-        ServerSocket serverSocket = new ServerSocket(0);
-        int port = serverSocket.getLocalPort();
-        serverSocket.close();
-        return port;
     }
 
     @Path("/")
@@ -74,5 +77,21 @@ public class JettyApiServerTest {
         public Response getFrameworkId() {
             return Response.ok(TEST, MediaType.APPLICATION_JSON).build();
         }
+    }
+
+    private void sleep(int ms) {
+        try {
+            Thread.sleep(ms);
+        } catch (InterruptedException e) { }
+    }
+
+    private int getJettyApiServerPort() {
+        if (jettyApiServer == null) {
+            return -1;
+        }
+        if (!jettyApiServer.isStarted()) {
+            return -2;
+        }
+        return jettyApiServer.getLocalPort();
     }
 }

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/api/JettyApiServerTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/api/JettyApiServerTest.java
@@ -27,6 +27,11 @@ public class JettyApiServerTest {
 
     @Before
     public void beforeEach() throws IOException {
+        // using a busy-wait and retry pattern to reach the sync point where
+        // server and client connect. This approach was chosen b/c it took a
+        // minimal amount of effort to use a generally applicable pattern to
+        // resolve local build/test failures, but a more elegant solution may
+        // be to use LifeCycle.Listener.
         final int jettyStartRetries = 10;
         final int jettyStartRetryDelay = 1000;
         MockitoAnnotations.initMocks(this);
@@ -80,6 +85,8 @@ public class JettyApiServerTest {
     }
 
     private void sleep(int ms) {
+        // an interruptable sleep b/c if interrupted, i.e. by SIGINT, np,
+        // continue to crash, don't worry about sleep
         try {
             Thread.sleep(ms);
         } catch (InterruptedException e) { }


### PR DESCRIPTION
* fixed jetty api server test use of bind any ip address (0.0.0.0) as the address that the client performs the http get against, but should be localhost (127.0.0.1 or ::1 or ...)
  * 0.0.0.0 is not universally hacked to be treated equivalent to proper loopback addresses, but it may be, i.e. on various linux distros that prefer UX over universally correct implementation.
* made the test ~properly threaded where properly is not using a busy wait.