### PR TITLE
[INFINITY-1734] Fix Deprecation of PortsSpec

### DIFF
--- a/frameworks/kafka/tests/test_upgrade.py
+++ b/frameworks/kafka/tests/test_upgrade.py
@@ -30,7 +30,6 @@ def teardown_module(module):
 
 @pytest.mark.sanity
 @pytest.mark.smoke
-@pytest.mark.skip(reason="PR 1071")
 def test_upgrade():
 
     test_version = upgrade.get_pkg_version(PACKAGE_NAME)

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/TaskResourceMapper.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/TaskResourceMapper.java
@@ -103,7 +103,7 @@ class TaskResourceMapper {
         List<OfferEvaluationStage> stages = new ArrayList<>();
 
         if (!orphanedResources.isEmpty()) {
-            logger.info("Orphaned task resources no longer in TaskSpec: {}",
+            logger.info("Unreserving orphaned task resources no longer in TaskSpec: {}",
                     orphanedResources.stream().map(r -> TextFormat.shortDebugString(r)).collect(Collectors.toList()));
         }
 
@@ -151,6 +151,14 @@ class TaskResourceMapper {
 
     private Optional<ResourceLabels> findMatchingPortSpec(
             Protos.Resource taskResource, Collection<ResourceSpec> resourceSpecs, Map<String, String> taskEnv) {
+        Protos.Value.Ranges ranges = taskResource.getRanges();
+        boolean hasMultiplePorts = ranges.getRangeCount() != 1
+                || ranges.getRange(0).getEnd() - ranges.getRange(0).getBegin() != 0;
+
+        if (hasMultiplePorts) {
+            return Optional.empty();
+        }
+
         for (ResourceSpec resourceSpec : resourceSpecs) {
             if (!(resourceSpec instanceof PortSpec)) {
                 continue;

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/PortsSpec.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/PortsSpec.java
@@ -2,6 +2,7 @@ package com.mesosphere.sdk.specification;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.mesosphere.sdk.offer.Constants;
 import com.mesosphere.sdk.specification.validation.ValidationUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -15,7 +16,7 @@ import java.util.Collection;
 /**
  * This class represents a ports resource with multiple ports.
  */
-public class PortsSpec {
+public class PortsSpec implements ResourceSpec {
     @NotNull
     @Size(min = 1)
     private final String name;
@@ -68,5 +69,30 @@ public class PortsSpec {
     @Override
     public int hashCode() {
         return HashCodeBuilder.reflectionHashCode(this);
+    }
+
+    @Override
+    public Protos.Value getValue() {
+        return value;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String getRole() {
+        return role;
+    }
+
+    @Override
+    public String getPreReservedRole() {
+        return Constants.ANY_ROLE;
+    }
+
+    @Override
+    public String getPrincipal() {
+        return principal;
     }
 }


### PR DESCRIPTION
As part of the very big refactor associated with resource reservation work, PortsSpec stopped being used.  However, we can't just remove it since it breaks upgrade from older versions of the framework that still used PortsSpec

This work detects situations where PortsSpec was used with more than one port, UNRESERVEs all those ports, and makes it clear that they must be re-reserved all within the confines of a single OfferEvaluation cycle.