### PR TITLE
[HDFS-462] Add readiness check to journal nodes

### DIFF
--- a/frameworks/hdfs/src/main/dist/svc.yml
+++ b/frameworks/hdfs/src/main/dist/svc.yml
@@ -51,6 +51,13 @@ pods:
           {{/TLS_ENABLED}}
         env:
           JOURNALNODE: true
+        readiness-check:
+          cmd: >
+              READY=$(grep "IPC Server listener on {{TASKCFG_ALL_JOURNAL_NODE_RPC_PORT}}: starting" stderr| wc -l) &&
+              [ $READY -ge 1 ]
+          interval: 10
+          delay: 60
+          timeout: 60
   name:
     count: 2
     user: {{TASKCFG_ALL_TASK_USER}}

--- a/frameworks/hdfs/src/main/dist/svc.yml
+++ b/frameworks/hdfs/src/main/dist/svc.yml
@@ -53,11 +53,10 @@ pods:
           JOURNALNODE: true
         readiness-check:
           cmd: >
-              READY=$(grep "IPC Server listener on {{TASKCFG_ALL_JOURNAL_NODE_RPC_PORT}}: starting" stderr| wc -l) &&
-              [ $READY -ge 1 ]
+            export JOURNAL_STARTED=$(grep "IPC Server idle connection scanner for port {{TASKCFG_ALL_JOURNAL_NODE_RPC_PORT}}: task running" stderr | wc -l) &&
+            [[ $JOURNAL_STARTED -ge 1 ]]
           interval: 10
-          delay: 60
-          timeout: 60
+          timeout: 10
   name:
     count: 2
     user: {{TASKCFG_ALL_TASK_USER}}

--- a/frameworks/hdfs/src/main/dist/svc.yml
+++ b/frameworks/hdfs/src/main/dist/svc.yml
@@ -51,12 +51,20 @@ pods:
           {{/TLS_ENABLED}}
         env:
           JOURNALNODE: true
+        # The existence of the journal-data/hdfs/current/committed-txid file indicates HDFS has already been deployed once
         readiness-check:
           cmd: >
-            export JOURNAL_STARTED=$(grep "IPC Server idle connection scanner for port {{TASKCFG_ALL_JOURNAL_NODE_RPC_PORT}}: task running" stderr | wc -l) &&
-            [[ $JOURNAL_STARTED -ge 1 ]]
-          interval: 10
-          timeout: 10
+            if [ ! -d journal-data/hdfs ]; then
+              exit 0
+            else
+              export COMMITTED_ID_TIME=$(ls -l --time-style='+%Y-%m-%d %H:%M:%S' journal-data/hdfs/current/committed-txid | awk '{print $6 FS $7}') &&
+              export CURRENT_TIME=$(date '+%Y-%m-%d %H:%M:%S') &&
+              export TIME_DIFF=$(( ( $(date -ud "$CURRENT_TIME" +'%s') - $(date -ud "$COMMITTED_ID_TIME" +'%s') ) )) &&
+              [[ $TIME_DIFF -le 12 ]]
+            fi
+          delay: 60
+          interval: 3
+          timeout: 1
   name:
     count: 2
     user: {{TASKCFG_ALL_TASK_USER}}

--- a/frameworks/hdfs/src/main/dist/svc.yml
+++ b/frameworks/hdfs/src/main/dist/svc.yml
@@ -51,7 +51,11 @@ pods:
           {{/TLS_ENABLED}}
         env:
           JOURNALNODE: true
