### PR TITLE
Improve robustness of DefaultSchedulerTest

### DIFF
--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/DefaultSchedulerTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/DefaultSchedulerTest.java
@@ -872,6 +872,16 @@ public class DefaultSchedulerTest {
         taskIds.add(installStep(1, 0, getSufficientOfferForTaskB()));
         taskIds.add(installStep(1, 1, getSufficientOfferForTaskB()));
 
+        while (true) {
+            if (defaultScheduler.deploymentPlanManager.getPlan().isComplete()) {
+                break;
+            }
+
+            try {
+                Thread.sleep(100);
+            } catch (Exception e) {}
+        }
+
         Assert.assertEquals(Arrays.asList(Status.COMPLETE, Status.COMPLETE, Status.COMPLETE),
                 PlanTestUtils.getStepStatuses(plan));
         Assert.assertTrue(StateStoreUtils.isSuppressed(stateStore));

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/DefaultSchedulerTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/DefaultSchedulerTest.java
@@ -872,11 +872,7 @@ public class DefaultSchedulerTest {
         taskIds.add(installStep(1, 0, getSufficientOfferForTaskB()));
         taskIds.add(installStep(1, 1, getSufficientOfferForTaskB()));
 
-        while (true) {
-            if (defaultScheduler.deploymentPlanManager.getPlan().isComplete()) {
-                break;
-            }
-
+        while (!defaultScheduler.deploymentPlanManager.getPlan().isComplete()) {
             try {
                 Thread.sleep(100);
             } catch (Exception e) {}


### PR DESCRIPTION
Verify that plan has completed before checking the expected results. Test suite has a 30 second per test timeout, so test will timeout despite infinite loop.