### PR TITLE
[INFINITY-1953] Remove user field from pod specs

### DIFF
--- a/frameworks/cassandra/src/main/dist/svc.yml
+++ b/frameworks/cassandra/src/main/dist/svc.yml
@@ -21,7 +21,6 @@ pods:
       - {{SCHEDULER_URI}}
       - {{CASSANDRA_URI}}
       - {{BOOTSTRAP_URI}}
-    user: {{SERVICE_USER}}
     resource-sets:
       server-resources:
         cpus: {{CASSANDRA_CPUS}}

--- a/frameworks/elastic/src/main/dist/svc.yml
+++ b/frameworks/elastic/src/main/dist/svc.yml
@@ -24,7 +24,6 @@ pods:
         soft: 128000
         hard: 128000
     placement: {{MASTER_NODE_PLACEMENT}}
-    user: {{FRAMEWORK_USER}}
     tasks:
       node:
         goal: RUNNING
@@ -91,7 +90,6 @@ pods:
         soft: 128000
         hard: 128000
     placement: {{DATA_NODE_PLACEMENT}}
-    user: {{FRAMEWORK_USER}}
     tasks:
       node:
         goal: RUNNING
@@ -158,7 +156,6 @@ pods:
         soft: 128000
         hard: 128000
     placement: {{INGEST_NODE_PLACEMENT}}
-    user: {{FRAMEWORK_USER}}
     tasks:
       node:
         goal: RUNNING
@@ -225,7 +222,6 @@ pods:
         soft: 128000
         hard: 128000
     placement: {{COORDINATOR_NODE_PLACEMENT}}
-    user: {{FRAMEWORK_USER}}
     tasks:
       node:
         goal: RUNNING

--- a/frameworks/hdfs/src/main/dist/svc.yml
+++ b/frameworks/hdfs/src/main/dist/svc.yml
@@ -5,7 +5,6 @@ scheduler:
 pods:
   journal:
     count: 3
-    user: {{TASKCFG_ALL_TASK_USER}}
     uris:
       - {{HDFS_URI}}
       - {{HDFS_BIN_URI}}
@@ -78,7 +77,6 @@ pods:
         {{/JOURNAL_READINESS_CHECK_ENABLED}}
   name:
     count: 2
-    user: {{TASKCFG_ALL_TASK_USER}}
     uris:
       - {{HDFS_URI}}
       - {{HDFS_BIN_URI}}
@@ -250,7 +248,6 @@ pods:
           ZKFC: true
   data:
     count: {{DATA_COUNT}}
-    user: {{TASKCFG_ALL_TASK_USER}}
     uris:
       - {{HDFS_URI}}
       - {{HDFS_BIN_URI}}

--- a/frameworks/helloworld/src/main/dist/examples/canary.yml
+++ b/frameworks/helloworld/src/main/dist/examples/canary.yml
@@ -5,7 +5,6 @@ scheduler:
 pods:
   hello:
     count: {{HELLO_COUNT}}
-    user: {{SERVICE_USER}}
     tasks:
       server:
         goal: RUNNING
@@ -24,7 +23,6 @@ pods:
 
   world:
     count: {{WORLD_COUNT}}
-    user: {{SERVICE_USER}}
     resource-sets:
       world-resource:
         cpus: {{WORLD_CPUS}}

--- a/frameworks/helloworld/src/main/dist/examples/discovery.yml
+++ b/frameworks/helloworld/src/main/dist/examples/discovery.yml
@@ -5,7 +5,6 @@ scheduler:
 pods:
   hello:
     count: 1
-    user: {{SERVICE_USER}}
     resource-sets:
       hello-resources:
         cpus: {{HELLO_CPUS}}

--- a/frameworks/helloworld/src/main/dist/examples/executor_volume.yml
+++ b/frameworks/helloworld/src/main/dist/examples/executor_volume.yml
@@ -5,7 +5,6 @@ scheduler:
 pods:
   hello:
     count: 2
-    user: {{SERVICE_USER}}
     volume:
       path: "hello-container-path"
       type: ROOT
@@ -25,7 +24,6 @@ pods:
         memory: 256
   world:
     count: 1
-    user: {{SERVICE_USER}}
     volumes:
       world-volume:
         path: "world-container-path"

