### PR TITLE
Upgrade http adapter to 0.4.1

### DIFF
--- a/sdk/scheduler/build.gradle
+++ b/sdk/scheduler/build.gradle
@@ -101,7 +101,7 @@ dependencies {
     compile "org.hibernate:hibernate-validator:${hibernateValidatorVer}"
     compile "javax.el:javax.el-api:${elVer}"
     compile "org.glassfish.web:javax.el:${elVer}"
-    compile 'com.mesosphere:mesos-http-adapter:0.4.0'
+    compile 'com.mesosphere:mesos-http-adapter:0.4.1'
     testCompile "org.hamcrest:hamcrest-all:${hamcrestVer}" // note: must be above junit
     testCompile "junit:junit:${junitVer}"
     testCompile "com.github.stefanbirkner:system-rules:${systemRulesVer}"


### PR DESCRIPTION
Upgrades `mesos-http-adapter` to version `0.4.1`. Please see release notes for more details:
https://github.com/mesosphere/mesos-http-adapter/releases/tag/0.4.1