### PR TITLE
Make Cassandra "auto_snapshot" option configurable

### DIFF
--- a/frameworks/cassandra/README.md
+++ b/frameworks/cassandra/README.md
@@ -238,6 +238,7 @@ You can configure most of the settings exposed in Apache Cassandra's `cassandra.
 *   `dynamic_snitch_update_interval_in_ms`
 *   `dynamic_snitch_reset_interval_in_ms`
 *   `dynamic_snitch_badness_threshold`
+*   `auto_snapshot`
 *   `roles_update_interval_in_ms`
 *   `permissions_update_interval_in_ms`
 *   `key_cache_keys_to_save`

--- a/frameworks/cassandra/src/main/dist/cassandra.yaml
+++ b/frameworks/cassandra/src/main/dist/cassandra.yaml
@@ -95,7 +95,7 @@ trickle_fsync_interval_in_kb: 10240
 rpc_server_type: sync
 incremental_backups: false
 snapshot_before_compaction: false
-auto_snapshot: true
+auto_snapshot: {{CASSANDRA_AUTO_SNAPSHOT}}
 cross_node_timeout: false
 endpoint_snitch: SimpleSnitch
 roles_update_interval_in_ms: {{CASSANDRA_ROLES_UPDATE_INTERVAL_IN_MS}}

--- a/frameworks/cassandra/universe/config.json
+++ b/frameworks/cassandra/universe/config.json
@@ -391,6 +391,11 @@
           "description": "The total size of the commit log in Mb.",
           "default": 8192
         },
+        "auto_snapshot": {
+          "type": "boolean",
+          "description": "Take a snapshot of the data before truncating a keyspace or dropping a table",
+          "default": true
+        },
         "roles_update_interval_in_ms": {
           "type": "integer",
           "description": "The refresh interval for the roles cache",
@@ -587,6 +592,7 @@
         "hints_flush_period_in_ms",
         "concurrent_materialized_view_writes",
         "commitlog_total_space_in_mb",
+        "auto_snapshot",
         "roles_update_interval_in_ms",
         "permissions_update_interval_in_ms",
         "key_cache_keys_to_save",

--- a/frameworks/cassandra/universe/config.json
+++ b/frameworks/cassandra/universe/config.json
@@ -394,7 +394,7 @@
         "auto_snapshot": {
           "type": "boolean",
           "description": "Take a snapshot of the data before truncating a keyspace or dropping a table",
-          "default": true
+          "default": false
         },
         "roles_update_interval_in_ms": {
           "type": "integer",

--- a/frameworks/cassandra/universe/marathon.json.mustache
+++ b/frameworks/cassandra/universe/marathon.json.mustache
@@ -93,6 +93,7 @@
     "TASKCFG_ALL_CASSANDRA_HINTS_FLUSH_PERIOD_IN_MS": "{{cassandra.hints_flush_period_in_ms}}",
     "TASKCFG_ALL_CASSANDRA_MATERIALIZED_VIEW_WRITES": "{{cassandra.concurrent_materialized_view_writes}}",
     "TASKCFG_ALL_CASSANDRA_COMMITLOG_TOTAL_SPACE_IN_MB": "{{cassandra.commitlog_total_space_in_mb}}",
+    "TASKCFG_ALL_CASSANDRA_AUTO_SNAPSHOT": "{{cassandra.auto_snapshot}}",
     "TASKCFG_ALL_CASSANDRA_ROLES_UPDATE_INTERVAL_IN_MS": "{{cassandra.roles_update_interval_in_ms}}",
     "TASKCFG_ALL_CASSANDRA_PERMISSIONS_UPDATE_INTERVAL_IN_MS": "{{cassandra.permissions_update_interval_in_ms}}",
     "TASKCFG_ALL_CASSANDRA_KEY_CACHE_KEYS_TO_SAVE": "{{cassandra.key_cache_keys_to_save}}",


### PR DESCRIPTION
Before, the Cassandra "auto_snapshot" setting was set to "true". This PR makes the setting configurable, with a default setting of "false".