### PR TITLE
Guard against 1.8 flake.

### DIFF
--- a/testing/sdk_jobs.py
+++ b/testing/sdk_jobs.py
@@ -65,6 +65,13 @@ def run_job(job_dict, timeout_seconds=600, raise_on_failure=True):
     job_name = job_dict['id']
 
     sdk_cmd.run_cli('job run {}'.format(job_name))
+
+    def wait_for_run_id():
+        runs = json.loads(sdk_cmd.run_cli('job show runs {} --json'.format(job_name)))
+        if len(runs) < 1:
+            return False
+        return True
+    shakedown.wait_for(wait_for_run_id, noisy=True, timeout_seconds=60, ignore_exceptions=False)
     run_id = json.loads(sdk_cmd.run_cli('job show runs {} --json'.format(job_name)))[0]['id']
 
     def fun():

--- a/testing/sdk_jobs.py
+++ b/testing/sdk_jobs.py
@@ -68,11 +68,10 @@ def run_job(job_dict, timeout_seconds=600, raise_on_failure=True):
 
     def wait_for_run_id():
         runs = json.loads(sdk_cmd.run_cli('job show runs {} --json'.format(job_name)))
-        if len(runs) < 1:
-            return False
-        return True
-    shakedown.wait_for(wait_for_run_id, noisy=True, timeout_seconds=60, ignore_exceptions=False)
-    run_id = json.loads(sdk_cmd.run_cli('job show runs {} --json'.format(job_name)))[0]['id']
+        if len(runs) > 0:
+            return runs[0]['id']
+        return ''
+    run_id = shakedown.wait_for(wait_for_run_id, noisy=True, timeout_seconds=60, ignore_exceptions=False)
 
     def fun():
         # catch errors from CLI: ensure that the only error raised is our own:


### PR DESCRIPTION
In 1.8, jobs run, does not appear to be reliably synchronous, causing flaky behavior.

See: https://teamcity.mesosphere.io/viewLog.html?buildId=707813&tab=buildResultsDiv&buildTypeId=DcosIo_DcosCommons_Cassandra_DcOs18Permissive#testNameId-9174911189671957622