### PR TITLE
Move hello-world upgrade test into separate file

### DIFF
--- a/frameworks/helloworld/tests/test_sanity.py
+++ b/frameworks/helloworld/tests/test_sanity.py
@@ -9,7 +9,6 @@ import sdk_cmd as cmd
 import sdk_install as install
 import sdk_marathon as marathon
 import sdk_tasks as tasks
-import sdk_test_upgrade
 import sdk_utils
 from tests.config import (
     PACKAGE_NAME,
@@ -262,8 +261,6 @@ def test_lock():
     zk_config_new = shakedown.get_zk_node_data(zk_path)
     assert zk_config_old == zk_config_new
 
-
-@pytest.mark.upgrade
-@pytest.mark.sanity
-def test_upgrade_downgrade():
-    sdk_test_upgrade.upgrade_downgrade(PACKAGE_NAME, PACKAGE_NAME, DEFAULT_TASK_COUNT)
+    # Don't bother scaling back to 1 instance as we're about to be uninstalled anyway.
+    #marathon_client.update_app(FOLDERED_SERVICE_NAME, {"instances": 1})
+    #shakedown.deployment_wait()

--- a/frameworks/helloworld/tests/test_sanity.py
+++ b/frameworks/helloworld/tests/test_sanity.py
@@ -262,5 +262,3 @@ def test_lock():
     assert zk_config_old == zk_config_new
 
     # Don't bother scaling back to 1 instance as we're about to be uninstalled anyway.
-    #marathon_client.update_app(FOLDERED_SERVICE_NAME, {"instances": 1})
-    #shakedown.deployment_wait()

--- a/frameworks/helloworld/tests/test_upgrade.py
+++ b/frameworks/helloworld/tests/test_upgrade.py
@@ -1,0 +1,13 @@
+import pytest
+
+import sdk_test_upgrade
+
+from tests.config import (
+    PACKAGE_NAME,
+    DEFAULT_TASK_COUNT
+)
+
+@pytest.mark.upgrade
+@pytest.mark.sanity
+def test_upgrade_downgrade():
+    sdk_test_upgrade.upgrade_downgrade(PACKAGE_NAME, PACKAGE_NAME, DEFAULT_TASK_COUNT, reinstall_test_version=False)


### PR DESCRIPTION
- If the test is run in test_sanity, it results in two hello-world instances being installed simultaneously: one with folders (from test_sanity) and one without (from the upgrade test run)
- Skip 2nd upgrade to test version in upgrade test run, as there aren't any followup tests which need the test version to be reinstalled