### PR TITLE
INFINITY-1761 Use 'nodetool' instead of direct task lookup in cassandra node replace test

### DIFF
--- a/frameworks/cassandra/tests/config.py
+++ b/frameworks/cassandra/tests/config.py
@@ -19,7 +19,7 @@ DEFAULT_NODE_PORT = os.getenv('CASSANDRA_NODE_PORT', '9042')
 
 def _get_test_job(name, cmd, restart_policy='NEVER'):
     return {
-        'description': 'Utility job for Cassandra integration tests',
+        'description': 'Integration test job: ' + name,
         'id': 'test.cassandra.' + name,
         'run': {
             'cmd': cmd,
@@ -75,25 +75,6 @@ def get_write_data_job(node_address=DEFAULT_NODE_ADDRESS, node_port=DEFAULT_NODE
     return _get_test_job(
         'write-data',
         'cqlsh --cqlversion=3.4.0 -e "{}" {} {}'.format(cql, node_address, node_port))
-
-
-def get_verify_node_replace_job(replaced_address, node_address=DEFAULT_NODE_ADDRESS, node_port=DEFAULT_NODE_PORT):
-    # TODO something like this, except it'd need to run on a node host:
-    #    'nodetool -p {jmx_port} status > status.txt',
-    #    'cat status.txt',
-    #    'echo CHECKING FOR LACK OF {replaced_address}',
-    #    '[ 0 = $(grep "{replaced_address}" status.txt | wc -l) ]',
-    #    '[ 0 != $(grep -E "[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+" status.txt | wc -l) ]'])
-    cmd = ' && '.join([
-        'cqlsh --no-color -e "select peer from system.peers;" {query_address} {query_port} > peers.txt',
-        'cat peers.txt',
-        'echo CHECKING FOR LACK OF {replaced_address}',
-        '[ 0 = $(grep "{replaced_address}" peers.txt | wc -l) ]',
-        '[ 2 = $(grep -E "[0-9.]+$" peers.txt | wc -l) ]'])
-    return _get_test_job(
-        'verify-node-replace',
-        cmd.format(replaced_address=replaced_address, query_address=node_address, query_port=node_port),
-        restart_policy="ON_FAILURE")
 
 
 def run_backup_and_restore(


### PR DESCRIPTION
The table can flake out and never update (or did once, at least...), whereas nodetool is hopefully more consistent(?). Waits for the old node to disappear and a new node to appear with UN status.