### PR TITLE
Build and eventually install javadoc and sources artifacts.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,22 @@ allprojects {
         gradleVersion = '3.2'
     }
 
+    task sourcesJar(type: Jar, dependsOn: classes) {
+        classifier = 'sources'
+        from sourceSets.main.allSource
+    }
+
+    task javadocJar(type: Jar, dependsOn: javadoc) {
+        classifier = 'javadoc'
+        from javadoc.destinationDir
+        javadoc.failOnError = false
+    }
+
+    artifacts {
+        archives sourcesJar
+        archives javadocJar
+    }
+
     idea {
         if (project.hasProperty('ideaParentDefined')) {
             project {


### PR DESCRIPTION
This PR enables javadoc and sources artifacts generation and eventual installation.

```
$ ls ~/.m2/repository/mesosphere/scheduler/0.20.0-SNAPSHOT/
maven-metadata-local.xml              scheduler-0.20.0-SNAPSHOT.jar         scheduler-0.20.0-SNAPSHOT.zip
scheduler-0.20.0-SNAPSHOT-javadoc.jar scheduler-0.20.0-SNAPSHOT.pom
scheduler-0.20.0-SNAPSHOT-sources.jar scheduler-0.20.0-SNAPSHOT.tar
```

Note to reviewer(s): javadoc doesn't pass so I had to explicitly instruct Gradle to not fail on error, otherwise the build doesn't pass.