### PR TITLE
[ELASTIC-109] Statsd resource ZIP downloaded twice

### DIFF
--- a/frameworks/elastic/src/main/dist/install-plugins.sh
+++ b/frameworks/elastic/src/main/dist/install-plugins.sh
@@ -17,6 +17,7 @@ if [ "$XPACK_ENABLED" = true ]; then
 fi
 
 if [ -n "$STATSD_UDP_HOST" ]; then
+    STATSD_PLUGIN="file://$MESOS_SANDBOX/elasticsearch-statsd-$ELASTIC_VERSION.0.zip"
     if [ -n "$PLUGINS" ]; then
         PLUGINS="$PLUGINS$IFS$STATSD_PLUGIN"
     else

--- a/frameworks/elastic/src/main/dist/svc.yml
+++ b/frameworks/elastic/src/main/dist/svc.yml
@@ -15,7 +15,7 @@ pods:
       - {{ELASTICSEARCH_URI}}
       - {{XPACK_URI}}
       - {{DIAGNOSTICS_URI}}
-      - {{STATSD_PLUGIN}}
+      - {{STATSD_URI}}
     rlimits:
       RLIMIT_NOFILE:
         soft: 128000
@@ -50,7 +50,6 @@ pods:
           INGEST_ENABLED: false
           ES_JAVA_OPTS: "-Xms{{MASTER_NODE_HEAP_MB}}M -Xmx{{MASTER_NODE_HEAP_MB}}M"
           ELASTIC_VERSION: {{ELASTIC_VERSION}}
-          STATSD_PLUGIN: {{STATSD_PLUGIN}}
         configs:
           elasticsearch:
             template: "{{CONFIG_TEMPLATE_PATH}}/elasticsearch.yml"
@@ -80,7 +79,7 @@ pods:
       - {{ELASTICSEARCH_URI}}
       - {{XPACK_URI}}
       - {{DIAGNOSTICS_URI}}
-      - {{STATSD_PLUGIN}}
+      - {{STATSD_URI}}
     rlimits:
       RLIMIT_NOFILE:
         soft: 128000
@@ -115,7 +114,6 @@ pods:
           INGEST_ENABLED: false
           ES_JAVA_OPTS: "-Xms{{DATA_NODE_HEAP_MB}}M -Xmx{{DATA_NODE_HEAP_MB}}M"
           ELASTIC_VERSION: {{ELASTIC_VERSION}}
-          STATSD_PLUGIN: {{STATSD_PLUGIN}}
         configs:
           elasticsearch:
             template: "{{CONFIG_TEMPLATE_PATH}}/elasticsearch.yml"
@@ -145,7 +143,7 @@ pods:
       - {{ELASTICSEARCH_URI}}
       - {{XPACK_URI}}
       - {{DIAGNOSTICS_URI}}
-      - {{STATSD_PLUGIN}}
+      - {{STATSD_URI}}
     rlimits:
       RLIMIT_NOFILE:
         soft: 128000
@@ -180,7 +178,6 @@ pods:
           INGEST_ENABLED: true
           ES_JAVA_OPTS: "-Xms{{INGEST_NODE_HEAP_MB}}M -Xmx{{INGEST_NODE_HEAP_MB}}M"
           ELASTIC_VERSION: {{ELASTIC_VERSION}}
-          STATSD_PLUGIN: {{STATSD_PLUGIN}}
         configs:
           elasticsearch:
             template: "{{CONFIG_TEMPLATE_PATH}}/elasticsearch.yml"
@@ -210,7 +207,7 @@ pods:
       - {{ELASTICSEARCH_URI}}
       - {{XPACK_URI}}
       - {{DIAGNOSTICS_URI}}
-      - {{STATSD_PLUGIN}}
+      - {{STATSD_URI}}
     rlimits:
       RLIMIT_NOFILE:
         soft: 128000
@@ -245,7 +242,6 @@ pods:
           INGEST_ENABLED: false
           ES_JAVA_OPTS: "-Xms{{COORDINATOR_NODE_HEAP_MB}}M -Xmx{{COORDINATOR_NODE_HEAP_MB}}M"
           ELASTIC_VERSION: {{ELASTIC_VERSION}}
-          STATSD_PLUGIN: {{STATSD_PLUGIN}}
         configs:
           elasticsearch:
             template: "{{CONFIG_TEMPLATE_PATH}}/elasticsearch.yml"

--- a/frameworks/elastic/universe/marathon.json.mustache
+++ b/frameworks/elastic/universe/marathon.json.mustache
@@ -23,7 +23,7 @@
   {{/service.secret_name}}
   "env": {
     "ELASTIC_VERSION": "{{elastic-version}}",
-    "STATSD_PLUGIN": "{{resource.assets.uris.statsd-plugin-zip}}",
+    "STATSD_URI": "{{resource.assets.uris.statsd-plugin-zip}}",
     "ELASTICSEARCH_URI" : "{{resource.assets.uris.elasticsearch-tar-gz}}",
     "XPACK_URI" : "{{resource.assets.uris.xpack-zip}}",
     "DIAGNOSTICS_URI" : "{{resource.assets.uris.diagnostics-zip}}",


### PR DESCRIPTION
I removed the `STATSD_PLUGIN` environment variable altogether as it's redundant. The new behavior is that the statsd plugin bits are downloaded for each elasticsearch task, and the versioned plugin is installed from its location in the sandbox using the `file://` protocol **if** we're running in an environment with statsd support.