### PR TITLE
[INFINITY-1927] File path for Secrets can start with / if in a container

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultSecretSpec.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultSecretSpec.java
@@ -23,10 +23,10 @@ public class DefaultSecretSpec implements SecretSpec {
     private final String envKey;
 
     /** Regexp in @Pattern:
-     *      sub-pattern = [a-zA-Z0-9]+([a-zA-Z0-9_-]*[/\\\\]*)*
+     *      sub-pattern = [.a-zA-Z0-9]+([.a-zA-Z0-9_-]*[/\\\\]*)*
      *      (sub-pattern)?  = either NULL, or sub-pattern.  So It can be Null.
      */
-    @Pattern(regexp = "([a-zA-Z0-9]+([a-zA-Z0-9_-]*[/\\\\]*)*)?")
+    @Pattern(regexp = "([.a-zA-Z0-9]+([.a-zA-Z0-9_-]*[/\\\\]*)*)?")
     private final String filePath;
 
     @JsonCreator

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultSecretSpec.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultSecretSpec.java
@@ -23,10 +23,10 @@ public class DefaultSecretSpec implements SecretSpec {
     private final String envKey;
 
     /** Regexp in @Pattern:
-     *      sub-pattern = [.a-zA-Z0-9]+([.a-zA-Z0-9_-]*[/\\\\]*)*
+     *      sub-pattern = ([.a-zA-Z0-9_-]*[/\\\\]*)*
      *      (sub-pattern)?  = either NULL, or sub-pattern.  So It can be Null.
      */
-    @Pattern(regexp = "([.a-zA-Z0-9]+([.a-zA-Z0-9_-]*[/\\\\]*)*)?")
+    @Pattern(regexp = "([.a-zA-Z0-9_-]*[/\\\\]*)*)?")
     private final String filePath;
 
     @JsonCreator

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultSecretSpec.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultSecretSpec.java
@@ -26,7 +26,7 @@ public class DefaultSecretSpec implements SecretSpec {
      *      sub-pattern = ([.a-zA-Z0-9_-]*[/\\\\]*)*
      *      (sub-pattern)?  = either NULL, or sub-pattern.  So It can be Null.
      */
-    @Pattern(regexp = "([.a-zA-Z0-9_-]*[/\\\\]*)*)?")
+    @Pattern(regexp = "(([.a-zA-Z0-9_-]*[/\\\\]*)*)?")
     private final String filePath;
 
     @JsonCreator

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/config/validate/VerifySecretFilePathTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/config/validate/VerifySecretFilePathTest.java
@@ -22,7 +22,7 @@ public class VerifySecretFilePathTest {
         new DefaultSecretSpec( secretPath, envKey, " ");
     }
 
-    @Test(expected = Exception.class)
+    @Test
     public void testFilePathSlash()  {
         new DefaultSecretSpec( secretPath, envKey, "/path/to/file");
     }
@@ -32,9 +32,20 @@ public class VerifySecretFilePathTest {
         new DefaultSecretSpec( secretPath, envKey, "@?test");
     }
 
-    @Test(expected = Exception.class)
+    @Test
     public void testFilePathBeg() {
         new DefaultSecretSpec( secretPath, envKey, "-test");
+    }
+
+    @Test
+    public void testFilePathBegDot() {
+        new DefaultSecretSpec( secretPath, envKey, ".test");
+    }
+
+
+    @Test
+    public void testFilePathDot() {
+        new DefaultSecretSpec( secretPath, envKey, "somePath/someFile.test");
     }
 
     @Test


### PR DESCRIPTION
If using an image, user may need to set for example a cert file in /etc/... 
We need to allow file path starting with /