### PR TITLE
[SDK] Annotate Secrets tests for dcos 1.10

### DIFF
--- a/frameworks/helloworld/tests/test_secrets.py
+++ b/frameworks/helloworld/tests/test_secrets.py
@@ -72,6 +72,7 @@ def teardown_module(module):
 @pytest.mark.sanity
 @pytest.mark.smoke
 @pytest.mark.secrets
+@dcos_1_10
 def test_secrets_basic():
     # 1) create Secrets
     # 2) install examples/secrets.yml
@@ -110,6 +111,7 @@ def test_secrets_basic():
 
 @pytest.mark.sanity
 @pytest.mark.secrets
+@dcos_1_10
 def test_secrets_verify():
     # 1) create Secrets
     # 2) install examples/secrets.yml
@@ -163,6 +165,7 @@ def test_secrets_verify():
 
 @pytest.mark.sanity
 @pytest.mark.secrets
+@dcos_1_10
 def test_secrets_update():
     # 1) create Secrets
     # 2) install examples/secrets.yml
@@ -223,6 +226,7 @@ def test_secrets_update():
 
 @pytest.mark.sanity
 @pytest.mark.secrets
+@dcos_1_10
 def test_secrets_config_update():
     # 1) install examples/secrets.yml
     # 2) create new Secrets, delete old Secrets
@@ -299,6 +303,7 @@ def test_secrets_config_update():
 @pytest.mark.sanity
 @pytest.mark.secrets
 @pytest.mark.skip(reason="DCOS_SPACE authorization is not working in testing/master. Enable this test later.")
+@dcos_1_10
 def test_secrets_dcos_space():
     # 1) create secrets in hello-world/somePath, i.e. hello-world/somePath/secret1 ...
     # 2) Tasks with DCOS_SPACE hello-world/somePath

--- a/frameworks/helloworld/tests/test_secrets.py
+++ b/frameworks/helloworld/tests/test_secrets.py
@@ -1,5 +1,5 @@
 import pytest
-import shakedown
+from shakedown import *
 
 import sdk_cmd as cmd
 import sdk_install as install


### PR DESCRIPTION
SDK supports Secrets only for DC/OS 1.10