### PR TITLE
[INFINITY-2019] Change "principle" to "service-account" 

### DIFF
--- a/frameworks/cassandra/universe/config.json
+++ b/frameworks/cassandra/universe/config.json
@@ -15,7 +15,7 @@
           "type": "string",
           "default": ""
         },
-        "principal": {
+        "service-account": {
           "description": "The principal for the service instance.",
           "type": "string",
           "default": ""

--- a/frameworks/elastic/universe/config.json
+++ b/frameworks/elastic/universe/config.json
@@ -20,7 +20,7 @@
           "type": "string",
           "default": "nobody"
         },
-        "principal": {
+        "service-account": {
           "description": "The principal for the Elasticsearch service instance.",
           "type": "string",
           "default": ""

--- a/frameworks/hdfs/universe/config.json
+++ b/frameworks/hdfs/universe/config.json
@@ -20,7 +20,7 @@
           "description": "The linux user used to run the scheduler and all executors.",
           "default": "nobody"
         },
-        "principal" : {
+        "service-account" : {
           "description":"The principal for the HDFS service instance.",
           "type":"string",
           "default":""

--- a/frameworks/helloworld/universe/config.json
+++ b/frameworks/helloworld/universe/config.json
@@ -35,7 +35,7 @@
             "type": "string",
             "default": "nobody"
           },
-          "principal": {
+          "service-account": {
             "description": "The principal for the service instance.",
             "type": "string",
             "default": ""

--- a/frameworks/kafka/universe/config.json
+++ b/frameworks/kafka/universe/config.json
@@ -20,7 +20,7 @@
             "description": "The user that the service will run as.",
             "default": "nobody"
           },
-          "principal": {
+          "service-account": {
             "description": "The principal for the Kafka service instance.",
             "type": "string",
             "default": ""

--- a/frameworks/template/universe/config.json
+++ b/frameworks/template/universe/config.json
@@ -22,7 +22,7 @@
             "type": "string",
             "default": "root"
           },
-          "principal": {
+          "service-account": {
             "title": "Custom principal (optional)",
             "description": "The principal for the service instance, or empty to use the default.",
             "type": "string",

--- a/testing/sdk_install.py
+++ b/testing/sdk_install.py
@@ -128,7 +128,7 @@ def get_package_options(additional_options={}):
         # strict mode requires correct principal and secret to perform install.
         # see also: tools/setup_permissions.sh and tools/create_service_account.sh
         return _merge_dictionary(additional_options, {
-            'service': { 'principal': 'service-acct', 'secret_name': 'secret',
+            'service': { 'service-account': 'service-acct', 'secret_name': 'secret',
                          'mesos_api_version': 'V0'}
         })
     else:


### PR DESCRIPTION
Do we really want to do this? "principle" is used in many places including docs/tests....
cc: @gabrielhartmann 