### PR TITLE
Fix local tests

### DIFF
--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/SchedulerApiServerTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/SchedulerApiServerTest.java
@@ -28,7 +28,7 @@ public class SchedulerApiServerTest {
         SchedulerApiServer schedulerApiServer = new SchedulerApiServer(12345, Collections.emptyList(),
                 Duration.ofMillis(TIMEOUT_MILLIS));
         new Thread(schedulerApiServer).start();
-        Thread.sleep(TIMEOUT_MILLIS * 10);
+        Thread.sleep(TIMEOUT_MILLIS * 50);
         Assert.assertTrue(schedulerApiServer.ready());
     }
 

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/SchedulerApiServerTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/SchedulerApiServerTest.java
@@ -26,9 +26,11 @@ public class SchedulerApiServerTest {
     @Test
     public void testApiServerReady() throws Exception {
         SchedulerApiServer schedulerApiServer = new SchedulerApiServer(12345, Collections.emptyList(),
-                Duration.ofMillis(TIMEOUT_MILLIS));
+                Duration.ofSeconds(30));
         new Thread(schedulerApiServer).start();
-        Thread.sleep(TIMEOUT_MILLIS * 50);
+        while (!schedulerApiServer.ready()) {
+            Thread.sleep(TIMEOUT_MILLIS);
+        }
         Assert.assertTrue(schedulerApiServer.ready());
     }
 

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/plan/DefaultPlanCoordinatorTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/plan/DefaultPlanCoordinatorTest.java
@@ -10,10 +10,7 @@ import com.mesosphere.sdk.specification.*;
 import com.mesosphere.sdk.state.DefaultStateStore;
 import com.mesosphere.sdk.state.StateStore;
 import com.mesosphere.sdk.storage.MemPersister;
-import com.mesosphere.sdk.testutils.OfferRequirementTestUtils;
-import com.mesosphere.sdk.testutils.OfferTestUtils;
-import com.mesosphere.sdk.testutils.ResourceTestUtils;
-import com.mesosphere.sdk.testutils.TestConstants;
+import com.mesosphere.sdk.testutils.*;
 import org.apache.mesos.Protos;
 import org.apache.mesos.SchedulerDriver;
 import org.junit.*;
@@ -28,7 +25,7 @@ import static org.mockito.Mockito.spy;
 /**
  * Tests for {@code DefaultPlanCoordinator}.
  */
-public class DefaultPlanCoordinatorTest {
+public class DefaultPlanCoordinatorTest extends DefaultCapabilitiesTestSuite {
 
     private static final String SERVICE_NAME = "test-service-name";
     public static final int SUFFICIENT_CPUS = 2;


### PR DESCRIPTION
This PR fixes issues that came up running unit tests on a fresh environment. 

- A number of the tests in `DefaultPlanCoordinatorTest` were failing due to `leader.mesos` not being defined in my environment (thanks to @gabrielhartmann) for the quick fix suggestion.
- I'm not 100% happy with the solution of waiting a little longer for `SchedulerApiServerTest`, where the timeout was being triggered on my machine, but I couldn't come up with a better solution without taking a little more time. In theory, we would want to inject the dependency on the `JettyApiServer` in some way so that we can better control the behaviour and make the tests deterministic. I could also revert the changes to `SchedulerApiServerTest`.