### PR TITLE
Airgap linter should ignore id lines in files.

### DIFF
--- a/tools/airgap_linter.py
+++ b/tools/airgap_linter.py
@@ -23,6 +23,9 @@ def extract_uris(file_name):
         # Do not grab comments
         if line.startswith("*") or line.startswith("#") or line.startswith("//"):
             continue
+        # Do not grab "id" lines
+        if "\"id\": " in line:
+            continue
 
         match = matcher.match(line)
         if match:

--- a/tools/airgap_linter.py
+++ b/tools/airgap_linter.py
@@ -24,7 +24,7 @@ def extract_uris(file_name):
         if line.startswith("*") or line.startswith("#") or line.startswith("//"):
             continue
         # Do not grab "id" lines
-        if "\"id\": " in line:
+        if "\"id\":" in line:
             continue
 
         match = matcher.match(line)


### PR DESCRIPTION
This should catch lines that contain `"id":`, which should just get JSON lines.