### PR TITLE
Elastic ga2 mult package per framework

### DIFF
--- a/frameworks/elastic/build.sh
+++ b/frameworks/elastic/build.sh
@@ -14,3 +14,12 @@ ${ROOT_DIR}/tools/build_framework.sh $PUBLISH_STEP elastic $FRAMEWORK_DIR $BUILD
 
 # capture anonymous metrics for reporting
 curl https://mesosphere.com/wp-content/themes/mesosphere/library/images/assets/sdk/build-sh-finish.png >/dev/null 2>&1
+
+# Chain to build kibana as well
+if [ "$UNIVERSE_URL_PATH" ]; then
+    KIBANA_URL_PATH=${UNIVERSE_URL_PATH}.kibana
+    UNIVERSE_URL_PATH=$KIBANA_URL_PATH $FRAMEWORK_DIR/build-kibana.sh $1
+    cat $KIBANA_URL_PATH >> $UNIVERSE_URL_PATH
+else
+    $FRAMEWORK_DIR/build-kibana.sh $1
+fi

--- a/tools/cli_install.py
+++ b/tools/cli_install.py
@@ -109,10 +109,12 @@ def download_cli(dcos_url, write_dir):
     url_template = 'https://downloads.dcos.io/binaries/cli/{}/x86-64/dcos-{}/{}'
     cluster_version = get_cluster_version(dcos_url)
     # we only care about the target release number
-    if '-' in cluster_version:
-        cluster_version, _ = cluster_version.split('-', 1) # "1.9-dev" -> 1.9
-    major, minor = cluster_version.split('.')[:2] # 1.8.8 -> 1.8
-    cluster_version = '%s.%s' % (major, minor)
+    #if '-' in cluster_version:
+    #    cluster_version, _ = cluster_version.split('-', 1) # "1.9-dev" -> 1.9
+    #major, minor = cluster_version.split('.')[:2] # 1.8.8 -> 1.8
+    #cluster_version = '%s.%s' % (major, minor)
+    # XXX 1.10 cli is buggy and floods logs
+    cluster_version = "1.9"
     cli_url = url_template.format(get_download_platform(), cluster_version,
                                   get_cli_filename())
     # actually download to unique filename, then rename into place atomically.

--- a/tools/fwinfo.py
+++ b/tools/fwinfo.py
@@ -85,7 +85,7 @@ class FrameworkTestInfo(object):
         self.running = False
         self.cluster = None
         self.test_success = None # set to True or False later
-        self.stub_universe_url = None # url where cluster can download framework
+        self.stub_universe_urls = [] # url(s) where cluster can download framework
         self.output_file = None # in background
         self.popen = None
         self.dir = os.path.join(repo_root, 'frameworks', self.name)

--- a/tools/run_tests.py
+++ b/tools/run_tests.py
@@ -228,12 +228,39 @@ def _rand_str(size):
     return ''.join(random.choice(string.ascii_lowercase + string.digits) for _ in range(size))
 
 
+def _make_packagename():
+    return 'testpkg-' + _rand_str(8)
+
+
+def handle_stub_options(argv):
+    stub_flag = '--stub-universe'
+    stub_universes = {}
+    if not stub_flag in argv:
+        return argv, stub_universes
+    argv_copy = argv[:]
+    while stub_flag in argv_copy:
+        flag_pos = argv_copy.index(stub_flag)
+        try:
+            flag_val = argv_copy[flag_pos + 1]
+        except:
+            sys.exit("Missing url argument for flag --stub-universe")
+        stub_universes[_make_packagename()] = flag_val
+        # drop flag + arg
+        del argv_copy[flag_pos:flag_pos+2]
+    return argv_copy, stub_universes
+
+
 def main(argv):
     if len(argv) < 3:
         print_help(argv)
         return 1
     test_type = argv[1]
     test_dirs = argv[2]
+
+    # Destructively handle --stub-universe args to avoid disturbing below
+    # messy arg parsing
+    argv, stub_universes = handle_stub_options(argv)
+
 
     cluster_url = os.environ.get('CLUSTER_URL', '').strip('"').strip('\'')
     if cluster_url:
@@ -252,10 +279,10 @@ def main(argv):
 
     tester = CITester(cluster_url, os.environ.get('TEST_GITHUB_LABEL', test_type))
 
-    stub_universes = {}
-    stub_universe_url = os.environ.get('STUB_UNIVERSE_URL', '')
-    if stub_universe_url:
-        stub_universes['testpkg-' + _rand_str(8)] = stub_universe_url
+    if not stub_universes:
+        stub_universe_url = os.environ.get('STUB_UNIVERSE_URL', '')
+        if stub_universe_url:
+            stub_universes[_make_packagename()] = stub_universe_url
 
     pytest_types = os.environ.get('TEST_TYPES', 'sanity')
 


### PR DESCRIPTION
This does a couple things:

* elastic build.sh calls build-kibana.sh
* elastic build.sh arranges to augment its url file with the second url
* test.py handles providing both urls over to run_tests.py
* run_tests.py in turn handles adding both stub_universe definitions to the cluster, so that they can be installed.