-        # The existence of the journal-data/hdfs/current/committed-txid file indicates HDFS has already been deployed once
+        # The absence of journal-data/hdfs/current/committed-txid indicates HDFS is about to be deployed for the first time.
+        # Its existence is used during an update plan to check that the given Journal Node has in fact started and by writing 
+        # to the committed-txid file, hence updating the file's last modified timestamp within the last 12 seconds, signals that
+        # the Journal Node is newly running as part of the update plan.
+        {{#JOURNAL_READINESS_CHECK_ENABLED}}
         readiness-check:
           cmd: >
             if [ ! -d journal-data/hdfs ]; then
@@ -65,6 +69,7 @@ pods:
           delay: 60
           interval: 3
           timeout: 1
+        {{/JOURNAL_READINESS_CHECK_ENABLED}}
   name:
     count: 2
     user: {{TASKCFG_ALL_TASK_USER}}

--- a/frameworks/hdfs/tests/config.py
+++ b/frameworks/hdfs/tests/config.py
@@ -5,8 +5,10 @@ import sdk_utils as utils
 import sdk_tasks as tasks
 
 PACKAGE_NAME = 'hdfs'
+FOLDERED_SERVICE_NAME = utils.get_foldered_name(PACKAGE_NAME)
 DEFAULT_TASK_COUNT = 10  # 3 data nodes, 3 journal nodes, 2 name nodes, 2 zkfc nodes
 
+ZK_SERVICE_PATH = utils.get_zk_path(PACKAGE_NAME)
 TEST_CONTENT_SMALL = "This is some test data"
 # use long-read alignments to human chromosome 1 as large file input (11GB)
 TEST_CONTENT_LARGE_SOURCE = "http://s3.amazonaws.com/nanopore-human-wgs/chr1.sorted.bam"

--- a/frameworks/hdfs/tests/config.py
+++ b/frameworks/hdfs/tests/config.py
@@ -82,6 +82,6 @@ def find_java_home(host):
 
 
 def check_healthy(count=DEFAULT_TASK_COUNT):
-    plan.wait_for_completed_deployment(PACKAGE_NAME, timeout_seconds=20 * 60)
-    plan.wait_for_completed_recovery(PACKAGE_NAME, timeout_seconds=20 * 60)
+    plan.wait_for_completed_deployment(PACKAGE_NAME, timeout_seconds=25 * 60)
+    plan.wait_for_completed_recovery(PACKAGE_NAME, timeout_seconds=25 * 60)
     tasks.check_running(PACKAGE_NAME, count)

--- a/frameworks/hdfs/tests/test_overlay.py
+++ b/frameworks/hdfs/tests/test_overlay.py
@@ -20,6 +20,7 @@ def setup_module(module):
     utils.gc_frameworks()
     install.install(PACKAGE_NAME, DEFAULT_TASK_COUNT,
                     additional_options=networks.ENABLE_VIRTUAL_NETWORKS_OPTIONS)
+    plan.wait_for_completed_deployment(PACKAGE_NAME)
 
 
 def setup_function(function):

--- a/frameworks/hdfs/tests/test_shakedown.py
+++ b/frameworks/hdfs/tests/test_shakedown.py
@@ -274,8 +274,9 @@ def test_bump_data_nodes():
 
 @pytest.mark.sanity
 def test_modify_app_config():
-    app_config_field = 'TASKCFG_ALL_CLIENT_READ_SHORTCIRCUIT_STREAMS_CACHE_SIZE_EXPIRY_MS'
+    old_recovery_plan = plan.get_recovery_plan(PACKAGE_NAME).json()
 
+    app_config_field = 'TASKCFG_ALL_CLIENT_READ_SHORTCIRCUIT_STREAMS_CACHE_SIZE_EXPIRY_MS'
     journal_ids = tasks.get_task_ids(FOLDERED_SERVICE_NAME, 'journal')
     name_ids = tasks.get_task_ids(FOLDERED_SERVICE_NAME, 'name')
 
@@ -291,6 +292,10 @@ def test_modify_app_config():
     tasks.check_tasks_updated(FOLDERED_SERVICE_NAME, 'journal', journal_ids)
     tasks.check_tasks_updated(FOLDERED_SERVICE_NAME, 'name', name_ids)
     tasks.check_tasks_updated(FOLDERED_SERVICE_NAME, 'data', journal_ids)
+
+    new_recovery_plan = plan.get_recovery_plan(PACKAGE_NAME).json()
+    # Recovery should not have been modified at all
+    assert(old_recovery_plan_status == new_recovery_plan_status)
 
 
 @pytest.mark.sanity

--- a/frameworks/hdfs/tests/test_shakedown.py
+++ b/frameworks/hdfs/tests/test_shakedown.py
@@ -14,15 +14,6 @@ import sdk_utils as utils
 import sdk_metrics as metrics
 from tests.config import *
 
-FOLDERED_SERVICE_NAME = utils.get_foldered_name(PACKAGE_NAME)
-ZK_SERVICE_PATH = utils.get_zk_path(PACKAGE_NAME)
-TEST_CONTENT_SMALL = "This is some test data"
-# TODO: TEST_CONTENT_LARGE = Give a large file as input to the write/read commands...
-TEST_FILE_1_NAME = "test_1"
-TEST_FILE_2_NAME = "test_2"
-HDFS_CMD_TIMEOUT_SEC = 5 * 60
-HDFS_POD_TYPES = {"journal", "name", "data"}
-
 def setup_module(module):
     install.uninstall(FOLDERED_SERVICE_NAME, package_name=PACKAGE_NAME)
     utils.gc_frameworks()
@@ -363,7 +354,7 @@ def write_some_data(data_node_name, file_name):
         rc, _ = run_hdfs_command(data_node_name, write_command)
         # rc being True is effectively it being 0...
         return rc
-    shakedown.wait_for(lambda: write_data_to_hdfs(), timeout_seconds=HDFS_CMD_TIMEOUT_SEC)
+    shakedown.wait_for(lambda: write_data_to_hdfs(), timeout_seconds=DEFAULT_HDFS_TIMEOUT)
 
 
 def read_some_data(data_node_name, file_name):
@@ -371,7 +362,7 @@ def read_some_data(data_node_name, file_name):
         read_command = "./bin/hdfs dfs -cat /{}".format(file_name)
         rc, output = run_hdfs_command(data_node_name, read_command)
         return rc and output.rstrip() == TEST_CONTENT_SMALL
-    shakedown.wait_for(lambda: read_data_from_hdfs(), timeout_seconds=HDFS_CMD_TIMEOUT_SEC)
+    shakedown.wait_for(lambda: read_data_from_hdfs(), timeout_seconds=DEFAULT_HDFS_TIMEOUT)
 
 
 def run_hdfs_command(task_name, command):
@@ -429,7 +420,7 @@ def wait_for_failover_to_complete(namenode):
             utils.out("Failover to {} successfully completed".format(namenode))
         return rc
 
-    shakedown.wait_for(lambda: failover_detection(), timeout_seconds=HDFS_CMD_TIMEOUT_SEC)
+    shakedown.wait_for(lambda: failover_detection(), timeout_seconds=DEFAULT_HDFS_TIMEOUT)
 
 
 def check_healthy(count=DEFAULT_TASK_COUNT):

--- a/frameworks/hdfs/universe/config.json
+++ b/frameworks/hdfs/universe/config.json
@@ -318,7 +318,7 @@
         "hadoop_root_logger": {
           "type": "string",
           "description": "",
-          "default": "INFO,console"
+          "default": "DEBUG,console"
         }
       },
       "required": [

--- a/frameworks/hdfs/universe/config.json
+++ b/frameworks/hdfs/universe/config.json
@@ -128,6 +128,11 @@
           "description": "Labels to pass to CNI plugin. Comma-seperated key:value pairs. For example [k_0:v_0,k_1:v_1,...,k_n:v_n]",
           "type": "string",
           "default": ""
+        },
+        "enable_readiness_check": {
+          "description": "Determines whether to enable readiness checks for Journal Nodes.",
+          "type": "boolean",
+          "default": true
         }
       },
       "required":[

--- a/frameworks/hdfs/universe/config.json
+++ b/frameworks/hdfs/universe/config.json
@@ -318,7 +318,7 @@
         "hadoop_root_logger": {
           "type": "string",
           "description": "",
-          "default": "DEBUG,console"
+          "default": "INFO,console"
         }
       },
       "required": [

--- a/frameworks/hdfs/universe/marathon.json.mustache
+++ b/frameworks/hdfs/universe/marathon.json.mustache
@@ -71,6 +71,12 @@
     "TASKCFG_ALL_TLS_ENABLED": "{{service.tls.enabled}}",
     {{/service.tls.enabled}}
 
+    {{#journal_node.enable_readiness_check}}
+    "JOURNAL_READINESS_CHECK_ENABLED": "{{journal_node.enable_readiness_check}}",
+    "TASKCFG_ALL_JOURNAL_READINESS_CHECK_ENABLED": "{{journal_node.enable_readiness_check}}",
+    {{/journal_node.enable_readiness_check}}
+
+
     {{#service.kerberos.enabled}}
     "KEYTABS_URI": "{{service.kerberos.keytabs_uri}}",
     "KRB5_CONF_URI": "{{service.kerberos.krb5_conf_uri}}",

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultReadinessCheckSpec.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultReadinessCheckSpec.java
@@ -16,7 +16,6 @@ public class DefaultReadinessCheckSpec implements ReadinessCheckSpec {
     @NotNull
     private String command;
 
-    @NotNull
     @Min(0)
     private Integer delay;
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/YAMLToInternalMappers.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/YAMLToInternalMappers.java
@@ -117,7 +117,7 @@ public class YAMLToInternalMappers {
     private static ReadinessCheckSpec from(RawReadinessCheck rawReadinessCheck) {
         return DefaultReadinessCheckSpec.newBuilder()
                 .command(rawReadinessCheck.getCmd())
-                .delay(rawReadinessCheck.getDelay())
+                .delay(rawReadinessCheck.getDelay() == null ? Integer.valueOf(0) : rawReadinessCheck.getDelay())
                 .interval(rawReadinessCheck.getInterval())
                 .timeout(rawReadinessCheck.getTimeout())
                 .build();

--- a/testing/sdk_marathon.py
+++ b/testing/sdk_marathon.py
@@ -24,7 +24,7 @@ def get_config(app_name):
     return config
 
 
-def update_app(app_name, config):
+def update_app(app_name, config, timeout=600):
     if "env" in config:
         sdk_utils.out("Environment for marathon app {} ({} values):".format(app_name, len(config["env"])))
         for k in sorted(config["env"]):
@@ -34,7 +34,7 @@ def update_app(app_name, config):
     assert response.ok, "Marathon configuration update failed for {} with config {}".format(app_name, config)
 
     sdk_utils.out("Waiting for Marathon deployment of {} to complete...".format(app_name))
-    shakedown.deployment_wait(app_id=app_name, timeout=600)
+    shakedown.deployment_wait(app_id=app_name, timeout=timeout)
 
 
 def destroy_app(app_name):

--- a/testing/sdk_plan.py
+++ b/testing/sdk_plan.py
@@ -9,8 +9,6 @@ import shakedown
 def get_deployment_plan(service_name):
     return get_plan(service_name, "deploy")
 
-def get_recovery_plan(service_name):
-    return get_plan(service_name, "recovery")
 
 def get_plan(service_name, plan):
     def fn():

--- a/testing/sdk_plan.py
+++ b/testing/sdk_plan.py
@@ -9,6 +9,8 @@ import shakedown
 def get_deployment_plan(service_name):
     return get_plan(service_name, "deploy")
 
+def get_recovery_plan(service_name):
+    return get_plan(service_name, "recovery")
 
 def get_plan(service_name, plan):
     def fn():


### PR DESCRIPTION
The deployment plan now waits for the journal nodes to succeed their readiness check before proceeding to deploying the name nodes.