--- a/frameworks/helloworld/src/main/dist/examples/gpu_resource.yml
+++ b/frameworks/helloworld/src/main/dist/examples/gpu_resource.yml
@@ -5,7 +5,6 @@ scheduler:
 pods:
   hello:
     count: {{HELLO_COUNT}}
-    user: {{SERVICE_USER}}
     placement: {{HELLO_PLACEMENT}}
     container:
       networks:
@@ -32,7 +31,6 @@ pods:
           max-consecutive-failures: 3
   world:
     count: {{WORLD_COUNT}}
-    user: {{SERVICE_USER}}
     placement: {{WORLD_PLACEMENT}}
     tasks:
       server:

--- a/frameworks/helloworld/src/main/dist/examples/marathon_constraint.yml
+++ b/frameworks/helloworld/src/main/dist/examples/marathon_constraint.yml
@@ -5,7 +5,6 @@ scheduler:
 pods:
   hello:
     count: {{HELLO_COUNT}}
-    user: {{SERVICE_USER}}
     placement: {{HELLO_PLACEMENT}}
     tasks:
       server:
@@ -21,7 +20,6 @@ pods:
           SLEEP_DURATION: {{SLEEP_DURATION}}
   world:
     count: {{WORLD_COUNT}}
-    user: {{SERVICE_USER}}
     placement: {{WORLD_PLACEMENT}}
     tasks:
       server:

--- a/frameworks/helloworld/src/main/dist/examples/multistep_plan.yml
+++ b/frameworks/helloworld/src/main/dist/examples/multistep_plan.yml
@@ -6,7 +6,6 @@ pods:
   hello:
     count: {{HELLO_COUNT}}
     placement: {{HELLO_PLACEMENT}}
-    user: {{SERVICE_USER}}
     tasks:
       first:
         goal: RUNNING
@@ -47,7 +46,6 @@ pods:
   world:
     count: {{WORLD_COUNT}}
     placement: {{WORLD_PLACEMENT}}
-    user: {{SERVICE_USER}}
     tasks:
       server:
         goal: RUNNING

--- a/frameworks/helloworld/src/main/dist/examples/overlay.yml
+++ b/frameworks/helloworld/src/main/dist/examples/overlay.yml
@@ -1,8 +1,9 @@
 name: {{FRAMEWORK_NAME}}
+scheduler:
+  user: {{SERVICE_USER}}
 pods:
   hello-overlay-vip:
     count: 1
-    user: {{SERVICE_USER}}
     uris:
       # this python script starts a basic HTTP server, it responds on a specific port with a given message
       # USAGE: python3 http_py3responder.py <port> <message>
@@ -30,7 +31,6 @@ pods:
         resource-set: hello-resource
   hello-overlay:
     count: 1
-    user: {{SERVICE_USER}}
     uris:
       - "https://s3-us-west-2.amazonaws.com/infinity-artifacts/testing/http_py3responder.py"
       - {{BOOTSTRAP_URI}}
@@ -54,7 +54,6 @@ pods:
         resource-set: hello-resource
   hello-host-vip:
     count: 1
-    user: {{SERVICE_USER}}
     uris:
       - "https://s3-us-west-2.amazonaws.com/infinity-artifacts/testing/http_py3responder.py"
       - {{BOOTSTRAP_URI}}
@@ -76,7 +75,6 @@ pods:
         resource-set: hello-resource
   hello-host:
     count: 1
-    user: {{SERVICE_USER}}
     uris:
       - "https://s3-us-west-2.amazonaws.com/infinity-artifacts/testing/http_py3responder.py"
       - {{BOOTSTRAP_URI}}
@@ -95,7 +93,6 @@ pods:
         resource-set: hello-resource
   getter:
     count: {{HELLO_COUNT}}
-    user: {{SERVICE_USER}}
     uris:
       - {{BOOTSTRAP_URI}}
     networks:

--- a/frameworks/helloworld/src/main/dist/examples/plan.yml
+++ b/frameworks/helloworld/src/main/dist/examples/plan.yml
@@ -5,7 +5,6 @@ scheduler:
 pods:
   hello:
     count: {{HELLO_COUNT}}
-    user: {{SERVICE_USER}}
     tasks:
       server:
         goal: RUNNING
