### PR TITLE
Fix TaskSpec cloning

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/TaskUtils.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/TaskUtils.java
@@ -133,21 +133,12 @@ public class TaskUtils {
             return true;
         }
 
-        // CommandInfos
+        // Goal States
 
-        Optional<CommandSpec> oldCommand = oldTaskSpec.getCommand();
-        Optional<CommandSpec> newCommand = newTaskSpec.getCommand();
-        if (!Objects.equals(oldCommand, newCommand)) {
-            LOGGER.debug("Task commands '{}' and '{}' are different.", oldCommand, newCommand);
-            return true;
-        }
-
-        // Health checks
-
-        Optional<HealthCheckSpec> oldHealthCheck = oldTaskSpec.getHealthCheck();
-        Optional<HealthCheckSpec> newHealthCheck = newTaskSpec.getHealthCheck();
-        if (!Objects.equals(oldHealthCheck, newHealthCheck)) {
-            LOGGER.debug("Task healthchecks '{}' and '{}' are different.", oldHealthCheck, newHealthCheck);
+        GoalState oldGoalState = oldTaskSpec.getGoal();
+        GoalState newGoalState = newTaskSpec.getGoal();
+        if (!Objects.equals(oldGoalState, newGoalState)) {
+            LOGGER.debug("Task goals '{}' and '{}' are different.", oldGoalState, newGoalState);
             return true;
         }
 
@@ -186,12 +177,48 @@ public class TaskUtils {
             return true;
         }
 
+        // CommandSpecs
+
+        Optional<CommandSpec> oldCommand = oldTaskSpec.getCommand();
+        Optional<CommandSpec> newCommand = newTaskSpec.getCommand();
+        if (!Objects.equals(oldCommand, newCommand)) {
+            LOGGER.debug("Task commands '{}' and '{}' are different.", oldCommand, newCommand);
+            return true;
+        }
+
+        // Health checks
+
+        Optional<HealthCheckSpec> oldHealthCheck = oldTaskSpec.getHealthCheck();
+        Optional<HealthCheckSpec> newHealthCheck = newTaskSpec.getHealthCheck();
+        if (!Objects.equals(oldHealthCheck, newHealthCheck)) {
+            LOGGER.debug("Task healthchecks '{}' and '{}' are different.", oldHealthCheck, newHealthCheck);
+            return true;
+        }
+
+        // Readiness checks
+
+        Optional<ReadinessCheckSpec> oldReadinessCheck = oldTaskSpec.getReadinessCheck();
+        Optional<ReadinessCheckSpec> newReadinessCheck = newTaskSpec.getReadinessCheck();
+        if (!Objects.equals(oldReadinessCheck, newReadinessCheck)) {
+            LOGGER.debug("Task readinesschecks '{}' and '{}' are different.", oldReadinessCheck, newReadinessCheck);
+            return true;
+        }
+
         // Config files
 
         Map<String, ConfigFileSpec> oldConfigMap = getConfigTemplateMap(oldTaskSpec.getConfigFiles());
         Map<String, ConfigFileSpec> newConfigMap = getConfigTemplateMap(newTaskSpec.getConfigFiles());
         if (!Objects.equals(oldConfigMap, newConfigMap)) {
             LOGGER.debug("Config templates '{}' and '{}' are different.", oldConfigMap, newConfigMap);
+            return true;
+        }
+
+        // DiscoverySpecs
+
+        Optional<DiscoverySpec> oldDiscoverySpec = oldTaskSpec.getDiscovery();
+        Optional<DiscoverySpec> newDiscoverySpec = newTaskSpec.getDiscovery();
+        if (!Objects.equals(oldDiscoverySpec, newDiscoverySpec)) {
+            LOGGER.debug("DiscoverySpecs '{}' and '{}' are different.", oldDiscoverySpec, newDiscoverySpec);
             return true;
         }
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultTaskSpec.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultTaskSpec.java
@@ -87,7 +87,9 @@ public class DefaultTaskSpec implements TaskSpec {
         builder.resourceSet = copy.getResourceSet();
         builder.commandSpec = copy.getCommand().orElse(null);
         builder.healthCheckSpec = copy.getHealthCheck().orElse(null);
+        builder.readinessCheckSpec = copy.getReadinessCheck().orElse(null);
         builder.configFiles = copy.getConfigFiles();
+        builder.discoverySpec = copy.getDiscovery().orElse(null);
         return builder;
     }
 

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/specification/DefaultTaskSpecTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/specification/DefaultTaskSpecTest.java
@@ -1,0 +1,56 @@
+package com.mesosphere.sdk.specification;
+
+import com.mesosphere.sdk.testutils.TestConstants;
+import org.apache.mesos.Protos;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+
+/**
+ * This class tests DefaultTaskSpec.
+ */
+public class DefaultTaskSpecTest {
+    @Test
+    public void cloneTaskSpec() {
+        DefaultTaskSpec original = new DefaultTaskSpec(
+                "task",
+                GoalState.RUNNING,
+                new DefaultResourceSet(
+                        "rs-id",
+                        Arrays.asList(
+                                new DefaultResourceSpec(
+                                        "cpus",
+                                        Protos.Value.newBuilder()
+                                                .setType(Protos.Value.Type.SCALAR)
+                                                .setScalar(Protos.Value.Scalar.newBuilder()
+                                                        .setValue(1.0))
+                                                .build(),
+                                        TestConstants.ROLE,
+                                        TestConstants.PRE_RESERVED_ROLE,
+                                        TestConstants.PRINCIPAL,
+                                        "env-key")),
+                        Arrays.asList(
+                                new DefaultVolumeSpec(
+                                        100,
+                                        VolumeSpec.Type.ROOT,
+                                        TestConstants.CONTAINER_PATH,
+                                        TestConstants.ROLE,
+                                        TestConstants.PRE_RESERVED_ROLE,
+                                        TestConstants.PRINCIPAL,
+                                        "env-key")),
+                        TestConstants.ROLE,
+                        TestConstants.PRE_RESERVED_ROLE,
+                        TestConstants.PRINCIPAL),
+                new DefaultCommandSpec("./cmd", new HashMap<>()),
+                new DefaultHealthCheckSpec("./health-check", 1, 1, 1, 1, 1),
+                new DefaultReadinessCheckSpec("./readiness-check", 2, 2, 2),
+                Arrays.asList(
+                        new DefaultConfigFileSpec("name", "relative-path", "template-content")),
+                new DefaultDiscoverySpec("prefix", Protos.DiscoveryInfo.Visibility.CLUSTER));
+
+        DefaultTaskSpec clone = DefaultTaskSpec.newBuilder(original).build();
+        Assert.assertEquals(original, clone);
+    }
+}


### PR DESCRIPTION
We weren't cloning ReadinessCheckSpec or DiscoverySpec for TaskSpec.  The test also caught that our `areDifferent` function was out of date.

Ran across this when cloning TaskSpecs for some other work.  Main changes are the DefaultTaskSpec.java, lines 90 and 92.