### PR TITLE
[INFINITY-1768] Fix disk resource reservation

### DIFF
--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluatorVolumesTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluatorVolumesTest.java
@@ -57,6 +57,7 @@ public class OfferEvaluatorVolumesTest extends OfferEvaluatorTestBase {
         Assert.assertEquals(TestConstants.ROLE, ResourceUtils.getRole(reserveResource).get());
         Assert.assertEquals(TestConstants.PRINCIPAL, reservation.getPrincipal());
         Assert.assertEquals(36, getResourceId(reserveResource).length());
+        Assert.assertFalse(reserveResource.hasDisk());
 
         // Validate CREATE Operation
         String resourceId = getResourceId(reserveResource);
@@ -145,6 +146,9 @@ public class OfferEvaluatorVolumesTest extends OfferEvaluatorTestBase {
         Assert.assertEquals(TestConstants.MOUNT_ROOT, reserveResource.getDisk().getSource().getMount().getRoot());
         Assert.assertEquals(TestConstants.PRINCIPAL, reservation.getPrincipal());
         Assert.assertEquals(36, getResourceId(reserveResource).length());
+        Assert.assertTrue(reserveResource.hasDisk());
+        Assert.assertFalse(reserveResource.getDisk().hasPersistence());
+        Assert.assertFalse(reserveResource.getDisk().hasVolume());
 
         // Validate CREATE Operation
         String resourceId = getResourceId(reserveResource);


### PR DESCRIPTION
See the JIRA.  I broke MOUNT volume resource reservation.  [Replaced the function that used to be there](https://github.com/mesosphere/dcos-commons/blob/c2068b3f66eccfd7cbadf0068a9ce2db8a8297cd/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/ReserveOfferRecommendation.java#L42-L55).

@susanxhuynh has validated it works on a real cluster with MOUNT volumes.

Extended the unit tests to prevent future regressions.