### PR TITLE
change in testing/sdk_package 

### DIFF
--- a/testing/sdk_package.py
+++ b/testing/sdk_package.py
@@ -9,7 +9,7 @@ import re
 def get_pkg_version(package_name):
     return re.search(
         r'"version": "(\S+)"',
-        sdk_cmd.run_cli('dcos package describe {}'.format(package_name))).group(1)
+        sdk_cmd.run_cli('package describe {}'.format(package_name))).group(1)
 
 
 def get_repo_list():


### PR DESCRIPTION
- Changing from "dcos dcos package describe" -> "dcos package describe"

- This is because sdk_cmd.run_cli = shakedown.run_dcos_command() NOT shakedown.run_command()