### PR TITLE
[INFINITY-1619] proxylite requires 1.9.

### DIFF
--- a/frameworks/proxylite/universe/package.json
+++ b/frameworks/proxylite/universe/package.json
@@ -1,5 +1,6 @@
 {
   "packagingVersion": "2.0",
+  "minDcosReleaseVersion": "1.9",
   "name": "proxylite",
   "version": "{{package-version}}",
   "maintainer": "support@mesosphere.io",


### PR DESCRIPTION
This has been true for a while, but now that we're trying to test on 1.8,
making it explicit is important.