### PR TITLE
cli: Fix bug with url parse

### DIFF
--- a/cli/client/http.go
+++ b/cli/client/http.go
@@ -188,7 +188,7 @@ func getDCOSURL() {
 			"Run 'dcos config set core.dcos_url http://your-cluster.com' to configure.")
 	}
 	// Trim eg "/#/" from copy-pasted Dashboard URL:
-	config.DcosUrl = strings.TrimRight(config.DcosUrl, "#/")
+	config.DcosUrl = strings.TrimSuffix(config.DcosUrl, "#/")
 }
 
 func createServiceURL(urlPath, urlQuery string) *url.URL {

--- a/cli/client/http_test.go
+++ b/cli/client/http_test.go
@@ -1,0 +1,23 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/mesosphere/dcos-commons/cli/config"
+)
+
+func TestGetDCOSURL(t *testing.T) {
+	intendedUrl := "myurl/"
+	config.DcosUrl = "myurl/#/"
+	getDCOSURL()
+	if config.DcosUrl != intendedUrl {
+		t.Fatal("expected %s got %s", intendedUrl, config.DcosUrl)
+	}
+
+	intendedUrl = "myurl/#/"
+	config.DcosUrl = "myurl/#/#/"
+	getDCOSURL()
+	if config.DcosUrl != intendedUrl {
+		t.Fatal("expected %s got %s", intendedUrl, config.DcosUrl)
+	}
+}


### PR DESCRIPTION
TrimRight will remove all characters in the cutset, the intended
behavior is to remove an exact substring, which is TrimSuffix