### PR TITLE
[SDK] Avoid 'from X import *' in python integration tests

### DIFF
--- a/frameworks/helloworld/tests/test_secrets.py
+++ b/frameworks/helloworld/tests/test_secrets.py
@@ -8,6 +8,7 @@ import sdk_install as install
 import sdk_plan as plan
 import sdk_tasks as tasks
 import sdk_marathon as marathon
+import sdk_utils as utils
 
 from tests.config import (
     PACKAGE_NAME
@@ -72,7 +73,7 @@ def teardown_module(module):
 @pytest.mark.sanity
 @pytest.mark.smoke
 @pytest.mark.secrets
-@pytest.mark.skipif('shakedown.dcos_version_less_than("1.10")')
+@utils.dcos_1_10_or_higher
 def test_secrets_basic():
     # 1) create Secrets
     # 2) install examples/secrets.yml
@@ -111,7 +112,7 @@ def test_secrets_basic():
 
 @pytest.mark.sanity
 @pytest.mark.secrets
-@pytest.mark.skipif('shakedown.dcos_version_less_than("1.10")')
+@utils.dcos_1_10_or_higher
 def test_secrets_verify():
     # 1) create Secrets
     # 2) install examples/secrets.yml
@@ -165,7 +166,7 @@ def test_secrets_verify():
 
 @pytest.mark.sanity
 @pytest.mark.secrets
-@pytest.mark.skipif('shakedown.dcos_version_less_than("1.10")')
+@utils.dcos_1_10_or_higher
 def test_secrets_update():
     # 1) create Secrets
     # 2) install examples/secrets.yml
@@ -226,7 +227,7 @@ def test_secrets_update():
 
 @pytest.mark.sanity
 @pytest.mark.secrets
-@pytest.mark.skipif('shakedown.dcos_version_less_than("1.10")')
+@utils.dcos_1_10_or_higher
 def test_secrets_config_update():
     # 1) install examples/secrets.yml
     # 2) create new Secrets, delete old Secrets
@@ -303,7 +304,7 @@ def test_secrets_config_update():
 @pytest.mark.sanity
 @pytest.mark.secrets
 @pytest.mark.skip(reason="DCOS_SPACE authorization is not working in testing/master. Enable this test later.")
-@pytest.mark.skipif('shakedown.dcos_version_less_than("1.10")')
+@utils.dcos_1_10_or_higher
 def test_secrets_dcos_space():
     # 1) create secrets in hello-world/somePath, i.e. hello-world/somePath/secret1 ...
     # 2) Tasks with DCOS_SPACE hello-world/somePath

--- a/frameworks/helloworld/tests/test_secrets.py
+++ b/frameworks/helloworld/tests/test_secrets.py
@@ -1,13 +1,13 @@
 import pytest
-from shakedown import *
+import shakedown
+import time
+import json
 
 import sdk_cmd as cmd
 import sdk_install as install
 import sdk_plan as plan
 import sdk_tasks as tasks
 import sdk_marathon as marathon
-import time
-import json
 
 from tests.config import (
     PACKAGE_NAME
@@ -72,7 +72,7 @@ def teardown_module(module):
 @pytest.mark.sanity
 @pytest.mark.smoke
 @pytest.mark.secrets
-@dcos_1_10
+@pytest.mark.skipif('shakedown.dcos_version_less_than("1.10")')
 def test_secrets_basic():
     # 1) create Secrets
     # 2) install examples/secrets.yml
@@ -111,7 +111,7 @@ def test_secrets_basic():
 
 @pytest.mark.sanity
 @pytest.mark.secrets
-@dcos_1_10
+@pytest.mark.skipif('shakedown.dcos_version_less_than("1.10")')
 def test_secrets_verify():
     # 1) create Secrets
     # 2) install examples/secrets.yml
@@ -165,7 +165,7 @@ def test_secrets_verify():
 
 @pytest.mark.sanity
 @pytest.mark.secrets
-@dcos_1_10
+@pytest.mark.skipif('shakedown.dcos_version_less_than("1.10")')
 def test_secrets_update():
     # 1) create Secrets
     # 2) install examples/secrets.yml
@@ -226,7 +226,7 @@ def test_secrets_update():
 
 @pytest.mark.sanity
 @pytest.mark.secrets
-@dcos_1_10
+@pytest.mark.skipif('shakedown.dcos_version_less_than("1.10")')
 def test_secrets_config_update():
     # 1) install examples/secrets.yml
     # 2) create new Secrets, delete old Secrets
@@ -303,7 +303,7 @@ def test_secrets_config_update():
 @pytest.mark.sanity
 @pytest.mark.secrets
 @pytest.mark.skip(reason="DCOS_SPACE authorization is not working in testing/master. Enable this test later.")
-@dcos_1_10
+@pytest.mark.skipif('shakedown.dcos_version_less_than("1.10")')
 def test_secrets_dcos_space():
     # 1) create secrets in hello-world/somePath, i.e. hello-world/somePath/secret1 ...
     # 2) Tasks with DCOS_SPACE hello-world/somePath


### PR DESCRIPTION
We need to make sure integration tests with shadown.dcos_1_10 are not totally skipped...