### PR TITLE
[HDFS-461] Revert #990: Include FRAMEWORK_NAME when rendering xml endpoints

### DIFF
--- a/frameworks/hdfs/src/main/java/com/mesosphere/sdk/hdfs/scheduler/Main.java
+++ b/frameworks/hdfs/src/main/java/com/mesosphere/sdk/hdfs/scheduler/Main.java
@@ -4,6 +4,7 @@ import com.mesosphere.sdk.api.types.EndpointProducer;
 import com.mesosphere.sdk.config.DefaultTaskConfigRouter;
 import com.mesosphere.sdk.offer.evaluate.placement.AndRule;
 import com.mesosphere.sdk.offer.evaluate.placement.TaskTypeRule;
+import com.mesosphere.sdk.offer.taskdata.EnvConstants;
 import com.mesosphere.sdk.scheduler.DefaultScheduler;
 import com.mesosphere.sdk.scheduler.SchedulerFlags;
 import com.mesosphere.sdk.specification.*;
@@ -72,7 +73,11 @@ public class Main {
             return error;
         }
 
+        // Simulate the envvars that would be passed to a task. We want to render the config as though it was being done
+        // in a task. Manually copy over FRAMEWORK_NAME which is included in tasks by default.
+        // TODO(nickbp): Consider switching to dedicated client xml templates instead of reusing these ones?
         Map<String, String> env = new HashMap<>(new DefaultTaskConfigRouter().getConfig("ALL").getAllEnv());
+        env.put(EnvConstants.FRAMEWORK_NAME_TASKENV, System.getenv(EnvConstants.FRAMEWORK_NAME_TASKENV));
 
         String fileStr = new String(bytes, Charset.defaultCharset());
         return TemplateUtils.applyEnvToMustache(fileStr, env);

--- a/frameworks/hdfs/src/test/java/com/mesosphere/sdk/hdfs/scheduler/ServiceSpecTest.java
+++ b/frameworks/hdfs/src/test/java/com/mesosphere/sdk/hdfs/scheduler/ServiceSpecTest.java
@@ -2,6 +2,7 @@ package com.mesosphere.sdk.hdfs.scheduler;
 
 import com.google.common.collect.ImmutableMap;
 import com.mesosphere.sdk.config.DefaultTaskConfigRouter;
+import com.mesosphere.sdk.offer.taskdata.EnvConstants;
 import com.mesosphere.sdk.specification.yaml.TemplateUtils;
 import com.mesosphere.sdk.testing.BaseServiceSpecTest;
 import org.junit.Assert;
@@ -9,9 +10,8 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
@@ -96,11 +96,12 @@ public class ServiceSpecTest extends BaseServiceSpecTest {
     }
 
     private void renderTemplate(String pathStr) throws IOException {
-        Path path = Paths.get(pathStr);
-        byte[] bytes = Files.readAllBytes(path);
-        String fileStr = new String(bytes, Charset.defaultCharset());
+        String fileStr = new String(Files.readAllBytes(Paths.get(pathStr)), StandardCharsets.UTF_8);
+
+        // Reproduction of what's done in Main.java:
         ImmutableMap<String, String> allEnv = new DefaultTaskConfigRouter().getConfig("ALL").getAllEnv();
         Map<String, String> updatedEnv = new HashMap<>(allEnv);
+        updatedEnv.put(EnvConstants.FRAMEWORK_NAME_TASKENV, System.getenv(EnvConstants.FRAMEWORK_NAME_TASKENV));
 
         String renderedFileStr = TemplateUtils.applyEnvToMustache(fileStr, updatedEnv);
         Assert.assertEquals(-1, renderedFileStr.indexOf("<value></value>"));


### PR DESCRIPTION
Reverts #990 with some commentary on what's going on.
Scheduler is reproducing what the tasks do when rendering the xml connection files locally.