### PR TITLE
Disallow tasks/volumes/secrets being set to null in the DefaultPodSpec

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultPodSpec.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultPodSpec.java
@@ -394,7 +394,12 @@ public class DefaultPodSpec implements PodSpec {
          * @return a reference to this Builder
          */
         public Builder secrets(Collection<SecretSpec> secrets) {
-            this.secrets = secrets;
+            if (secrets == null) {
+                this.secrets = new ArrayList<>();
+            } else {
+                this.secrets = secrets;
+            }
+
             return this;
         }
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultPodSpec.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultPodSpec.java
@@ -329,7 +329,12 @@ public class DefaultPodSpec implements PodSpec {
          * @return a reference to this Builder
          */
         public Builder tasks(List<TaskSpec> tasks) {
-            this.tasks = tasks;
+            if (tasks == null) {
+                this.tasks = new ArrayList<>();
+            } else {
+                this.tasks = tasks;
+            }
+
             return this;
         }
 
@@ -384,7 +389,6 @@ public class DefaultPodSpec implements PodSpec {
 
             return this;
         }
-
 
         /**
          * Sets the {@code secrets} and returns a reference to this Builder so that the methods can be

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultPodSpec.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultPodSpec.java
@@ -369,7 +369,12 @@ public class DefaultPodSpec implements PodSpec {
          * @return a reference to this Builder
          */
         public Builder volumes(Collection<VolumeSpec> volumes) {
-            this.volumes = volumes;
+            if (volumes == null) {
+                this.volumes = new ArrayList<>();
+            } else {
+                this.volumes = volumes;
+            }
+
             return this;
         }
 


### PR DESCRIPTION
Make sure empty collections are returned in DefaultPodSpec if tasks/volumes/secrets are null