### PR TITLE
Added ability for hello-world framework installation to specify the pod-level user

### DIFF
--- a/frameworks/helloworld/src/main/dist/svc.yml
+++ b/frameworks/helloworld/src/main/dist/svc.yml
@@ -4,6 +4,7 @@ scheduler:
   user: {{SERVICE_USER}}
 pods:
   hello:
+    user: {{SERVICE_USER}}
     count: {{HELLO_COUNT}}
     placement: {{HELLO_PLACEMENT}}
     user: {{SERVICE_USER}}
@@ -27,6 +28,7 @@ pods:
           timeout: 10
           max-consecutive-failures: 3
   world:
+    user: {{SERVICE_USER}}
     count: {{WORLD_COUNT}}
     placement: {{WORLD_PLACEMENT}}
     user: {{SERVICE_USER}}


### PR DESCRIPTION
* added ability for hello-world framework installation to specify the pod-level user.
  * as it stands, the same user is used for the scheduler and both pods: hello and world.
  * this fix is required to be able to install in strict mode since the user "nobody" should be used, but w/o this change "root" is used for the pods.
  * we may expand this functionality to allow for distinct users for each, but there is currently very little value in such a thing.