### PR TITLE
[INFINITY-1138][INFINITY-1139] Don't run unnecessary pull-request tests.

### DIFF
--- a/test.py
+++ b/test.py
@@ -592,7 +592,8 @@ def main():
 
     repo_root = get_repo_root()
     fwinfo.init_repo_root(repo_root)
-    fwinfo.set_buildtypes(branch_changes.get_branch_changetypes())
+    if 'PULL_REQUEST' in os.environ:
+        fwinfo.set_buildtypes(branch_changes.get_branch_changetypes())
 
     setup_frameworks(run_attrs)
 

--- a/test.py
+++ b/test.py
@@ -17,6 +17,7 @@ logger = logging.getLogger("dcos-commons-test")
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(name)s %(message)s")
 
 sys.path.append(os.path.join(get_repo_root(), 'tools'))
+import branch_changes
 import clustinfo
 import fwinfo
 import launch_ccm_cluster
@@ -591,6 +592,7 @@ def main():
 
     repo_root = get_repo_root()
     fwinfo.init_repo_root(repo_root)
+    fwinfo.set_buildtypes(branch_changes.get_branch_changetypes())
 
     setup_frameworks(run_attrs)
 

--- a/tools/branch_changes.py
+++ b/tools/branch_changes.py
@@ -1,26 +1,27 @@
 #!/usr/bin/python3
 
 import subprocess
+import sys
 
 def fetch_origin_master():
-    subprocess.check_call([b'git', b'fetch', b'origin', b'master'])
+    subprocess.check_call([b'git', b'fetch', b'origin', b'master', b'--quiet'])
 
 def get_changed_files():
     fetch_origin_master()
 
-    output = subprocess.check_output([b'git', b'diff', b'...origin/master',
+    output = subprocess.check_output([b'git', b'diff', b'origin/master',
                                       b'--name-only'])
     files = output.splitlines()
     return files
 
 def categorize_file(filename):
-    if filename.endswith(".md"):
+    if filename.endswith(b".md"):
         return "DOC"
-    if filename.startswith("doc/"):
+    if filename.startswith(b"doc/"):
         return "DOC"
-    if filename.startswith("frameworks/"):
-        literal, specific_framework, rest = filename.split('/', 2)
-        return specific_framework
+    if filename.startswith(b"frameworks/"):
+        literal, specific_framework, rest = filename.split(b'/', 2)
+        return specific_framework.decode('utf-8')
     return "SDK"
 
 def categorize_branch_changes():
@@ -31,10 +32,10 @@ def categorize_branch_changes():
 
     # any SDK changes means build/test everything
     if "SDK" in file_types:
-        return "SDK"
+        return {"SDK"}
     # only DOC changes means build/test nothing
     if file_types == {"DOC"}:
-        return "DOC"
+        return {"DOC"}
     # Otherwise return the frameworks changed
     file_types.discard("DOC")
     return file_types
@@ -49,3 +50,7 @@ def memoized_branch_changes():
 get_branch_changetypes=memoized_branch_changes
 
 __all__ = ('get_branch_changetypes',)
+
+if __name__ == "__main__":
+    for item in get_branch_changetypes():
+        sys.stdout.write(item + "\n")

--- a/tools/branch_changes.py
+++ b/tools/branch_changes.py
@@ -1,0 +1,51 @@
+#!/usr/bin/python3
+
+import subprocess
+
+def fetch_origin_master():
+    subprocess.check_call([b'git', b'fetch', b'origin', b'master'])
+
+def get_changed_files():
+    fetch_origin_master()
+
+    output = subprocess.check_output([b'git', b'diff', b'...origin/master',
+                                      b'--name-only'])
+    files = output.splitlines()
+    return files
+
+def categorize_file(filename):
+    if filename.endswith(".md"):
+        return "DOC"
+    if filename.startswith("doc/"):
+        return "DOC"
+    if filename.startswith("frameworks/"):
+        literal, specific_framework, rest = filename.split('/', 2)
+        return specific_framework
+    return "SDK"
+
+def categorize_branch_changes():
+    file_types = set()
+    for filename in get_changed_files():
+        file_type = categorize_file(filename)
+        file_types.add(file_type)
+
+    # any SDK changes means build/test everything
+    if "SDK" in file_types:
+        return "SDK"
+    # only DOC changes means build/test nothing
+    if file_types == {"DOC"}:
+        return "DOC"
+    # Otherwise return the frameworks changed
+    file_types.discard("DOC")
+    return file_types
+
+saved_branch_changes = None
+def memoized_branch_changes():
+    global saved_branch_changes
+    if not saved_branch_changes:
+        saved_branch_changes = categorize_branch_changes()
+    return saved_branch_changes
+
+get_branch_changetypes=memoized_branch_changes
+
+__all__ = ('get_branch_changetypes',)

--- a/tools/fwinfo.py
+++ b/tools/fwinfo.py
@@ -27,6 +27,12 @@ def init_repo_root(repo_root):
     _repo_root=repo_root
 
 
+pr_build_change_types = None
+def set_buildtypes(build_set):
+    global pr_build_change_types
+    pr_build_change_types = build_set
+    logging.debug("build_types set to %s", build_set)
+
 def add_framework(framework_name, repo_root=None, dcos_version=None):
     if not repo_root:
         repo_root=_repo_root
@@ -38,6 +44,20 @@ def add_framework(framework_name, repo_root=None, dcos_version=None):
         logger.info("Skipping framework %s, which does not support dcos version %s",
                 framework_name, dcos_version)
         return None
+    if pr_build_change_types:
+        if "DOC" in pr_build_change_types:
+            logger.info("Skipping framework %s, docs-only branch", framework_name)
+            return None
+        if not "SDK" in pr_build_change_types:
+            if not framework_name in pr_build_change_types:
+                msg = "Skipping framework %s, no changes for this framework."
+                msg += " Changes for %s frameworks and not SDK itself."
+                logger.info(msg, framework_name, pr_build_change_types)
+                return None
+            else:
+                logging.info("adding framework %s to run, since PR has framework in list.", framework_name)
+        else:
+            logging.info("adding framework %s to run, since there are SDK changes.", framework_name)
     _framework_infos.append(fwobj)
     return fwobj
 


### PR DESCRIPTION
As written, this implements INFINITY-1138 & INFINITY-1139.

Basically if only docs files are changed, no frameworks are built or tested.  (Unit tests still run because it doesn't seem worth turning them off;  short runtime and no false failures).

If only files in frameworks/<name> dirs are changed, then those frameworks are built and tested, not others.

If other files are changed, everything is built and tested.