### PR TITLE
[INFINITY-1854] Flaky unit test

### DIFF
--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/DefaultSchedulerTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/DefaultSchedulerTest.java
@@ -853,7 +853,7 @@ public class DefaultSchedulerTest {
         statusUpdate(getTaskId(operations), Protos.TaskState.TASK_RUNNING);
 
         // Wait for the Step to become Complete
-        Awaitility.await().atMost(1, TimeUnit.SECONDS).untilCall(to(step).isComplete(), equalTo(true));
+        Awaitility.await().atMost(5, TimeUnit.SECONDS).untilCall(to(step).isComplete(), equalTo(true));
 
         return taskId;
     }


### PR DESCRIPTION
Raise timeout on individual step installs.

Previously, the timeout was increased on the overall deployment completion