### PR TITLE
[INFINITY-1863] [INFINITY-1889] Add better handling for Cosmos JSON validation errors.

### DIFF
--- a/cli/client/cosmos.go
+++ b/cli/client/cosmos.go
@@ -64,13 +64,15 @@ type cosmosErrorResponse struct {
 }
 
 func createBadVersionError(data cosmosData) error {
-	updateVersion := fmt.Sprintf("\"%s\"", data.UpdateVersion)
-	validVersions := PrettyPrintSlice(data.ValidVersions)
-
-	errorString := `Unable to update %s to requested version: %s
-Valid versions are: %s`
-
-	return fmt.Errorf(errorString, config.ServiceName, updateVersion, validVersions)
+	var buf bytes.Buffer
+	buf.WriteString(fmt.Sprintf("Unable to update %s to requested version: \"%s\"\n", config.ServiceName, data.UpdateVersion))
+	if len(data.ValidVersions) > 0 {
+		validVersions := PrettyPrintSlice(data.ValidVersions)
+		buf.WriteString(fmt.Sprintf("Valid package versions are: %s", validVersions))
+	} else {
+		buf.WriteString("No valid package versions to update to.")
+	}
+	return fmt.Errorf(buf.String())
 }
 func createJSONMismatchError(data cosmosData) error {
 	var buf bytes.Buffer

--- a/cli/client/cosmos.go
+++ b/cli/client/cosmos.go
@@ -83,10 +83,6 @@ func createCosmosJSONMismatchError(data cosmosData) error {
 	return fmt.Errorf(buf.String(), config.ServiceName)
 }
 
-func createGenericCosmosError(errorType, message string) error {
-	return fmt.Errorf("Could not execute command: %s: %s", errorType, message)
-}
-
 func parseCosmosHTTPErrorResponse(response *http.Response, body []byte) error {
 	var errorResponse cosmosErrorResponse
 	err := json.Unmarshal(body, &errorResponse)
@@ -103,7 +99,7 @@ func parseCosmosHTTPErrorResponse(response *http.Response, body []byte) error {
 		case jsonSchemaMismatch:
 			return createCosmosJSONMismatchError(errorResponse.Data)
 		default:
-			return createGenericCosmosError(errorResponse.ErrorType, errorResponse.Message)
+			return fmt.Errorf("Could not execute command: %s", errorResponse.Message)
 		}
 	}
 	return createResponseError(response)

--- a/cli/client/cosmos.go
+++ b/cli/client/cosmos.go
@@ -1,11 +1,17 @@
 package client
 
 import (
+	"bytes"
 	"fmt"
 	"net/http"
 	"net/url"
 	"path"
 	"strings"
+	"text/tabwriter"
+
+	"encoding/json"
+
+	"bufio"
 
 	"github.com/mesosphere/dcos-commons/cli/config"
 )
@@ -14,6 +20,7 @@ const (
 	cosmosURLConfigKey  = "package.cosmos_url"
 	marathonAppNotFound = "MarathonAppNotFound"
 	badVersionUpdate    = "BadVersionUpdate"
+	jsonSchemaMismatch  = "JsonSchemaMismatch"
 )
 
 // HTTPCosmosPostJSON triggers a HTTP POST request containing jsonPayload to
@@ -23,41 +30,80 @@ func HTTPCosmosPostJSON(urlPath, jsonPayload string) ([]byte, error) {
 	return checkHTTPResponse(httpQuery(createCosmosHTTPJSONRequest("POST", urlPath, jsonPayload)))
 }
 
-func createBadVersionError(response *http.Response, data map[string]interface{}) error {
-	requestedVersion, err := GetValueFromJSON(data, "updateVersion")
-	if err != nil {
-		return err
-	}
-	validVersions, err := GetValueFromJSON(data, "validVersions")
-	if err != nil {
-		return err
-	}
-	if config.Verbose {
-		printResponseError(response)
-	}
+type cosmosErrorInstance struct {
+	Pointer string
+}
+
+type cosmosError struct {
+	Keyword  string
+	Message  string
+	Found    string
+	Expected []string
+	Instance cosmosErrorInstance
+	// deliberately omitting:
+	// level
+	// schema
+	// domain
+}
+
+type cosmosData struct {
+	Errors        []cosmosError
+	UpdateVersion string
+	ValidVersions []string
+}
+
+type cosmosErrorResponse struct {
+	ErrorType string `json:"type"`
+	Message   string
+	Data      cosmosData
+}
+
+func createBadVersionError(data cosmosData) error {
+	updateVersion := fmt.Sprintf("\"%s\"", data.UpdateVersion)
+	validVersions := PrettyPrintSlice(data.ValidVersions)
 
 	errorString := `Unable to update %s to requested version: %s
 Valid versions are: %s`
 
-	return fmt.Errorf(errorString, config.ServiceName, requestedVersion, validVersions)
+	return fmt.Errorf(errorString, config.ServiceName, updateVersion, validVersions)
+}
+func createCosmosJSONMismatchError(data cosmosData) error {
+	var buf bytes.Buffer
+	writer := bufio.NewWriter(&buf)
+	writer.WriteString("Unable to update %s to requested configuration: options JSON failed validation.")
+	writer.WriteString("\n\n")
+	tWriter := tabwriter.NewWriter(writer, 0, 4, 1, ' ', 0)
+	fmt.Fprintf(tWriter, "Field\tError\t\n")
+	fmt.Fprintf(tWriter, "-----\t-----\t")
+	for _, err := range data.Errors {
+		fmt.Fprintf(tWriter, "\n%s\t%s\t", err.Instance.Pointer, err.Message)
+	}
+	tWriter.Flush()
+	writer.Flush()
+	return fmt.Errorf(buf.String(), config.ServiceName)
+}
+
+func createGenericCosmosError(errorType, message string) error {
+	return fmt.Errorf("Could not execute command: %s: %s", errorType, message)
 }
 
 func parseCosmosHTTPErrorResponse(response *http.Response, body []byte) error {
-	responseJSON, err := UnmarshalJSON(body)
+	var errorResponse cosmosErrorResponse
+	err := json.Unmarshal(body, &errorResponse)
 	if err != nil {
+		printMessage(err.Error())
 		return createResponseError(response)
 	}
-	if errorType, present := responseJSON["type"]; present {
-		message := responseJSON["message"]
-		switch errorType {
+	if errorResponse.ErrorType != "" {
+		switch errorResponse.ErrorType {
 		case marathonAppNotFound:
-			return createServiceNameError(response)
+			return createServiceNameError()
 		case badVersionUpdate:
-			return createBadVersionError(response, responseJSON["data"].(map[string]interface{}))
+			return createBadVersionError(errorResponse.Data)
+		case jsonSchemaMismatch:
+			return createCosmosJSONMismatchError(errorResponse.Data)
 		default:
-			if config.Verbose {
-				PrintMessage("Cosmos error: %s: %s", errorType, message)
-			}
+			return createGenericCosmosError(errorResponse.ErrorType, errorResponse.Message)
 		}
 	}
 	return createResponseError(response)

--- a/cli/client/cosmos_test.go
+++ b/cli/client/cosmos_test.go
@@ -103,8 +103,9 @@ func (suite *CosmosTestSuite) TestAppNotFoundErrorResponse() {
 }
 
 func (suite *CosmosTestSuite) TestBadVersionErrorResponse() {
-	// create 400 response for BadVersionUpdate
+	// create 400 responses for BadVersionUpdate
 	suite.test400ErrorResponse("testdata/responses/cosmos/1.10/enterprise/bad-version.json", "testdata/output/bad-version.txt")
+	suite.test400ErrorResponse("testdata/responses/cosmos/1.10/enterprise/bad-version-no-versions.json", "testdata/output/bad-version-no-versions.txt")
 }
 
 func (suite *CosmosTestSuite) TestJSONMismatchErrorResponse() {

--- a/cli/client/cosmos_test.go
+++ b/cli/client/cosmos_test.go
@@ -85,36 +85,41 @@ func (suite *CosmosTestSuite) Test404ErrorResponse() {
 	assert.Equal(suite.T(), string(expectedOutput), err.Error())
 }
 
+func (suite *CosmosTestSuite) test400ErrorResponse(responseBody, output string) {
+	// fake 400 response for MarathonAppNotFound
+	fourHundredResponse, body := suite.createExampleResponse(http.StatusBadRequest, responseBody)
+
+	err := checkCosmosHTTPResponse(&fourHundredResponse, body)
+
+	expectedOutput := suite.loadFile(output)
+	assert.Equal(suite.T(), string(expectedOutput), err.Error())
+}
+
 func (suite *CosmosTestSuite) TestAppNotFoundErrorResponse() {
 	config.ServiceName = "hello-world-1"
 
 	// fake 400 response for MarathonAppNotFound
-	fourHundredResponse, body := suite.createExampleResponse(http.StatusBadRequest, "testdata/responses/cosmos/1.10/enterprise/bad-name.json")
-
-	err := checkCosmosHTTPResponse(&fourHundredResponse, body)
-
-	expectedOutput := suite.loadFile("testdata/output/bad-name.txt")
-	assert.Equal(suite.T(), string(expectedOutput), err.Error())
+	suite.test400ErrorResponse("testdata/responses/cosmos/1.10/enterprise/bad-name.json", "testdata/output/bad-name.txt")
 }
 
 func (suite *CosmosTestSuite) TestBadVersionErrorResponse() {
 	// create 400 response for BadVersionUpdate
-	fourHundredResponse, body := suite.createExampleResponse(http.StatusBadRequest, "testdata/responses/cosmos/1.10/enterprise/bad-version.json")
-
-	err := checkCosmosHTTPResponse(&fourHundredResponse, body)
-
-	expectedOutput := suite.loadFile("testdata/output/bad-version.txt")
-	assert.Equal(suite.T(), string(expectedOutput), err.Error())
+	suite.test400ErrorResponse("testdata/responses/cosmos/1.10/enterprise/bad-version.json", "testdata/output/bad-version.txt")
 }
 
 func (suite *CosmosTestSuite) TestJSONMismatchErrorResponse() {
 	// create 400 response for JsonSchemaMismatch
-	fourHundredResponse, body := suite.createExampleResponse(http.StatusBadRequest, "testdata/responses/cosmos/1.10/enterprise/bad-json.json")
+	suite.test400ErrorResponse("testdata/responses/cosmos/1.10/enterprise/bad-json.json", "testdata/output/bad-json.txt")
+}
 
-	err := checkCosmosHTTPResponse(&fourHundredResponse, body)
+func (suite *CosmosTestSuite) TestAppIDChangedErrorResponse() {
+	// create 400 response for JsonSchemaMismatch
+	suite.test400ErrorResponse("testdata/responses/cosmos/1.10/enterprise/bad-app-id.json", "testdata/output/bad-app-id.txt")
+}
 
-	expectedOutput := suite.loadFile("testdata/output/bad-json.txt")
-	assert.Equal(suite.T(), string(expectedOutput), err.Error())
+func (suite *CosmosTestSuite) TestGenericErrorResponse() {
+	// create 400 response for a generic error
+	suite.test400ErrorResponse("testdata/responses/cosmos/1.10/enterprise/generic-error.json", "testdata/output/generic-error.txt")
 }
 
 func (suite *CosmosTestSuite) TestCreateCosmosHTTPJSONRequest() {

--- a/cli/client/cosmos_test.go
+++ b/cli/client/cosmos_test.go
@@ -106,6 +106,17 @@ func (suite *CosmosTestSuite) TestBadVersionErrorResponse() {
 	expectedOutput := suite.loadFile("testdata/output/bad-version.txt")
 	assert.Equal(suite.T(), string(expectedOutput), err.Error())
 }
+
+func (suite *CosmosTestSuite) TestJSONMismatchErrorResponse() {
+	// create 400 response for JsonSchemaMismatch
+	fourHundredResponse, body := suite.createExampleResponse(http.StatusBadRequest, "testdata/responses/cosmos/1.10/enterprise/bad-json.json")
+
+	err := checkCosmosHTTPResponse(&fourHundredResponse, body)
+
+	expectedOutput := suite.loadFile("testdata/output/bad-json.txt")
+	assert.Equal(suite.T(), string(expectedOutput), err.Error())
+}
+
 func (suite *CosmosTestSuite) TestCreateCosmosHTTPJSONRequest() {
 	// create a request
 	request, requestBody := suite.createExampleRequest()

--- a/cli/client/print.go
+++ b/cli/client/print.go
@@ -42,7 +42,7 @@ func printResponseErrorAndExit(response *http.Response) {
 	PrintMessageAndExit(createResponseError(response).Error())
 }
 
-func createServiceNameError(response *http.Response) error {
+func createServiceNameError() error {
 	errorString := `Could not reach the service scheduler with name '%s'.
 Did you provide the correct service name? Specify a different name with '--name=<name>'.
 Was the service recently installed or updated? It may still be initializing, wait a bit and try again.`
@@ -54,7 +54,7 @@ func printServiceNameErrorAndExit(response *http.Response) {
 	if config.Verbose {
 		printResponseError(response)
 	}
-	PrintMessageAndExit(createServiceNameError(response).Error())
+	PrintMessageAndExit(createServiceNameError().Error())
 }
 
 // PrintJSONBytes pretty prints responseBytes assuming it is valid JSON.

--- a/cli/client/response.go
+++ b/cli/client/response.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"sort"
+	"strings"
 )
 
 type responseCheck func(response *http.Response, body []byte) error
@@ -105,13 +106,11 @@ func PrettyPrintSlice(slice []string) string {
 	sort.Strings(slice)
 	var buf bytes.Buffer
 	buf.WriteString("[")
-	for index, element := range slice {
-		quotedElement := fmt.Sprintf("\"%s\"", element)
-		buf.WriteString(quotedElement)
-		if index+1 < len(slice) {
-			buf.WriteString(", ")
-		}
+	var bits []string
+	for _, element := range slice {
+		bits = append(bits, fmt.Sprintf("\"%s\"", element))
 	}
+	buf.WriteString(strings.Join(bits, ", "))
 	buf.WriteString("]")
 	return buf.String()
 }

--- a/cli/client/response.go
+++ b/cli/client/response.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -41,7 +42,7 @@ func defaultResponseCheck(response *http.Response) error {
 "- Bad auth token? Run 'dcos auth login' to log in.`
 		return fmt.Errorf(errorString, response.Request.URL)
 	case response.StatusCode == http.StatusInternalServerError || response.StatusCode == http.StatusBadGateway || response.StatusCode == http.StatusNotFound:
-		return createServiceNameError(response)
+		return createServiceNameError()
 	case response.StatusCode < 200 || response.StatusCode >= 300:
 		return createResponseError(response)
 	}
@@ -98,16 +99,19 @@ func JSONBytesToArray(bytes []byte) ([]string, error) {
 	return array, err
 }
 
-// SortAndPrettyPrintJSONArray unmarshals an array of JSON strings, sorts and counts it and
-// returns a JSON marshaled version of it for pretty printing.
-func SortAndPrettyPrintJSONArray(bytes []byte) (bool, []byte, error) {
-	// Unmarshal into a []string so that we can count and sort the array
-	convertedArray, err := JSONBytesToArray(bytes)
-	if err != nil {
-		return false, nil, err
+// PrettyPrintSlice takes a slice (e.g. [0 1 2]), sorts it and returns a pretty printed string
+// in the same style as a JSON string array (e.g. ["0", "1", "2"]).
+func PrettyPrintSlice(slice []string) string {
+	sort.Strings(slice)
+	var buf bytes.Buffer
+	buf.WriteString("[")
+	for index, element := range slice {
+		quotedElement := fmt.Sprintf("\"%s\"", element)
+		buf.WriteString(quotedElement)
+		if index+1 < len(slice) {
+			buf.WriteString(", ")
+		}
 	}
-	sort.Strings(convertedArray)
-	// Marshal back to JSON, this should preserve the order of elements
-	jsonBytes, err := json.Marshal(convertedArray)
-	return (len(convertedArray) == 0), jsonBytes, err
+	buf.WriteString("]")
+	return buf.String()
 }

--- a/cli/client/testdata/output/bad-app-id.txt
+++ b/cli/client/testdata/output/bad-app-id.txt
@@ -1,0 +1,2 @@
+Could not update service name from "/hello-world2" to "/hello-world".
+The service name cannot be changed once installed. Ensure service.name is set to "/hello-world2" in options JSON.

--- a/cli/client/testdata/output/bad-json.txt
+++ b/cli/client/testdata/output/bad-json.txt
@@ -1,0 +1,6 @@
+Unable to update hello-world to requested configuration: options JSON failed validation.
+
+Field                      Error                                                                                            
+-----                      -----                                                                                            
+/world/cpus                instance type (string) does not match any allowed primitive type (allowed: ["integer","number"]) 
+/service/mesos_api_version instance type (integer) does not match any allowed primitive type (allowed: ["string"])

--- a/cli/client/testdata/output/bad-version-no-versions.txt
+++ b/cli/client/testdata/output/bad-version-no-versions.txt
@@ -1,2 +1,2 @@
 Unable to update hello-world to requested version: "not-a-valid"
-Valid package versions are: ["v0.8", "v0.9", "v1.1", "v2.0"]
+No valid package versions to update to.

--- a/cli/client/testdata/output/bad-version.txt
+++ b/cli/client/testdata/output/bad-version.txt
@@ -1,2 +1,2 @@
-git theUnable to update hello-world to requested version: "not-a-valid"
+Unable to update hello-world to requested version: "not-a-valid"
 Valid versions are: ["v0.8", "v0.9", "v1.1", "v2.0"]

--- a/cli/client/testdata/output/bad-version.txt
+++ b/cli/client/testdata/output/bad-version.txt
@@ -1,2 +1,2 @@
-Unable to update hello-world to requested version: "not-a-valid"
-Valid versions are: ["v0.8","v0.9","v1.1","v2.0"]
+git theUnable to update hello-world to requested version: "not-a-valid"
+Valid versions are: ["v0.8", "v0.9", "v1.1", "v2.0"]

--- a/cli/client/testdata/output/generic-error.txt
+++ b/cli/client/testdata/output/generic-error.txt
@@ -1,0 +1,1 @@
+Could not execute command: This an example of a generic Cosmos error response.

--- a/cli/client/testdata/responses/cosmos/1.10/enterprise/bad-app-id.json
+++ b/cli/client/testdata/responses/cosmos/1.10/enterprise/bad-app-id.json
@@ -1,0 +1,8 @@
+{
+  "type": "AppIdChanged",
+  "message": "The new appId /hello-world must be equal to the old appId /hello-world2",
+  "data": {
+    "newAppId": "/hello-world",
+    "oldAppId": "/hello-world2"
+  }
+}

--- a/cli/client/testdata/responses/cosmos/1.10/enterprise/bad-json.json
+++ b/cli/client/testdata/responses/cosmos/1.10/enterprise/bad-json.json
@@ -1,0 +1,43 @@
+{
+  "type": "JsonSchemaMismatch",
+  "message": "Options JSON failed validation",
+  "data": {
+    "errors": [
+      {
+        "level": "error",
+        "schema": {
+          "loadingURI": "#",
+          "pointer": "/properties/world/properties/cpus"
+        },
+        "instance": {
+          "pointer": "/world/cpus"
+        },
+        "domain": "validation",
+        "keyword": "type",
+        "message": "instance type (string) does not match any allowed primitive type (allowed: [\"integer\",\"number\"])",
+        "found": "string",
+        "expected": [
+          "integer",
+          "number"
+        ]
+      },
+      {
+        "domain": "validation",
+        "expected": [
+          "string"
+        ],
+        "found": "integer",
+        "instance": {
+          "pointer": "/service/mesos_api_version"
+        },
+        "keyword": "type",
+        "level": "error",
+        "message": "instance type (integer) does not match any allowed primitive type (allowed: [\"string\"])",
+        "schema": {
+          "loadingURI": "#",
+          "pointer": "/properties/service/properties/mesos_api_version"
+        }
+      }
+    ]
+  }
+}

--- a/cli/client/testdata/responses/cosmos/1.10/enterprise/bad-version-no-versions.json
+++ b/cli/client/testdata/responses/cosmos/1.10/enterprise/bad-version-no-versions.json
@@ -1,0 +1,9 @@
+{
+  "data": {
+    "currentVersion": "stub-universe",
+    "updateVersion": "not-a-valid",
+    "validVersions": []
+  },
+  "message": "The service of version stub-universe cannot update to the requested version not-a-valid",
+  "type": "BadVersionUpdate"
+}

--- a/cli/client/testdata/responses/cosmos/1.10/enterprise/generic-error.json
+++ b/cli/client/testdata/responses/cosmos/1.10/enterprise/generic-error.json
@@ -1,0 +1,6 @@
+{
+  "data": {
+  },
+  "message": "This an example of a generic Cosmos error response.",
+  "type": "GenericErrorType"
+}

--- a/cli/commands/testdata/output/package-versions.txt
+++ b/cli/commands/testdata/output/package-versions.txt
@@ -1,3 +1,3 @@
 Current package version is: "v1.0"
-Package can be downgraded to: ["v0.8","v0.9"]
-Package can be upgraded to: ["v1.1","v2.0"]
+Package can be downgraded to: ["v0.8", "v0.9"]
+Package can be upgraded to: ["v1.1", "v2.0"]

--- a/cli/commands/update.go
+++ b/cli/commands/update.go
@@ -88,22 +88,22 @@ func printPackageVersions() {
 	checkError(err, responseBytes)
 	downgradeVersionsBytes, err := client.GetValueFromJSONResponse(responseBytes, "downgradesTo")
 	checkError(err, responseBytes)
-	noDowngradeVersions, downgradeVersionsSorted, err := client.SortAndPrettyPrintJSONArray(downgradeVersionsBytes)
+	downgradeVersions, err := client.JSONBytesToArray(downgradeVersionsBytes)
 	checkError(err, responseBytes)
 	upgradeVersionsBytes, err := client.GetValueFromJSONResponse(responseBytes, "upgradesTo")
 	checkError(err, responseBytes)
-	noUpgradeVersions, upgradeVersionsSorted, err := client.SortAndPrettyPrintJSONArray(upgradeVersionsBytes)
+	updateVersions, err := client.JSONBytesToArray(upgradeVersionsBytes)
 	checkError(err, responseBytes)
 	client.PrintMessage("Current package version is: %s", currentVersionBytes)
-	if noDowngradeVersions {
+	if len(downgradeVersions) > 0 {
+		client.PrintMessage("Package can be downgraded to: %s", client.PrettyPrintSlice(downgradeVersions))
+	} else {
 		client.PrintMessage("No valid package downgrade versions.")
-	} else {
-		client.PrintMessage("Package can be downgraded to: %s", downgradeVersionsSorted)
 	}
-	if noUpgradeVersions {
-		client.PrintMessage("No valid package upgrade versions.")
+	if len(updateVersions) > 0 {
+		client.PrintMessage("Package can be upgraded to: %s", client.PrettyPrintSlice(updateVersions))
 	} else {
-		client.PrintMessage("Package can be upgraded to: %s", upgradeVersionsSorted)
+		client.PrintMessage("No valid package upgrade versions.")
 	}
 }
 


### PR DESCRIPTION
I've corrected a bug that prevented Cosmos errors from being displayed and added some extra error handling that unpacks Cosmos JSON errors and displays them in a table. Also tidied up a couple of the JSON parsing functions to avoid unnecessary marshaling back and forth.