### PR TITLE
[INFINITY-1840] Update build instructions for new uninstall

### DIFF
--- a/tools/publish_aws.py
+++ b/tools/publish_aws.py
@@ -168,8 +168,10 @@ class AWSPublisher(object):
         logger.info('---')
         logger.info('(Re)install your package using the following commands:')
         logger.info('dcos package uninstall {}'.format(self._pkg_name))
+        logger.info('\n- - - -\nFor 1.9 or older clusters only')
         logger.info('dcos node ssh --master-proxy --leader ' +
                     '"docker run mesosphere/janitor /janitor.py -r {0}-role -p {0}-principal -z dcos-service-{0}"'.format(self._pkg_name))
+        logger.info('- - - -\n')
         logger.info('dcos package repo remove {}-aws'.format(self._pkg_name))
         logger.info('dcos package repo add --index=0 {}-aws {}'.format(self._pkg_name, universe_url))
         logger.info('dcos package install --yes {}'.format(self._pkg_name))

--- a/tools/publish_http.py
+++ b/tools/publish_http.py
@@ -241,8 +241,10 @@ Artifacts:       {}
     logger.info('---')
     logger.info('(Re)install your package using the following commands:')
     logger.info('dcos package uninstall {}'.format(package_name))
+    logger.info('\n- - - -\nFor 1.9 or older clusters only')
     logger.info('dcos node ssh --master-proxy --leader ' +
                 '"docker run mesosphere/janitor /janitor.py -r {0}-role -p {0}-principal -z dcos-service-{0}"'.format(package_name))
+    logger.info('- - - -\n')
     if not repo_added:
         logger.info('dcos package repo remove {}-local'.format(package_name))
         logger.info('dcos package repo add --index=0 {}-local {}'.format(package_name, universe_url))


### PR DESCRIPTION
Updates (re)install instructions so that users are not confused on when to run janitor or not.

This is the new output:
```
dcos package uninstall hdfs

- - - -
For 1.9 or older clusters only
dcos node ssh --master-proxy --leader "docker run mesosphere/janitor /janitor.py -r hdfs-role -p hdfs-principal -z dcos-service-hdfs"
- - - -

dcos package repo remove hdfs-aws
dcos package repo add --index=0 hdfs-aws https://infinity-artifacts.s3.amazonaws.com/autodelete7d/hdfs/20170623-131101-ev7MAymdnadIMmtc/stub-universe-hdfs.json
dcos package install --yes hdfs
```