### PR TITLE
Delete directory in new-framework.sh that causes build.sh to fail

### DIFF
--- a/new-framework.sh
+++ b/new-framework.sh
@@ -44,3 +44,5 @@ else
     echo "Failed to create new project"
     exit 1
 fi
+
+rm -rf $1/cli/dcos-$PROJECT_NAME/vendor/gopkg.in/alecthomas


### PR DESCRIPTION
Delete vendor/gopkg/alecthomas directory in new-framework.sh script that will cause build.sh on newly created framework to fail