### PR TITLE
Adding in the yum install commands to add python3 to the base box

### DIFF
--- a/tools/vagrant/build-dcos-docker.sh
+++ b/tools/vagrant/build-dcos-docker.sh
@@ -122,6 +122,10 @@ if [ ! -f ${ARTIFACT_JDK} ]; then
 fi &&
 sudo tar -C /opt -xzf ${ARTIFACT_JDK} &&
 
+echo '#### Installing Python3' &&
+yes | sudo yum install epel-release &&
+yes | sudo yum install python34 &&
+
 echo '### Configure env' &&
 echo 'export GOPATH=/home/vagrant/go' >> ~/.bash_profile &&
 echo 'export JAVA_HOME=\$(echo /opt/jdk*)' >> ~/.bash_profile &&


### PR DESCRIPTION
Adding in python3 into the base dcos box. 
It should fix the issue that occurs when you run `./build.sh local` command.
```
cd /dcos-commons/frameworks/helloworld/ && ./build.sh local
PUBLISH_STEP=none
FRAMEWORK_NAME=hello-world
FRAMEWORK_DIR=/dcos-commons/frameworks/helloworld
ARTIFACT_FILES=/dcos-commons/frameworks/helloworld/build/distributions/executor.zip /dcos-commons/frameworks/helloworld/build/distributions/hello-world-scheduler.zip
/usr/bin/env: python3: No such file or directory
```