### PR TITLE
[SDK] Add file path validation for Secrets

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultSecretSpec.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultSecretSpec.java
@@ -8,6 +8,7 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
 import java.util.*;
 
@@ -18,7 +19,14 @@ public class DefaultSecretSpec implements SecretSpec {
     @NotNull
     @Size(min = 1)
     private final String secretPath;
+
     private final String envKey;
+
+    /** Regexp in @Pattern:
+     *      sub-pattern = [a-zA-Z0-9]+([a-zA-Z0-9_-]*[/\\\\]*)*
+     *      (sub-pattern)?  = either NULL, or sub-pattern.  So It can be Null.
+     */
+    @Pattern(regexp = "([a-zA-Z0-9]+([a-zA-Z0-9_-]*[/\\\\]*)*)?")
     private final String filePath;
 
     @JsonCreator
@@ -29,6 +37,7 @@ public class DefaultSecretSpec implements SecretSpec {
         this.secretPath = secretPath;
         this.envKey = envKey;
         this.filePath = filePath;
+        ValidationUtils.validate(this);
     }
 
     private DefaultSecretSpec(Builder builder) {

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/config/validate/VerifySecretFilePathTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/config/validate/VerifySecretFilePathTest.java
@@ -1,0 +1,66 @@
+package com.mesosphere.sdk.config.validate;
+
+import com.mesosphere.sdk.specification.DefaultSecretSpec;
+import org.junit.Test;
+
+public class VerifySecretFilePathTest {
+
+    private static final String secretPath = "test/secret";
+    private static final String envKey = "TEST_ENV";
+
+    /* Exception.class is generic (in case we add/change fields)
+           If Pattern is used in DefaultVolumeSpec,  exception is ValidationException
+           If not using Pattern,  exception is ConstraintViolationException
+    */
+    @Test
+    public void testFilePathEmpty() {
+        new DefaultSecretSpec( secretPath, envKey, "");
+    }
+
+    @Test(expected = Exception.class)
+    public void testFilePathBlank()  {
+        new DefaultSecretSpec( secretPath, envKey, " ");
+    }
+
+    @Test(expected = Exception.class)
+    public void testFilePathSlash()  {
+        new DefaultSecretSpec( secretPath, envKey, "/path/to/file");
+    }
+
+    @Test(expected = Exception.class)
+    public void testFilePathChar() {
+        new DefaultSecretSpec( secretPath, envKey, "@?test");
+    }
+
+    @Test(expected = Exception.class)
+    public void testFilePathBeg() {
+        new DefaultSecretSpec( secretPath, envKey, "-test");
+    }
+
+    @Test
+    public void testFilePathString() {
+        new DefaultSecretSpec( secretPath, envKey, "file");
+    }
+
+    @Test
+    public void testFilePathLong() {
+        new DefaultSecretSpec( secretPath, envKey, "file-0/file1/file-2/file3/file_4");
+    }
+
+    @Test
+    public void testSecretPathLong() {
+        new DefaultSecretSpec( "file-0/file1/file-2/file3/file_4", envKey, "file" );
+    }
+
+    @Test
+    public void testSecretPathString() {
+        new DefaultSecretSpec( "file", envKey, "file" );
+    }
+
+    @Test
+    public void testEnvKeyEmpty() {
+        new DefaultSecretSpec( "file", "", "file" );
+    }
+
+
+}


### PR DESCRIPTION
If file path (file keyword) starts with "/", user may not have permission outside of its SANDBOX.  Still can write to /tmp for example. 

We are enforcing file path to be relative to the SANDBOX (do not start with "/"). It can be NULL.

    @Pattern(regexp = "([a-zA-Z0-9]+([a-zA-Z0-9_-]*[/\\\\]*)*)?")

```
pods:
  pod_name:	
     secrets:
       secret_name1:
           secret: hello-world/secret1              <secret path>
           env-key: SECRET1_ENV                <environment variable name>
           file: some/path/secret2_file             <file path>
```
