### PR TITLE
Fix SDK Docs for health- and readiness-check, YAML indentation

### DIFF
--- a/docs/pages/developer-guide.md
+++ b/docs/pages/developer-guide.md
@@ -1367,13 +1367,13 @@ pods:
         cmd: "echo hello && sleep 1000"
         cpus: 0.1
         memory: 256
-      health-check:
-        cmd: "./check-up"
-        interval: 5
-        grace-period: 30
-        max-consecutive-failures: 3
-        delay: 0
-        timeout: 10
+        health-check:
+          cmd: "./check-up"
+          interval: 5
+          grace-period: 30
+          max-consecutive-failures: 3
+          delay: 0
+          timeout: 10
 ```
 
 The interval, grace-period, delay, and timeout elements are denominated in seconds. If the maximum consecutive number of failures is exceeded, the task will be killed.
@@ -1393,11 +1393,11 @@ pods:
         cmd: "echo hello && sleep 1000"
         cpus: 0.1
         memory: 256
-      readiness-check:
-        cmd: "./readiness-check"
-        interval: 5
-        delay: 0
-        timeout: 10
+        readiness-check:
+          cmd: "./readiness-check"
+          interval: 5
+          delay: 0
+          timeout: 10
 ```
 
 The interval, delay, and timeout elements are denominated in seconds.


### PR DESCRIPTION
* fixed sdk docs developer guide for health- and readiness-check, properly indenting the YAML to match the necessary level as a TaskSpec attribute.