### PR TITLE
[INFINITY-2000] Persistent Volume container-path can not contain slash character

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultVolumeSpec.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultVolumeSpec.java
@@ -21,7 +21,15 @@ public class DefaultVolumeSpec extends DefaultResourceSpec implements VolumeSpec
 
     /** Regexp in @Pattern will detect blank string. No need to use @NotEmpty or @NotBlank. */
     @NotNull
-    @Pattern(regexp = "[a-zA-Z0-9]+([a-zA-Z0-9_-]*[/\\\\]*)*")
+    /*  No Slash character is allowed in container-path if using Persistent Volume
+         Mesos isolator/containerizer silently ignores mount operation:
+            mesos: src/slave/containerizer/mesos/isolators/filesystem/linux.cpp#L628
+            mesos:/src/slave/containerizer/docker.cpp#L473
+      Previous pattern:
+           @Pattern(regexp = "[a-zA-Z0-9]+([a-zA-Z0-9_-]*[/\\\\]*)*")
+                someDir/anotherDir in SandBox is not a valid path
+     */
+    @Pattern(regexp = "[a-zA-Z0-9]+([a-zA-Z0-9_-]*)*")
     private final String containerPath;
 
     public DefaultVolumeSpec(

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/config/validate/VerifyVolumePathTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/config/validate/VerifyVolumePathTest.java
@@ -42,19 +42,25 @@ public class VerifyVolumePathTest {
     }
 
     @Test
+    public void testVolumePathNumber() {
+        new DefaultVolumeSpec(
+                DISK_SIZE_MB, VolumeSpec.Type.ROOT, "path-0_1-path", "role", "*", "principal", "VOLUME");
+    }
+
+    @Test
     public void testVolumePathCorrect0() {
         new DefaultVolumeSpec(
                 DISK_SIZE_MB, VolumeSpec.Type.ROOT, "path", "role", "*", "principal", "VOLUME");
     }
 
 
-    @Test
+    @Test(expected = Exception.class)
     public void testVolumePathCorrect1() {
         new DefaultVolumeSpec(
                 DISK_SIZE_MB, VolumeSpec.Type.ROOT, "path/path", "role", "*", "principal", "VOLUME");
     }
 
-    @Test
+    @Test(expected = Exception.class)
     public void testVolumePathCorrect2() {
         new DefaultVolumeSpec(
                 DISK_SIZE_MB, VolumeSpec.Type.ROOT, "path-0/1-path", "role", "*", "principal", "VOLUME");

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/config/validate/VerifyVolumePathTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/config/validate/VerifyVolumePathTest.java
@@ -55,13 +55,13 @@ public class VerifyVolumePathTest {
 
 
     @Test(expected = Exception.class)
-    public void testVolumePathCorrect1() {
+    public void testVolumePathSlash1() {
         new DefaultVolumeSpec(
                 DISK_SIZE_MB, VolumeSpec.Type.ROOT, "path/path", "role", "*", "principal", "VOLUME");
     }
 
     @Test(expected = Exception.class)
-    public void testVolumePathCorrect2() {
+    public void testVolumePathSlash2() {
         new DefaultVolumeSpec(
                 DISK_SIZE_MB, VolumeSpec.Type.ROOT, "path-0/1-path", "role", "*", "principal", "VOLUME");
     }


### PR DESCRIPTION
 
 
Comparing with Secrets volumes: 

- container-path can start with / 
   This will only work if running in an image (docker container), and have permission, for example user=root. If for example, there is no image, then task will fail - no absolute path.
-  container-path can be relative to Sandbox.
    For example:  `someDir/anotherDir/secretFile`
 
Persistent Volumes: 
- container-path can not have ‘/‘ at all.  (Mesos requirement, see below for the code)
You can not have ` /someDir` (even if under docker image)
You can also not have `someDir/anotherDir`
 
I experimented with ROOT volumes but this looks a general pattern (including docker isolator).

- **mesos:/src/slave/containerizer/mesos/isolators/filesystem/linux.cpp#L628**
- **mesos:/src/slave/containerizer/docker.cpp#L473**

 
**PROBLEM:** If container-path includes a ‘/‘, mount operation is ignored. This can create a situation where we think task is using the persistent volume but in reality it is writing to its own Sandbox (data will get lost when restarted).
 
 
**Temporary Solution**:   _DefaultVolumeSpec should not let any ‘/‘ character_
**Permanent Solution**:  Instead of  only printing a warning message, just fail if not mounting the Volume.
**Permanent Solution**:  _Allow mounting Volumes to a path relative to Sandbox, such as someDir/anotherDir_
 
 
 
 
 