### PR TITLE
[CASSANDRA-623] Fixed cassandra.yaml "listen_address" to use LIBPROCESS_IP

### DIFF
--- a/frameworks/cassandra/src/main/dist/cassandra.yaml
+++ b/frameworks/cassandra/src/main/dist/cassandra.yaml
@@ -1,6 +1,6 @@
 cluster_name: {{CASSANDRA_CLUSTER_NAME}}
 rpc_address: {{LIBPROCESS_IP}}
-listen_address: "{{TASK_NAME}}.{{SERVICE_NAME}}.autoip.dcos.thisdcos.directory"
+listen_address: {{LIBPROCESS_IP}}
 hints_directory: {{MESOS_SANDBOX}}/container-path/hints
 data_file_directories:
   - {{MESOS_SANDBOX}}/container-path/data


### PR DESCRIPTION
The "listen_address" in cassandra.yaml was previously set to "{{TASK_NAME}}.{{SERVICE_NAME}}.autoip.dcos.thisdcos.directory". However this dns name can sometimes be invalid during a "replace" operation, since it may still be pointing to the original task host IP.
This PR changes the "listen_address" to be based on LIBPROCESS_IP instead.