### PR TITLE
[INFINITY-1365] Prepare refine resources

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/dcos/Capabilities.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/dcos/Capabilities.java
@@ -57,8 +57,7 @@ public class Capabilities {
     }
 
     public boolean supportsPreReservedResources() {
-        // RESERVATION_REFINEMENT is supported by DC/OS 1.10 upwards
-        return hasOrExceedsVersion(1, 10);
+        return false;
     }
 
     private boolean hasOrExceedsVersion(int major, int minor) {

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/dcos/Capabilities.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/dcos/Capabilities.java
@@ -36,32 +36,41 @@ public class Capabilities {
         this.dcosCluster = dcosCluster;
     }
 
-    public boolean supportsNamedVips() throws IOException {
+    public boolean supportsNamedVips() {
         // Named Vips are supported by DC/OS 1.8 upwards.
         return hasOrExceedsVersion(1, 8);
     }
 
-    public boolean supportsRLimits() throws IOException {
+    public boolean supportsRLimits() {
         // Container rlimits are supported by DC/OS 1.9 upwards.
         return hasOrExceedsVersion(1, 9);
     }
 
-    public boolean supportsGpuResource() throws IOException {
+    public boolean supportsGpuResource() {
         // GPU_RESOURCE is supported by DC/OS 1.9 upwards
         return hasOrExceedsVersion(1, 9);
     }
 
-    public boolean supportsCNINetworking() throws IOException {
-        // CNI port-mapping is supported by DC/OS 1.10 upwards
+    public boolean supportsCNINetworking() {
+        // CNI port-mapping is supported by DC/OS 1.9 upwards
         return hasOrExceedsVersion(1, 9);
     }
 
     public boolean supportsPreReservedResources() {
-        return false;
+        // RESERVATION_REFINEMENT is supported by DC/OS 1.10 upwards
+        return hasOrExceedsVersion(1, 10);
     }
 
-    private boolean hasOrExceedsVersion(int major, int minor) throws IOException {
-        DcosVersion.Elements versionElements = dcosCluster.getDcosVersion().getElements();
+    private boolean hasOrExceedsVersion(int major, int minor) {
+        DcosVersion dcosVersion = null;
+        try {
+            dcosVersion = dcosCluster.getDcosVersion();
+        } catch (IOException e) {
+            LOGGER.error("Unable to fetch DC/OS version.");
+            throw new IllegalStateException(e);
+        }
+
+        DcosVersion.Elements versionElements = dcosVersion.getElements();
         try {
             if (versionElements.getFirstElement() > major) {
                 return true;
@@ -71,9 +80,8 @@ public class Capabilities {
             return false;
         } catch (NumberFormatException ex) {
             // incorrect version string.
-            LOGGER.error("Unable to parse DC/OS version string: {}", dcosCluster.getDcosVersion().getVersion());
-            return false;
+            LOGGER.error("Unable to parse DC/OS version string: {}", dcosVersion.getVersion());
+            throw new IllegalStateException(ex);
         }
-
     }
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/ResourceBuilder.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/ResourceBuilder.java
@@ -190,8 +190,9 @@ public class ResourceBuilder {
     public Resource build() {
         Resource.Builder builder =
                 mesosResource == null ? Resource.newBuilder() : mesosResource.getResource().toBuilder();
-        builder.setName(resourceName).setRole(preReservedRole);
-        builder.setType(value.getType());
+        builder.setName(resourceName)
+                .setRole(Constants.ANY_ROLE)
+                .setType(value.getType());
 
         if (role.isPresent() && !Capabilities.getInstance().supportsPreReservedResources()) {
             builder.setRole(role.get());
@@ -202,7 +203,14 @@ public class ResourceBuilder {
             Resource.ReservationInfo reservationInfo = getReservationInfo(role.get(), resId);
 
             if (Capabilities.getInstance().supportsPreReservedResources()) {
+                if (!preReservedRole.equals(Constants.ANY_ROLE) && mesosResource == null) {
+                    builder.addReservations(
+                            Resource.ReservationInfo.newBuilder()
+                            .setRole(preReservedRole)
+                            .setType(Resource.ReservationInfo.Type.STATIC));
+                }
                 builder.addReservations(reservationInfo);
+                builder.clearRole();
             } else {
                 builder.setReservation(reservationInfo);
             }

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/DefaultResourceCleanerTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/DefaultResourceCleanerTest.java
@@ -2,10 +2,7 @@ package com.mesosphere.sdk.offer;
 
 import com.mesosphere.sdk.scheduler.recovery.FailureUtils;
 import com.mesosphere.sdk.state.StateStore;
-import com.mesosphere.sdk.testutils.OfferTestUtils;
-import com.mesosphere.sdk.testutils.ResourceTestUtils;
-import com.mesosphere.sdk.testutils.TaskTestUtils;
-import com.mesosphere.sdk.testutils.TestConstants;
+import com.mesosphere.sdk.testutils.*;
 import org.apache.mesos.Protos.Offer;
 import org.apache.mesos.Protos.Offer.Operation;
 import org.apache.mesos.Protos.Resource;
@@ -23,7 +20,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class DefaultResourceCleanerTest {
+public class DefaultResourceCleanerTest extends DefaultCapabilitiesTestSuite {
 
     private static final String EXPECTED_RESOURCE_1_ID = "expected-resource-id";
     private static final String EXPECTED_RESOURCE_2_ID = "expected-volume-id";

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/MesosResourcePoolTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/MesosResourcePoolTest.java
@@ -1,5 +1,6 @@
 package com.mesosphere.sdk.offer;
 
+import com.mesosphere.sdk.testutils.DefaultCapabilitiesTestSuite;
 import com.mesosphere.sdk.testutils.OfferTestUtils;
 import com.mesosphere.sdk.testutils.ResourceTestUtils;
 import org.apache.mesos.Protos;
@@ -11,7 +12,7 @@ import org.junit.Test;
 import java.util.Arrays;
 import java.util.Optional;
 
-public class MesosResourcePoolTest {
+public class MesosResourcePoolTest extends DefaultCapabilitiesTestSuite {
 
     @Test
     public void testEmptyUnreservedAtomicPool() {

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/ResourceBuilderTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/ResourceBuilderTest.java
@@ -6,6 +6,7 @@ import com.mesosphere.sdk.specification.DefaultResourceSpec;
 import com.mesosphere.sdk.specification.DefaultVolumeSpec;
 import com.mesosphere.sdk.specification.ResourceSpec;
 import com.mesosphere.sdk.specification.VolumeSpec;
+import com.mesosphere.sdk.testutils.DefaultCapabilitiesTestSuite;
 import com.mesosphere.sdk.testutils.TestConstants;
 import org.apache.mesos.Protos;
 import org.junit.Assert;
@@ -17,7 +18,7 @@ import java.util.UUID;
 /**
  * Test construction of Resource protobufs.
  */
-public class ResourceBuilderTest {
+public class ResourceBuilderTest extends DefaultCapabilitiesTestSuite {
     /*
         name: "cpus"
         type: SCALAR

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/ResourceBuilderTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/ResourceBuilderTest.java
@@ -123,7 +123,7 @@ public class ResourceBuilderTest extends DefaultCapabilitiesTestSuite {
 
             Protos.Resource resource = resourceBuilder.build();
             Assert.assertEquals(2, resource.getReservationsCount());
-            validateScalarResourceRefined(TestConstants.PRE_RESERVED_ROLE, resource);
+            validateScalarResourceRefined(resource);
             Assert.assertEquals(Protos.Resource.ReservationInfo.Type.STATIC, resource.getReservations(0).getType());
             Assert.assertEquals(TestConstants.PRE_RESERVED_ROLE, resource.getReservations(0).getRole());
         } finally {
@@ -483,10 +483,6 @@ public class ResourceBuilderTest extends DefaultCapabilitiesTestSuite {
     }
 
     private void validateScalarResourceRefined(Protos.Resource resource) {
-        validateScalarResourceRefined(Constants.ANY_ROLE, resource);
-    }
-
-    private void validateScalarResourceRefined(String preReservedRole, Protos.Resource resource) {
         Assert.assertEquals(Protos.Value.Type.SCALAR, resource.getType());
         Assert.assertEquals(Constants.ANY_ROLE, resource.getRole());
         Assert.assertFalse(resource.hasReservation());

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/UnreserveOfferRecommendationTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/UnreserveOfferRecommendationTest.java
@@ -1,5 +1,6 @@
 package com.mesosphere.sdk.offer;
 
+import com.mesosphere.sdk.testutils.DefaultCapabilitiesTestSuite;
 import com.mesosphere.sdk.testutils.OfferTestUtils;
 import com.mesosphere.sdk.testutils.ResourceTestUtils;
 import org.apache.mesos.Protos;
@@ -9,7 +10,7 @@ import org.junit.Test;
 /**
  * This class tests the {@link UnreserveOfferRecommendation} class.
  */
-public class UnreserveOfferRecommendationTest {
+public class UnreserveOfferRecommendationTest extends DefaultCapabilitiesTestSuite {
 
     @Test
     public void testUnreserveRootDisk() {

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/ExecutorEvaluationStageTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/ExecutorEvaluationStageTest.java
@@ -16,7 +16,7 @@ import java.util.Arrays;
 import java.util.Optional;
 import java.util.UUID;
 
-public class ExecutorEvaluationStageTest extends OfferEvaluatorTestBase{
+public class ExecutorEvaluationStageTest extends OfferEvaluatorTestBase {
     @Test
     public void testRejectOfferWithoutExpectedExecutorId() throws Exception {
         PodInstanceRequirement podInstanceRequirement = PodInstanceRequirementTestUtils.getCpuRequirement(1.0);

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/LaunchEvaluationStageTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/LaunchEvaluationStageTest.java
@@ -5,10 +5,7 @@ import com.mesosphere.sdk.offer.MesosResourcePool;
 import com.mesosphere.sdk.scheduler.plan.PodInstanceRequirement;
 import com.mesosphere.sdk.scheduler.plan.PodInstanceRequirementTestUtils;
 import com.mesosphere.sdk.specification.GoalState;
-import com.mesosphere.sdk.testutils.OfferRequirementTestUtils;
-import com.mesosphere.sdk.testutils.OfferTestUtils;
-import com.mesosphere.sdk.testutils.ResourceTestUtils;
-import com.mesosphere.sdk.testutils.TestConstants;
+import com.mesosphere.sdk.testutils.*;
 import org.apache.mesos.Protos;
 import org.junit.Assert;
 import org.junit.Test;
@@ -17,7 +14,7 @@ import java.util.Collections;
 import java.util.Optional;
 import java.util.UUID;
 
-public class LaunchEvaluationStageTest {
+public class LaunchEvaluationStageTest extends DefaultCapabilitiesTestSuite {
     @Test
     public void testTaskInfoIsModifiedCorrectly() throws Exception {
         Protos.Resource offeredResource = ResourceTestUtils.getUnreservedScalar("cpus", 2.0);

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/NamedVIPEvaluationStageTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/NamedVIPEvaluationStageTest.java
@@ -7,10 +7,7 @@ import com.mesosphere.sdk.offer.MesosResourcePool;
 import com.mesosphere.sdk.scheduler.plan.DefaultPodInstance;
 import com.mesosphere.sdk.scheduler.plan.PodInstanceRequirement;
 import com.mesosphere.sdk.specification.*;
-import com.mesosphere.sdk.testutils.OfferRequirementTestUtils;
-import com.mesosphere.sdk.testutils.OfferTestUtils;
-import com.mesosphere.sdk.testutils.ResourceTestUtils;
-import com.mesosphere.sdk.testutils.TestConstants;
+import com.mesosphere.sdk.testutils.*;
 import org.apache.mesos.Protos;
 import org.apache.mesos.Protos.DiscoveryInfo;
 import org.junit.Assert;
@@ -21,7 +18,7 @@ import java.util.*;
 /**
  * Tests for {@link NamedVIPEvaluationStage}.
  */
-public class NamedVIPEvaluationStageTest {
+public class NamedVIPEvaluationStageTest extends DefaultCapabilitiesTestSuite {
 
     @Test
     public void testDiscoveryInfoPopulated() throws Exception {

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluatorTestBase.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluatorTestBase.java
@@ -6,6 +6,7 @@ import com.mesosphere.sdk.scheduler.plan.PodInstanceRequirement;
 import com.mesosphere.sdk.state.DefaultStateStore;
 import com.mesosphere.sdk.state.StateStore;
 import com.mesosphere.sdk.storage.MemPersister;
+import com.mesosphere.sdk.testutils.DefaultCapabilitiesTestSuite;
 import com.mesosphere.sdk.testutils.OfferRequirementTestUtils;
 import com.mesosphere.sdk.testutils.OfferTestUtils;
 import com.mesosphere.sdk.testutils.TestConstants;
@@ -21,7 +22,7 @@ import java.util.UUID;
 /**
  * A base class for use in writing offer evaluation tests.
  */
-public class OfferEvaluatorTestBase {
+public class OfferEvaluatorTestBase extends DefaultCapabilitiesTestSuite {
     protected static final SchedulerFlags flags = OfferRequirementTestUtils.getTestSchedulerFlags();
     protected static final String ROOT_ZK_PATH = "/test-root-path";
     protected StateStore stateStore;

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/PlacementRuleEvaluationStageTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/PlacementRuleEvaluationStageTest.java
@@ -11,10 +11,7 @@ import com.mesosphere.sdk.scheduler.plan.PodInstanceRequirementTestUtils;
 import com.mesosphere.sdk.specification.DefaultPodSpec;
 import com.mesosphere.sdk.specification.PodInstance;
 import com.mesosphere.sdk.specification.PodSpec;
-import com.mesosphere.sdk.testutils.OfferRequirementTestUtils;
-import com.mesosphere.sdk.testutils.OfferTestUtils;
-import com.mesosphere.sdk.testutils.ResourceTestUtils;
-import com.mesosphere.sdk.testutils.TestConstants;
+import com.mesosphere.sdk.testutils.*;
 import org.apache.mesos.Protos;
 import org.junit.Assert;
 import org.junit.Test;
@@ -24,7 +21,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
-public class PlacementRuleEvaluationStageTest {
+public class PlacementRuleEvaluationStageTest extends DefaultCapabilitiesTestSuite {
     @Test
     public void testOfferPassesPlacementRule() throws Exception {
         String agent = "test-agent";

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/PortEvaluationStageTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/PortEvaluationStageTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
 import java.util.*;
 import java.util.stream.Collectors;
 
-public class PortEvaluationStageTest {
+public class PortEvaluationStageTest extends DefaultCapabilitiesTestSuite {
     private static final SchedulerFlags flags = OfferRequirementTestUtils.getTestSchedulerFlags();
 
     private Protos.Value getPort(int port) {

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/VolumeEvaluationStageTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/VolumeEvaluationStageTest.java
@@ -5,10 +5,7 @@ import com.mesosphere.sdk.scheduler.plan.PodInstanceRequirement;
 import com.mesosphere.sdk.scheduler.plan.PodInstanceRequirementTestUtils;
 import com.mesosphere.sdk.specification.PodInstance;
 import com.mesosphere.sdk.specification.VolumeSpec;
-import com.mesosphere.sdk.testutils.OfferRequirementTestUtils;
-import com.mesosphere.sdk.testutils.OfferTestUtils;
-import com.mesosphere.sdk.testutils.ResourceTestUtils;
-import com.mesosphere.sdk.testutils.TestConstants;
+import com.mesosphere.sdk.testutils.*;
 import org.apache.mesos.Protos;
 import org.junit.Assert;
 import org.junit.Test;
@@ -19,7 +16,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
-public class VolumeEvaluationStageTest {
+public class VolumeEvaluationStageTest extends DefaultCapabilitiesTestSuite {
     @Test
     public void testCreateSucceeds() throws Exception {
         Protos.Resource offeredResource = ResourceTestUtils.getUnreservedMountVolume(2000);

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/testutils/DefaultCapabilitiesTestSuite.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/testutils/DefaultCapabilitiesTestSuite.java
@@ -1,0 +1,37 @@
+package com.mesosphere.sdk.testutils;
+
+import com.mesosphere.sdk.dcos.Capabilities;
+import com.mesosphere.sdk.dcos.ResourceRefinementCapabilityContext;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * This class provides default a context with the default set of capabilities.
+ */
+public abstract class DefaultCapabilitiesTestSuite {
+    private static ResourceRefinementCapabilityContext context;
+    private static Capabilities capabilities;
+
+    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings("ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD")
+    public DefaultCapabilitiesTestSuite() {
+        capabilities = mock(Capabilities.class);
+        when(capabilities.supportsGpuResource()).thenReturn(true);
+        when(capabilities.supportsCNINetworking()).thenReturn(true);
+        when(capabilities.supportsNamedVips()).thenReturn(true);
+        when(capabilities.supportsRLimits()).thenReturn(true);
+        when(capabilities.supportsPreReservedResources()).thenReturn(true);
+    }
+
+    @BeforeClass
+    public static void beforeAll() throws Exception {
+        context = new ResourceRefinementCapabilityContext(Capabilities.getInstance());
+    }
+
+    @AfterClass
+    public static void afterAll() {
+        context.reset();
+    }
+}


### PR DESCRIPTION
This should be sufficient changes such that a one line change in `Capabilities` will enable resource refinement.

I tested this on `testing/master` and `testing/pull/1524` manually.