### PR TITLE
Fix encoding issues when creating service accounts with Python 3.

### DIFF
--- a/tools/create_service_account.sh
+++ b/tools/create_service_account.sh
@@ -1,6 +1,10 @@
 set -x
 MODE=
 
+# Otherwise, Python will complain.
+export LC_ALL=en_US.UTF-8
+export LANG=en_US.UTF-8
+
 if [ "$#" -ge 2 ]; then
     # Set some cluster configs if they are passed in.
     echo At least 2 arguments, must be dcos_url and acs_token


### PR DESCRIPTION
Without this, I run into the following:
```
$ ./tools/create_service_account.sh
++ MODE=
++ '[' 0 -ge 2 ']'
++ '[' '!' 0 -eq 0 ']'
++ SERVICE_ACCOUNT_NAME=dcos_kubernetes
++ SECRET_NAME=dcos_kubernetes
++ echo Creating service account for account=dcos_kubernetes secret=dcos_kubernetes
Creating service account for account=dcos_kubernetes secret=dcos_kubernetes
++ echo Install cli necessary for security...
Install cli necessary for security...
++ dcos package install dcos-enterprise-cli --package-version=1.0.7
Installing CLI subcommand for package [dcos-enterprise-cli] version [1.0.7]
New command available: dcos security
++ echo Create keypair...
Create keypair...
++ dcos security org service-accounts keypair private-key.pem public-key.pem
Failed to execute script dcos-security
Traceback (most recent call last):
  File "dcos-security.py", line 19, in <module>
  File "site-packages/click/core.py", line 716, in __call__
  File "site-packages/click/core.py", line 675, in main
  File "site-packages/click/_unicodefun.py", line 119, in _verify_python3_env
RuntimeError: Click will abort further execution because Python 3 was configured to use ASCII as encoding for the environment.  Either run this under Python 2 or consult http://click.pocoo.org/python3/ for mitigation steps.

This system lists a couple of UTF-8 supporting locales that
you can pick from.  The following suitable locales where
discovered: af_ZA.UTF-8, am_ET.UTF-8, be_BY.UTF-8, bg_BG.UTF-8, ca_ES.UTF-8, cs_CZ.UTF-8, da_DK.UTF-8, de_AT.UTF-8, de_CH.UTF-8, de_DE.UTF-8, el_GR.UTF-8, en_AU.UTF-8, en_CA.UTF-8, en_GB.UTF-8, en_IE.UTF-8, en_NZ.UTF-8, en_US.UTF-8, es_ES.UTF-8, et_EE.UTF-8, eu_ES.UTF-8, fi_FI.UTF-8, fr_BE.UTF-8, fr_CA.UTF-8, fr_CH.UTF-8, fr_FR.UTF-8, he_IL.UTF-8, hr_HR.UTF-8, hu_HU.UTF-8, hy_AM.UTF-8, is_IS.UTF-8, it_CH.UTF-8, it_IT.UTF-8, ja_JP.UTF-8, kk_KZ.UTF-8, ko_KR.UTF-8, lt_LT.UTF-8, nl_BE.UTF-8, nl_NL.UTF-8, no_NO.UTF-8, pl_PL.UTF-8, pt_BR.UTF-8, pt_PT.UTF-8, ro_RO.UTF-8, ru_RU.UTF-8, sk_SK.UTF-8, sl_SI.UTF-8, sr_YU.UTF-8, sv_SE.UTF-8, tr_TR.UTF-8, uk_UA.UTF-8, zh_CN.UTF-8, zh_HK.UTF-8, zh_TW.UTF-8
++ echo 'Failed to create keypair for testing service account'
Failed to create keypair for testing service account
++ exit 1
```