@@ -24,7 +23,6 @@ pods:
 
   world:
     count: {{WORLD_COUNT}}
-    user: {{SERVICE_USER}}
     resource-sets:
       world-resource:
         cpus: {{WORLD_CPUS}}

--- a/frameworks/helloworld/src/main/dist/examples/pre-reserved.yml
+++ b/frameworks/helloworld/src/main/dist/examples/pre-reserved.yml
@@ -7,7 +7,6 @@ pods:
     pre-reserved-role: slave_public
     count: {{HELLO_COUNT}}
     placement: {{HELLO_PLACEMENT}}
-    user: {{SERVICE_USER}}
     tasks:
       server:
         goal: RUNNING
@@ -30,7 +29,6 @@ pods:
   world:
     count: {{WORLD_COUNT}}
     placement: {{WORLD_PLACEMENT}}
-    user: {{SERVICE_USER}}
     tasks:
       server:
         goal: RUNNING

--- a/frameworks/helloworld/src/main/dist/examples/secrets.yml
+++ b/frameworks/helloworld/src/main/dist/examples/secrets.yml
@@ -7,7 +7,6 @@ pods:
     container:
       image-name: ubuntu:14.04
     count: {{HELLO_COUNT}}
-    user: {{SERVICE_USER}}
     placement: {{HELLO_PLACEMENT}}
     secrets:
       s1:
@@ -43,7 +42,6 @@ pods:
           max-consecutive-failures: 3
   world:
     count: {{WORLD_COUNT}}
-    user: {{SERVICE_USER}}
     placement: {{WORLD_PLACEMENT}}
     secrets:
       s1:

--- a/frameworks/helloworld/src/main/dist/examples/sidecar.yml
+++ b/frameworks/helloworld/src/main/dist/examples/sidecar.yml
@@ -5,7 +5,6 @@ scheduler:
 pods:
   hello:
     count: 2
-    user: {{SERVICE_USER}}
     volume:
       path: "hello-container-path"
       type: ROOT

--- a/frameworks/helloworld/src/main/dist/examples/simple.yml
+++ b/frameworks/helloworld/src/main/dist/examples/simple.yml
@@ -5,7 +5,6 @@ scheduler:
 pods:
   hello:
     count: {{HELLO_COUNT}}
-    user: {{SERVICE_USER}}
     tasks:
       server:
         goal: RUNNING

--- a/frameworks/helloworld/src/main/dist/examples/taskcfg.yml
+++ b/frameworks/helloworld/src/main/dist/examples/taskcfg.yml
@@ -5,7 +5,6 @@ scheduler:
 pods:
   hello:
     count: {{HELLO_COUNT}}
-    user: {{SERVICE_USER}}
     placement: {{HELLO_PLACEMENT}}
     tasks:
       server:

--- a/frameworks/helloworld/src/main/dist/examples/uri.yml
+++ b/frameworks/helloworld/src/main/dist/examples/uri.yml
@@ -5,7 +5,6 @@ scheduler:
 pods:
   hello:
     count: {{HELLO_COUNT}}
-    user: {{SERVICE_USER}}
     uris:
       - "https://github.com/mesosphere/dcos-commons/blob/master/README.md"
       - "https://github.com/mesosphere/dcos-commons/blob/master/docs/generate.sh"
@@ -27,7 +26,6 @@ pods:
 
   world:
     count: {{WORLD_COUNT}}
-    user: {{SERVICE_USER}}
     resource-sets:
       world-resource:
         cpus: {{WORLD_CPUS}}

--- a/frameworks/helloworld/src/main/dist/examples/web-url.yml
+++ b/frameworks/helloworld/src/main/dist/examples/web-url.yml
@@ -6,7 +6,6 @@ web-url: http://hello-world.marathon.mesos:{{PORT_API}}
 pods:
   hello:
     count: {{HELLO_COUNT}}
-    user: {{SERVICE_USER}}
     tasks:
       server:
         goal: RUNNING

--- a/frameworks/helloworld/src/main/dist/svc.yml
+++ b/frameworks/helloworld/src/main/dist/svc.yml
@@ -6,7 +6,6 @@ pods:
   hello:
     count: {{HELLO_COUNT}}
     placement: {{HELLO_PLACEMENT}}
