### PR TITLE
Patch for PersistentLaunchRecorderTest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,20 @@
 // Config shared by the dcos-commons library and the examples:
 
+// Gradle is bundled with jansi 1.9 which can crash the JVM in some cases
+// Solution taken from: https://github.com/gradle/gradle/issues/778
+buildscript {
+    dependencies {
+        classpath group: 'org.fusesource.jansi', name: 'jansi', version: '1.14'
+    }
+}
+
 plugins {
     id 'com.github.johnrengelman.shadow' version '1.2.3'
     id 'com.github.ksoichiro.console.reporter' version '0.4.0'
 }
+
+// Importing org.fusesource.jansi.AnsiConsole is not enough to avoid aforementioned failure
+org.fusesource.jansi.AnsiConsole.out.print('init workaround')
 
 allprojects {
     apply plugin: 'java'

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/state/PersistentLaunchRecorderTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/state/PersistentLaunchRecorderTest.java
@@ -29,7 +29,8 @@ public class PersistentLaunchRecorderTest extends OfferEvaluatorTestBase {
             .build();
 
     @BeforeClass
-    public static void beforeAll() throws Exception {
+    public static void beforeAll2() throws Exception {
+        // Use a new beforeAll name to avoid shadowing parent final void
         ClassLoader classLoader = PersistentLaunchRecorderTest.class.getClassLoader();
         File file = new File(classLoader.getResource("shared-resource-set.yml").getFile());
         RawServiceSpec rawServiceSpec = RawServiceSpec.newBuilder(file).build();

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/state/PersistentLaunchRecorderTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/state/PersistentLaunchRecorderTest.java
@@ -28,7 +28,6 @@ public class PersistentLaunchRecorderTest extends OfferEvaluatorTestBase {
             .setSlaveId(TestConstants.AGENT_ID)
             .build();
 
-    /** Use a new beforeAll name to avoid shadowing parent final void */
     @BeforeClass
     public static void beforeAll() throws Exception {
         ClassLoader classLoader = PersistentLaunchRecorderTest.class.getClassLoader();

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/state/PersistentLaunchRecorderTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/state/PersistentLaunchRecorderTest.java
@@ -28,9 +28,9 @@ public class PersistentLaunchRecorderTest extends OfferEvaluatorTestBase {
             .setSlaveId(TestConstants.AGENT_ID)
             .build();
 
+    /** Use a new beforeAll name to avoid shadowing parent final void */
     @BeforeClass
-    public static void beforeAll2() throws Exception {
-        // Use a new beforeAll name to avoid shadowing parent final void
+    public static void beforeAll() throws Exception {
         ClassLoader classLoader = PersistentLaunchRecorderTest.class.getClassLoader();
         File file = new File(classLoader.getResource("shared-resource-set.yml").getFile());
         RawServiceSpec rawServiceSpec = RawServiceSpec.newBuilder(file).build();

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/testutils/DefaultCapabilitiesTestSuite.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/testutils/DefaultCapabilitiesTestSuite.java
@@ -15,7 +15,7 @@ public abstract class DefaultCapabilitiesTestSuite {
     private static ResourceRefinementCapabilityContext context;
 
     @BeforeClass
-    public static final void beforeAll() throws Exception {
+    public static final void beforeAllSuites() throws Exception {
         Capabilities capabilities = mock(Capabilities.class);
         when(capabilities.supportsGpuResource()).thenReturn(true);
         when(capabilities.supportsCNINetworking()).thenReturn(true);

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/testutils/DefaultCapabilitiesTestSuite.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/testutils/DefaultCapabilitiesTestSuite.java
@@ -13,11 +13,10 @@ import static org.mockito.Mockito.when;
  */
 public abstract class DefaultCapabilitiesTestSuite {
     private static ResourceRefinementCapabilityContext context;
-    private static Capabilities capabilities;
 
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings("ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD")
-    public DefaultCapabilitiesTestSuite() {
-        capabilities = mock(Capabilities.class);
+    @BeforeClass
+    public static final void beforeAll() throws Exception {
+        Capabilities capabilities = mock(Capabilities.class);
         when(capabilities.supportsGpuResource()).thenReturn(true);
         when(capabilities.supportsCNINetworking()).thenReturn(true);
         when(capabilities.supportsNamedVips()).thenReturn(true);
@@ -26,15 +25,12 @@ public abstract class DefaultCapabilitiesTestSuite {
         when(capabilities.supportsFileBasedSecrets()).thenReturn(true);
         when(capabilities.supportsEnvBasedSecretsProtobuf()).thenReturn(true);
         when(capabilities.supportsEnvBasedSecretsDirectiveLabel()).thenReturn(true);
-    }
-
-    @BeforeClass
-    public static void beforeAll() throws Exception {
         context = new ResourceRefinementCapabilityContext(Capabilities.getInstance());
+
     }
 
     @AfterClass
-    public static void afterAll() {
+    public static final void afterAll() {
         context.reset();
     }
 }


### PR DESCRIPTION
This test would only fail when ordering was changed and would also
segfault the JVM. The segfault was due to an incompatibility with
gradle's native jansi module. This was fixed with explicitly importing
a newer module. The initial failure was due to
PeristentLaunchRecorderTest shadowing the beforeClass method of parent
DefaultCapabilities test suite. Parent classes were made final to avoid
future NPEs in other classes.