### PR TITLE
[INFINITY-2062][INFINITY-2069] Detect no user from previous service spec

### DIFF
--- a/frameworks/helloworld/tests/test_recovery.py
+++ b/frameworks/helloworld/tests/test_recovery.py
@@ -5,6 +5,7 @@ import shakedown
 
 import sdk_cmd
 import sdk_install
+import sdk_utils
 import sdk_marathon
 import sdk_tasks
 from tests.config import (
@@ -30,6 +31,7 @@ def configure_package(configure_universe):
 @pytest.mark.sanity
 @pytest.mark.recovery
 def test_kill_hello_node():
+    check_running()
     hello_ids = sdk_tasks.get_task_ids(PACKAGE_NAME, 'hello-0')
     sdk_tasks.kill_task_with_pattern('hello', 'hello-0-server.hello-world.mesos')
     sdk_tasks.check_tasks_updated(PACKAGE_NAME, 'hello', hello_ids)

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/config/DefaultConfigurationUpdater.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/config/DefaultConfigurationUpdater.java
@@ -6,10 +6,10 @@ import com.google.common.collect.Lists;
 import com.google.protobuf.TextFormat;
 import com.mesosphere.sdk.config.validate.ConfigValidationError;
 import com.mesosphere.sdk.config.validate.ConfigValidator;
+import com.mesosphere.sdk.dcos.DcosConstants;
 import com.mesosphere.sdk.offer.TaskException;
 import com.mesosphere.sdk.offer.taskdata.TaskLabelReader;
 import com.mesosphere.sdk.offer.taskdata.TaskLabelWriter;
-import com.mesosphere.sdk.scheduler.SchedulerUtils;
 import com.mesosphere.sdk.specification.DefaultPodSpec;
 import com.mesosphere.sdk.specification.DefaultServiceSpec;
 import com.mesosphere.sdk.specification.PodSpec;
@@ -161,14 +161,14 @@ public class DefaultConfigurationUpdater implements ConfigurationUpdater<Service
         DefaultServiceSpec.Builder serviceSpecWithUser = DefaultServiceSpec.newBuilder(targetConfig.get());
 
         if (targetConfig.get().getUser() == null) {
-            serviceSpecWithUser.user(SchedulerUtils.DEFAULT_SCHEDULER_USER);
+            serviceSpecWithUser.user(DcosConstants.DEFAULT_SERVICE_USER);
         }
 
         List<PodSpec> podsWithUser = new ArrayList<>();
         for (PodSpec podSpec : targetConfig.get().getPods()) {
             podsWithUser.add(
                     podSpec.getUser() != null && podSpec.getUser().isPresent() ? podSpec :
-                            DefaultPodSpec.newBuilder(podSpec).user(SchedulerUtils.DEFAULT_SCHEDULER_USER).build()
+                            DefaultPodSpec.newBuilder(podSpec).user(DcosConstants.DEFAULT_SERVICE_USER).build()
             );
         }
         serviceSpecWithUser.pods(podsWithUser);

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/dcos/DcosConstants.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/dcos/DcosConstants.java
@@ -28,6 +28,8 @@ public class DcosConstants {
     public static final Integer OVERLAY_DYNAMIC_PORT_RANGE_START = 1025;
     public static final Integer OVERLAY_DYNAMIC_PORT_RANGE_END = 2025;
 
+    public static final String DEFAULT_SERVICE_USER = "root";
+
     // Network Names
 
     private static final String DEFAULT_OVERLAY_NETWORK = "dcos";

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/taskdata/TaskLabelReader.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/taskdata/TaskLabelReader.java
@@ -126,7 +126,7 @@ public class TaskLabelReader {
     }
 
     /**
-     * Returns whether the task has a readiness check label
+     * Returns whether the task has a readiness check label.
      */
     public boolean hasReadinessCheckLabel() {
         // null is false

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerUtils.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerUtils.java
@@ -16,8 +16,6 @@ public class SchedulerUtils {
     /** Reasonable zk host on DC/OS systems. */
     private static final String DEFAULT_ZK_HOST_PORT = "master.mesos:2181";
 
-    public static final String DEFAULT_SCHEDULER_USER = "root";
-
     /**
      * Escape sequence to use for slashes in service names. Slashes are used in DC/OS for folders, and we don't want to
      * confuse ZK with those.

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerUtils.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerUtils.java
@@ -15,7 +15,7 @@ public class SchedulerUtils {
     /** Reasonable zk host on DC/OS systems. */
     private static final String DEFAULT_ZK_HOST_PORT = "master.mesos:2181";
 
-    private static final String DEFAULT_SCHEDULER_USER = "root";
+    public static final String DEFAULT_SCHEDULER_USER = "root";
 
     /**
      * Escape sequence to use for slashes in service names. Slashes are used in DC/OS for folders, and we don't want to

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerUtils.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerUtils.java
@@ -1,5 +1,6 @@
 package com.mesosphere.sdk.scheduler;
 
+import com.mesosphere.sdk.dcos.DcosConstants;
 import org.apache.commons.lang3.StringUtils;
 
 import com.mesosphere.sdk.specification.yaml.RawServiceSpec;
@@ -114,7 +115,7 @@ public class SchedulerUtils {
         }
 
         // Fallback: Use the default scheduler user
-        return DEFAULT_SCHEDULER_USER;
+        return DcosConstants.DEFAULT_SERVICE_USER;
     }
 
     /**

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/config/ConfigurationUpdaterTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/config/ConfigurationUpdaterTest.java
@@ -1,7 +1,7 @@
 package com.mesosphere.sdk.config;
 
+import com.mesosphere.sdk.dcos.DcosConstants;
 import com.mesosphere.sdk.scheduler.DefaultScheduler;
-import com.mesosphere.sdk.scheduler.SchedulerUtils;
 import com.mesosphere.sdk.specification.*;
 import com.mesosphere.sdk.state.ConfigStore;
 import com.mesosphere.sdk.state.ConfigStoreException;
@@ -87,7 +87,7 @@ public class ConfigurationUpdaterTest {
         return DefaultServiceSpec.newBuilder()
                 .name(SERVICE_NAME)
                 .role(TestConstants.ROLE)
-                .user(SchedulerUtils.DEFAULT_SCHEDULER_USER)
+                .user(DcosConstants.DEFAULT_SERVICE_USER)
                 .principal(TestConstants.PRINCIPAL)
                 .zookeeperConnection("foo.bar.com")
                 .pods(Arrays.asList(podA, podB))
@@ -99,7 +99,7 @@ public class ConfigurationUpdaterTest {
     private static final ServiceSpec BAD_UPDATED_SERVICE_SPECIFICATION = getServiceSpec(podA, badPodB);
     private static final ServiceSpec ORIGINAL_SERVICE_SPECIFICATION_WITH_USER =
             DefaultServiceSpec.newBuilder(ORIGINAL_SERVICE_SPECIFICATION)
-                    .user(SchedulerUtils.DEFAULT_SCHEDULER_USER).build();
+                    .user(DcosConstants.DEFAULT_SERVICE_USER).build();
 
     @Mock private StateStore mockStateStore;
     @Mock private ConfigStore<ServiceSpec> mockConfigStore;
@@ -220,7 +220,7 @@ public class ConfigurationUpdaterTest {
                 mockStateStore, mockConfigStore, DefaultServiceSpec.getComparatorInstance(), DefaultScheduler.defaultConfigValidators());
         when(mockConfigStore.getTargetConfig()).thenReturn(TARGET_ID);
         DefaultServiceSpec.Builder serviceSpecWithUser = DefaultServiceSpec.newBuilder(ORIGINAL_SERVICE_SPECIFICATION)
-                .user(SchedulerUtils.DEFAULT_SCHEDULER_USER);
+                .user(DcosConstants.DEFAULT_SERVICE_USER);
         List<PodSpec> podsWithoutUsers = new ArrayList<>();
         for (PodSpec podSpec : ORIGINAL_SERVICE_SPECIFICATION.getPods()) {
             podsWithoutUsers.add(
@@ -245,7 +245,7 @@ public class ConfigurationUpdaterTest {
                 mockStateStore, mockConfigStore, DefaultServiceSpec.getComparatorInstance(), DefaultScheduler.defaultConfigValidators());
         when(mockConfigStore.getTargetConfig()).thenReturn(TARGET_ID);
         DefaultServiceSpec.Builder serviceSpecWithUser = DefaultServiceSpec.newBuilder(ORIGINAL_SERVICE_SPECIFICATION)
-                .user(SchedulerUtils.DEFAULT_SCHEDULER_USER);
+                .user(DcosConstants.DEFAULT_SERVICE_USER);
         List<PodSpec> podsWithoutUsers = new ArrayList<>();
         for (PodSpec podSpec : ORIGINAL_SERVICE_SPECIFICATION.getPods()) {
             podsWithoutUsers.add(
@@ -261,7 +261,7 @@ public class ConfigurationUpdaterTest {
         List<PodSpec> podsWithUsers = new ArrayList<>();
         for (PodSpec podSpec : ORIGINAL_SERVICE_SPECIFICATION_WITH_USER.getPods()) {
             podsWithUsers.add(
-                DefaultPodSpec.newBuilder(podSpec).user(SchedulerUtils.DEFAULT_SCHEDULER_USER).build()
+                DefaultPodSpec.newBuilder(podSpec).user(DcosConstants.DEFAULT_SERVICE_USER).build()
             );
         }
         ServiceSpec SERVICE_SPECIFICATION_WITH_USER = DefaultServiceSpec

--- a/testing/sdk_tasks.py
+++ b/testing/sdk_tasks.py
@@ -66,15 +66,22 @@ def check_tasks_not_updated(service_name, prefix, old_task_ids):
     assert set(old_task_ids).issubset(set(task_ids)), "Tasks got updated:{}".format(task_sets)
 
 
-def kill_task_with_pattern(pattern, agent_host=None):
-    command = (
-        "sudo kill -9 "
-        "$(ps ax | grep {} | grep -v grep | tr -s ' ' | sed 's/^ *//g' | "
-        "cut -d ' ' -f 1)".format(pattern))
-    if agent_host is None:
-        result = shakedown.run_command_on_master(command)
-    else:
-        result = shakedown.run_command_on_agent(agent_host, command)
+def kill_task_with_pattern(pattern, agent_host=None, timeout_seconds=15 * 60):
+    exit_status = 0
+    def fn():
+        command = (
+            "sudo kill -9 "
+            "$(ps ax | grep {} | grep -v grep | tr -s ' ' | sed 's/^ *//g' | "
+            "cut -d ' ' -f 1)".format(pattern))
+        if agent_host is None:
+            exit_status, _ = shakedown.run_command_on_master(command)
+        else:
+            exit_status, _ = shakedown.run_command_on_agent(agent_host, command)
 
-    if not result:
-        raise RuntimeError('Failed to kill task with pattern "{}"'.format(pattern))
+        return exit_status
+
+    # might not be able to connect to the agent on first try so we repeat until we can
+    shakedown.wait_for(lambda: fn(), noisy=True, timeout_seconds=timeout_seconds)
+
+    if exit_status != 0:
+        raise RuntimeError('Failed to kill task with pattern "{}", exit status: {}'.format(pattern, exit_status))


### PR DESCRIPTION
The commons used in universe packages doesn't set the user, and Mesos interprets this as it should set user to root.

Upon an update from release to master, even overriding the default user from "nobody" to "root" doesn't work as the user-change validation fails since the comparison is actually null vs "root".

This fixes that by detecting if the user has been set.

This also adds resiliency to a hello-world test to prevent flakiness, as it also happened to be a blocker for this PR.