-    user: {{SERVICE_USER}}
     tasks:
       server:
         goal: RUNNING
@@ -29,7 +28,6 @@ pods:
   world:
     count: {{WORLD_COUNT}}
     placement: {{WORLD_PLACEMENT}}
-    user: {{SERVICE_USER}}
     tasks:
       server:
         goal: RUNNING

--- a/frameworks/kafka/src/main/dist/svc.yml
+++ b/frameworks/kafka/src/main/dist/svc.yml
@@ -6,7 +6,6 @@ pods:
   kafka:
     count: {{BROKER_COUNT}}
     placement: {{PLACEMENT_CONSTRAINTS}}
-    user: {{FRAMEWORK_USER}}
     uris:
       - {{KAFKA_URI}}
       - {{KAFKA_JAVA_URI}}

--- a/frameworks/template/src/main/dist/svc.yml
+++ b/frameworks/template/src/main/dist/svc.yml
@@ -6,7 +6,6 @@ pods:
   template:
     count: {{NODE_COUNT}}
     placement: {{NODE_PLACEMENT}}
-    user: {{FRAMEWORK_USER}}
     {{#ENABLE_VIRTUAL_NETWORK}}
     networks:
       {{VIRTUAL_NETWORK_NAME}}:

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/RawPod.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/RawPod.java
@@ -19,7 +19,6 @@ public class RawPod implements RawContainerInfoProvider {
     private final String image;
     private final WriteOnceLinkedHashMap<String, RawNetwork> networks;
     private final WriteOnceLinkedHashMap<String, RawRLimit> rlimits;
-    private final String user;
     private final Collection<String> uris;
     private final WriteOnceLinkedHashMap<String, RawTask> tasks;
     private final WriteOnceLinkedHashMap<String, RawResourceSet> resourceSets;
@@ -38,7 +37,6 @@ public class RawPod implements RawContainerInfoProvider {
             @JsonProperty("rlimits") WriteOnceLinkedHashMap<String, RawRLimit> rlimits,
             @JsonProperty("uris") Collection<String> uris,
             @JsonProperty("tasks") WriteOnceLinkedHashMap<String, RawTask> tasks,
-            @JsonProperty("user") String user,
             @JsonProperty("volume") RawVolume volume,
             @JsonProperty("volumes") WriteOnceLinkedHashMap<String, RawVolume> volumes,
             @JsonProperty("pre-reserved-role") String preReservedRole,
@@ -49,7 +47,6 @@ public class RawPod implements RawContainerInfoProvider {
         this.image = image;
         this.networks = networks == null ? new WriteOnceLinkedHashMap<>() : networks;
         this.rlimits = rlimits == null ? new WriteOnceLinkedHashMap<>() : rlimits;
-        this.user = user;
         this.uris = uris;
         this.tasks = tasks;
         this.resourceSets = resourceSets;
@@ -90,10 +87,6 @@ public class RawPod implements RawContainerInfoProvider {
 
     public Collection<String> getUris() {
         return CollectionUtils.isEmpty(uris) ? Collections.emptyList() : uris;
-    }
-
-    public String getUser() {
-        return user;
     }
 
     public WriteOnceLinkedHashMap<String, RawResourceSet> getResourceSets() {

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/YAMLToInternalMappers.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/YAMLToInternalMappers.java
@@ -83,7 +83,8 @@ public class YAMLToInternalMappers {
                     taskEnvRouter.getConfig(entry.getKey()),
                     role,
                     principal,
-                    schedulerFlags.getExecutorURI()));
+                    schedulerFlags.getExecutorURI(),
+                    user));
 
         }
         builder.pods(pods);
@@ -178,11 +179,12 @@ public class YAMLToInternalMappers {
             Map<String, String> additionalEnv,
             String role,
             String principal,
-            String executorUri) throws Exception {
+            String executorUri,
+            String user) throws Exception {
         DefaultPodSpec.Builder builder = DefaultPodSpec.newBuilder(executorUri)
                 .count(rawPod.getCount())
                 .type(podName)
-                .user(rawPod.getUser())
+                .user(user)
                 .preReservedRole(rawPod.getPreReservedRole());
 
         // ContainerInfo parsing section: we allow Networks and RLimits to be within RawContainer, but new

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/config/validate/UserCannotChangeTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/config/validate/UserCannotChangeTest.java
@@ -37,6 +37,29 @@ public class UserCannotChangeTest {
     }
 
     @Test
+    public void testSameServiceUser() {
+        when(mockNewPodSpec.getUser()).thenReturn(Optional.of(USER_A));
+
+        ServiceSpec oldServiceSpec = DefaultServiceSpec.newBuilder()
+                .name("svc")
+                .role(TestConstants.ROLE)
+                .principal(TestConstants.PRINCIPAL)
+                .pods(Arrays.asList(mockOldPodSpec))
+                .user(USER_A)
+                .build();
+
+        ServiceSpec newServiceSpec = DefaultServiceSpec.newBuilder()
+                .name("svc")
+                .role(TestConstants.ROLE)
+                .principal(TestConstants.PRINCIPAL)
+                .pods(Arrays.asList(mockNewPodSpec))
+                .user(USER_A)
+                .build();
+
+        Assert.assertEquals(0, VALIDATOR.validate(Optional.of(oldServiceSpec), newServiceSpec).size());
+    }
+
+    @Test
     public void testSameUser() {
         when(mockNewPodSpec.getUser()).thenReturn(Optional.of(USER_A));
 
@@ -58,6 +81,29 @@ public class UserCannotChangeTest {
     }
 
     @Test
+    public void testDifferentServiceUser() {
+        when(mockNewPodSpec.getUser()).thenReturn(Optional.of(USER_A));
+
+        ServiceSpec oldServiceSpec = DefaultServiceSpec.newBuilder()
+                .name("svc")
+                .role(TestConstants.ROLE)
+                .principal(TestConstants.PRINCIPAL)
+                .pods(Arrays.asList(mockOldPodSpec))
+                .user(USER_A)
+                .build();
+
+        ServiceSpec newServiceSpec = DefaultServiceSpec.newBuilder()
+                .name("svc")
+                .role(TestConstants.ROLE)
+                .principal(TestConstants.PRINCIPAL)
+                .pods(Arrays.asList(mockNewPodSpec))
+                .user(USER_B)
+                .build();
+
+        Assert.assertEquals(1, VALIDATOR.validate(Optional.of(oldServiceSpec), newServiceSpec).size());
+    }
+
+    @Test
     public void testDifferentUser() {
         when(mockNewPodSpec.getUser()).thenReturn(Optional.of(USER_B));
 
@@ -76,6 +122,28 @@ public class UserCannotChangeTest {
                 .build();
 
         Assert.assertEquals(1, VALIDATOR.validate(Optional.of(oldServiceSpec), newServiceSpec).size());
+    }
+
+    @Test
+    public void testOldServiceUserUnset() {
+        when(mockNewPodSpec.getUser()).thenReturn(Optional.of(USER_A));
+
+        ServiceSpec oldServiceSpec = DefaultServiceSpec.newBuilder()
+                .name("svc")
+                .role(TestConstants.ROLE)
+                .principal(TestConstants.PRINCIPAL)
+                .pods(Arrays.asList(mockOldPodSpec))
+                .build();
+
+        ServiceSpec newServiceSpec = DefaultServiceSpec.newBuilder()
+                .name("svc")
+                .role(TestConstants.ROLE)
+                .principal(TestConstants.PRINCIPAL)
+                .pods(Arrays.asList(mockNewPodSpec))
+                .user(USER_A)
+                .build();
+
+        Assert.assertEquals(0, VALIDATOR.validate(Optional.of(oldServiceSpec), newServiceSpec).size());
     }
 
     @Test

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/DefaultSchedulerTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/DefaultSchedulerTest.java
@@ -172,6 +172,7 @@ public class DefaultSchedulerTest {
                 .principal(TestConstants.PRINCIPAL)
                 .zookeeperConnection("badhost-shouldbeignored:2181")
                 .pods(Arrays.asList(pods))
+                .user(TestConstants.SERVICE_USER)
                 .build();
     }
 


### PR DESCRIPTION
Now that we set the user on the framework itself, there's no need to have a separate user field on pod specs. This change depends on the default executor, so I'll rebase once that's merged.