### PR TITLE
Skip all overlay tests in 1.8.

### DIFF
--- a/frameworks/cassandra/tests/test_overlay.py
+++ b/frameworks/cassandra/tests/test_overlay.py
@@ -43,6 +43,7 @@ def teardown_module(module):
 @pytest.mark.sanity
 @pytest.mark.smoke
 @pytest.mark.overlay
+@utils.dcos_1_9_or_higher
 def test_service_overlay_health():
     shakedown.service_healthy(PACKAGE_NAME)
     node_tasks = (
@@ -57,6 +58,7 @@ def test_service_overlay_health():
 @pytest.mark.sanity
 @pytest.mark.smoke
 @pytest.mark.overlay
+@utils.dcos_1_9_or_higher
 def test_functionality():
     parameters = {'CASSANDRA_KEYSPACE': 'testspace1'}
 
@@ -74,6 +76,7 @@ def test_functionality():
 
 @pytest.mark.sanity
 @pytest.mark.overlay
+@utils.dcos_1_9_or_higher
 def test_endpoints():
     endpoints = networks.get_and_test_endpoints("", PACKAGE_NAME, 1)  # tests that the correct number of endpoints are found, should just be "node"
     assert "node" in endpoints, "Cassandra endpoints should contain only 'node', got {}".format(endpoints)

--- a/frameworks/elastic/tests/test_overlay.py
+++ b/frameworks/elastic/tests/test_overlay.py
@@ -32,12 +32,14 @@ def default_populated_index():
 @pytest.mark.sanity
 @pytest.mark.smoke
 @pytest.mark.overlay
+@utils.dcos_1_9_or_higher
 def test_service_health():
     assert shakedown.service_healthy(PACKAGE_NAME)
 
 
 @pytest.mark.sanity
 @pytest.mark.overlay
+@utils.dcos_1_9_or_higher
 def test_indexing(default_populated_index):
     indices_stats = get_elasticsearch_indices_stats(DEFAULT_INDEX_NAME)
     observed_count = indices_stats["_all"]["primaries"]["docs"]["count"]
@@ -49,6 +51,7 @@ def test_indexing(default_populated_index):
 
 @pytest.mark.sanity
 @pytest.mark.overlay
+@utils.dcos_1_9_or_higher
 def test_tasks_on_overlay():
     elastic_tasks = shakedown.get_service_task_ids(PACKAGE_NAME)
     assert len(elastic_tasks) == DEFAULT_TASK_COUNT, \
@@ -59,6 +62,7 @@ def test_tasks_on_overlay():
 
 @pytest.mark.sanity
 @pytest.mark.overlay
+@utils.dcos_1_9_or_higher
 def test_endpoints_on_overlay():
     observed_endpoints = networks.get_and_test_endpoints("", PACKAGE_NAME, 4)
     expected_endpoints = ("coordinator",

--- a/frameworks/hdfs/tests/test_overlay.py
+++ b/frameworks/hdfs/tests/test_overlay.py
@@ -6,7 +6,7 @@ from tests.config import *
 
 import sdk_install as install
 import sdk_networks as networks
-
+import sdk_utils as utils
 
 
 
@@ -27,6 +27,7 @@ def teardown_module(module):
 
 @pytest.mark.sanity
 @pytest.mark.overlay
+@utils.dcos_1_9_or_higher
 def test_tasks_on_overlay():
     hdfs_tasks = shakedown.shakedown.get_service_task_ids(PACKAGE_NAME)
     assert len(hdfs_tasks) == DEFAULT_TASK_COUNT, "Not enough tasks got launched,"\
@@ -37,6 +38,7 @@ def test_tasks_on_overlay():
 
 @pytest.mark.overlay
 @pytest.mark.sanity
+@utils.dcos_1_9_or_higher
 def test_endpoints_on_overlay():
     observed_endpoints = networks.get_and_test_endpoints("", PACKAGE_NAME, 2)
     expected_endpoints = ("hdfs-site.xml", "core-site.xml")
@@ -50,6 +52,7 @@ def test_endpoints_on_overlay():
 @pytest.mark.overlay
 @pytest.mark.sanity
 @pytest.mark.data_integrity
+@utils.dcos_1_9_or_higher
 def test_write_and_read_data_on_overlay():
     # use mesos DNS here because we want the host IP to run the command
     shakedown.wait_for(

--- a/frameworks/helloworld/tests/test_overlay.py
+++ b/frameworks/helloworld/tests/test_overlay.py
@@ -48,6 +48,7 @@ TASKS_WITH_PORTS = [task for task in EXPECTED_TASKS if "hello" in task]
 
 @pytest.mark.sanity
 @pytest.mark.overlay
+@utils.dcos_1_9_or_higher
 def test_overlay_network():
     """Verify that the current deploy plan matches the expected plan from the spec."""
 
@@ -123,6 +124,7 @@ def test_overlay_network():
 
 @pytest.mark.sanity
 @pytest.mark.overlay
+@utils.dcos_1_9_or_higher
 def test_port_names():
     def check_task_ports(task_name, expected_port_count, expected_port_names):
         endpoint = "/v1/tasks/info/{}".format(task_name)
@@ -140,6 +142,7 @@ def test_port_names():
 
 @pytest.mark.sanity
 @pytest.mark.overlay
+@utils.dcos_1_9_or_higher
 def test_srv_records():
     fmk_srvs = networks.get_framework_srv_records(PACKAGE_NAME)
     for task in TASKS_WITH_PORTS:

--- a/frameworks/kafka/tests/test_overlay.py
+++ b/frameworks/kafka/tests/test_overlay.py
@@ -29,6 +29,7 @@ def teardown_module(module):
 @pytest.mark.overlay
 @pytest.mark.smoke
 @pytest.mark.sanity
+@utils.dcos_1_9_or_higher
 def test_service_overlay_health():
     """Installs SDK based Kafka on with virtual networks set to True. Tests that the deployment completes
     and the service is healthy, then checks that all of the service tasks (brokers) are on the overlay network
@@ -46,6 +47,7 @@ def test_service_overlay_health():
 @pytest.mark.smoke
 @pytest.mark.sanity
 @pytest.mark.overlay
+@utils.dcos_1_9_or_higher
 def test_overlay_network_deployment_and_endpoints():
     # double check
     tasks.check_running(SERVICE_NAME, DEFAULT_BROKER_COUNT)
@@ -61,6 +63,7 @@ def test_overlay_network_deployment_and_endpoints():
 
 @pytest.mark.sanity
 @pytest.mark.overlay
+@utils.dcos_1_9_or_higher
 def test_pods_restart_on_overlay():
     restart_broker_pods()
     test_overlay_network_deployment_and_endpoints()
@@ -68,6 +71,7 @@ def test_pods_restart_on_overlay():
 
 @pytest.mark.sanity
 @pytest.mark.overlay
+@utils.dcos_1_9_or_higher
 def test_pods_replace_on_overlay():
     replace_broker_pod()
     test_overlay_network_deployment_and_endpoints()
@@ -75,11 +79,13 @@ def test_pods_replace_on_overlay():
 
 @pytest.mark.sanity
 @pytest.mark.overlay
+@utils.dcos_1_9_or_higher
 def test_topic_create_overlay():
     create_topic()
 
 
 @pytest.mark.sanity
 @pytest.mark.overlay
+@utils.dcos_1_9_or_higher
 def test_topic_delete_overlay():
     delete_topic()

--- a/frameworks/template/tests/test_overlay.py
+++ b/frameworks/template/tests/test_overlay.py
@@ -4,6 +4,9 @@ import sdk_install as install
 import sdk_utils as utils
 import sdk_networks as networks
 
+import shakedown
+
+
 from tests.config import (
     PACKAGE_NAME,
     DEFAULT_TASK_COUNT

--- a/frameworks/template/tests/test_overlay.py
+++ b/frameworks/template/tests/test_overlay.py
@@ -23,5 +23,6 @@ def teardown_module(module):
 @pytest.mark.sanity
 @pytest.mark.smoke
 @pytest.mark.overlay
+@utils.dcos_1_9_or_higher
 def test_install():
     networks.check_task_network("template-0-node")

--- a/testing/sdk_utils.py
+++ b/testing/sdk_utils.py
@@ -1,6 +1,6 @@
 import sys
 import shakedown
-
+import pytest
 
 def out(msg):
     '''Emit an informational message on test progress during test runs'''
@@ -40,3 +40,8 @@ def get_foldered_name(service_name):
     if shakedown.dcos_version_less_than("1.10"):
         return service_name
     return "/test/integration/" + service_name
+
+
+dcos_1_9_or_higher = pytest.mark.skipif('shakedown.dcos_version_less_than("1.9")')
+dcos_1_10_or_higher = pytest.mark.skipif('shakedown.dcos_version_less_than("1.10")')
+


### PR DESCRIPTION
Also, adds a utility to do this (as I can't get shakedown's built in marks to work)