### PR TITLE
Second prelude to PR #977

### DIFF
--- a/frameworks/kafka/src/main/java/com/mesosphere/sdk/kafka/scheduler/KafkaService.java
+++ b/frameworks/kafka/src/main/java/com/mesosphere/sdk/kafka/scheduler/KafkaService.java
@@ -35,7 +35,6 @@ public class KafkaService extends DefaultService {
         /* Upgrade */
         new KafkaConfigUpgrade(schedulerBuilder.getServiceSpec(), schedulerFlags);
         FilterStateStore stateStore = new FilterStateStore(
-                schedulerBuilder.getServiceSpec().getName(),
                 CuratorPersister.newBuilder(schedulerBuilder.getServiceSpec()).build());
         stateStore.setIgnoreFilter(RegexMatcher.create("broker-[0-9]*"));
         schedulerBuilder.setStateStore(stateStore);

--- a/frameworks/kafka/src/main/java/com/mesosphere/sdk/kafka/upgrade/FilterStateStore.java
+++ b/frameworks/kafka/src/main/java/com/mesosphere/sdk/kafka/upgrade/FilterStateStore.java
@@ -1,9 +1,10 @@
 package com.mesosphere.sdk.kafka.upgrade;
 
-import com.mesosphere.sdk.curator.CuratorPersister;
 import com.mesosphere.sdk.offer.evaluate.placement.StringMatcher;
 import com.mesosphere.sdk.state.DefaultStateStore;
 import com.mesosphere.sdk.state.StateStoreException;
+import com.mesosphere.sdk.storage.Persister;
+
 import java.util.Collection;
 import java.util.stream.Collectors;
 
@@ -13,8 +14,8 @@ import java.util.stream.Collectors;
 public class FilterStateStore extends DefaultStateStore {
     private StringMatcher ignoreFilter = null;
 
-    public FilterStateStore(String frameworkName, CuratorPersister persister) {
-        super(frameworkName, persister);
+    public FilterStateStore(Persister persister) {
+        super(persister);
     }
 
     public void setIgnoreFilter(StringMatcher ignoreFilter) {
@@ -29,7 +30,6 @@ public class FilterStateStore extends DefaultStateStore {
         return super.fetchTaskNames()
                 .stream()
                 .filter(name -> !(ignoreFilter.matches(name)))
-                .collect(Collectors.toSet());
+                .collect(Collectors.toList());
     }
-
 }

--- a/frameworks/kafka/src/main/java/com/mesosphere/sdk/kafka/upgrade/KafkaConfigUpgrade.java
+++ b/frameworks/kafka/src/main/java/com/mesosphere/sdk/kafka/upgrade/KafkaConfigUpgrade.java
@@ -49,7 +49,7 @@ public class KafkaConfigUpgrade {
      *  KafkaConfigUpgrade.
      */
     public KafkaConfigUpgrade(ServiceSpec serviceSpec, SchedulerFlags schedulerFlags) throws Exception {
-        this.stateStore = new UpdateStateStore(serviceSpec.getName(), CuratorPersister.newBuilder(serviceSpec).build());
+        this.stateStore = new UpdateStateStore(CuratorPersister.newBuilder(serviceSpec).build());
 
         // if framework_id exist and not disabled
         if (!KafkaConfigUpgrade.disabled() && !runningFirstTime(stateStore)) {
@@ -172,9 +172,7 @@ public class KafkaConfigUpgrade {
 
         /* We assume that old and new configurations both have same name. */
         ConfigStore<KafkaSchedulerConfiguration> oldConfigStore = new DefaultConfigStore<>(
-                KafkaSchedulerConfiguration.getFactoryInstance(),
-                serviceSpec.getName(),
-                CuratorPersister.newBuilder(serviceSpec).build());
+                KafkaSchedulerConfiguration.getFactoryInstance(), CuratorPersister.newBuilder(serviceSpec).build());
 
         try {
             this.oldTargetId = oldConfigStore.getTargetConfig();
@@ -380,7 +378,4 @@ public class KafkaConfigUpgrade {
         }
         return false;
     }
-
-
-
 }

--- a/frameworks/kafka/src/main/java/com/mesosphere/sdk/kafka/upgrade/UpdateStateStore.java
+++ b/frameworks/kafka/src/main/java/com/mesosphere/sdk/kafka/upgrade/UpdateStateStore.java
@@ -1,9 +1,9 @@
 package com.mesosphere.sdk.kafka.upgrade;
 
-import com.mesosphere.sdk.curator.CuratorPersister;
 import com.mesosphere.sdk.offer.TaskUtils;
 import com.mesosphere.sdk.state.DefaultStateStore;
 import com.mesosphere.sdk.state.StateStoreException;
+import com.mesosphere.sdk.storage.Persister;
 import com.mesosphere.sdk.storage.StorageError;
 import org.apache.mesos.Protos;
 import org.slf4j.Logger;
@@ -18,8 +18,8 @@ import java.util.Optional;
 public class UpdateStateStore extends DefaultStateStore {
     private static final Logger logger = LoggerFactory.getLogger(UpdateStateStore.class);
 
-    public UpdateStateStore(String frameworkName, CuratorPersister persister) {
-        super(frameworkName, persister);
+    public UpdateStateStore(Persister persister) {
+        super(persister);
     }
 
     public void storeStatus(String taskName, Protos.TaskStatus status) throws StateStoreException {
@@ -56,7 +56,7 @@ public class UpdateStateStore extends DefaultStateStore {
                             currentStatusOptional.get().getState(), taskName));
         }
 
-        String path = taskPathMapper.getTaskStatusPath(taskName);
+        String path = getTaskStatusPath(taskName);
         logger.info("Storing status '{}' for '{}' in '{}'", status.getState(), taskName, path);
 
         try {
@@ -65,5 +65,4 @@ public class UpdateStateStore extends DefaultStateStore {
             throw new StateStoreException(StorageError.Reason.STORAGE_ERROR, e);
         }
     }
-
 }

--- a/frameworks/kafka/src/test/java/com/mesosphere/sdk/kafka/upgrade/FilterStateStoreTest.java
+++ b/frameworks/kafka/src/test/java/com/mesosphere/sdk/kafka/upgrade/FilterStateStoreTest.java
@@ -10,7 +10,6 @@ import org.apache.curator.retry.RetryOneTime;
 import org.apache.curator.test.TestingServer;
 import org.apache.mesos.Protos;
 import org.apache.mesos.Protos.SlaveID;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -38,12 +37,7 @@ public class FilterStateStoreTest {
     @Before
     public void beforeEach() throws Exception {
         clear();
-        store = new FilterStateStore(ROOT_ZK_PATH, CuratorPersister.newBuilder(testZk.getConnectString()).build());
-    }
-
-    @After
-    public void afterEach() {
-        store.closeForTesting();
+        store = new FilterStateStore(CuratorPersister.newBuilder(ROOT_ZK_PATH, testZk.getConnectString()).build());
     }
 
     @Test
@@ -53,7 +47,7 @@ public class FilterStateStoreTest {
         String testTaskName1 = testTaskNamePrefix + "-1";
 
         store.storeTasks(createTasks(testTaskName0, testTaskName1));
-        assertEquals(new TreeSet<>(Arrays.asList(testTaskName0, testTaskName1)), store.fetchTaskNames());
+        assertEquals(Arrays.asList(testTaskName0, testTaskName1), store.fetchTaskNames());
         Collection<Protos.TaskInfo> taskInfos = store.fetchTasks();
         assertEquals(2, taskInfos.size());
         Iterator<Protos.TaskInfo> iter2 = taskInfos.iterator();
@@ -70,18 +64,18 @@ public class FilterStateStoreTest {
         String testTaskName11 = testTaskNamePrefix + "-1";
 
         store.storeTasks(createTasks(testTaskName00, testTaskName11));
-        assertEquals(new TreeSet<>(Arrays.asList(testTaskName00, testTaskName11)), store.fetchTaskNames());
+        assertEquals(Arrays.asList(testTaskName00, testTaskName11), store.fetchTaskNames());
         taskInfos = store.fetchTasks();
         assertEquals(2, taskInfos.size());
 
         store.setIgnoreFilter(RegexMatcher.create("z*"));
-        assertEquals(new TreeSet<>(Arrays.asList(testTaskName0, testTaskName1, testTaskName00, testTaskName11)),
+        assertEquals(Arrays.asList(testTaskName0, testTaskName1, testTaskName00, testTaskName11),
                 store.fetchTaskNames());
         taskInfos = store.fetchTasks();
         assertEquals(4, taskInfos.size());
 
         store.setIgnoreFilter(null);
-        assertEquals(new TreeSet<>(Arrays.asList(testTaskName0, testTaskName1, testTaskName00, testTaskName11)),
+        assertEquals(Arrays.asList(testTaskName0, testTaskName1, testTaskName00, testTaskName11),
                 store.fetchTaskNames());
         taskInfos = store.fetchTasks();
         assertEquals(4, taskInfos.size());

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/config/ConfigStoreException.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/config/ConfigStoreException.java
@@ -2,6 +2,7 @@ package com.mesosphere.sdk.config;
 
 import java.io.IOException;
 
+import com.mesosphere.sdk.storage.PersisterException;
 import com.mesosphere.sdk.storage.StorageError.Reason;
 
 /**
@@ -12,6 +13,16 @@ import com.mesosphere.sdk.storage.StorageError.Reason;
 public class ConfigStoreException extends IOException {
 
     private final Reason reason;
+
+    public ConfigStoreException(PersisterException e) {
+        super(e);
+        this.reason = Reason.STORAGE_ERROR;
+    }
+
+    public ConfigStoreException(PersisterException e, String message) {
+        super(message, e);
+        this.reason = Reason.STORAGE_ERROR;
+    }
 
     public ConfigStoreException(Reason reason, Throwable cause) {
         super(cause);

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/curator/CuratorPersister.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/curator/CuratorPersister.java
@@ -3,7 +3,9 @@ package com.mesosphere.sdk.curator;
 import com.google.common.annotations.VisibleForTesting;
 import com.mesosphere.sdk.specification.ServiceSpec;
 import com.mesosphere.sdk.storage.Persister;
+import com.mesosphere.sdk.storage.PersisterException;
 import com.mesosphere.sdk.storage.PersisterUtils;
+import com.mesosphere.sdk.storage.StorageError.Reason;
 
 import org.apache.curator.RetryPolicy;
 import org.apache.curator.framework.CuratorFramework;
@@ -11,7 +13,6 @@ import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.api.ACLProvider;
 import org.apache.curator.framework.api.transaction.CuratorTransaction;
 import org.apache.curator.framework.api.transaction.CuratorTransactionFinal;
-import org.apache.curator.framework.api.transaction.CuratorTransactionResult;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.data.ACL;
@@ -22,8 +23,9 @@ import java.nio.charset.StandardCharsets;
 import java.util.*;
 
 /**
- * The CuratorPersistor implementation of the {@link Persister} interface
- * provides for persistence and retrieval of data from Zookeeper.
+ * The Curator implementation of the {@link Persister} interface provides for persistence and retrieval of data from
+ * Zookeeper. All paths passed to this instance are automatically namespaced within a framework-specific znode to avoid
+ * conflicts with other users of the same ZK instance.
  */
 public class CuratorPersister implements Persister {
 
@@ -35,11 +37,14 @@ public class CuratorPersister implements Persister {
      */
     private static final int ATOMIC_WRITE_ATTEMPTS = 3;
 
+    private final String serviceRootPath;
     private final CuratorFramework client;
+
     /**
      * Builder for constructing {@link CuratorPersister} instances.
      */
     public static class Builder {
+        private final String serviceName;
         private final String connectionString;
         private RetryPolicy retryPolicy;
         private String username;
@@ -47,12 +52,11 @@ public class CuratorPersister implements Persister {
 
         /**
          * Creates a new {@link Builder} instance which has been initialized with reasonable default values.
-         *
-         * @param zkConnectionString the zookeeper host:port
          */
-        private Builder(String zkConnectionString) {
+        private Builder(String serviceName, String zookeeperConnection) {
+            this.serviceName = serviceName;
             // Set defaults for customizable options:
-            this.connectionString = zkConnectionString;
+            this.connectionString = zookeeperConnection;
             this.retryPolicy = CuratorUtils.getDefaultRetry();
             this.username = "";
             this.password = "";
@@ -116,7 +120,7 @@ public class CuratorPersister implements Persister {
                         "username and password must both be provided, or both must be empty.");
             }
 
-            return new CuratorPersister(client);
+            return new CuratorPersister(serviceName, client);
         }
     }
 
@@ -126,88 +130,188 @@ public class CuratorPersister implements Persister {
      * @param serviceSpec the service for which data will be stored
      */
     public static Builder newBuilder(ServiceSpec serviceSpec) {
-        return newBuilder(serviceSpec.getZookeeperConnection());
+        return newBuilder(serviceSpec.getName(), serviceSpec.getZookeeperConnection());
     }
 
     /**
      * Creates a new {@link Builder} instance which has been initialized with reasonable default values.
      */
-    public static Builder newBuilder(String zkConnectionString) {
-        return new Builder(zkConnectionString);
+    @VisibleForTesting
+    public static Builder newBuilder(String serviceName, String zookeeperConnection) {
+        return new Builder(serviceName, zookeeperConnection);
     }
 
     @VisibleForTesting
-    CuratorPersister(CuratorFramework client) {
+    CuratorPersister(String serviceName, CuratorFramework client) {
+        this.serviceRootPath = CuratorUtils.getServiceRootPath(serviceName);
         this.client = client;
         this.client.start();
     }
 
     @Override
-    public void setMany(Map<String, byte[]> pathBytesMap) throws Exception {
-        if (pathBytesMap.isEmpty()) {
-            return;
+    public byte[] get(String unprefixedPath) throws PersisterException {
+        final String path = withFrameworkPrefix(unprefixedPath);
+        try {
+            return client.getData().forPath(path);
+        } catch (KeeperException.NoNodeException e) {
+            if (path.equals(serviceRootPath)) {
+                // Special case: Root is always present. Missing root should be treated as a root with no data.
+                return null;
+            }
+            throw new PersisterException(Reason.NOT_FOUND, String.format("Path to get does not exist: %s", path), e);
+        } catch (Exception e) {
+            throw new PersisterException(Reason.STORAGE_ERROR,
+                    String.format("Unable to retrieve data from %s", path), e);
         }
-        for (int i = 0; i < ATOMIC_WRITE_ATTEMPTS; ++i) {
-            // Phase 1: Determine which nodes already exist. This determination can be rendered
-            //          invalid by an out-of-band change to the data.
-            final Set<String> pathsWhichExist = selectPathsWhichExist(pathBytesMap.keySet());
-            List<String> parentPathsToCreate = getParentPathsToCreate(pathBytesMap.keySet(), pathsWhichExist);
+    }
 
-            logger.debug("Atomic write attempt {}/{}:\n-Parent paths: {}\n-All paths: {}\n-Paths which exist: {}",
-                    i + 1, ATOMIC_WRITE_ATTEMPTS, parentPathsToCreate, pathBytesMap.keySet(), pathsWhichExist);
+    @Override
+    public Collection<String> getChildren(String unprefixedPath) throws PersisterException {
+        final String path = withFrameworkPrefix(unprefixedPath);
+        try {
+            return new TreeSet<>(client.getChildren().forPath(path));
+        } catch (KeeperException.NoNodeException e) {
+            if (path.equals(serviceRootPath)) {
+                // Special case: Root is always present. Missing root should be treated as a root with no data.
+                return Collections.emptySet();
+            }
+            throw new PersisterException(Reason.NOT_FOUND, String.format("Path to list does not exist: %s", path), e);
+        } catch (Exception e) {
+            throw new PersisterException(Reason.STORAGE_ERROR, String.format("Unable to get children of %s", path), e);
+        }
+    }
 
-            // Phase 2: Compose a single transaction that updates and/or creates nodes according to
-            //          the above determinations (retry if there's an out-of-band modification)
-            final CuratorTransactionFinal transaction =
-                    getTransaction(pathBytesMap, pathsWhichExist, parentPathsToCreate);
-            if (i + 1 < ATOMIC_WRITE_ATTEMPTS) {
-                try {
-                    transaction.commit();
-                    break; // Success!
-                } catch (Exception e) {
-                    // Transaction failed! Bad connection? Existence check rendered invalid?
-                    // Swallow exception and try again
-                    logger.error(String.format("Failed to complete transaction attempt %d/%d: %s",
-                            i + 1, ATOMIC_WRITE_ATTEMPTS, transaction), e);
+    @Override
+    public void deleteAll(String unprefixedPath) throws PersisterException {
+        final String path = withFrameworkPrefix(unprefixedPath);
+        if (path.equals(serviceRootPath)) {
+            // Special case: If we're being told to delete root, we should instead delete the contents OF root. We don't
+            // have access to delete the root-level '/dcos-service-<svcname>' node itself, despite having created it.
+            /* Effective 5/8/2017:
+             * We cannot delete the root node of a service directly.
+             * This is due to the ACLs on the global DC/OS ZK.
+             *
+             * The root has:
+             * [zk: localhost:2181(CONNECTED) 1] getAcl /
+             * 'world,'anyone
+             * : cr
+             * 'ip,'127.0.0.1
+             * : cdrwa
+             *
+             * Our service nodes have:
+             * [zk: localhost:2181(CONNECTED) 0] getAcl /dcos-service-hello-world
+             * 'world,'anyone
+             * : cdrwa
+             *
+             * The best we can do is to wipe everything under the root node. A proposed way to "fix" things
+             * lives at https://jira.mesosphere.com/browse/INFINITY-1470.
+             */
+            logger.debug("Deleting children of root {}", path);
+            try {
+                CuratorTransactionFinal transaction = client.inTransaction().check().forPath(serviceRootPath).and();
+                for (String child : client.getChildren().forPath(serviceRootPath)) {
+                    // Custom logic for root-level children: don't delete the lock node
+                    if (child.equals(CuratorLocker.LOCK_PATH_NAME)) {
+                        continue;
+                    }
+                    String childPath = PersisterUtils.join(serviceRootPath, child);
+                    transaction = deleteChildrenOf(client, childPath, transaction)
+                            .delete().forPath(childPath).and();
                 }
-            } else {
-                // Last try: Any exception should be forwarded upstream
                 transaction.commit();
+            } catch (Exception e) {
+                throw new PersisterException(Reason.STORAGE_ERROR,
+                        String.format("Unable to delete children of root %s: %s", path, e.getMessage()), e);
+            }
+            // Need to explicitly set null or else curator will return a zero-bytes value later:
+            set(unprefixedPath, null);
+        } else {
+            // Normal case: Delete node itself and any/all children.
+            logger.debug("Deleting {} (and any children)", path);
+            try {
+                client.delete().deletingChildrenIfNeeded().forPath(path);
+            } catch (KeeperException.NoNodeException e) {
+                throw new PersisterException(
+                        Reason.NOT_FOUND, String.format("Path to delete does not exist: %s", path), e);
+            } catch (Exception e) {
+                throw new PersisterException(Reason.STORAGE_ERROR, String.format("Unable to delete %s", path), e);
             }
         }
     }
 
+    private static CuratorTransactionFinal deleteChildrenOf(
+            CuratorFramework client, String path, CuratorTransactionFinal curatorTransactionFinal) throws Exception {
+        // For each child: recurse into child (to delete any grandchildren, etc..), THEN delete child itself
+        for (String child : client.getChildren().forPath(path)) {
+            String childPath = PersisterUtils.join(path, child);
+            curatorTransactionFinal =
+                    deleteChildrenOf(client, childPath, curatorTransactionFinal) // RECURSE
+                    .delete().forPath(childPath).and();
+        }
+        return curatorTransactionFinal;
+    }
+
     @Override
-    public void set(String path, byte[] bytes) throws Exception {
+    public void set(String unprefixedPath, byte[] bytes) throws PersisterException {
+        final String path = withFrameworkPrefix(unprefixedPath);
+        logger.debug("Setting {} => {}", path, getInfo(bytes));
         try {
-            client.create().creatingParentsIfNeeded().forPath(path, bytes);
-        } catch (KeeperException.NodeExistsException e) {
-            client.setData().forPath(path, bytes);
+            try {
+                client.create().creatingParentsIfNeeded().forPath(path, bytes);
+            } catch (KeeperException.NodeExistsException e) {
+                client.setData().forPath(path, bytes);
+            }
+        } catch (Exception e) {
+            throw new PersisterException(Reason.STORAGE_ERROR,
+                    String.format("Unable to set %d bytes in %s", bytes.length, path), e);
         }
     }
 
     @Override
-    public byte[] get(String path) throws Exception {
-        return client.getData().forPath(path);
-    }
+    public void setMany(Map<String, byte[]> unprefixedPathBytesMap) throws PersisterException {
+        if (unprefixedPathBytesMap.isEmpty()) {
+            return;
+        }
+        // Convert map to translated prefixed paths:
+        Map<String, byte[]> pathBytesMap = new TreeMap<>(); // use consistent ordering
+        for (Map.Entry<String, byte[]> entry : unprefixedPathBytesMap.entrySet()) {
+            pathBytesMap.put(withFrameworkPrefix(entry.getKey()), entry.getValue());
+        }
+        logger.debug("Setting many entries: {}", pathBytesMap.keySet());
+        try {
+            for (int i = 0; i < ATOMIC_WRITE_ATTEMPTS; ++i) {
+                // Phase 1: Determine which nodes already exist. This determination can be rendered
+                //          invalid by an out-of-band change to the data.
+                final Set<String> pathsWhichExist = selectPathsWhichExist(pathBytesMap.keySet());
+                List<String> parentPathsToCreate = getParentPathsToCreate(pathBytesMap.keySet(), pathsWhichExist);
 
-    @Override
-    public void deleteAll(String path) throws Exception {
-        client.delete().deletingChildrenIfNeeded().forPath(path);
-    }
+                logger.debug("Atomic write attempt {}/{}:\n-Parent paths: {}\n-All paths: {}\n-Paths which exist: {}",
+                        i + 1, ATOMIC_WRITE_ATTEMPTS, parentPathsToCreate, pathBytesMap.keySet(), pathsWhichExist);
 
-    @Override
-    public Collection<String> getChildren(String path) throws Exception {
-        return new TreeSet<>(client.getChildren().forPath(path));
-    }
+                // Phase 2: Compose a single transaction that updates and/or creates nodes according to
+                //          the above determinations (retry if there's an out-of-band modification)
+                final CuratorTransactionFinal transaction =
+                        getWriteTransaction(pathBytesMap, pathsWhichExist, parentPathsToCreate);
 
-    public CuratorTransaction startTransaction() throws Exception {
-        return client.inTransaction();
-    }
-
-    public Collection<CuratorTransactionResult> commitTransaction(CuratorTransactionFinal curatorTransactionFinal)
-            throws Exception {
-        return curatorTransactionFinal.commit();
+                // Attempt to run the transaction, retrying if applicable:
+                if (i + 1 < ATOMIC_WRITE_ATTEMPTS) {
+                    try {
+                        transaction.commit();
+                        break; // Success!
+                    } catch (Exception e) {
+                        // Transaction failed! Bad connection? Existence check rendered invalid?
+                        // Swallow exception and try again
+                        logger.error(String.format("Failed to complete transaction attempt %d/%d: %s",
+                                i + 1, ATOMIC_WRITE_ATTEMPTS, transaction), e);
+                    }
+                } else {
+                    // Last try: Any exception should be forwarded upstream
+                    transaction.commit();
+                }
+            }
+        } catch (Exception e) {
+            throw new PersisterException(Reason.STORAGE_ERROR, e);
+        }
     }
 
     @Override
@@ -215,6 +319,9 @@ public class CuratorPersister implements Persister {
         client.close();
     }
 
+    /**
+     * Returns the subset of the provided (prefixed) paths which exist in ZK.
+     */
     private Set<String> selectPathsWhichExist(Set<String> paths) throws Exception {
         Set<String> pathsWhichExist = new HashSet<>();
         for (String path : paths) {
@@ -225,8 +332,10 @@ public class CuratorPersister implements Persister {
         return pathsWhichExist;
     }
 
-    private List<String> getParentPathsToCreate(Set<String> paths, Set<String> pathsWhichExist)
-            throws Exception {
+    /**
+     * Returns the list of parent paths which need to be created, given a list of paths which already exist.
+     */
+    private List<String> getParentPathsToCreate(Set<String> paths, Set<String> pathsWhichExist) throws Exception {
         List<String> parentPathsToCreate = new ArrayList<>();
         for (String path : paths) {
             if (pathsWhichExist.contains(path)) {
@@ -243,10 +352,9 @@ public class CuratorPersister implements Persister {
         return parentPathsToCreate;
     }
 
-    private CuratorTransactionFinal getTransaction(
-            Map<String, byte[]> pathBytesMap,
-            Set<String> pathsWhichExist,
-            List<String> parentPathsToCreate) throws Exception {
+    private CuratorTransactionFinal getWriteTransaction(
+            Map<String, byte[]> pathBytesMap, Set<String> pathsWhichExist, List<String> parentPathsToCreate)
+                    throws Exception {
         CuratorTransactionFinal transactionFinal = null;
         CuratorTransaction transaction = client.inTransaction();
         for (String parentPath : parentPathsToCreate) {
@@ -262,5 +370,27 @@ public class CuratorPersister implements Persister {
             transaction = transactionFinal;
         }
         return transactionFinal;
+    }
+
+    /**
+     * Maps the provided external path into a framework-namespaced path. This translation MUST be performed against all
+     * externally-provided paths, or else unintended data loss in ZK may result!!
+     *
+     * <p>Examples:
+     * <ul><li>"/foo" => "/dcos-service-svcname/foo"</li>
+     * <li>"/" => "/dcos-service-svcname"</li>
+     * <li>"" => "/dcos-service-svcname"</li></ul>
+     */
+    private String withFrameworkPrefix(String path) {
+        path = PersisterUtils.join(serviceRootPath, path);
+        // Avoid any trailing slashes, which lead to STORAGE_ERRORs:
+        while (path.endsWith(PersisterUtils.PATH_DELIM)) {
+            path = path.substring(0, path.length() - 1);
+        }
+        return path;
+    }
+
+    private static String getInfo(byte[] bytes) {
+        return bytes == null ? "NULL" : String.format("%d bytes", bytes.length);
     }
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/curator/CuratorUtils.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/curator/CuratorUtils.java
@@ -22,8 +22,7 @@ public class CuratorUtils {
      */
     public static RetryPolicy getDefaultRetry() {
         return new ExponentialBackoffRetry(
-                CuratorUtils.DEFAULT_CURATOR_POLL_DELAY_MS,
-                CuratorUtils.DEFAULT_CURATOR_MAX_RETRIES);
+                CuratorUtils.DEFAULT_CURATOR_POLL_DELAY_MS, CuratorUtils.DEFAULT_CURATOR_MAX_RETRIES);
     }
 
     /**

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/DefaultScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/DefaultScheduler.java
@@ -456,8 +456,9 @@ public class DefaultScheduler implements Scheduler, Observer {
      */
     public static StateStore createStateStore(
             ServiceSpec serviceSpec, SchedulerFlags schedulerFlags, CuratorPersister persister) {
-        StateStore stateStore = new DefaultStateStore(serviceSpec.getName(), persister);
+        StateStore stateStore = new DefaultStateStore(persister);
         if (schedulerFlags.isStateCacheEnabled()) {
+            // Wrap persister with a cache, so that we aren't constantly hitting ZK for state queries:
             return StateStoreCache.getInstance(stateStore);
         } else {
             return stateStore;
@@ -491,9 +492,7 @@ public class DefaultScheduler implements Scheduler, Observer {
             ServiceSpec serviceSpec, Collection<Class<?>> customDeserializationSubtypes, Persister persister)
                     throws ConfigStoreException {
         return new DefaultConfigStore<>(
-                DefaultServiceSpec.getConfigurationFactory(serviceSpec, customDeserializationSubtypes),
-                serviceSpec.getName(),
-                persister);
+                DefaultServiceSpec.getConfigurationFactory(serviceSpec, customDeserializationSubtypes), persister);
     }
 
     /**

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerFlags.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerFlags.java
@@ -1,6 +1,5 @@
 package com.mesosphere.sdk.scheduler;
 
-import com.mesosphere.sdk.state.StateStoreCache;
 import org.apache.mesos.Protos.Credential;
 
 import java.time.Duration;
@@ -68,7 +67,7 @@ public class SchedulerFlags {
     private static final String SDK_UNINSTALL = "SDK_UNINSTALL";
 
     /**
-     * Controls whether the {@link StateStoreCache} is disabled (enabled by default).
+     * Controls whether ZK write-through caching is disabled (enabled by default).
      * If this envvar is set (to anything at all), the cache is disabled.
      */
     private static final String DISABLE_STATE_CACHE_ENV = "DISABLE_STATE_CACHE";

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/state/DefaultConfigStore.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/state/DefaultConfigStore.java
@@ -4,12 +4,10 @@ import com.mesosphere.sdk.config.ConfigStore;
 import com.mesosphere.sdk.config.ConfigStoreException;
 import com.mesosphere.sdk.config.Configuration;
 import com.mesosphere.sdk.config.ConfigurationFactory;
-import com.mesosphere.sdk.curator.CuratorUtils;
 import com.mesosphere.sdk.storage.Persister;
+import com.mesosphere.sdk.storage.PersisterException;
 import com.mesosphere.sdk.storage.PersisterUtils;
 import com.mesosphere.sdk.storage.StorageError.Reason;
-
-import org.apache.zookeeper.KeeperException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -19,7 +17,7 @@ import java.util.Collection;
 import java.util.UUID;
 
 /**
- * Stores String Configurations in Zookeeper.
+ * An implementation of {@link ConfigStore} which relies on the provided {@link Persister} for data persistence.
  *
  * <p>The ZNode structure in Zookeeper is as follows:
  * <br>rootPath/
@@ -47,18 +45,16 @@ public class DefaultConfigStore<T extends Configuration> implements ConfigStore<
 
     private final ConfigurationFactory<T> factory;
     private final Persister persister;
-    private final String configurationsPath;
-    private final String targetPath;
 
     /**
      * Creates a new {@link ConfigStore} which uses the provided {@link Persister} to access configuration data.
      */
-    public DefaultConfigStore(ConfigurationFactory<T> factory, String frameworkName, Persister persister) {
+    public DefaultConfigStore(ConfigurationFactory<T> factory, Persister persister) {
         this.factory = factory;
         this.persister = persister;
 
         // Check version up-front:
-        int currentVersion = new DefaultSchemaVersionStore(persister, frameworkName).fetch();
+        int currentVersion = new DefaultSchemaVersionStore(persister).fetch();
         if (!SchemaVersionStore.isSupported(
                 currentVersion, MIN_SUPPORTED_SCHEMA_VERSION, MAX_SUPPORTED_SCHEMA_VERSION)) {
             throw new IllegalStateException(String.format(
@@ -66,10 +62,6 @@ public class DefaultConfigStore<T extends Configuration> implements ConfigStore<
                             "(support: min=%d, max=%d)",
                     currentVersion, MIN_SUPPORTED_SCHEMA_VERSION, MAX_SUPPORTED_SCHEMA_VERSION));
         }
-
-        final String rootPath = CuratorUtils.getServiceRootPath(frameworkName);
-        this.targetPath = PersisterUtils.join(rootPath, TARGET_PATH_NAME);
-        this.configurationsPath = PersisterUtils.join(rootPath, CONFIGURATIONS_PATH_NAME);
     }
 
     @Override
@@ -79,9 +71,9 @@ public class DefaultConfigStore<T extends Configuration> implements ConfigStore<
         byte[] data = config.getBytes();
         try {
             persister.set(path, data);
-        } catch (Exception e) {
-            throw new ConfigStoreException(Reason.STORAGE_ERROR, String.format(
-                    "Failed to store configuration to path '%s': %s", path, config), e);
+        } catch (PersisterException e) {
+            throw new ConfigStoreException(e, String.format(
+                    "Failed to store configuration to path '%s': %s", path, config));
         }
 
         return id;
@@ -93,12 +85,14 @@ public class DefaultConfigStore<T extends Configuration> implements ConfigStore<
         byte[] data;
         try {
             data = persister.get(path);
-        } catch (KeeperException.NoNodeException e) {
-            throw new ConfigStoreException(Reason.NOT_FOUND, String.format(
-                    "Configuration '%s' was not found at path '%s'", id, path), e);
-        } catch (Exception e) {
-            throw new ConfigStoreException(Reason.STORAGE_ERROR, String.format(
-                    "Failed to retrieve configuration '%s' from path '%s'", id, path), e);
+        } catch (PersisterException e) {
+            if (e.getReason() == Reason.NOT_FOUND) {
+                throw new ConfigStoreException(Reason.NOT_FOUND, String.format(
+                        "Configuration '%s' was not found at path '%s'", id, path), e);
+            } else {
+                throw new ConfigStoreException(e, String.format(
+                        "Failed to retrieve configuration '%s' from path '%s'", id, path));
+            }
         }
         return factory.parse(data);
     }
@@ -108,15 +102,15 @@ public class DefaultConfigStore<T extends Configuration> implements ConfigStore<
         String path = getConfigPath(id);
         try {
             persister.deleteAll(path);
-        } catch (KeeperException.NoNodeException e) {
-            // Clearing a non-existent Configuration should not
-            // result in an exception.
-            logger.warn("Requested configuration '{}' to be deleted does not exist at path '{}'",
-                    id, path);
-            return;
-        } catch (Exception e) {
-            throw new ConfigStoreException(Reason.STORAGE_ERROR, String.format(
-                    "Failed to delete configuration '%s' at path '%s'", id, path), e);
+        } catch (PersisterException e) {
+            if (e.getReason() == Reason.NOT_FOUND) {
+                // Clearing a non-existent Configuration should not result in an exception.
+                logger.warn("Requested configuration '{}' to be deleted does not exist at path '{}'", id, path);
+                return;
+            } else {
+                throw new ConfigStoreException(e, String.format(
+                        "Failed to delete configuration '%s' at path '%s'", id, path));
+            }
         }
     }
 
@@ -124,32 +118,36 @@ public class DefaultConfigStore<T extends Configuration> implements ConfigStore<
     public Collection<UUID> list() throws ConfigStoreException {
         try {
             Collection<UUID> ids = new ArrayList<>();
-            for (String id : persister.getChildren(configurationsPath)) {
-                ids.add(UUID.fromString(id));
+            for (String id : persister.getChildren(CONFIGURATIONS_PATH_NAME)) {
+                try {
+                    ids.add(UUID.fromString(id));
+                } catch (IllegalArgumentException e) {
+                    throw new ConfigStoreException(Reason.SERIALIZATION_ERROR,
+                            String.format("Invalid UUID value: %s", id), e);
+                }
             }
             return ids;
-        } catch (KeeperException.NoNodeException e) {
-            // Clearing a non-existent Configuration should not
-            // result in an exception.
-            logger.warn("Configuration list at path '{}' does not exist: returning empty list",
-                    configurationsPath);
-            return new ArrayList<>();
-        } catch (IllegalArgumentException e) {
-            throw new ConfigStoreException(Reason.SERIALIZATION_ERROR, String.format("Invalid UUID value"), e);
-        } catch (Exception e) {
-            throw new ConfigStoreException(Reason.STORAGE_ERROR, String.format(
-                    "Failed to retrieve list of configurations from '%s'", configurationsPath), e);
+        } catch (PersisterException e) {
+            if (e.getReason() == Reason.NOT_FOUND) {
+                // Clearing a non-existent Configuration should not result in an exception.
+                logger.warn("Configuration list at path '{}' does not exist: returning empty list",
+                        CONFIGURATIONS_PATH_NAME);
+                return new ArrayList<>();
+            } else {
+                throw new ConfigStoreException(Reason.STORAGE_ERROR, String.format(
+                        "Failed to retrieve list of configurations from '%s'", CONFIGURATIONS_PATH_NAME), e);
+            }
         }
     }
 
     @Override
     public void setTargetConfig(UUID id) throws ConfigStoreException {
         try {
-            persister.set(targetPath, id.toString().getBytes(StandardCharsets.UTF_8));
-        } catch (Exception e) {
-            throw new ConfigStoreException(Reason.STORAGE_ERROR, String.format(
+            persister.set(TARGET_PATH_NAME, id.toString().getBytes(StandardCharsets.UTF_8));
+        } catch (PersisterException e) {
+            throw new ConfigStoreException(e, String.format(
                     "Failed to assign current target configuration to '%s' at path '%s'",
-                    id, targetPath), e);
+                    id, TARGET_PATH_NAME));
         }
     }
 
@@ -157,15 +155,15 @@ public class DefaultConfigStore<T extends Configuration> implements ConfigStore<
     public UUID getTargetConfig() throws ConfigStoreException {
         String uuidStr;
         try {
-            uuidStr = new String(persister.get(targetPath), StandardCharsets.UTF_8);
-        } catch (KeeperException.NoNodeException e) {
-            throw new ConfigStoreException(Reason.NOT_FOUND, String.format(
-                    "Current target configuration couldn't be found at path '%s'",
-                    targetPath), e);
-        } catch (Exception e) {
-            throw new ConfigStoreException(Reason.STORAGE_ERROR, String.format(
-                    "Failed to retrieve current target configuration from path '%s'",
-                    targetPath), e);
+            uuidStr = new String(persister.get(TARGET_PATH_NAME), StandardCharsets.UTF_8);
+        } catch (PersisterException e) {
+            if (e.getReason() == Reason.NOT_FOUND) {
+                throw new ConfigStoreException(Reason.NOT_FOUND, String.format(
+                        "Current target configuration couldn't be found at path '%s'", TARGET_PATH_NAME), e);
+            } else {
+                throw new ConfigStoreException(e, String.format(
+                        "Failed to retrieve current target configuration from path '%s'", TARGET_PATH_NAME));
+            }
         }
         try {
             return UUID.fromString(uuidStr);
@@ -179,7 +177,7 @@ public class DefaultConfigStore<T extends Configuration> implements ConfigStore<
         persister.close();
     }
 
-    private String getConfigPath(UUID id) {
-        return PersisterUtils.join(configurationsPath, id.toString());
+    private static String getConfigPath(UUID id) {
+        return PersisterUtils.join(CONFIGURATIONS_PATH_NAME, id.toString());
     }
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/storage/Persister.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/storage/Persister.java
@@ -18,9 +18,9 @@ public interface Persister {
      * Retrieves the previously stored data at the specified path, or throws an exception if the path doesn't exist.
      * If the path is valid but has no data (i.e. is a parent of another path), this returns {@code null}.
      *
-     * @throws Exception if the requested path doesn't exist, or for other access errors
+     * @throws PersisterException if the requested path doesn't exist, or for other access errors
      */
-    byte[] get(String path) throws Exception;
+    byte[] get(String path) throws PersisterException;
 
     /**
      * Returns the names of child nodes at the provided path. Some returned nodes may have {@code null} data when
@@ -31,34 +31,34 @@ public interface Persister {
      *
      * <p>To get the list of nodes at the root, use "" or "/" as the input path.
      *
-     * @throws Exception if the requested path doesn't exist, or for other access errors
+     * @throws PersisterException if the requested path doesn't exist, or for other access errors
      */
-    Collection<String> getChildren(String path) throws Exception;
+    Collection<String> getChildren(String path) throws PersisterException;
 
     /**
      * Writes a single value to storage at the specified path, replacing any existing data at the path or creating the
      * path if it doesn't exist yet.
      *
-     * @throws Exception in the event of an access error
+     * @throws PersisterException in the event of an access error
      */
-    void set(String path, byte[] bytes) throws Exception;
+    void set(String path, byte[] bytes) throws PersisterException;
 
     /**
      * Atomically writes many values to storage at once.
      *
      * @see #set(String, byte[])
-     * @throws Exception in the event of an access error, in which case no changes should have been made
+     * @throws PersisterException in the event of an access error, in which case no changes should have been made
      */
-    void setMany(Map<String, byte[]> pathBytesMap) throws Exception;
+    void setMany(Map<String, byte[]> pathBytesMap) throws PersisterException;
 
     /**
      * Recursively deletes the data at the specified path, or throws an exception if no data existed at that location.
      *
      * <p>Deleting the root node (as "" or "/") will result in all nodes EXCEPT the root node being deleted.
      *
-     * @throws Exception if the data at the requested path didn't exist, or for other access errors
+     * @throws PersisterException if the data at the requested path didn't exist, or for other access errors
      */
-    void deleteAll(String path) throws Exception;
+    void deleteAll(String path) throws PersisterException;
 
     /**
      * Closes this storage and cleans up any local client resources. No other operations should be performed against the

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/storage/PersisterException.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/storage/PersisterException.java
@@ -1,38 +1,29 @@
-package com.mesosphere.sdk.state;
+package com.mesosphere.sdk.storage;
 
-import com.mesosphere.sdk.storage.PersisterException;
+import java.io.IOException;
+
 import com.mesosphere.sdk.storage.StorageError.Reason;
 
 /**
- * Exception that indicates that there was an issue with storing or accessing values in the state store.
+ * Exception that indicates that there was an issue with storing or accessing values in the persister.
  * The underlying exception from the storage implementation, if any, is intended to nested inside this exception for
  * developer understanding.
  */
-public class StateStoreException extends RuntimeException {
+public class PersisterException extends IOException {
 
     private final Reason reason;
 
-    public StateStoreException(PersisterException e) {
-        super(e);
-        this.reason = Reason.STORAGE_ERROR;
-    }
-
-    public StateStoreException(PersisterException e, String message) {
-        super(message, e);
-        this.reason = Reason.STORAGE_ERROR;
-    }
-
-    public StateStoreException(Reason reason, Throwable e) {
+    public PersisterException(Reason reason, Throwable e) {
         super(e);
         this.reason = reason;
     }
 
-    public StateStoreException(Reason reason, String message) {
+    public PersisterException(Reason reason, String message) {
         super(message);
         this.reason = reason;
     }
 
-    public StateStoreException(Reason reason, String message, Throwable cause) {
+    public PersisterException(Reason reason, String message, Throwable cause) {
         super(message, cause);
         this.reason = reason;
     }

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/curator/CuratorLockerTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/curator/CuratorLockerTest.java
@@ -5,7 +5,6 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import com.mesosphere.sdk.specification.ServiceSpec;
-import com.mesosphere.sdk.testutils.CuratorTestUtils;
 import com.mesosphere.sdk.testutils.TestConstants;
 
 import static org.junit.Assert.*;

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/curator/CuratorPersisterTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/curator/CuratorPersisterTest.java
@@ -12,14 +12,21 @@ import org.apache.curator.framework.api.transaction.TransactionCheckBuilder;
 import org.apache.curator.framework.api.transaction.TransactionCreateBuilder;
 import org.apache.curator.framework.api.transaction.TransactionDeleteBuilder;
 import org.apache.curator.framework.api.transaction.TransactionSetDataBuilder;
+import org.apache.curator.test.TestingServer;
 import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.data.ACL;
 import org.apache.zookeeper.data.Stat;
 import org.junit.*;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import com.mesosphere.sdk.state.DefaultStateStore;
+import com.mesosphere.sdk.specification.ServiceSpec;
+import com.mesosphere.sdk.storage.Persister;
+import com.mesosphere.sdk.storage.PersisterException;
+import com.mesosphere.sdk.storage.PersisterUtils;
+import com.mesosphere.sdk.storage.StorageError.Reason;
+import com.mesosphere.sdk.testutils.TestConstants;
 
 import java.nio.charset.Charset;
 import java.util.*;
@@ -28,7 +35,7 @@ import static org.junit.Assert.*;
 import static org.mockito.Mockito.when;
 
 /**
- * Tests to validate the operation of the {@link DefaultStateStore}.
+ * Tests for {@link CuratorPersister}.
  */
 public class CuratorPersisterTest {
     @Mock private CuratorFramework mockClient;
@@ -36,16 +43,29 @@ public class CuratorPersisterTest {
     @Mock private CuratorTransactionFinal mockTransactionFinal;
     @Mock private ExistsBuilder mockExistsBuilder;
     @Mock private Stat mockStat;
-    private CuratorPersister persister;
+    private CuratorPersister mockedPersister;
 
+    @Mock private ServiceSpec mockServiceSpec;
+    private static TestingServer testZk;
+
+    // Paths passed to the interface:
     private static final String PATH_PARENT = "/path";
     private static final String PATH_1 = "/path/1";
     private static final String PATH_2 = "/path/2";
-    private static final String PATH_SUB_PARENT = "/path/sub";
     private static final String PATH_SUB_1 = "/path/sub/1";
     private static final String PATH_SUB_2 = "/path/sub/2";
-    private static final List<String> PATHS = Arrays.asList(
-            PATH_PARENT, PATH_1, PATH_2, PATH_SUB_PARENT, PATH_SUB_1, PATH_SUB_2);
+
+    // Paths accessed internally (where stuff actually goes, prefixed with dcos-service-<svcname>):
+    private static final String INTERNAL_PATH_SERVICE = String.format("/dcos-service-%s", TestConstants.SERVICE_NAME);
+    private static final String INTERNAL_PATH_PARENT = String.format("/dcos-service-%s/path", TestConstants.SERVICE_NAME);
+    private static final String INTERNAL_PATH_1 = String.format("/dcos-service-%s/path/1", TestConstants.SERVICE_NAME);
+    private static final String INTERNAL_PATH_2 = String.format("/dcos-service-%s/path/2", TestConstants.SERVICE_NAME);
+    private static final String INTERNAL_PATH_SUB_PARENT = String.format("/dcos-service-%s/path/sub", TestConstants.SERVICE_NAME);
+    private static final String INTERNAL_PATH_SUB_1 = String.format("/dcos-service-%s/path/sub/1", TestConstants.SERVICE_NAME);
+    private static final String INTERNAL_PATH_SUB_2 = String.format("/dcos-service-%s/path/sub/2", TestConstants.SERVICE_NAME);
+    private static final List<String> INTERNAL_PATHS = Arrays.asList(
+            INTERNAL_PATH_SERVICE, INTERNAL_PATH_PARENT, INTERNAL_PATH_1, INTERNAL_PATH_2, INTERNAL_PATH_SUB_PARENT,
+            INTERNAL_PATH_SUB_1, INTERNAL_PATH_SUB_2);
 
     private static final byte[] DATA_1 = "one".getBytes(Charset.defaultCharset());
     private static final byte[] DATA_2 = "two".getBytes(Charset.defaultCharset());
@@ -60,197 +80,280 @@ public class CuratorPersisterTest {
         MANY_MAP.put(PATH_SUB_2, DATA_SUB_2);
     }
 
+    @BeforeClass
+    public static void beforeAll() throws Exception {
+        testZk = new TestingServer();
+    }
+
     @Before
     public void beforeEach() throws Exception {
         MockitoAnnotations.initMocks(this);
-        persister = new CuratorPersister(mockClient);
+
+        // easier than creating a real ServiceSpec just for two fields (zk connect string is set in tests):
+        when(mockServiceSpec.getName()).thenReturn(TestConstants.SERVICE_NAME);
+
+        mockedPersister = new CuratorPersister(TestConstants.SERVICE_NAME, mockClient);
     }
 
     @Test
     public void testSetManyAgainstEmptySucceeds() throws Exception {
         when(mockClient.checkExists()).thenReturn(mockExistsBuilder);
-        for (String path : PATHS) {
+        for (String path : INTERNAL_PATHS) {
             when(mockExistsBuilder.forPath(path)).thenReturn(null);
         }
         TestTransaction transaction = new TestTransaction(TestTransaction.Result.SUCCESS);
         when(mockClient.inTransaction()).thenReturn(transaction);
-        persister.setMany(MANY_MAP);
-        assertEquals(transaction.operations.toString(), 6, transaction.operations.size());
+        mockedPersister.setMany(MANY_MAP);
+        assertEquals(transaction.operations.toString(), 7, transaction.operations.size());
         TestOperation op = transaction.operations.get(0);
         assertEquals(TestOperation.Mode.CREATE, op.mode);
-        assertEquals(PATH_PARENT, op.path);
+        assertEquals(INTERNAL_PATH_SERVICE, op.path);
         assertNull(op.data);
         op = transaction.operations.get(1);
         assertEquals(TestOperation.Mode.CREATE, op.mode);
-        assertEquals(PATH_SUB_PARENT, op.path);
+        assertEquals(INTERNAL_PATH_PARENT, op.path);
         assertNull(op.data);
         op = transaction.operations.get(2);
         assertEquals(TestOperation.Mode.CREATE, op.mode);
-        assertEquals(PATH_1, op.path);
-        assertArrayEquals(DATA_1, op.data);
+        assertEquals(INTERNAL_PATH_SUB_PARENT, op.path);
+        assertNull(op.data);
         op = transaction.operations.get(3);
         assertEquals(TestOperation.Mode.CREATE, op.mode);
-        assertEquals(PATH_2, op.path);
-        assertArrayEquals(DATA_2, op.data);
+        assertEquals(INTERNAL_PATH_1, op.path);
+        assertArrayEquals(DATA_1, op.data);
         op = transaction.operations.get(4);
         assertEquals(TestOperation.Mode.CREATE, op.mode);
-        assertEquals(PATH_SUB_1, op.path);
-        assertArrayEquals(DATA_SUB_1, op.data);
+        assertEquals(INTERNAL_PATH_2, op.path);
+        assertArrayEquals(DATA_2, op.data);
         op = transaction.operations.get(5);
         assertEquals(TestOperation.Mode.CREATE, op.mode);
-        assertEquals(PATH_SUB_2, op.path);
+        assertEquals(INTERNAL_PATH_SUB_1, op.path);
+        assertArrayEquals(DATA_SUB_1, op.data);
+        op = transaction.operations.get(6);
+        assertEquals(TestOperation.Mode.CREATE, op.mode);
+        assertEquals(INTERNAL_PATH_SUB_2, op.path);
         assertArrayEquals(DATA_SUB_2, op.data);
     }
 
     @Test
     public void testSetManyAgainstPartialOnesSucceeds() throws Exception {
         when(mockClient.checkExists()).thenReturn(mockExistsBuilder);
-        when(mockExistsBuilder.forPath(PATH_PARENT)).thenReturn(mockStat);
-        when(mockExistsBuilder.forPath(PATH_1)).thenReturn(null);
-        when(mockExistsBuilder.forPath(PATH_2)).thenReturn(mockStat);
-        when(mockExistsBuilder.forPath(PATH_SUB_PARENT)).thenReturn(mockStat);
-        when(mockExistsBuilder.forPath(PATH_SUB_1)).thenReturn(null);
-        when(mockExistsBuilder.forPath(PATH_SUB_2)).thenReturn(mockStat);
+        when(mockExistsBuilder.forPath(INTERNAL_PATH_SERVICE)).thenReturn(mockStat);
+        when(mockExistsBuilder.forPath(INTERNAL_PATH_PARENT)).thenReturn(mockStat);
+        when(mockExistsBuilder.forPath(INTERNAL_PATH_1)).thenReturn(null);
+        when(mockExistsBuilder.forPath(INTERNAL_PATH_2)).thenReturn(mockStat);
+        when(mockExistsBuilder.forPath(INTERNAL_PATH_SUB_PARENT)).thenReturn(mockStat);
+        when(mockExistsBuilder.forPath(INTERNAL_PATH_SUB_1)).thenReturn(null);
+        when(mockExistsBuilder.forPath(INTERNAL_PATH_SUB_2)).thenReturn(mockStat);
         TestTransaction transaction = new TestTransaction(TestTransaction.Result.SUCCESS);
         when(mockClient.inTransaction()).thenReturn(transaction);
-        persister.setMany(MANY_MAP);
+        mockedPersister.setMany(MANY_MAP);
         assertEquals(transaction.operations.toString(), 4, transaction.operations.size());
         TestOperation op = transaction.operations.get(0);
         assertEquals(TestOperation.Mode.CREATE, op.mode);
-        assertEquals(PATH_1, op.path);
+        assertEquals(INTERNAL_PATH_1, op.path);
         assertArrayEquals(DATA_1, op.data);
         op = transaction.operations.get(1);
         assertEquals(TestOperation.Mode.SET_DATA, op.mode);
-        assertEquals(PATH_2, op.path);
+        assertEquals(INTERNAL_PATH_2, op.path);
         assertArrayEquals(DATA_2, op.data);
         op = transaction.operations.get(2);
         assertEquals(TestOperation.Mode.CREATE, op.mode);
-        assertEquals(PATH_SUB_1, op.path);
+        assertEquals(INTERNAL_PATH_SUB_1, op.path);
         assertArrayEquals(DATA_SUB_1, op.data);
         op = transaction.operations.get(3);
         assertEquals(TestOperation.Mode.SET_DATA, op.mode);
-        assertEquals(PATH_SUB_2, op.path);
+        assertEquals(INTERNAL_PATH_SUB_2, op.path);
         assertArrayEquals(DATA_SUB_2, op.data);
     }
 
     @Test
     public void testSetManyAgainstPartialRootsSucceeds() throws Exception {
         when(mockClient.checkExists()).thenReturn(mockExistsBuilder);
-        when(mockExistsBuilder.forPath(PATH_PARENT)).thenReturn(null);
-        when(mockExistsBuilder.forPath(PATH_1)).thenReturn(null);
-        when(mockExistsBuilder.forPath(PATH_2)).thenReturn(null);
-        when(mockExistsBuilder.forPath(PATH_SUB_PARENT)).thenReturn(mockStat);
-        when(mockExistsBuilder.forPath(PATH_SUB_1)).thenReturn(mockStat);
-        when(mockExistsBuilder.forPath(PATH_SUB_2)).thenReturn(mockStat);
+        when(mockExistsBuilder.forPath(INTERNAL_PATH_SERVICE)).thenReturn(mockStat);
+        when(mockExistsBuilder.forPath(INTERNAL_PATH_PARENT)).thenReturn(null);
+        when(mockExistsBuilder.forPath(INTERNAL_PATH_1)).thenReturn(null);
+        when(mockExistsBuilder.forPath(INTERNAL_PATH_2)).thenReturn(null);
+        when(mockExistsBuilder.forPath(INTERNAL_PATH_SUB_PARENT)).thenReturn(mockStat);
+        when(mockExistsBuilder.forPath(INTERNAL_PATH_SUB_1)).thenReturn(mockStat);
+        when(mockExistsBuilder.forPath(INTERNAL_PATH_SUB_2)).thenReturn(mockStat);
         TestTransaction transaction = new TestTransaction(TestTransaction.Result.SUCCESS);
         when(mockClient.inTransaction()).thenReturn(transaction);
-        persister.setMany(MANY_MAP);
+        mockedPersister.setMany(MANY_MAP);
         assertEquals(transaction.operations.toString(), 5, transaction.operations.size());
         TestOperation op = transaction.operations.get(0);
         assertEquals(TestOperation.Mode.CREATE, op.mode);
-        assertEquals(PATH_PARENT, op.path);
+        assertEquals(INTERNAL_PATH_PARENT, op.path);
         assertNull(op.data);
         op = transaction.operations.get(1);
         assertEquals(TestOperation.Mode.CREATE, op.mode);
-        assertEquals(PATH_1, op.path);
+        assertEquals(INTERNAL_PATH_1, op.path);
         assertArrayEquals(DATA_1, op.data);
         op = transaction.operations.get(2);
         assertEquals(TestOperation.Mode.CREATE, op.mode);
-        assertEquals(PATH_2, op.path);
+        assertEquals(INTERNAL_PATH_2, op.path);
         assertArrayEquals(DATA_2, op.data);
         op = transaction.operations.get(3);
         assertEquals(TestOperation.Mode.SET_DATA, op.mode);
-        assertEquals(PATH_SUB_1, op.path);
+        assertEquals(INTERNAL_PATH_SUB_1, op.path);
         assertArrayEquals(DATA_SUB_1, op.data);
         op = transaction.operations.get(4);
         assertEquals(TestOperation.Mode.SET_DATA, op.mode);
-        assertEquals(PATH_SUB_2, op.path);
+        assertEquals(INTERNAL_PATH_SUB_2, op.path);
         assertArrayEquals(DATA_SUB_2, op.data);
     }
 
     @Test
     public void testSetManyAgainstPartialSubsSucceeds() throws Exception {
         when(mockClient.checkExists()).thenReturn(mockExistsBuilder);
-        when(mockExistsBuilder.forPath(PATH_PARENT)).thenReturn(mockStat);
-        when(mockExistsBuilder.forPath(PATH_1)).thenReturn(mockStat);
-        when(mockExistsBuilder.forPath(PATH_2)).thenReturn(mockStat);
-        when(mockExistsBuilder.forPath(PATH_SUB_PARENT)).thenReturn(null);
-        when(mockExistsBuilder.forPath(PATH_SUB_1)).thenReturn(null);
-        when(mockExistsBuilder.forPath(PATH_SUB_2)).thenReturn(null);
+        when(mockExistsBuilder.forPath(INTERNAL_PATH_SERVICE)).thenReturn(mockStat);
+        when(mockExistsBuilder.forPath(INTERNAL_PATH_PARENT)).thenReturn(mockStat);
+        when(mockExistsBuilder.forPath(INTERNAL_PATH_1)).thenReturn(mockStat);
+        when(mockExistsBuilder.forPath(INTERNAL_PATH_2)).thenReturn(mockStat);
+        when(mockExistsBuilder.forPath(INTERNAL_PATH_SUB_PARENT)).thenReturn(null);
+        when(mockExistsBuilder.forPath(INTERNAL_PATH_SUB_1)).thenReturn(null);
+        when(mockExistsBuilder.forPath(INTERNAL_PATH_SUB_2)).thenReturn(null);
         TestTransaction transaction = new TestTransaction(TestTransaction.Result.SUCCESS);
         when(mockClient.inTransaction()).thenReturn(transaction);
-        persister.setMany(MANY_MAP);
+        mockedPersister.setMany(MANY_MAP);
         assertEquals(transaction.operations.toString(), 5, transaction.operations.size());
         TestOperation op = transaction.operations.get(0);
         assertEquals(TestOperation.Mode.CREATE, op.mode);
-        assertEquals(PATH_SUB_PARENT, op.path);
+        assertEquals(INTERNAL_PATH_SUB_PARENT, op.path);
         assertNull(op.data);
         op = transaction.operations.get(1);
         assertEquals(TestOperation.Mode.SET_DATA, op.mode);
-        assertEquals(PATH_1, op.path);
+        assertEquals(INTERNAL_PATH_1, op.path);
         assertArrayEquals(DATA_1, op.data);
         op = transaction.operations.get(2);
         assertEquals(TestOperation.Mode.SET_DATA, op.mode);
-        assertEquals(PATH_2, op.path);
+        assertEquals(INTERNAL_PATH_2, op.path);
         assertArrayEquals(DATA_2, op.data);
         op = transaction.operations.get(3);
         assertEquals(TestOperation.Mode.CREATE, op.mode);
-        assertEquals(PATH_SUB_1, op.path);
+        assertEquals(INTERNAL_PATH_SUB_1, op.path);
         assertArrayEquals(DATA_SUB_1, op.data);
         op = transaction.operations.get(4);
         assertEquals(TestOperation.Mode.CREATE, op.mode);
-        assertEquals(PATH_SUB_2, op.path);
+        assertEquals(INTERNAL_PATH_SUB_2, op.path);
         assertArrayEquals(DATA_SUB_2, op.data);
     }
 
     @Test
     public void testSetManyAgainstFullSucceeds() throws Exception {
         when(mockClient.checkExists()).thenReturn(mockExistsBuilder);
-        for (String path : PATHS) {
+        for (String path : INTERNAL_PATHS) {
             when(mockExistsBuilder.forPath(path)).thenReturn(mockStat);
         }
         TestTransaction transaction = new TestTransaction(TestTransaction.Result.SUCCESS);
         when(mockClient.inTransaction()).thenReturn(transaction);
-        persister.setMany(MANY_MAP);
+        mockedPersister.setMany(MANY_MAP);
         assertEquals(transaction.operations.toString(), 4, transaction.operations.size());
         TestOperation op = transaction.operations.get(0);
         assertEquals(TestOperation.Mode.SET_DATA, op.mode);
-        assertEquals(PATH_1, op.path);
+        assertEquals(INTERNAL_PATH_1, op.path);
         assertArrayEquals(DATA_1, op.data);
         op = transaction.operations.get(1);
         assertEquals(TestOperation.Mode.SET_DATA, op.mode);
-        assertEquals(PATH_2, op.path);
+        assertEquals(INTERNAL_PATH_2, op.path);
         assertArrayEquals(DATA_2, op.data);
         op = transaction.operations.get(2);
         assertEquals(TestOperation.Mode.SET_DATA, op.mode);
-        assertEquals(PATH_SUB_1, op.path);
+        assertEquals(INTERNAL_PATH_SUB_1, op.path);
         assertArrayEquals(DATA_SUB_1, op.data);
         op = transaction.operations.get(3);
         assertEquals(TestOperation.Mode.SET_DATA, op.mode);
-        assertEquals(PATH_SUB_2, op.path);
+        assertEquals(INTERNAL_PATH_SUB_2, op.path);
         assertArrayEquals(DATA_SUB_2, op.data);
     }
 
-    @Test(expected=TestTransaction.TestException.class)
+    @Test(expected=PersisterException.class)
     public void testSetManyAgainstEmptyFails() throws Exception {
         when(mockClient.checkExists()).thenReturn(mockExistsBuilder);
-        for (String path : PATHS) {
+        for (String path : INTERNAL_PATHS) {
             when(mockExistsBuilder.forPath(path)).thenReturn(null);
         }
         TestTransaction transaction = new TestTransaction(TestTransaction.Result.EXCEPTION);
         when(mockClient.inTransaction()).thenReturn(transaction);
-        persister.setMany(MANY_MAP);
+        mockedPersister.setMany(MANY_MAP);
     }
 
-    @Test(expected=TestTransaction.TestException.class)
+    @Test(expected=PersisterException.class)
     public void testSetManyAgainstFullFails() throws Exception {
         when(mockClient.checkExists()).thenReturn(mockExistsBuilder);
-        for (String path : PATHS) {
+        for (String path : INTERNAL_PATHS) {
             when(mockExistsBuilder.forPath(path)).thenReturn(mockStat);
         }
         TestTransaction transaction = new TestTransaction(TestTransaction.Result.EXCEPTION);
         when(mockClient.inTransaction()).thenReturn(transaction);
-        persister.setMany(MANY_MAP);
+        mockedPersister.setMany(MANY_MAP);
+    }
+
+    // Uses a real ZK instance to ensure that our integration works as expected:
+    @Test
+    public void testAclBehavior() throws Exception {
+        CuratorTestUtils.clear(testZk);
+        when(mockServiceSpec.getZookeeperConnection()).thenReturn(testZk.getConnectString());
+        Persister nonAclPersister = CuratorPersister.newBuilder(mockServiceSpec).build();
+        Persister aclPersister = CuratorPersister.newBuilder(mockServiceSpec).setCredentials("testuser", "testpw").build();
+
+        // Store value with ACL.
+        aclPersister.set(PATH_1, DATA_1);
+
+        // Readable with appropriate Auth and ACL.
+        assertArrayEquals(DATA_1, aclPersister.get(PATH_1));
+
+        // Readable with world:anyone permission.
+        assertArrayEquals(DATA_1, nonAclPersister.get(PATH_1));
+
+        // Not overwriteable with world:anyone permission.
+        try {
+            nonAclPersister.set(PATH_1, DATA_2);
+            fail("Should have failed with auth exception");
+        } catch (PersisterException e) {
+            assertEquals(Reason.STORAGE_ERROR, e.getReason());
+            assertTrue(e.getCause() instanceof KeeperException.NoAuthException);
+        }
+
+        // Not overwriteable with incorrect Auth
+        try {
+            Persister wrongAclPersister = CuratorPersister.newBuilder(mockServiceSpec)
+                    .setCredentials("testuser", "otherpw").build();
+            wrongAclPersister.set(PATH_1, DATA_SUB_1);
+            fail("Should have failed with auth exception");
+        } catch ( PersisterException e ) {
+            assertEquals(Reason.STORAGE_ERROR, e.getReason());
+            assertTrue(e.getCause() instanceof KeeperException.NoAuthException);
+        }
+
+        // Delete ACL'ed data so that other tests don't have ACL problems trying to clear it:
+        aclPersister.deleteAll(PATH_PARENT);
+    }
+
+    // Uses a real ZK instance to ensure that our integration works as expected:
+    @Test
+    public void testDeleteRoot() throws Exception {
+        CuratorTestUtils.clear(testZk);
+        when(mockServiceSpec.getZookeeperConnection()).thenReturn(testZk.getConnectString());
+        Persister persister = CuratorPersister.newBuilder(mockServiceSpec).build();
+
+        persister.set("lock", DATA_1);
+        persister.set("a", DATA_2);
+        persister.set("a/1", DATA_1);
+        persister.set("a/lock", DATA_2);
+        persister.set("a/2/a", DATA_1);
+        persister.set("a/3", DATA_2);
+        persister.set("a/3/a/1", DATA_1);
+        persister.set("b", DATA_2);
+        persister.set("c", DATA_1);
+        persister.set("d/1/a/1", DATA_2);
+
+        persister.deleteAll("");
+
+        // The root-level "lock" is preserved:
+        assertEquals(Collections.singleton("lock"), persister.getChildren(""));
+        assertArrayEquals(DATA_1, persister.get("lock"));
+        assertEquals(Collections.singleton("/lock"), PersisterUtils.getAllKeys(persister));
     }
 
     /**

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/curator/CuratorTestUtils.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/curator/CuratorTestUtils.java
@@ -1,4 +1,4 @@
-package com.mesosphere.sdk.testutils;
+package com.mesosphere.sdk.curator;
 
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
@@ -16,7 +16,9 @@ public class CuratorTestUtils {
     public static final String PASSWORD = "testpassword";
 
     public static void clear(TestingServer testingServer) throws Exception {
-        CuratorFramework client = getClient(testingServer);
+        CuratorFramework client = CuratorFrameworkFactory.newClient(
+                testingServer.getConnectString(),
+                new RetryOneTime(RETRY_DELAY_MS));
         client.start();
 
         for (String rootNode : client.getChildren().forPath("/")) {
@@ -26,11 +28,5 @@ public class CuratorTestUtils {
         }
 
         client.close();
-    }
-
-    private static CuratorFramework getClient(TestingServer testingServer) {
-        return CuratorFrameworkFactory.newClient(
-                testingServer.getConnectString(),
-                new RetryOneTime(RETRY_DELAY_MS));
     }
 }

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluatorTestBase.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluatorTestBase.java
@@ -1,12 +1,12 @@
 package com.mesosphere.sdk.offer.evaluate;
 
 import com.mesosphere.sdk.curator.CuratorPersister;
+import com.mesosphere.sdk.curator.CuratorTestUtils;
 import com.mesosphere.sdk.offer.DefaultOfferRequirementProvider;
 import com.mesosphere.sdk.offer.OfferRequirementProvider;
 import com.mesosphere.sdk.scheduler.SchedulerFlags;
 import com.mesosphere.sdk.state.DefaultStateStore;
 import com.mesosphere.sdk.state.StateStore;
-import com.mesosphere.sdk.testutils.CuratorTestUtils;
 import com.mesosphere.sdk.testutils.OfferRequirementTestUtils;
 import com.mesosphere.sdk.testutils.TestConstants;
 import org.apache.curator.test.TestingServer;
@@ -24,7 +24,6 @@ import java.util.UUID;
 public class OfferEvaluatorTestBase {
     protected static final SchedulerFlags flags = OfferRequirementTestUtils.getTestSchedulerFlags();
 
-    protected static final String ROOT_ZK_PATH = "/test-root-path";
     static TestingServer testZk; // Findbugs wants this to be package-protected for some reason
 
     protected OfferRequirementProvider offerRequirementProvider;
@@ -40,8 +39,8 @@ public class OfferEvaluatorTestBase {
     public void beforeEach() throws Exception {
         CuratorTestUtils.clear(testZk);
         MockitoAnnotations.initMocks(this);
-        stateStore =
-                new DefaultStateStore(ROOT_ZK_PATH, CuratorPersister.newBuilder(testZk.getConnectString()).build());
+        stateStore = new DefaultStateStore(
+                CuratorPersister.newBuilder(TestConstants.SERVICE_NAME, testZk.getConnectString()).build());
         offerRequirementProvider =
                 new DefaultOfferRequirementProvider(stateStore, TestConstants.SERVICE_NAME, UUID.randomUUID(), flags);
         evaluator = new OfferEvaluator(stateStore, offerRequirementProvider);

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/plan/DefaultPlanCoordinatorTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/plan/DefaultPlanCoordinatorTest.java
@@ -2,6 +2,7 @@ package com.mesosphere.sdk.scheduler.plan;
 
 import com.mesosphere.sdk.config.ConfigStore;
 import com.mesosphere.sdk.curator.CuratorPersister;
+import com.mesosphere.sdk.curator.CuratorTestUtils;
 import com.mesosphere.sdk.offer.DefaultOfferRequirementProvider;
 import com.mesosphere.sdk.offer.OfferAccepter;
 import com.mesosphere.sdk.offer.evaluate.OfferEvaluator;
@@ -15,7 +16,6 @@ import com.mesosphere.sdk.specification.ServiceSpec;
 import com.mesosphere.sdk.specification.TestPodFactory;
 import com.mesosphere.sdk.state.DefaultStateStore;
 import com.mesosphere.sdk.state.StateStore;
-import com.mesosphere.sdk.testutils.CuratorTestUtils;
 import com.mesosphere.sdk.testutils.OfferRequirementTestUtils;
 import com.mesosphere.sdk.testutils.OfferTestUtils;
 import com.mesosphere.sdk.testutils.ResourceTestUtils;
@@ -116,7 +116,7 @@ public class DefaultPlanCoordinatorTest {
                 .pods(Arrays.asList(podA))
                 .build();
         stateStore = new DefaultStateStore(
-                serviceSpecification.getName(), CuratorPersister.newBuilder(testingServer.getConnectString()).build());
+                CuratorPersister.newBuilder(serviceSpecification.getName(), testingServer.getConnectString()).build());
         stepFactory = new DefaultStepFactory(mock(ConfigStore.class), stateStore);
         phaseFactory = new DefaultPhaseFactory(stepFactory);
         taskKiller = new DefaultTaskKiller(taskFailureListener, schedulerDriver);

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/plan/DefaultStepFactoryTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/plan/DefaultStepFactoryTest.java
@@ -3,15 +3,15 @@ package com.mesosphere.sdk.scheduler.plan;
 import org.apache.curator.test.TestingServer;
 import com.mesosphere.sdk.config.ConfigStore;
 import com.mesosphere.sdk.curator.CuratorPersister;
+import com.mesosphere.sdk.curator.CuratorTestUtils;
 import com.mesosphere.sdk.scheduler.DefaultScheduler;
 import com.mesosphere.sdk.scheduler.SchedulerFlags;
 import com.mesosphere.sdk.specification.*;
 import com.mesosphere.sdk.state.DefaultStateStore;
 import com.mesosphere.sdk.state.StateStore;
-import com.mesosphere.sdk.testutils.CuratorTestUtils;
+import com.mesosphere.sdk.storage.Persister;
 import com.mesosphere.sdk.testutils.OfferRequirementTestUtils;
 import com.mesosphere.sdk.testutils.TestConstants;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -37,10 +37,6 @@ public class DefaultStepFactoryTest {
     @BeforeClass
     public static void beforeAll() throws Exception {
         testingServer = new TestingServer();
-    }
-
-    @Before
-    public void beforeEach() throws Exception {
     }
 
     @Test(expected = Step.InvalidStepException.class)
@@ -86,13 +82,10 @@ public class DefaultStepFactoryTest {
 
         CuratorTestUtils.clear(testingServer);
 
-        stateStore = new DefaultStateStore(
-                "test-framework-name", CuratorPersister.newBuilder(testingServer.getConnectString()).build());
-
-        configStore = DefaultScheduler.createConfigStore(
-                serviceSpec,
-                Collections.emptyList(),
-                CuratorPersister.newBuilder(testingServer.getConnectString()).build());
+        Persister persister =
+                CuratorPersister.newBuilder(TestConstants.SERVICE_NAME, testingServer.getConnectString()).build();
+        stateStore = new DefaultStateStore(persister);
+        configStore = DefaultScheduler.createConfigStore(serviceSpec, Collections.emptyList(), persister);
 
         UUID configId = configStore.store(serviceSpec);
         configStore.setTargetConfig(configId);
@@ -127,13 +120,10 @@ public class DefaultStepFactoryTest {
 
         CuratorTestUtils.clear(testingServer);
 
-        stateStore = new DefaultStateStore(
-                "test-framework-name", CuratorPersister.newBuilder(testingServer.getConnectString()).build());
-
-        configStore = DefaultScheduler.createConfigStore(
-                serviceSpec,
-                Collections.emptyList(),
-                CuratorPersister.newBuilder(testingServer.getConnectString()).build());
+        Persister persister =
+                CuratorPersister.newBuilder(TestConstants.SERVICE_NAME, testingServer.getConnectString()).build();
+        stateStore = new DefaultStateStore(persister);
+        configStore = DefaultScheduler.createConfigStore(serviceSpec, Collections.emptyList(), persister);
 
         UUID configId = configStore.store(serviceSpec);
         configStore.setTargetConfig(configId);

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/recovery/DefaultRecoveryPlanManagerTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/recovery/DefaultRecoveryPlanManagerTest.java
@@ -2,6 +2,7 @@ package com.mesosphere.sdk.scheduler.recovery;
 
 import com.mesosphere.sdk.config.ConfigStore;
 import com.mesosphere.sdk.curator.CuratorPersister;
+import com.mesosphere.sdk.curator.CuratorTestUtils;
 import com.mesosphere.sdk.offer.*;
 import com.mesosphere.sdk.offer.evaluate.OfferEvaluator;
 import com.mesosphere.sdk.offer.taskdata.SchedulerLabelWriter;
@@ -16,7 +17,7 @@ import com.mesosphere.sdk.specification.*;
 import com.mesosphere.sdk.specification.yaml.YAMLServiceSpecFactory;
 import com.mesosphere.sdk.state.DefaultStateStore;
 import com.mesosphere.sdk.state.StateStore;
-import com.mesosphere.sdk.testutils.CuratorTestUtils;
+import com.mesosphere.sdk.storage.Persister;
 import com.mesosphere.sdk.testutils.OfferRequirementTestUtils;
 import com.mesosphere.sdk.testutils.OfferTestUtils;
 import com.mesosphere.sdk.testutils.ResourceTestUtils;
@@ -109,8 +110,9 @@ public class DefaultRecoveryPlanManagerTest {
         failureMonitor = spy(new TestingFailureMonitor());
         launchConstrainer = spy(new TestingLaunchConstrainer());
         offerAccepter = mock(OfferAccepter.class);
-        CuratorPersister persister = CuratorPersister.newBuilder(testingServer.getConnectString()).build();
-        stateStore = new DefaultStateStore(TestConstants.SERVICE_NAME, persister);
+        Persister persister =
+                CuratorPersister.newBuilder(TestConstants.SERVICE_NAME, testingServer.getConnectString()).build();
+        stateStore = new DefaultStateStore(persister);
 
         serviceSpec = YAMLServiceSpecFactory.generateServiceSpec(
                 YAMLServiceSpecFactory.generateRawSpecFromYAML(new File(getClass()

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/uninstall/UninstallSchedulerDeregisterTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/uninstall/UninstallSchedulerDeregisterTest.java
@@ -31,8 +31,7 @@ public class UninstallSchedulerDeregisterTest {
         StateStoreCache.resetInstanceForTests();
 
         StateStore stateStore = StateStoreCache.getInstance(new DefaultStateStore(
-                "testing-uninstall",
-                CuratorPersister.newBuilder(testingServer.getConnectString()).build()));
+                CuratorPersister.newBuilder("testing-uninstall", testingServer.getConnectString()).build()));
 
         // No framework ID is set yet, and there are no tasks, and no ScheduleDriver
         uninstallScheduler = new UninstallScheduler(0, Duration.ofSeconds(1), stateStore, configStore);

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/uninstall/UninstallSchedulerTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/uninstall/UninstallSchedulerTest.java
@@ -76,7 +76,7 @@ public class UninstallSchedulerTest {
         StateStoreCache.resetInstanceForTests();
 
         stateStore = StateStoreCache.getInstance(new DefaultStateStore(
-                "testing-uninstall", CuratorPersister.newBuilder(testingServer.getConnectString()).build()));
+                CuratorPersister.newBuilder("testing-uninstall", testingServer.getConnectString()).build()));
 
         stateStore.storeTasks(Collections.singletonList(TASK_A));
         stateStore.storeFrameworkId(TestConstants.FRAMEWORK_ID);

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/specification/DefaultPlanGeneratorTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/specification/DefaultPlanGeneratorTest.java
@@ -2,6 +2,7 @@ package com.mesosphere.sdk.specification;
 
 import com.mesosphere.sdk.config.ConfigStore;
 import com.mesosphere.sdk.curator.CuratorPersister;
+import com.mesosphere.sdk.curator.CuratorTestUtils;
 import com.mesosphere.sdk.scheduler.DefaultScheduler;
 import com.mesosphere.sdk.scheduler.SchedulerFlags;
 import com.mesosphere.sdk.scheduler.plan.Phase;
@@ -12,7 +13,6 @@ import com.mesosphere.sdk.specification.yaml.RawServiceSpec;
 import com.mesosphere.sdk.specification.yaml.YAMLServiceSpecFactory;
 import com.mesosphere.sdk.state.StateStore;
 import com.mesosphere.sdk.state.StateStoreCache;
-import com.mesosphere.sdk.testutils.CuratorTestUtils;
 import com.mesosphere.sdk.testutils.OfferRequirementTestUtils;
 import org.apache.curator.test.TestingServer;
 import org.junit.*;
@@ -57,7 +57,8 @@ public class DefaultPlanGeneratorTest {
         RawServiceSpec rawServiceSpec = YAMLServiceSpecFactory.generateRawSpecFromYAML(file);
         DefaultServiceSpec serviceSpec = YAMLServiceSpecFactory.generateServiceSpec(rawServiceSpec, flags);
 
-        CuratorPersister persister = CuratorPersister.newBuilder(testingServer.getConnectString()).build();
+        CuratorPersister persister = CuratorPersister.newBuilder(
+                serviceSpec.getName(), testingServer.getConnectString()).build();
         stateStore = DefaultScheduler.createStateStore(serviceSpec, flags, persister);
         configStore = DefaultScheduler.createConfigStore(serviceSpec, Collections.emptyList(), persister);
 

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/specification/DefaultServiceSpecTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/specification/DefaultServiceSpecTest.java
@@ -699,7 +699,8 @@ public class DefaultServiceSpecTest {
 
 
         TestingServer testingServer = new TestingServer();
-        CuratorPersister persister = CuratorPersister.newBuilder(testingServer.getConnectString()).build();
+        CuratorPersister persister =
+                CuratorPersister.newBuilder(serviceSpec.getName(), testingServer.getConnectString()).build();
         StateStoreCache.resetInstanceForTests();
         StateStore stateStore = DefaultScheduler.createStateStore(serviceSpec, flags, persister);
         ConfigStore<ServiceSpec> configStore =

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/state/DefaultSchemaVersionStoreTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/state/DefaultSchemaVersionStoreTest.java
@@ -1,9 +1,12 @@
 package com.mesosphere.sdk.state;
 
 import com.mesosphere.sdk.curator.CuratorPersister;
-import com.mesosphere.sdk.testutils.CuratorTestUtils;
+import com.mesosphere.sdk.curator.CuratorTestUtils;
+import com.mesosphere.sdk.storage.Persister;
+import com.mesosphere.sdk.storage.PersisterException;
+import com.mesosphere.sdk.storage.StorageError.Reason;
+
 import org.apache.curator.test.TestingServer;
-import org.apache.zookeeper.KeeperException;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -17,22 +20,16 @@ import static org.junit.Assert.*;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 
-/**
- * Tests for {@link DefaultSchemaVersionStore}.
- */
 public class DefaultSchemaVersionStoreTest {
+
     private static final Charset CHARSET = StandardCharsets.UTF_8;
-    private static final String ROOT_ZK_PATH = "/test-root-path";
-    private static final String PREFIXED_ROOT_ZK_PATH = "/dcos-service-test-root-path";
     // This value must never change. If you're changing it, you're wrong:
-    private static final String NODE_PATH = PREFIXED_ROOT_ZK_PATH + "/SchemaVersion";
+    private static final String NODE_PATH = "SchemaVersion";
 
     private static TestingServer testZk;
-    private CuratorPersister curator;
-    private CuratorPersister curatorWithAcl;
-    @Mock CuratorPersister mockCurator;
+    private Persister persister;
+    @Mock Persister mockPersister;
     private SchemaVersionStore store;
-    private SchemaVersionStore storeWithAcl;
     private SchemaVersionStore store2;
     private SchemaVersionStore storeWithMock;
 
@@ -45,21 +42,16 @@ public class DefaultSchemaVersionStoreTest {
     public void beforeEach() throws Exception {
         MockitoAnnotations.initMocks(this);
         CuratorTestUtils.clear(testZk);
-        curator = CuratorPersister.newBuilder(testZk.getConnectString()).build();
-        curatorWithAcl = CuratorPersister.newBuilder(testZk.getConnectString())
-                .setCredentials(CuratorTestUtils.USERNAME, CuratorTestUtils.PASSWORD)
-                .build();
-        store = new DefaultSchemaVersionStore(curator, ROOT_ZK_PATH);
-        storeWithAcl = new DefaultSchemaVersionStore(curatorWithAcl, ROOT_ZK_PATH);
-        store2 = new DefaultSchemaVersionStore(curator, ROOT_ZK_PATH);
-        storeWithMock = new DefaultSchemaVersionStore(mockCurator, ROOT_ZK_PATH);
+        persister = CuratorPersister.newBuilder("test-svc", testZk.getConnectString()).build();
+        store = new DefaultSchemaVersionStore(persister);
+        store2 = new DefaultSchemaVersionStore(persister);
+        storeWithMock = new DefaultSchemaVersionStore(mockPersister);
     }
 
     @Test
     public void testRootPathMapping() throws Exception {
         store.fetch();
-        CuratorPersister curator = CuratorPersister.newBuilder(testZk.getConnectString()).build();
-        assertNotEquals(0, curator.get("/dcos-service-test-root-path/SchemaVersion").length);
+        assertNotEquals(0, persister.get(NODE_PATH).length);
     }
 
     @Test
@@ -85,78 +77,6 @@ public class DefaultSchemaVersionStoreTest {
         store.store(val + 1);
         assertEquals(val + 1, getDirectVersion());
         assertEquals(val + 1, store.fetch());
-    }
-
-    @Test
-    public void testStoreWOAclAndFetchWithAcl() throws Exception {
-        assertFalse(directWithAclHasVersion());
-        final int val = 10;
-        final int valUpdate = 15;
-
-        // Store value with world:anyone then read with digest username:password.
-        store.store(val);
-        assertEquals(val, store.fetch());
-        assertEquals(val, storeWithAcl.fetch());
-        assertEquals(val, getDirectVersion());
-        assertEquals(val, getWithAclDirectVersion());
-
-        // Update the world:anyone value and should be readable with or without Auth
-        store.store(valUpdate);
-        assertEquals(valUpdate, store.fetch());
-        assertEquals(valUpdate, storeWithAcl.fetch());
-        assertEquals(valUpdate, getDirectVersion());
-        assertEquals(valUpdate, getWithAclDirectVersion());
-
-        storeWithAcl.store(valUpdate);
-        assertEquals(valUpdate, store.fetch());
-        assertEquals(valUpdate, storeWithAcl.fetch());
-        assertEquals(valUpdate, getDirectVersion());
-        assertEquals(valUpdate, getWithAclDirectVersion());
-    }
-
-    @Test
-    public void testStoreWithAclAndFetchWOAcl() throws Exception {
-        assertFalse(directWithAclHasVersion());
-        final int val = 10;
-        final int valUpdate = 15;
-
-        // Store value with ACL.
-        storeWithAcl.store(val);
-
-        // Readable with appropriate Auth and ACL.
-        assertEquals(val, storeWithAcl.fetch());
-        assertEquals(val, getWithAclDirectVersion());
-
-        // Readable with world:anyone permission.
-        assertEquals(val, store.fetch());
-        assertEquals(val, getDirectVersion());
-
-        // Not writeable with world:anyone permission.
-        try
-        {
-            storeDirectVersion(Integer.toString(valUpdate));
-            fail("Should have failed with auth exception");
-        }
-        catch ( KeeperException.NoAuthException e )
-        {
-            // expected
-        }
-
-        // Not writeable with incorrect Auth
-        try
-        {
-            CuratorPersister curatorAclSomeone = CuratorPersister.newBuilder(testZk.getConnectString())
-                    .setCredentials("someone", "else")
-                    .build();
-            curatorAclSomeone.set(NODE_PATH, "someoneelse".getBytes(CHARSET));
-            fail("Should have failed with auth exception");
-        }
-        catch ( KeeperException.NoAuthException e )
-        {
-            // expected
-        }
-
-        curatorWithAcl.deleteAll(NODE_PATH);
     }
 
     @Test
@@ -187,49 +107,31 @@ public class DefaultSchemaVersionStoreTest {
 
     @Test(expected=StateStoreException.class)
     public void testFetchOtherFailure() throws Exception {
-        when(mockCurator.get(NODE_PATH)).thenThrow(new Exception("hey"));
+        when(mockPersister.get(NODE_PATH)).thenThrow(new PersisterException(Reason.LOGIC_ERROR, "hey"));
         storeWithMock.fetch();
     }
 
     @Test(expected=StateStoreException.class)
     public void testStoreOtherFailure() throws Exception {
         final int val = 3;
-        doThrow(Exception.class)
-                .when(mockCurator).set(NODE_PATH, String.valueOf(val).getBytes(CHARSET));
+        doThrow(Exception.class).when(mockPersister).set(NODE_PATH, String.valueOf(val).getBytes(CHARSET));
         storeWithMock.store(3);
     }
 
     private boolean directHasVersion() throws Exception {
         try {
-            curator.get(NODE_PATH);
+            persister.get(NODE_PATH);
             return true;
-        } catch (KeeperException.NoNodeException e) {
-            return false;
-        }
-    }
-
-    private boolean directWithAclHasVersion() throws Exception {
-        try {
-            curatorWithAcl.get(NODE_PATH);
-            return true;
-        } catch (KeeperException.NoNodeException e) {
+        } catch (PersisterException e) {
             return false;
         }
     }
 
     private int getDirectVersion() throws Exception {
-        byte[] bytes = curator.get(NODE_PATH);
-        String str = new String(bytes, CHARSET);
-        return Integer.parseInt(str);
-    }
-
-    private int getWithAclDirectVersion() throws Exception {
-        byte[] bytes = curatorWithAcl.get(NODE_PATH);
-        String str = new String(bytes, CHARSET);
-        return Integer.parseInt(str);
+        return Integer.parseInt(new String(persister.get(NODE_PATH), CHARSET));
     }
 
     private void storeDirectVersion(String data) throws Exception {
-        curator.set(NODE_PATH, data.getBytes(CHARSET));
+        persister.set(NODE_PATH, data.getBytes(CHARSET));
     }
 }

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/state/SchedulerStateTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/state/SchedulerStateTest.java
@@ -25,7 +25,7 @@ public class SchedulerStateTest {
     @Before
     public void beforeEach() {
         schedulerState = new SchedulerState(
-                new DefaultStateStore(ROOT_ZK_PATH, CuratorPersister.newBuilder(testZk.getConnectString()).build()));
+                new DefaultStateStore(CuratorPersister.newBuilder(ROOT_ZK_PATH, testZk.getConnectString()).build()));
     }
 
     @Test

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/state/StateStoreCacheTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/state/StateStoreCacheTest.java
@@ -1,9 +1,9 @@
 package com.mesosphere.sdk.state;
 
 import com.mesosphere.sdk.curator.CuratorPersister;
+import com.mesosphere.sdk.curator.CuratorTestUtils;
 import com.mesosphere.sdk.offer.CommonIdUtils;
 import com.mesosphere.sdk.storage.StorageError.Reason;
-import com.mesosphere.sdk.testutils.CuratorTestUtils;
 import com.mesosphere.sdk.testutils.TaskTestUtils;
 import org.apache.curator.test.TestingServer;
 import org.apache.mesos.Protos;
@@ -11,7 +11,6 @@ import org.apache.mesos.Protos.FrameworkID;
 import org.apache.mesos.Protos.TaskInfo;
 import org.apache.mesos.Protos.TaskState;
 import org.apache.mesos.Protos.TaskStatus;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -73,7 +72,7 @@ public class StateStoreCacheTest {
     @Before
     public void beforeEach() throws Exception {
         CuratorTestUtils.clear(testZk);
-        store = new DefaultStateStore(ROOT_ZK_PATH, CuratorPersister.newBuilder(testZk.getConnectString()).build());
+        store = new DefaultStateStore(CuratorPersister.newBuilder(ROOT_ZK_PATH, testZk.getConnectString()).build());
         cache = new TestStateStoreCache(store);
 
         MockitoAnnotations.initMocks(this);
@@ -83,11 +82,6 @@ public class StateStoreCacheTest {
         when(mockStore.fetchPropertyKeys()).thenReturn(Arrays.asList(PROP_KEY));
         when(mockStore.fetchProperty(PROP_KEY)).thenReturn(PROP_VAL);
         mockedCache = new StateStoreCache(mockStore);
-    }
-
-    @After
-    public void afterEach() {
-        ((DefaultStateStore) store).closeForTesting();
     }
 
     @Test(expected=IllegalStateException.class)

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/storage/PersisterUtilsTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/storage/PersisterUtilsTest.java
@@ -4,13 +4,21 @@ import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-
+import org.apache.curator.test.TestingServer;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
  * Tests for {@link PersisterUtils}.
  */
 public class PersisterUtilsTest {
+
+    static TestingServer testZk;
+
+    @BeforeClass
+    public static void beforeAll() throws Exception {
+        testZk = new TestingServer();
+    }
 
     @Test
     public void testJoinPath() {

--- a/sdk/testing/src/main/java/com/mesosphere/sdk/testing/BaseServiceSpecTest.java
+++ b/sdk/testing/src/main/java/com/mesosphere/sdk/testing/BaseServiceSpecTest.java
@@ -74,12 +74,13 @@ public class BaseServiceSpecTest {
         when(capabilities.supportsNamedVips()).thenReturn(true);
         when(capabilities.supportsRLimits()).thenReturn(true);
 
-        CuratorPersister persister = CuratorPersister.newBuilder(testingServer.getConnectString()).build();
+        CuratorPersister persister =
+                CuratorPersister.newBuilder(serviceSpec.getName(), testingServer.getConnectString()).build();
 
         DefaultScheduler.newBuilder(serviceSpec, mockFlags)
-                .setStateStore(new DefaultStateStore(serviceSpec.getName(), persister))
-                .setConfigStore(new DefaultConfigStore<>(
-                        DefaultServiceSpec.getConfigurationFactory(serviceSpec), serviceSpec.getName(), persister))
+                .setStateStore(new DefaultStateStore(persister))
+                .setConfigStore(
+                        new DefaultConfigStore<>(DefaultServiceSpec.getConfigurationFactory(serviceSpec), persister))
                 .setCapabilities(capabilities)
                 .setPlansFrom(rawServiceSpec)
                 .build();


### PR DESCRIPTION
Removes remaining pieces of Curator-specific logic from the Default[Config|State|SchemaVersion]Stores.

- Moves `/dcos-service-foo` prefixing from Default[*]Stores into `CuratorPersister`. As a result the service name is now passed directly to the `CuratorPersister` instead of to the Default[*]Stores (updates callers to do so).
- Switches `Persister` interface over to `PersisterException`s. This replaces Curator-specific `KeeperException` type handling in `Persister` callers.
- Moves the new root-delete functionality in `DefaultStateStore` into `CuratorPersister` as a special case of `deleteAll()`. This localizes knowledge of the lock file as well as how the root node cannot be deleted by the Scheduler.