### PR TITLE
[CASSANDRA-622] Revert Cassandra "auto_snapshot" to default to "true"

### DIFF
--- a/frameworks/cassandra/universe/config.json
+++ b/frameworks/cassandra/universe/config.json
@@ -399,7 +399,7 @@
         "auto_snapshot": {
           "type": "boolean",
           "description": "Take a snapshot of the data before truncating a keyspace or dropping a table",
-          "default": false
+          "default": true
         },
         "roles_update_interval_in_ms": {
           "type": "integer",


### PR DESCRIPTION
The Cassandra "auto_snapshot" property was recently made configurable, with a default value of "false". This PR reverts the default value back to "true".