### PR TITLE
Break down TaskTestUtils into non-common parts

### DIFF
--- a/sdk/executor/src/test/java/com/mesosphere/sdk/executor/CustomExecutorTest.java
+++ b/sdk/executor/src/test/java/com/mesosphere/sdk/executor/CustomExecutorTest.java
@@ -2,7 +2,6 @@ package com.mesosphere.sdk.executor;
 
 import org.apache.mesos.ExecutorDriver;
 import org.apache.mesos.Protos;
-import com.mesosphere.sdk.testutils.TaskTestUtils;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -45,15 +44,7 @@ public class CustomExecutorTest {
                 .setTaskId(Protos.TaskID.newBuilder().setValue(UUID.randomUUID().toString()))
                 .setSlaveId(Protos.SlaveID.newBuilder().setValue(UUID.randomUUID().toString()))
                 .setExecutor(executorInfo)
-                .setData(Protos.CommandInfo
-                        .newBuilder()
-                        .setValue("date")
-                        .setEnvironment(Protos.Environment
-                                .newBuilder()
-                                .addVariables(
-                                        TaskTestUtils.createEnvironmentVariable(TASK_TYPE, TEST)))
-                        .build()
-                        .toByteString())
+                .setData(createCommandInfo().toByteString())
                 .build();
 
 
@@ -72,15 +63,7 @@ public class CustomExecutorTest {
                 .setTaskId(Protos.TaskID.newBuilder().setValue(UUID.randomUUID().toString()))
                 .setSlaveId(Protos.SlaveID.newBuilder().setValue(UUID.randomUUID().toString()))
                 .setExecutor(executorInfo)
-                .setData(Protos.CommandInfo
-                        .newBuilder()
-                        .setValue("date")
-                        .setEnvironment(Protos.Environment
-                                .newBuilder()
-                                .addVariables(
-                                        TaskTestUtils.createEnvironmentVariable(TASK_TYPE, TEST)))
-                        .build()
-                        .toByteString())
+                .setData(createCommandInfo().toByteString())
                 .build();
 
 
@@ -127,15 +110,7 @@ public class CustomExecutorTest {
                 .setTaskId(Protos.TaskID.newBuilder().setValue(UUID.randomUUID().toString()))
                 .setSlaveId(Protos.SlaveID.newBuilder().setValue(UUID.randomUUID().toString()))
                 .setExecutor(executorInfo)
-                .setData(Protos.CommandInfo
-                        .newBuilder()
-                        .setValue("date")
-                        .setEnvironment(Protos.Environment
-                                .newBuilder()
-                                .addVariables(
-                                        TaskTestUtils.createEnvironmentVariable(TASK_TYPE, TEST)))
-                        .build()
-                        .toByteString())
+                .setData(createCommandInfo().toByteString())
                 .build();
 
 
@@ -144,7 +119,14 @@ public class CustomExecutorTest {
         customExecutor.shutdown(mockExecutorDriver);
     }
 
-    private Protos.ExecutorInfo getTestExecutorInfo() {
+    private static Protos.CommandInfo createCommandInfo() {
+        Protos.CommandInfo.Builder commandInfoBuilder = Protos.CommandInfo.newBuilder()
+                .setValue("date");
+        commandInfoBuilder.getEnvironmentBuilder().addVariablesBuilder().setName(TASK_TYPE).setValue(TEST);
+        return commandInfoBuilder.build();
+    }
+
+    private static Protos.ExecutorInfo getTestExecutorInfo() {
         return Protos.ExecutorInfo
                 .newBuilder()
                 .setName("TEST_EXECUTOR")
@@ -153,7 +135,7 @@ public class CustomExecutorTest {
                 .build();
     }
 
-    private CustomExecutor getTestExecutor() {
+    private static CustomExecutor getTestExecutor() {
         final ExecutorService executorService = Executors.newCachedThreadPool();
         final TestExecutorTaskFactory testExecutorTaskFactory = new TestExecutorTaskFactory();
         return new CustomExecutor(executorService, testExecutorTaskFactory);

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/testutils/TaskTestUtils.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/testutils/TaskTestUtils.java
@@ -2,6 +2,8 @@ package com.mesosphere.sdk.testutils;
 
 import org.apache.mesos.Protos;
 
+import com.mesosphere.sdk.offer.taskdata.TaskLabelWriter;
+
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -23,8 +25,11 @@ public class TaskTestUtils {
                 .setName(TestConstants.TASK_NAME)
                 .setSlaveId(TestConstants.AGENT_ID)
                 .setCommand(TestConstants.COMMAND_INFO)
-                .setContainer(TestConstants.CONTAINER_INFO)
-                .setLabels(TestConstants.getRequiredTaskLabels(index));
+                .setContainer(TestConstants.CONTAINER_INFO);
+        builder.setLabels(new TaskLabelWriter(builder)
+                .setType(TestConstants.TASK_TYPE)
+                .setIndex(index)
+                .toProto());
         for (Protos.Resource r : resources) {
             String resourceId = "";
             String dynamicPortAssignment = null;
@@ -76,21 +81,11 @@ public class TaskTestUtils {
         return getTaskInfo(resources, Math.abs(random.nextInt()));
     }
 
-    public static List<Protos.TaskInfo> getPodTaskInfos(
-            List<Protos.Resource> resources0,
-            List<Protos.Resource> resources1) {
-
-        Protos.TaskInfo taskInfo0 = getTaskInfo(resources0);
-        Protos.TaskInfo taskInfo1 = getTaskInfo(resources1);
-
-        return Arrays.asList(taskInfo0, taskInfo1);
-    }
-
     public static Protos.ExecutorInfo getExecutorInfo(Protos.Resource resource) {
         return getExecutorInfo(Arrays.asList(resource));
     }
 
-    public static Protos.ExecutorInfo getExecutorInfo(List<Protos.Resource> resources) {
+    private static Protos.ExecutorInfo getExecutorInfo(List<Protos.Resource> resources) {
         return getExecutorInfoBuilder().addAllResources(resources).build();
     }
 
@@ -99,10 +94,6 @@ public class TaskTestUtils {
                 .addResources(resource)
                 .setExecutorId(TestConstants.EXECUTOR_ID)
                 .build();
-    }
-
-    public static Protos.Environment.Variable createEnvironmentVariable(String key, String value) {
-        return Protos.Environment.Variable.newBuilder().setName(key).setValue(value).build();
     }
 
     private static Protos.ExecutorInfo.Builder getExecutorInfoBuilder() {


### PR DESCRIPTION
Executor used one thing, Scheduler used the rest.