### PR TITLE
Fix package misname

### DIFF
--- a/frameworks/cassandra/tests/test_soak.py
+++ b/frameworks/cassandra/tests/test_soak.py
@@ -48,7 +48,7 @@ def test_soak_upgrade_downgrade():
     with open('cassandra.json') as options_file:
         install_options = json.load(options_file)
 
-    sdk_test_sdk_upgrade.soak_upgrade_downgrade(
+    sdk_test_upgrade.soak_upgrade_downgrade(
         PACKAGE_NAME, DEFAULT_TASK_COUNT, install_options
     )
 

--- a/frameworks/elastic/tests/test_soak.py
+++ b/frameworks/elastic/tests/test_soak.py
@@ -13,5 +13,5 @@ def test_soak_upgrade_downgrade():
     """
     with open('elastic.json') as options_file:
         install_options = json.load(options_file)
-    sdk_test_sdk_upgrade.soak_upgrade_downgrade("beta-{}".format(PACKAGE_NAME), PACKAGE_NAME, PACKAGE_NAME,
+    sdk_test_upgrade.soak_upgrade_downgrade("beta-{}".format(PACKAGE_NAME), PACKAGE_NAME, PACKAGE_NAME,
                                             DEFAULT_TASK_COUNT, install_options)

--- a/frameworks/elastic/tests/test_upgrade.py
+++ b/frameworks/elastic/tests/test_upgrade.py
@@ -8,7 +8,7 @@ from tests.config import *
 @pytest.mark.upgrade
 @pytest.mark.sanity
 def test_upgrade_downgrade():
-    sdk_test_sdk_upgrade.upgrade_downgrade(
+    sdk_test_upgrade.upgrade_downgrade(
         "beta-{}".format(PACKAGE_NAME),
         PACKAGE_NAME,
         DEFAULT_TASK_COUNT,


### PR DESCRIPTION
A few packages got misnamed as a result of cleaning namespaces.