### PR TITLE
[INFINITY-1932] Test for debian python, not debian OS.

### DIFF
--- a/tools/piputil.py
+++ b/tools/piputil.py
@@ -54,7 +54,10 @@ def pip_install_dir(path, requirements_filepath):
                '-r', requirements_filepath,
                ]
     # --system is a workaround for debian brain damage
-    if os.path.exists("/etc/debian_version"):
+    pip_version_cmd = [get_pip3_binary(), '--version']
+    output = subprocess.check_output(pip_version_cmd)
+    # dist-packages is the telltale of the debian patches
+    if b'dist-packages' in output:
         pip_cmd.append('--system')
 
     subprocess.check_call(pip_cmd)


### PR DESCRIPTION
Previous logic broke in soak-cluster used docker image which supplied python3 from python.org loaded in /usr/local on a debian base image.