### PR TITLE
[INFINITY-1606][INFINITY-1616] strict mode failures in helloworld

### DIFF
--- a/frameworks/helloworld/src/main/dist/examples/cni.yml
+++ b/frameworks/helloworld/src/main/dist/examples/cni.yml
@@ -1,4 +1,7 @@
 name: "hello-world"
+scheduler:
+  principal: {{SERVICE_PRINCIPAL}}
+  user: {{SERVICE_USER}}
 pods:
   hello:
     count: {{HELLO_COUNT}}

--- a/frameworks/helloworld/src/main/dist/examples/discovery.yml
+++ b/frameworks/helloworld/src/main/dist/examples/discovery.yml
@@ -1,4 +1,7 @@
 name: "hello-world"
+scheduler:
+  principal: {{SERVICE_PRINCIPAL}}
+  user: {{SERVICE_USER}}
 pods:
   hello:
     count: 1

--- a/frameworks/helloworld/src/main/dist/examples/executor_volume.yml
+++ b/frameworks/helloworld/src/main/dist/examples/executor_volume.yml
@@ -1,4 +1,7 @@
 name: "hello-world"
+scheduler:
+  principal: {{SERVICE_PRINCIPAL}}
+  user: {{SERVICE_USER}}
 pods:
   hello:
     count: 2

--- a/frameworks/helloworld/src/main/dist/examples/gpu_resource.yml
+++ b/frameworks/helloworld/src/main/dist/examples/gpu_resource.yml
@@ -1,4 +1,7 @@
 name: hello-world
+scheduler:
+  principal: {{SERVICE_PRINCIPAL}}
+  user: {{SERVICE_USER}}
 pods:
   hello:
     count: {{HELLO_COUNT}}

--- a/frameworks/helloworld/src/main/dist/examples/marathon_constraint.yml
+++ b/frameworks/helloworld/src/main/dist/examples/marathon_constraint.yml
@@ -1,4 +1,7 @@
 name: "hello-world"
+scheduler:
+  principal: {{SERVICE_PRINCIPAL}}
+  user: {{SERVICE_USER}}
 pods:
   hello:
     count: {{HELLO_COUNT}}

--- a/frameworks/helloworld/src/main/dist/examples/parameterized-plan.yml
+++ b/frameworks/helloworld/src/main/dist/examples/parameterized-plan.yml
@@ -1,4 +1,7 @@
 name: "hello-world"
+scheduler:
+  principal: {{SERVICE_PRINCIPAL}}
+  user: {{SERVICE_USER}}
 pods:
   hello:
     count: 2

--- a/frameworks/helloworld/src/main/dist/examples/plan.yml
+++ b/frameworks/helloworld/src/main/dist/examples/plan.yml
@@ -1,4 +1,7 @@
 name: "hello-world"
+scheduler:
+  principal: {{SERVICE_PRINCIPAL}}
+  user: {{SERVICE_USER}}
 pods:
   hello:
     count: {{HELLO_COUNT}}

--- a/frameworks/helloworld/src/main/dist/examples/sidecar.yml
+++ b/frameworks/helloworld/src/main/dist/examples/sidecar.yml
@@ -1,4 +1,7 @@
 name: "hello-world"
+scheduler:
+  principal: {{SERVICE_PRINCIPAL}}
+  user: {{SERVICE_USER}}
 pods:
   hello:
     count: 2

--- a/frameworks/helloworld/src/main/dist/examples/simple.yml
+++ b/frameworks/helloworld/src/main/dist/examples/simple.yml
@@ -1,4 +1,7 @@
 name: "hello-world"
+scheduler:
+  principal: {{SERVICE_PRINCIPAL}}
+  user: {{SERVICE_USER}}
 pods:
   hello:
     count: {{HELLO_COUNT}}

--- a/frameworks/helloworld/src/main/dist/examples/taskcfg.yml
+++ b/frameworks/helloworld/src/main/dist/examples/taskcfg.yml
@@ -1,4 +1,7 @@
 name: "hello-world"
+scheduler:
+  principal: {{SERVICE_PRINCIPAL}}
+  user: {{SERVICE_USER}}
 pods:
   hello:
     count: {{HELLO_COUNT}}

--- a/frameworks/helloworld/src/main/dist/examples/uri.yml
+++ b/frameworks/helloworld/src/main/dist/examples/uri.yml
@@ -1,4 +1,7 @@
 name: "hello-world"
+scheduler:
+  principal: {{SERVICE_PRINCIPAL}}
+  user: {{SERVICE_USER}}
 pods:
   hello:
     count: {{HELLO_COUNT}}

--- a/frameworks/helloworld/src/main/dist/examples/web-url.yml
+++ b/frameworks/helloworld/src/main/dist/examples/web-url.yml
@@ -1,4 +1,7 @@
 name: "hello-world"
+scheduler:
+  principal: {{SERVICE_PRINCIPAL}}
+  user: {{SERVICE_USER}}
 web-url: http://hello-world.marathon.mesos:{{PORT_API}}
 pods:
   hello:

--- a/frameworks/helloworld/src/main/dist/svc.yml
+++ b/frameworks/helloworld/src/main/dist/svc.yml
@@ -6,6 +6,7 @@ pods:
   hello:
     count: {{HELLO_COUNT}}
     placement: {{HELLO_PLACEMENT}}
+    user: {{SERVICE_USER}}
     tasks:
       server:
         goal: RUNNING
@@ -28,6 +29,7 @@ pods:
   world:
     count: {{WORLD_COUNT}}
     placement: {{WORLD_PLACEMENT}}
+    user: {{SERVICE_USER}}
     tasks:
       server:
         goal: RUNNING

--- a/test.py
+++ b/test.py
@@ -528,7 +528,13 @@ def _setup_strict(framework, cluster, repo_root):
         custom_env['CLUSTER_AUTH_TOKEN'] = cluster.auth_token
 
         for role_base in (framework.name, framework.name + "2"):
+
             role_arg = '%s-role' % role_base
+
+            # XXX helloworld is terrible and doesn't use its own name
+            if role_base == 'helloworld':
+                role_arg = 'hello-world-role'
+
             cmd_args = [perm_setup_script, 'root', role_arg]
 
             completed_cmd = subprocess.run(cmd_args, env=custom_env)

--- a/testing/sdk_install.py
+++ b/testing/sdk_install.py
@@ -111,7 +111,8 @@ def get_package_options(additional_options={}):
         # strict mode requires correct principal and secret to perform install.
         # see also: tools/setup_permissions.sh and tools/create_service_account.sh
         return _merge_dictionary(additional_options, {
-            'service': { 'principal': 'service-acct', 'secret_name': 'secret' }
+            'service': { 'principal': 'service-acct', 'secret_name': 'secret',
+                         'mesos_api_version': 'V0'}
         })
     else:
         return additional_options

--- a/tools/fwinfo.py
+++ b/tools/fwinfo.py
@@ -89,6 +89,8 @@ class FrameworkTestInfo(object):
         self.output_file = None # in background
         self.popen = None
         self.dir = os.path.join(repo_root, 'frameworks', self.name)
+        if not os.path.isdir(self.dir):
+            raise ValueError("Invalid framework name %s" % self.name)
         self.buildscript = os.path.join(self.dir, 'build.sh')
         # TODO figure out what this trailing slash is for and eliminate
         self.testdir = os.path.join(self.dir, 'tests') + "/"


### PR DESCRIPTION
1 - We were not allowing the install-time selection of service-account/principal to work in the examples/*.yml test configurations.
2 - We were creating the wrong role name due to problems with the helloworld/hello-world service name.