### PR TITLE
[HDFS-365] Upgrade HDFS to CDH 5.11.0

### DIFF
--- a/frameworks/hdfs/universe/marathon.json.mustache
+++ b/frameworks/hdfs/universe/marathon.json.mustache
@@ -21,7 +21,7 @@
   {{/service.secret_name}}
   "env": {
     "FRAMEWORK_NAME": "{{service.name}}",
-    "HDFS_VERSION": "hadoop-2.6.0-cdh5.9.1",
+    "HDFS_VERSION": "hadoop-2.6.0-cdh5.11.0",
     "JRE_VERSION": "jre1.8.0_131",
     "TASKCFG_ALL_JRE_VERSION": "jre1.8.0_131",
     "DEPLOY_STRATEGY": "{{service.deploy_strategy}}",

--- a/frameworks/hdfs/universe/resource.json
+++ b/frameworks/hdfs/universe/resource.json
@@ -3,7 +3,7 @@
     "uris": {
       "jre-tar-gz": "{{jre-jce-unlimited-url}}",
       "libmesos-bundle-tar-gz": "{{libmesos-bundle-url}}",
-      "hdfs-tar-gz": "https://s3-us-west-2.amazonaws.com/nima-dev/hadoop-2.6.0-cdh5.11.0.tar.gz",
+      "hdfs-tar-gz": "https://downloads.mesosphere.com/hdfs/assets/hadoop-2.6.0-cdh5.11.0.tar.gz",
       "bootstrap-zip": "{{artifact-dir}}/bootstrap.zip",
       "scheduler-zip": "{{artifact-dir}}/hdfs-scheduler.zip",
       "executor-zip": "{{artifact-dir}}/executor.zip"

--- a/frameworks/hdfs/universe/resource.json
+++ b/frameworks/hdfs/universe/resource.json
@@ -3,7 +3,7 @@
     "uris": {
       "jre-tar-gz": "{{jre-jce-unlimited-url}}",
       "libmesos-bundle-tar-gz": "{{libmesos-bundle-url}}",
-      "hdfs-tar-gz": "https://downloads.mesosphere.com/hdfs/assets/hadoop-2.6.0-cdh5.9.1-dcos.tar.gz",
+      "hdfs-tar-gz": "https://s3-us-west-2.amazonaws.com/nima-dev/hadoop-2.6.0-cdh5.11.0.tar.gz",
       "bootstrap-zip": "{{artifact-dir}}/bootstrap.zip",
       "scheduler-zip": "{{artifact-dir}}/hdfs-scheduler.zip",
       "executor-zip": "{{artifact-dir}}/executor.zip"


### PR DESCRIPTION
The update will take around 10 minutes as the tasks reconcile and the new HDFS stabilizes.