### PR TITLE
[ELASTIC-97] Increase Kibana install timeout

### DIFF
--- a/frameworks/elastic/tests/config.py
+++ b/frameworks/elastic/tests/config.py
@@ -12,7 +12,7 @@ import sdk_utils
 PACKAGE_NAME = 'elastic'
 DEFAULT_TASK_COUNT = 7
 WAIT_TIME_IN_SECONDS = 10 * 60
-KIBANA_WAIT_TIME_IN_SECONDS = 15 * 60
+KIBANA_WAIT_TIME_IN_SECONDS = 30 * 60
 DEFAULT_INDEX_NAME = 'customer'
 DEFAULT_INDEX_TYPE = 'entry'
 DCOS_URL = shakedown.run_dcos_command('config show core.dcos_url')[0].strip()


### PR DESCRIPTION
Increase from 15 to 30 minutes as it's sometimes taking 14+ mins during Jenkins runs