### PR TITLE
INFINITY-1793 Fix strict mode tests for foldered services (probably)

### DIFF
--- a/test.py
+++ b/test.py
@@ -499,15 +499,13 @@ def _setup_strict(framework, cluster, repo_root):
         custom_env['CLUSTER_URL'] = cluster.url
         custom_env['CLUSTER_AUTH_TOKEN'] = cluster.auth_token
 
-        for role_base in (framework.name, framework.name + "2"):
-
-            role_arg = '%s-role' % role_base
+        # include both base and foldered roles (tests exercise with /test/integration/svcname):
+        for role_base in (framework.name, 'test__integration__%s' % framework.name):
 
             # XXX helloworld is terrible and doesn't use its own name
-            if role_base == 'helloworld':
-                role_arg = 'hello-world-role'
+            role_base = role_base.replace('helloworld', 'hello-world')
 
-            cmd_args = [perm_setup_script, 'root', role_arg]
+            cmd_args = [perm_setup_script, 'root', '%s-role' % role_base]
 
             completed_cmd = subprocess.run(cmd_args, env=custom_env)
             if completed_cmd.returncode != 0:

--- a/test.sh
+++ b/test.sh
@@ -32,8 +32,8 @@ function run_framework_tests {
     echo Security: $SECURITY
     if [ "$SECURITY" = "strict" ]; then
         ${REPO_ROOT_DIR}/tools/setup_permissions.sh root ${framework}-role
-        # Some tests install a second instance of a framework, such as "hdfs2"
-        ${REPO_ROOT_DIR}/tools/setup_permissions.sh root ${framework}2-role
+        # include foldered roles (tests exercise with /test/integration/svcname):
+        ${REPO_ROOT_DIR}/tools/setup_permissions.sh root test__integration__${framework}-role
     fi
 
     # Run shakedown tests in framework directory:


### PR DESCRIPTION
- Foldered services are exercised as `/test/integration/svcname` which maps to a role of `test__integration__svcname-role`
- Removes `svcname2` role setup, as `grep -R 2 frameworks/*/tests/` shows that tests aren't installing a separate `2` instance anymore. Comments imply this was once the case in `dcos-hdfs-service` which is now long gone.