### PR TITLE
[INFINITY-1782] get ip addresses from statestore

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/api/EndpointsResource.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/api/EndpointsResource.java
@@ -10,7 +10,6 @@ import com.mesosphere.sdk.api.types.EndpointProducer;
 import com.mesosphere.sdk.offer.Constants;
 import com.mesosphere.sdk.offer.TaskException;
 import com.mesosphere.sdk.offer.taskdata.TaskLabelReader;
-import com.mesosphere.sdk.specification.TaskSpec;
 import com.mesosphere.sdk.state.StateStore;
 
 import com.mesosphere.sdk.state.StateStoreUtils;

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/api/EndpointsResource.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/api/EndpointsResource.java
@@ -1,6 +1,7 @@
 package com.mesosphere.sdk.api;
 
 import java.util.*;
+import java.util.stream.Collectors;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -140,8 +141,8 @@ public class EndpointsResource {
             String autoIpTaskName = discoveryInfo.hasName() ? discoveryInfo.getName() : taskInfo.getName();
             // Hostname of agent at offer time:
             String nativeHost = new TaskLabelReader(taskInfo).getHostname();
-            // get IP address(es) from container status on the TaskStatus, gives overlay
-            // network IP (IP-per-container) or host iff on host network.
+            // get IP address(es) from container status on the latest TaskStatus, if the latest TaskStatus has an IP
+            // otherwise use the lastest TaskStatus' IP stored in the stateStore
             List<String> ipAddresses = reconcileIpAddresses(taskInfo.getName());
             for (Port port : discoveryInfo.getPorts().getPortsList()) {
                 if (port.getVisibility() != Constants.DISPLAYED_PORT_VISIBILITY) {
@@ -176,17 +177,21 @@ public class EndpointsResource {
     }
 
     private static List<String> getIpAddresses(Protos.TaskStatus taskStatus) {
-        List<String> ipAddresses = new ArrayList<>();
         if (taskStatus != null && taskStatus.hasContainerStatus() &&
                 taskStatus.getContainerStatus().getNetworkInfosCount() > 0) {
-            taskStatus.getContainerStatus().getNetworkInfosList()
-                    .forEach(networkInfo -> networkInfo.getIpAddressesList()
-                            .forEach(ipAddress -> ipAddresses.add(ipAddress.getIpAddress())));
+            List<String> ipAddresses = taskStatus.getContainerStatus().getNetworkInfosList().stream()
+                    .flatMap(networkInfo -> networkInfo.getIpAddressesList().stream())
+                    .map(ipAddress -> ipAddress.getIpAddress())
+                    .collect(Collectors.toList());
+            return ipAddresses;
         }
-        return ipAddresses;
+        return Collections.emptyList();
     }
 
     private List<String> reconcileIpAddresses(String taskName) {
+        // get the IP addresses from the latest TaskStatus (currentTaskStatus), if that TaskStatus doesn't have an
+        // IP address (it's a TASK_KILLED, LOST, etc.) than use the last IP address recorded in the stateStore
+        // (this is better than nothing).
         TaskStatus currentTaskStatus = stateStore.fetchStatus(taskName).orElse(null);
         TaskStatus savedTaskStatus = StateStoreUtils.getTaskStatusFromProperty(stateStore, taskName)
                 .orElse(null);

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/api/EndpointsResourceTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/api/EndpointsResourceTest.java
@@ -2,6 +2,7 @@ package com.mesosphere.sdk.api;
 
 import com.mesosphere.sdk.api.types.EndpointProducer;
 import com.mesosphere.sdk.config.ConfigStoreException;
+import com.mesosphere.sdk.dcos.DcosConstants;
 import com.mesosphere.sdk.offer.Constants;
 import com.mesosphere.sdk.offer.taskdata.TaskLabelWriter;
 import com.mesosphere.sdk.state.StateStore;
@@ -303,10 +304,39 @@ public class EndpointsResourceTest {
     @SuppressWarnings("PMD.AvoidUsingHardCodedIP")
     @Test
     public void testOneOverlayEndpoint() throws ConfigStoreException {
+        when(mockStateStore.fetchTasks()).thenReturn(TASK_INFOS);
+        testEndpoint(TestConstants.HOSTNAME);  // confirm that we default to offer hostname
+
+        Protos.TaskStatus TASK_STATUS = createTaskStatus(TestConstants.OVERLAY_HOSTNAME);
+
+        for (TaskInfo taskInfo : TASK_INFOS) {
+            when(mockStateStore.fetchStatus(taskInfo.getName())).thenReturn(Optional.of(TASK_STATUS));
+            when(mockStateStore.fetchProperty(taskInfo.getName() + ":task-status")).thenReturn(TASK_STATUS.toByteArray());
+        }
+
+        testEndpoint(TestConstants.OVERLAY_HOSTNAME);
+
+        Protos.TaskStatus TASK_STATUS_2 = createTaskStatus("otherHost");
+
+        for (TaskInfo taskInfo : TASK_INFOS) {
+            when(mockStateStore.fetchProperty(taskInfo.getName() + ":task-status"))
+                    .thenReturn(TASK_STATUS_2.toByteArray());
+        }
+
+        testEndpoint(TestConstants.OVERLAY_HOSTNAME);
+
+        for (TaskInfo taskInfo : TASK_INFOS) {
+            when(mockStateStore.fetchStatus(taskInfo.getName())).thenReturn(Optional.empty());
+        }
+
+        testEndpoint("otherHost");
+    }
+
+    private Protos.TaskStatus createTaskStatus(String hostname) {
         // build mock stateStore from the inside out
         // IPAddress
         Protos.NetworkInfo.IPAddress.Builder ipAddressBuilder = Protos.NetworkInfo.IPAddress.newBuilder();
-        ipAddressBuilder.setIpAddress(TestConstants.OVERLAY_HOSTNAME);
+        ipAddressBuilder.setIpAddress(hostname);
         // NetworkInfo
         Protos.NetworkInfo.Builder networkInfoBuilder = Protos.NetworkInfo.newBuilder();
         networkInfoBuilder.addIpAddresses(ipAddressBuilder.build());
@@ -318,17 +348,7 @@ public class EndpointsResourceTest {
         taskStatusBuilder.setContainerStatus(containerStatusBuilder.build());
         taskStatusBuilder.setState(Protos.TaskState.TASK_RUNNING);
         taskStatusBuilder.setTaskId(TestConstants.TASK_ID);
-        Protos.TaskStatus TASK_STATUS = taskStatusBuilder.build();
-        when(mockStateStore.fetchTasks()).thenReturn(TASK_INFOS);
-
-        testEndpoint(TestConstants.HOSTNAME);
-
-        for (TaskInfo taskInfo : TASK_INFOS) {
-            when(mockStateStore.fetchStatus(taskInfo.getName())).thenReturn(Optional.of(TASK_STATUS));
-        }
-
-        testEndpoint(TestConstants.OVERLAY_HOSTNAME);
-
+        return taskStatusBuilder.build();
     }
 
     @Test

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/api/EndpointsResourceTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/api/EndpointsResourceTest.java
@@ -2,7 +2,6 @@ package com.mesosphere.sdk.api;
 
 import com.mesosphere.sdk.api.types.EndpointProducer;
 import com.mesosphere.sdk.config.ConfigStoreException;
-import com.mesosphere.sdk.dcos.DcosConstants;
 import com.mesosphere.sdk.offer.Constants;
 import com.mesosphere.sdk.offer.taskdata.TaskLabelWriter;
 import com.mesosphere.sdk.state.StateStore;


### PR DESCRIPTION
Use the `TaskStatus` stored in the stateStore (which should be the last `TaskStatus` with a IP address) as a fall-back for when the current `TaskStatus` doesn't gave a IP address when fetching endpoints. 

Tested with a unit test. 