### PR TITLE
[INFINITY-1912] Add dcos-commons cli support for update hash merge semantics

### DIFF
--- a/cli/commands/update.go
+++ b/cli/commands/update.go
@@ -132,7 +132,7 @@ func parseUpdateResponse(responseBytes []byte) (string, error) {
 
 func doUpdate(optionsFile, packageVersion string) {
 	// TODO: figure out KingPin's error handling
-	request := updateRequest{AppID: config.ServiceName, Replace: true}
+	request := updateRequest{AppID: config.ServiceName, Replace: false}
 	if len(packageVersion) == 0 && len(optionsFile) == 0 {
 		client.PrintMessage("Either --options and/or --package-version must be specified. See --help.")
 		return

--- a/cli/commands/update.go
+++ b/cli/commands/update.go
@@ -73,6 +73,7 @@ type updateRequest struct {
 	AppID          string                 `json:"appId"`
 	PackageVersion string                 `json:"packageVersion,omitempty"`
 	OptionsJSON    map[string]interface{} `json:"options,omitempty"`
+	Replace        bool                   `json:"replace"`
 }
 
 func printPackageVersions() {
@@ -131,7 +132,7 @@ func parseUpdateResponse(responseBytes []byte) (string, error) {
 
 func doUpdate(optionsFile, packageVersion string) {
 	// TODO: figure out KingPin's error handling
-	request := updateRequest{AppID: config.ServiceName}
+	request := updateRequest{AppID: config.ServiceName, Replace: true}
 	if len(packageVersion) == 0 && len(optionsFile) == 0 {
 		client.PrintMessage("Either --options and/or --package-version must be specified. See --help.")
 		return


### PR DESCRIPTION
* for `dcos ≤service_name≥ update start --options=≤options_file≥` (update), added replace field w/i request w/ a value of `false` to match change in cosmos requiring the presence of this new field and the expected upgrade semantic expected (hash merge => replace).

NOTE: This PR does NOT extend the underlying `replace` field w/i the update request to the customer/user b/c this PR is a breakfix. Additionally, hash merge semantics cover >80% of the use cases for update where the uncovered region is for unsetting fields (use cases that are not currently in the area of exposure). An upcoming PR will extend the replace as well as add/update documentation to explain the difference, covered uses, and relation between the update command and describe command w/i this context.