### PR TITLE
[HDFS-462] Add readiness check to journal nodes

### DIFF
--- a/frameworks/cassandra/tests/config.py
+++ b/frameworks/cassandra/tests/config.py
@@ -19,7 +19,7 @@ DEFAULT_NODE_PORT = os.getenv('CASSANDRA_NODE_PORT', '9042')
 
 def _get_test_job(name, cmd, restart_policy='NEVER'):
     return {
-        'description': 'Utility job for Cassandra integration tests',
+        'description': 'Integration test job: ' + name,
         'id': 'test.cassandra.' + name,
         'run': {
             'cmd': cmd,
@@ -75,25 +75,6 @@ def get_write_data_job(node_address=DEFAULT_NODE_ADDRESS, node_port=DEFAULT_NODE
     return _get_test_job(
         'write-data',
         'cqlsh --cqlversion=3.4.0 -e "{}" {} {}'.format(cql, node_address, node_port))
-
-
-def get_verify_node_replace_job(replaced_address, node_address=DEFAULT_NODE_ADDRESS, node_port=DEFAULT_NODE_PORT):
-    # TODO something like this, except it'd need to run on a node host:
-    #    'nodetool -p {jmx_port} status > status.txt',
-    #    'cat status.txt',
-    #    'echo CHECKING FOR LACK OF {replaced_address}',
-    #    '[ 0 = $(grep "{replaced_address}" status.txt | wc -l) ]',
-    #    '[ 0 != $(grep -E "[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+" status.txt | wc -l) ]'])
-    cmd = ' && '.join([
-        'cqlsh --no-color -e "select peer from system.peers;" {query_address} {query_port} > peers.txt',
-        'cat peers.txt',
-        'echo CHECKING FOR LACK OF {replaced_address}',
-        '[ 0 = $(grep "{replaced_address}" peers.txt | wc -l) ]',
-        '[ 2 = $(grep -E "[0-9.]+$" peers.txt | wc -l) ]'])
-    return _get_test_job(
-        'verify-node-replace',
-        cmd.format(replaced_address=replaced_address, query_address=node_address, query_port=node_port),
-        restart_policy="ON_FAILURE")
 
 
 def run_backup_and_restore(

--- a/frameworks/hdfs/src/main/dist/svc.yml
+++ b/frameworks/hdfs/src/main/dist/svc.yml
@@ -49,6 +49,13 @@ pods:
           {{/TLS_ENABLED}}
         env:
           JOURNALNODE: true
+        readiness-check:
+          cmd: >
+              READY=$(grep "IPC Server listener on {{TASKCFG_ALL_JOURNAL_NODE_RPC_PORT}}: starting" stderr| wc -l) &&
+              [ $READY -ge 1 ]
+          interval: 10
+          delay: 60
+          timeout: 60
   name:
     count: 2
     uris:

--- a/frameworks/hdfs/src/main/dist/svc.yml
+++ b/frameworks/hdfs/src/main/dist/svc.yml
@@ -51,10 +51,9 @@ pods:
           JOURNALNODE: true
         readiness-check:
           cmd: >
-              READY=$(grep "IPC Server listener on {{TASKCFG_ALL_JOURNAL_NODE_RPC_PORT}}: starting" stderr| wc -l) &&
+              READY=$(grep "IPC Server listener on {{TASKCFG_ALL_JOURNAL_NODE_RPC_PORT}}: starting" stderr | wc -l) &&
               [ $READY -ge 1 ]
           interval: 10
-          delay: 60
           timeout: 60
   name:
     count: 2

--- a/frameworks/hdfs/src/main/dist/svc.yml
+++ b/frameworks/hdfs/src/main/dist/svc.yml
@@ -50,9 +50,7 @@ pods:
         env:
           JOURNALNODE: true
         readiness-check:
-          cmd: >
-              READY=$(grep "IPC Server listener on {{TASKCFG_ALL_JOURNAL_NODE_RPC_PORT}}: starting" stderr | wc -l) &&
-              [ $READY -ge 1 ]
+          cmd: READY=$(grep "Initializing journal in directory" stderr | wc -l) && [ $READY -ge 1 ]
           interval: 10
           timeout: 60
   name:

--- a/frameworks/hdfs/tests/test_shakedown.py
+++ b/frameworks/hdfs/tests/test_shakedown.py
@@ -266,8 +266,9 @@ def test_bump_data_nodes():
 
 @pytest.mark.sanity
 def test_modify_app_config():
-    app_config_field = 'TASKCFG_ALL_CLIENT_READ_SHORTCIRCUIT_STREAMS_CACHE_SIZE_EXPIRY_MS'
+    old_recovery_plan = plan.get_recovery_plan(PACKAGE_NAME).json()
 
+    app_config_field = 'TASKCFG_ALL_CLIENT_READ_SHORTCIRCUIT_STREAMS_CACHE_SIZE_EXPIRY_MS'
     journal_ids = tasks.get_task_ids(FOLDERED_SERVICE_NAME, 'journal')
     name_ids = tasks.get_task_ids(FOLDERED_SERVICE_NAME, 'name')
 
@@ -283,6 +284,10 @@ def test_modify_app_config():
     tasks.check_tasks_updated(FOLDERED_SERVICE_NAME, 'journal', journal_ids)
     tasks.check_tasks_updated(FOLDERED_SERVICE_NAME, 'name', name_ids)
     tasks.check_tasks_updated(FOLDERED_SERVICE_NAME, 'data', journal_ids)
+
+    new_recovery_plan = plan.get_recovery_plan(PACKAGE_NAME).json()
+    # Recovery should not have been modified at all
+    assert(old_recovery_plan_status == new_recovery_plan_status)
 
 
 @pytest.mark.sanity

--- a/frameworks/hdfs/tests/test_shakedown.py
+++ b/frameworks/hdfs/tests/test_shakedown.py
@@ -263,10 +263,10 @@ def test_bump_data_nodes():
     check_healthy(DEFAULT_TASK_COUNT + 1)
     tasks.check_tasks_not_updated(FOLDERED_SERVICE_NAME, 'data', data_ids)
 
-
 @pytest.mark.sanity
 def test_modify_app_config():
-    old_recovery_plan = plan.get_recovery_plan(PACKAGE_NAME).json()
+    plan.wait_for_completed_recovery(FOLDERED_SERVICE_NAME)
+    old_recovery_plan = plan.get_recovery_plan(FOLDERED_SERVICE_NAME)
 
     app_config_field = 'TASKCFG_ALL_CLIENT_READ_SHORTCIRCUIT_STREAMS_CACHE_SIZE_EXPIRY_MS'
     journal_ids = tasks.get_task_ids(FOLDERED_SERVICE_NAME, 'journal')
@@ -285,9 +285,9 @@ def test_modify_app_config():
     tasks.check_tasks_updated(FOLDERED_SERVICE_NAME, 'name', name_ids)
     tasks.check_tasks_updated(FOLDERED_SERVICE_NAME, 'data', journal_ids)
 
-    new_recovery_plan = plan.get_recovery_plan(PACKAGE_NAME).json()
-    # Recovery should not have been modified at all
-    assert(old_recovery_plan_status == new_recovery_plan_status)
+    plan.wait_for_completed_recovery(FOLDERED_SERVICE_NAME)
+    new_recovery_plan = plan.get_recovery_plan(FOLDERED_SERVICE_NAME)
+    assert(old_recovery_plan == new_recovery_plan)
 
 
 @pytest.mark.sanity

--- a/frameworks/hdfs/universe/marathon.json.mustache
+++ b/frameworks/hdfs/universe/marathon.json.mustache
@@ -22,7 +22,7 @@
   {{/service.secret_name}}
   "env": {
     "FRAMEWORK_NAME": "{{service.name}}",
-    "HDFS_VERSION": "hadoop-2.6.0-cdh5.9.1",
+    "HDFS_VERSION": "hadoop-2.6.0-cdh5.11.0",
     "JRE_VERSION": "jre1.8.0_131",
     "TASKCFG_ALL_JRE_VERSION": "jre1.8.0_131",
     "DEPLOY_STRATEGY": "{{service.deploy_strategy}}",

--- a/frameworks/hdfs/universe/resource.json
+++ b/frameworks/hdfs/universe/resource.json
@@ -3,7 +3,7 @@
     "uris": {
       "jre-tar-gz": "{{jre-jce-unlimited-url}}",
       "libmesos-bundle-tar-gz": "{{libmesos-bundle-url}}",
-      "hdfs-tar-gz": "https://downloads.mesosphere.com/hdfs/assets/hadoop-2.6.0-cdh5.9.1-dcos.tar.gz",
+      "hdfs-tar-gz": "https://downloads.mesosphere.com/hdfs/assets/hadoop-2.6.0-cdh5.11.0.tar.gz",
       "bootstrap-zip": "{{artifact-dir}}/bootstrap.zip",
       "scheduler-zip": "{{artifact-dir}}/hdfs-scheduler.zip",
       "executor-zip": "{{artifact-dir}}/executor.zip"

--- a/frameworks/kafka/docs/limitations.md
+++ b/frameworks/kafka/docs/limitations.md
@@ -6,22 +6,22 @@ enterprise: 'no'
 ---
 
 
-* Configurations
+## Configurations
 
-    The "disk" configuration value is denominated in MB. We recommend you set the configuration value `log_retention_bytes` to a value smaller than the indicated "disk" configuration. See the Configuring section for instructions for customizing these values.
+The "disk" configuration value is denominated in MB. We recommend you set the configuration value `log_retention_bytes` to a value smaller than the indicated "disk" configuration. See the Configuring section for instructions for customizing these values.
 
-* Managing Configurations Outside of the Service
+## Managing Configurations Outside of the Service
 
-    The Kafka service's core responsibility is to deploy and maintain the deployment of a Kafka cluster whose configuration has been specified. In order to do this the service makes the assumption that it has ownership of broker configuration. If an end-user makes modifications to individual brokers through out-of-band configuration operations, the service will almost certainly override those modifications at a later time. If a broker crashes, it will be restarted with the configuration known to the scheduler, not one modified out-of-band. If a configuration update is initiated, all out-of-band modifications will be overwritten during the rolling update.
+The Kafka service's core responsibility is to deploy and maintain the deployment of a Kafka cluster whose configuration has been specified. In order to do this, the service assumes that it has ownership of broker configuration. If an end-user makes modifications to individual brokers through out-of-band configuration operations, the service will almost certainly override those modifications at a later time. If a broker crashes, it will be restarted with the configuration known to the scheduler, not one modified out-of-band. If a configuration update is initiated, all out-of-band modifications will be overwritten during the rolling update.
 
-* Brokers
+## Brokers
 
-    The number of deployable brokers is constrained by two factors. First, brokers have specified required resources, so brokers may not be placed if the DC/OS cluster lacks the requisite resources. Second, the specified "PLACEMENT_STRATEGY" environment variable may affect how many brokers can be created in a Kafka cluster. By default the value is "ANY," so brokers are placed anywhere and are only constrained by the resources of the cluster. A second option is "NODE." In this case only one broker may be placed on a given DC/OS agent.
+The number of deployable brokers is constrained by two factors. First, brokers have specified required resources, so brokers may not be placed if the DC/OS cluster lacks the requisite resources. Second, the specified "PLACEMENT_STRATEGY" environment variable may affect how many brokers can be created in a Kafka cluster. By default the value is "ANY," so brokers are placed anywhere and are only constrained by the resources of the cluster. A second option is "NODE." In this case only one broker may be placed on a given DC/OS agent.
 
-* Security
+## Security
 
-    The security features introduced in Apache Kafka 0.9 are not supported at this time.
+The security features introduced in Apache Kafka 0.9 are not supported at this time.
 
-* Overlay networks
+## Overlay networks
 
-    When kafka is deployed on the `dcos` overlay network, the configuration cannot be updated to use the host network.
+When Kafka is deployed on the `dcos` overlay network, the configuration cannot be updated to use the host network.

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/MesosResourcePool.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/MesosResourcePool.java
@@ -217,8 +217,11 @@ public class MesosResourcePool {
 
         String previousRole = mesosResource.getPreviousRole();
         Map<String, Value> pool = reservableMergedPoolByRole.get(previousRole);
-        Value currValue = pool.get(mesosResource.getName());
+        if (pool == null) {
+            pool = new HashMap<>();
+        }
 
+        Value currValue = pool.get(mesosResource.getName());
         if (currValue == null) {
             currValue = ValueUtils.getZero(mesosResource.getType());
         }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultPodSpec.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultPodSpec.java
@@ -369,7 +369,12 @@ public class DefaultPodSpec implements PodSpec {
          * @return a reference to this Builder
          */
         public Builder volumes(Collection<VolumeSpec> volumes) {
-            this.volumes = volumes;
+            if (volumes == null) {
+                volumes = new ArrayList<>();
+            } else {
+                this.volumes = volumes;
+            }
+
             return this;
         }
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultPodSpec.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultPodSpec.java
@@ -394,7 +394,12 @@ public class DefaultPodSpec implements PodSpec {
          * @return a reference to this Builder
          */
         public Builder secrets(Collection<SecretSpec> secrets) {
-            this.secrets = secrets;
+            if (secrets == null) {
+                this.secrets = new ArrayList<>();
+            } else {
+                this.secrets = secrets;
+            }
+
             return this;
         }
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultPodSpec.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultPodSpec.java
@@ -329,7 +329,12 @@ public class DefaultPodSpec implements PodSpec {
          * @return a reference to this Builder
          */
         public Builder tasks(List<TaskSpec> tasks) {
-            this.tasks = tasks;
+            if (tasks == null) {
+                this.tasks = new ArrayList<>();
+            } else {
+                this.tasks = tasks;
+            }
+
             return this;
         }
 
@@ -384,7 +389,6 @@ public class DefaultPodSpec implements PodSpec {
 
             return this;
         }
-
 
         /**
          * Sets the {@code secrets} and returns a reference to this Builder so that the methods can be

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultReadinessCheckSpec.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultReadinessCheckSpec.java
@@ -16,7 +16,6 @@ public class DefaultReadinessCheckSpec implements ReadinessCheckSpec {
     @NotNull
     private String command;
 
-    @NotNull
     @Min(0)
     private Integer delay;
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/YAMLToInternalMappers.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/YAMLToInternalMappers.java
@@ -116,7 +116,7 @@ public class YAMLToInternalMappers {
     private static ReadinessCheckSpec from(RawReadinessCheck rawReadinessCheck) {
         return DefaultReadinessCheckSpec.newBuilder()
                 .command(rawReadinessCheck.getCmd())
-                .delay(rawReadinessCheck.getDelay())
+                .delay(rawReadinessCheck.getDelay() == null ? Integer.valueOf(0) : rawReadinessCheck.getDelay())
                 .interval(rawReadinessCheck.getInterval())
                 .timeout(rawReadinessCheck.getTimeout())
                 .build();

--- a/test.py
+++ b/test.py
@@ -499,15 +499,13 @@ def _setup_strict(framework, cluster, repo_root):
         custom_env['CLUSTER_URL'] = cluster.url
         custom_env['CLUSTER_AUTH_TOKEN'] = cluster.auth_token
 
-        for role_base in (framework.name, framework.name + "2"):
-
-            role_arg = '%s-role' % role_base
+        # include both base and foldered roles (tests exercise with /test/integration/svcname):
+        for role_base in (framework.name, 'test__integration__%s' % framework.name):
 
             # XXX helloworld is terrible and doesn't use its own name
-            if role_base == 'helloworld':
-                role_arg = 'hello-world-role'
+            role_base = role_base.replace('helloworld', 'hello-world')
 
-            cmd_args = [perm_setup_script, 'root', role_arg]
+            cmd_args = [perm_setup_script, 'root', '%s-role' % role_base]
 
             completed_cmd = subprocess.run(cmd_args, env=custom_env)
             if completed_cmd.returncode != 0:

--- a/test.sh
+++ b/test.sh
@@ -32,8 +32,8 @@ function run_framework_tests {
     echo Security: $SECURITY
     if [ "$SECURITY" = "strict" ]; then
         ${REPO_ROOT_DIR}/tools/setup_permissions.sh root ${framework}-role
-        # Some tests install a second instance of a framework, such as "hdfs2"
-        ${REPO_ROOT_DIR}/tools/setup_permissions.sh root ${framework}2-role
+        # include foldered roles (tests exercise with /test/integration/svcname):
+        ${REPO_ROOT_DIR}/tools/setup_permissions.sh root test__integration__${framework}-role
     fi
 
     # Run shakedown tests in framework directory:

--- a/testing/sdk_plan.py
+++ b/testing/sdk_plan.py
@@ -9,6 +9,8 @@ import shakedown
 def get_deployment_plan(service_name):
     return get_plan(service_name, "deploy")
 
+def get_recovery_plan(service_name):
+    return get_plan(service_name, "recovery")
 
 def get_plan(service_name, plan):
     def fn():


### PR DESCRIPTION
The deployment plan now waits for the journal nodes to succeed their readiness check before proceeding to deploying the name nodes.