### PR TITLE
[INFINITY-1696] PortSpec conflict validation

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/YAMLToInternalMappers.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/YAMLToInternalMappers.java
@@ -524,8 +524,8 @@ public class YAMLToInternalMappers {
             RawPort rawPort = portEntry.getValue();
             boolean ok = ports.add(rawPort.getPort());
             if (!ok && rawPort.getPort() > 0) {
-                throw new IllegalArgumentException(String.format("Cannot have duplicate ports, your spec has duplicate " +
-                        "port requests for port %d with name %s", rawPort.getPort(), name));
+                throw new IllegalArgumentException(String.format("Cannot have duplicate ports, your spec has " +
+                        "duplicate port requests for port %d with name %s", rawPort.getPort(), name));
             }
             Protos.Value.Builder portValueBuilder = Protos.Value.newBuilder()
                     .setType(Protos.Value.Type.RANGES);

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/YAMLToInternalMappers.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/YAMLToInternalMappers.java
@@ -508,15 +508,6 @@ public class YAMLToInternalMappers {
         return ports;
     }
 
-    private static boolean maybeUsePortResources(Collection<String> networkNames) {
-        for (String networkName : networkNames) {
-            if (DcosConstants.networkSupportsPortMapping(networkName)) {
-                return true;
-            }
-        }
-        return networkNames.size() == 0;  // if we have no networks, we want to use port resources
-    }
-
     private static PortsSpec from(
             String role,
             String preReservedRole,
@@ -524,11 +515,18 @@ public class YAMLToInternalMappers {
             WriteOnceLinkedHashMap<String, RawPort> rawPorts,
                                      Collection<String> networkNames) {
         Collection<PortSpec> portSpecs = new ArrayList<>();
+        Set<Integer> ports = new HashSet<>();
         Protos.Value.Builder portsValueBuilder = Protos.Value.newBuilder().setType(Protos.Value.Type.RANGES);
         String envKey = null;
+
         for (Map.Entry<String, RawPort> portEntry : rawPorts.entrySet()) {
             String name = portEntry.getKey();
             RawPort rawPort = portEntry.getValue();
+            boolean ok = ports.add(rawPort.getPort());
+            if (!ok && rawPort.getPort() > 0) {
+                throw new IllegalArgumentException(String.format("Cannot have duplicate ports, your spec has duplicate " +
+                        "port requests for port %d with name %s", rawPort.getPort(), name));
+            }
             Protos.Value.Builder portValueBuilder = Protos.Value.newBuilder()
                     .setType(Protos.Value.Type.RANGES);
             portValueBuilder.getRangesBuilder().addRangeBuilder()

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/specification/DefaultServiceSpecTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/specification/DefaultServiceSpecTest.java
@@ -163,6 +163,14 @@ public class DefaultServiceSpecTest {
         Assert.assertEquals(8088, another.getRange(0).getBegin(), another.getRange(0).getEnd());
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void invalidDuplicatePorts() throws Exception {
+        ClassLoader classLoader = getClass().getClassLoader();
+        File file = new File(classLoader.getResource("invalid-duplicate-ports.yml").getFile());
+        RawServiceSpec rawServiceSpec = RawServiceSpec.newBuilder(file).build();
+        DefaultServiceSpec.newGenerator(rawServiceSpec, flags).build();
+    }
+
     @Test
     public void validReadinessCheck() throws Exception {
         ClassLoader classLoader = getClass().getClassLoader();

--- a/sdk/scheduler/src/test/resources/invalid-duplicate-ports.yml
+++ b/sdk/scheduler/src/test/resources/invalid-duplicate-ports.yml
@@ -1,0 +1,23 @@
+name: "data-store"
+pods:
+  meta-data:
+    count: 2
+    tasks:
+      meta-data-task:
+        goal: RUNNING
+        cmd: "echo $TASK_NAME >> $TASK_NAME$CONTAINER_PATH_SUFFIX/output && sleep $SLEEP_DURATION"
+        cpus: 0.1
+        memory: 512
+        ports:
+          http:
+            port: 8080
+          another:
+            port: 8080
+        volume:
+          path: "meta-data-container-path"
+          type: ROOT
+          size: 5000
+        env:
+          TASK_NAME: "meta-data"
+          CONTAINER_PATH_SUFFIX: "-container-path"
+          SLEEP_DURATION: "1000"


### PR DESCRIPTION
Adds validation to a DefaultServiceSpec to check for duplicate port requests e.g.: 
```
ports:
  aport:
    port: 4444
  bport:
    port: 4444
```
will fail at compile time now. 