### PR TITLE
INFINITY-1876 Specify minDcosVersion in package, not release script

### DIFF
--- a/frameworks/cassandra/universe/package.json
+++ b/frameworks/cassandra/universe/package.json
@@ -1,16 +1,13 @@
 {
-  "packagingVersion": "2.0",
+  "packagingVersion": "3.0",
+  "minDcosReleaseVersion": "1.8",
   "name": "cassandra",
   "version": "{{package-version}}",
   "maintainer": "support@mesosphere.io",
-  "description": "An example implementation of a stateful service using the DC/OS SDK",
+  "description": "Apache Cassandra",
   "selected": false,
   "framework": true,
-  "tags": [
-    "example",
-    "reference",
-    "cassandra"
-  ],
+  "tags": ["cassandra"],
   "preInstallNotes": "This DC/OS Service is currently a beta candidate undergoing testing as part of a formal beta test program. There may be bugs, incomplete features, incorrect documentation, or other discrepancies. Contact Mesosphere before deploying this beta candidate service. Product support is available to approved participants in the beta test program.",
   "postInstallNotes": "DC/OS Cassandra is being installed!\n\n\tDocumentation: https://docs.mesosphere.com/latest/usage/service-guides/cassandra\n\tIssues: https://docs.mesosphere.com/support/",
   "postUninstallNotes": "DC/OS cassandra is being uninstalled."

--- a/frameworks/elastic/universe-kibana/package.json
+++ b/frameworks/elastic/universe-kibana/package.json
@@ -7,10 +7,7 @@
   "description": "Kibana 5, and optionally X-Pack",
   "selected": true,
   "framework": true,
-  "tags": [
-    "kibana",
-    "x-pack"
-  ],
+  "tags": ["elastic", "elasticsearch", "kibana", "x-pack"],
   "preInstallNotes": "This DC/OS Service is currently a beta candidate undergoing testing as part of a formal beta test program. There may be bugs, incomplete features, incorrect documentation, or other discrepancies. Contact Mesosphere before deploying this beta candidate service. Product support is available to approved participants in the beta test program.",
   "postInstallNotes": "DC/OS Kibana service is being installed!\n\n\tDocumentation: https://docs.mesosphere.com/1.9/usage/service-guides/elastic\n\tIssues: https://docs.mesosphere.com/support/",
   "postUninstallNotes": "DC/OS Kibana service has been uninstalled."

--- a/frameworks/elastic/universe/package.json
+++ b/frameworks/elastic/universe/package.json
@@ -7,10 +7,7 @@
   "description": "Elasticsearch 5, and optionally X-Pack",
   "selected": true,
   "framework": true,
-  "tags": [
-    "elasticsearch",
-    "x-pack"
-  ],
+  "tags": ["elastic", "elasticsearch", "kibana", "x-pack"],
   "preInstallNotes": "This DC/OS Service is currently a beta candidate undergoing testing as part of a formal beta test program. There may be bugs, incomplete features, incorrect documentation, or other discrepancies. Contact Mesosphere before deploying this beta candidate service. Product support is available to approved participants in the beta test program.",
   "postInstallNotes": "DC/OS elastic service is being installed!\n\n\tDocumentation: https://docs.mesosphere.com/1.9/usage/service-guides/elastic\n\tIssues: https://docs.mesosphere.com/support/",
   "postUninstallNotes": "DC/OS elastic service is being uninstalled."

--- a/frameworks/hdfs/universe/package.json
+++ b/frameworks/hdfs/universe/package.json
@@ -1,5 +1,6 @@
 {
-  "packagingVersion": "2.0",
+  "packagingVersion": "3.0",
+  "minDcosReleaseVersion": "1.8",
   "name": "hdfs",
   "version": "{{package-version}}",
   "maintainer": "support@mesosphere.io",

--- a/frameworks/kafka/universe/package.json
+++ b/frameworks/kafka/universe/package.json
@@ -1,12 +1,13 @@
 {
-  "packagingVersion": "2.0",
+  "packagingVersion": "3.0",
+  "minDcosReleaseVersion": "1.8",
   "name": "kafka",
   "version": "{{package-version}}",
   "maintainer": "support@mesosphere.io",
-  "description": "Apache Kafka framework running on DC/OS",
+  "description": "Apache Kafka",
   "selected": false,
   "framework": true,
-  "tags": ["message", "broker", "pubsub"],
+  "tags": ["message", "broker", "kafka", "pubsub"],
   "preInstallNotes": "This DC/OS Service is currently a beta candidate undergoing testing as part of a formal beta test program. There may be bugs, incomplete features, incorrect documentation, or other discrepancies. Contact Mesosphere before deploying this beta candidate service. Product support is available to approved participants in the beta test program.",
   "postInstallNotes": "DC/OS Apache Kafka Service is being installed.\n\n\tDocumentation: https://docs.mesosphere.com/current/usage/service-guides/kafka\n\tIssues: https://dcosjira.atlassian.net/projects/KAFKA/issues",
   "postUninstallNotes": "DC/OS Apache Kafka Service is being uninstalled.\nPlease follow the instructions at https://docs.mesosphere.com/current/usage/service-guides/kafka/uninstall to remove any persistent state if required."

--- a/frameworks/template/universe/package.json
+++ b/frameworks/template/universe/package.json
@@ -1,6 +1,6 @@
 {
-  "packagingVersion": "2.0",
-  "minDcosReleaseVersion": "1.9",
+  "packagingVersion": "3.0",
+  "minDcosReleaseVersion": "1.8",
   "name": "template",
   "version": "{{package-version}}",
   "maintainer": "support@YOURNAMEHERE.COM",


### PR DESCRIPTION
The current minDcosVersion handling was only in the release script because our stub-universe.zips were stuck on universe-2.x, which didn't understand this field and which would refuse to install packages that contained it. So at the time we omitted it from stub-universe.zips and just added it when releasing them to universe.

Now that we're on universe-3.x packages in the form of stub-universe.jsons, we can specify it explicitly in the source-controlled package files. This PR also updates the release tooling to require that it already be populated, as it should currently be AT LEAST 1.8 for SDK-based services (leaving the field unset means the package can be installed back to 1.6 IIRC).

TODO separately: Remove the option/envvar from the jenkins release job as this makes the option a noop.