### PR TITLE
Detect and fix user not being set

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultPodSpec.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultPodSpec.java
@@ -25,7 +25,7 @@ public class DefaultPodSpec implements PodSpec {
     @NotNull
     @Size(min = 1)
     private final String type;
-    private final String user;
+    private String user;
     @NotNull
     @Min(0)
     private final Integer count;
@@ -125,6 +125,11 @@ public class DefaultPodSpec implements PodSpec {
     @Override
     public Optional<String> getUser() {
         return Optional.ofNullable(user);
+    }
+
+    @Override
+    public void setUser(String user) {
+        this.user = user;
     }
 
     @Override

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/PodSpec.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/PodSpec.java
@@ -37,6 +37,8 @@ public interface PodSpec {
     @JsonProperty("user")
     Optional<String> getUser();
 
+    void setUser(String user);
+
     @JsonProperty("task-specs")
     List<TaskSpec> getTasks();
 


### PR DESCRIPTION
The commons used in universe packages doesn't set the user at the pod level, and Mesos interprets this as it should set user to `root`.

Upon an update from release to master, even overriding the default user from "nobody" to "root"  pod-level user-change validation fails as the comparison is actually `null` vs "root".

This fixes that by detecting if the pod-level user has been set.