### PR TITLE
create service account and set permissions

### DIFF
--- a/frameworks/cassandra/tests/conftest.py
+++ b/frameworks/cassandra/tests/conftest.py
@@ -1,12 +1,12 @@
 import pytest
-import sdk_repository as repo
+import sdk_repository
+import sdk_security
 
 
 @pytest.fixture(scope='session')
 def configure_universe():
-    stub_urls = {}
-    try:
-        stub_urls = repo.add_universe_repos()
-        yield # let the test session execute
-    finally:
-        repo.remove_universe_repos(stub_urls)
+    yield from sdk_repository.universe_session()
+
+@pytest.fixture(scope='session')
+def configure_security(configure_universe):
+    yield from sdk_security.security_session('cassandra')

--- a/frameworks/cassandra/tests/test_backup_and_restore.py
+++ b/frameworks/cassandra/tests/test_backup_and_restore.py
@@ -18,7 +18,7 @@ no_strict_for_azure = pytest.mark.skipif(os.environ.get("SECURITY") == "strict",
         reason="backup/restore doesn't work in strict as user needs to be root")
 
 @pytest.fixture(scope='module', autouse=True)
-def configure_package(configure_universe):
+def configure_package(configure_security):
     try:
         sdk_install.uninstall(FOLDERED_SERVICE_NAME, package_name=PACKAGE_NAME)
         sdk_utils.gc_frameworks()

--- a/frameworks/cassandra/tests/test_overlay.py
+++ b/frameworks/cassandra/tests/test_overlay.py
@@ -22,7 +22,7 @@ TEST_JOBS = [WRITE_DATA_JOB, VERIFY_DATA_JOB, DELETE_DATA_JOB, VERIFY_DELETION_J
 
 
 @pytest.fixture(scope='module', autouse=True)
-def configure_package(configure_universe):
+def configure_package(configure_security):
     successfully_installed = False
     try:
         sdk_install.uninstall(PACKAGE_NAME)

--- a/frameworks/cassandra/tests/test_recovery.py
+++ b/frameworks/cassandra/tests/test_recovery.py
@@ -23,7 +23,7 @@ log = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope='module', autouse=True)
-def configure_package(configure_universe):
+def configure_package(configure_security):
     try:
         sdk_install.uninstall(PACKAGE_NAME)
         sdk_utils.gc_frameworks()

--- a/frameworks/cassandra/tests/test_sanity.py
+++ b/frameworks/cassandra/tests/test_sanity.py
@@ -23,7 +23,7 @@ FOLDERED_SERVICE_NAME = sdk_utils.get_foldered_name(PACKAGE_NAME)
 
 
 @pytest.fixture(scope='module', autouse=True)
-def configure_package(configure_universe):
+def configure_package(configure_security):
     try:
         sdk_install.uninstall(FOLDERED_SERVICE_NAME, package_name=PACKAGE_NAME)
         sdk_utils.gc_frameworks()

--- a/frameworks/elastic/tests/conftest.py
+++ b/frameworks/elastic/tests/conftest.py
@@ -1,12 +1,12 @@
 import pytest
-import sdk_repository as repo
+import sdk_repository
+import sdk_security
 
 
 @pytest.fixture(scope='session')
 def configure_universe():
-    stub_urls = {}
-    try:
-        stub_urls = repo.add_universe_repos()
-        yield # let the test session execute
-    finally:
-        repo.remove_universe_repos(stub_urls)
+    yield from sdk_repository.universe_session()
+
+@pytest.fixture(scope='session')
+def configure_security(configure_universe):
+    yield from sdk_security.security_session('elastic')

--- a/frameworks/elastic/tests/test_overlay.py
+++ b/frameworks/elastic/tests/test_overlay.py
@@ -9,7 +9,7 @@ import sdk_utils
 from tests.config import *
 
 @pytest.fixture(scope='module', autouse=True)
-def configure_package(configure_universe):
+def configure_package(configure_security):
     try:
         sdk_install.uninstall(PACKAGE_NAME)
         sdk_utils.gc_frameworks()

--- a/frameworks/elastic/tests/test_shakedown.py
+++ b/frameworks/elastic/tests/test_shakedown.py
@@ -15,7 +15,7 @@ FOLDERED_SERVICE_NAME = sdk_utils.get_foldered_name(PACKAGE_NAME)
 
 
 @pytest.fixture(scope='module', autouse=True)
-def configure_package(configure_universe):
+def configure_package(configure_security):
     try:
         log.info("Ensure elasticsearch and kibana are uninstalled...")
         sdk_install.uninstall(KIBANA_PACKAGE_NAME)

--- a/frameworks/hdfs/tests/conftest.py
+++ b/frameworks/hdfs/tests/conftest.py
@@ -1,12 +1,12 @@
 import pytest
-import sdk_repository as repo
+import sdk_repository
+import sdk_security
 
 
 @pytest.fixture(scope='session')
 def configure_universe():
-    stub_urls = {}
-    try:
-        stub_urls = repo.add_universe_repos()
-        yield # let the test session execute
-    finally:
-        repo.remove_universe_repos(stub_urls)
+    yield from sdk_repository.universe_session()
+
+@pytest.fixture(scope='session')
+def configure_security(configure_universe):
+    yield from sdk_security.security_session('hdfs')

--- a/frameworks/hdfs/tests/test_overlay.py
+++ b/frameworks/hdfs/tests/test_overlay.py
@@ -15,7 +15,7 @@ import sdk_tasks
 import shakedown
 
 @pytest.fixture(scope='module', autouse=True)
-def configure_package(configure_universe):
+def configure_package(configure_security):
     try:
         sdk_install.uninstall(PACKAGE_NAME)
         sdk_utils.gc_frameworks()

--- a/frameworks/hdfs/tests/test_shakedown.py
+++ b/frameworks/hdfs/tests/test_shakedown.py
@@ -26,7 +26,7 @@ log = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope='module', autouse=True)
-def configure_package(configure_universe):
+def configure_package(configure_security):
     try:
         sdk_install.uninstall(FOLDERED_SERVICE_NAME, package_name=PACKAGE_NAME)
         sdk_utils.gc_frameworks()

--- a/frameworks/helloworld/tests/conftest.py
+++ b/frameworks/helloworld/tests/conftest.py
@@ -1,12 +1,12 @@
 import pytest
 import sdk_repository
+import sdk_security
 
 
 @pytest.fixture(scope='session')
 def configure_universe():
-    stub_urls = {}
-    try:
-        stub_urls = sdk_repository.add_universe_repos()
-        yield # let the test session execute
-    finally:
-        sdk_repository.remove_universe_repos(stub_urls)
+    yield from sdk_repository.universe_session()
+
+@pytest.fixture(scope='session')
+def configure_security(configure_universe):
+    yield from sdk_security.security_session('hello-world')

--- a/frameworks/helloworld/tests/test_canary_strategy.py
+++ b/frameworks/helloworld/tests/test_canary_strategy.py
@@ -18,7 +18,7 @@ log = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope='module', autouse=True)
-def configure_package(configure_universe):
+def configure_package(configure_security):
     try:
         sdk_install.uninstall(PACKAGE_NAME)
         sdk_utils.gc_frameworks()

--- a/frameworks/helloworld/tests/test_discovery.py
+++ b/frameworks/helloworld/tests/test_discovery.py
@@ -11,7 +11,7 @@ from tests.config import (
 
 
 @pytest.fixture(scope='module', autouse=True)
-def configure_package(configure_universe):
+def configure_package(configure_security):
     try:
         sdk_install.uninstall(PACKAGE_NAME)
         options = {

--- a/frameworks/helloworld/tests/test_executor_volumes.py
+++ b/frameworks/helloworld/tests/test_executor_volumes.py
@@ -13,7 +13,7 @@ log = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope='module', autouse=True)
-def configure_package(configure_universe):
+def configure_package(configure_security):
     try:
         sdk_install.uninstall(PACKAGE_NAME)
         options = {

--- a/frameworks/helloworld/tests/test_multistep_plan.py
+++ b/frameworks/helloworld/tests/test_multistep_plan.py
@@ -17,7 +17,7 @@ log = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope='module', autouse=True)
-def configure_package(configure_universe):
+def configure_package(configure_security):
     try:
         sdk_install.uninstall(PACKAGE_NAME)
         options = {
@@ -56,4 +56,3 @@ def test_bump_hello_cpus():
     running_tasks = [t for t in all_tasks if t['name'].startswith('hello') and t['state'] == "TASK_RUNNING"]
     for t in running_tasks:
         assert close_enough(t['resources']['cpus'], updated_cpus)
-

--- a/frameworks/helloworld/tests/test_overlay.py
+++ b/frameworks/helloworld/tests/test_overlay.py
@@ -23,7 +23,7 @@ log = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope='module', autouse=True)
-def configure_package(configure_universe):
+def configure_package(configure_security):
     try:
         sdk_install.uninstall(PACKAGE_NAME)
         sdk_utils.gc_frameworks()

--- a/frameworks/helloworld/tests/test_placement.py
+++ b/frameworks/helloworld/tests/test_placement.py
@@ -20,7 +20,7 @@ num_private_agents = len(shakedown.get_private_agents())
 
 
 @pytest.fixture(scope='module', autouse=True)
-def configure_package(configure_universe):
+def configure_package(configure_security):
     try:
         sdk_install.uninstall(PACKAGE_NAME)
 

--- a/frameworks/helloworld/tests/test_recovery.py
+++ b/frameworks/helloworld/tests/test_recovery.py
@@ -18,7 +18,7 @@ from tests.config import (
 
 
 @pytest.fixture(scope='module', autouse=True)
-def configure_package(configure_universe):
+def configure_package(configure_security):
     try:
         sdk_install.uninstall(PACKAGE_NAME)
         sdk_install.install(PACKAGE_NAME, DEFAULT_TASK_COUNT)

--- a/frameworks/helloworld/tests/test_resource_refinement.py
+++ b/frameworks/helloworld/tests/test_resource_refinement.py
@@ -11,7 +11,7 @@ from tests.config import (
 )
 
 @pytest.fixture(scope='module', autouse=True)
-def configure_package(configure_universe):
+def configure_package(configure_security):
     try:
         sdk_install.uninstall(PACKAGE_NAME)
         sdk_install.install(PACKAGE_NAME, DEFAULT_TASK_COUNT)

--- a/frameworks/helloworld/tests/test_sanity.py
+++ b/frameworks/helloworld/tests/test_sanity.py
@@ -28,7 +28,7 @@ log = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope='module', autouse=True)
-def configure_package(configure_universe):
+def configure_package(configure_security):
     try:
         sdk_install.uninstall(FOLDERED_SERVICE_NAME, package_name=PACKAGE_NAME)
 

--- a/frameworks/helloworld/tests/test_secrets.py
+++ b/frameworks/helloworld/tests/test_secrets.py
@@ -58,7 +58,7 @@ options_dcos_space_test = {
 
 
 @pytest.fixture(scope='module', autouse=True)
-def configure_package(configure_universe):
+def configure_package(configure_security):
     try:
         sdk_install.uninstall(PACKAGE_NAME)
         sdk_cmd.run_cli("package install --cli dcos-enterprise-cli")

--- a/frameworks/helloworld/tests/test_sidecar.py
+++ b/frameworks/helloworld/tests/test_sidecar.py
@@ -13,7 +13,7 @@ log = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope='module', autouse=True)
-def configure_package(configure_universe):
+def configure_package(configure_security):
     try:
         sdk_install.uninstall(PACKAGE_NAME)
         options = {

--- a/frameworks/helloworld/tests/test_taskcfg.py
+++ b/frameworks/helloworld/tests/test_taskcfg.py
@@ -14,7 +14,7 @@ log = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope='module', autouse=True)
-def configure_package(configure_universe):
+def configure_package(configure_security):
     try:
         sdk_install.uninstall(PACKAGE_NAME)
         options = sdk_install.get_package_options({ "service": { "spec_file": "examples/taskcfg.yml" } })

--- a/frameworks/helloworld/tests/test_uninstall.py
+++ b/frameworks/helloworld/tests/test_uninstall.py
@@ -12,7 +12,7 @@ from tests.config import (
 
 
 @pytest.fixture(scope='module', autouse=True)
-def configure_package(configure_universe):
+def configure_package(configure_security):
     try:
         sdk_install.uninstall(PACKAGE_NAME)
         sdk_install.install(PACKAGE_NAME, DEFAULT_TASK_COUNT)

--- a/frameworks/helloworld/tests/test_web_url.py
+++ b/frameworks/helloworld/tests/test_web_url.py
@@ -13,7 +13,7 @@ log = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope='module', autouse=True)
-def configure_package(configure_universe):
+def configure_package(configure_security):
     try:
         sdk_install.uninstall(PACKAGE_NAME)
         options = {

--- a/frameworks/kafka/tests/conftest.py
+++ b/frameworks/kafka/tests/conftest.py
@@ -1,12 +1,12 @@
 import pytest
-import sdk_repository as repo
+import sdk_repository
+import sdk_security
 
 
 @pytest.fixture(scope='session')
 def configure_universe():
-    stub_urls = {}
-    try:
-        stub_urls = repo.add_universe_repos()
-        yield # let the test session execute
-    finally:
-        repo.remove_universe_repos(stub_urls)
+    yield from sdk_repository.universe_session()
+
+@pytest.fixture(scope='session')
+def configure_security(configure_universe):
+    yield from sdk_security.security_session('kafka')

--- a/frameworks/kafka/tests/test_overlay.py
+++ b/frameworks/kafka/tests/test_overlay.py
@@ -10,7 +10,7 @@ import sdk_utils
 from tests.test_utils import  *
 
 @pytest.fixture(scope='module', autouse=True)
-def configure_package(configure_universe):
+def configure_package(configure_security):
     try:
         install.uninstall(SERVICE_NAME, PACKAGE_NAME)
         sdk_utils.gc_frameworks()

--- a/frameworks/kafka/tests/test_ports.py
+++ b/frameworks/kafka/tests/test_ports.py
@@ -17,7 +17,7 @@ DYNAMIC_PORT_OPTIONS_DICT = {"brokers": {"port": 0}}
 
 
 @pytest.fixture(scope='module', autouse=True)
-def configure_package(configure_universe):
+def configure_package(configure_security):
     try:
         sdk_install.uninstall(SERVICE_NAME, PACKAGE_NAME)
         utils.gc_frameworks()

--- a/frameworks/kafka/tests/test_sanity.py
+++ b/frameworks/kafka/tests/test_sanity.py
@@ -25,7 +25,7 @@ ZK_SERVICE_PATH = sdk_utils.get_zk_path(PACKAGE_NAME)
 
 
 @pytest.fixture(scope='module', autouse=True)
-def configure_package(configure_universe):
+def configure_package(configure_security):
     try:
         install.uninstall(FOLDERED_SERVICE_NAME, package_name=PACKAGE_NAME)
         sdk_utils.gc_frameworks()

--- a/frameworks/template/tests/conftest.py
+++ b/frameworks/template/tests/conftest.py
@@ -1,12 +1,12 @@
 import pytest
-import sdk_repository as repo
+import sdk_repository
+import sdk_security
 
 
 @pytest.fixture(scope='session')
 def configure_universe():
-    stub_urls = {}
-    try:
-        stub_urls = repo.add_universe_repos()
-        yield # let the test session execute
-    finally:
-        repo.remove_universe_repos(stub_urls)
+    yield from sdk_repository.universe_session()
+
+@pytest.fixture(scope='session')
+def configure_security(configure_universe):
+    yield from sdk_security.security_session('template')

--- a/frameworks/template/tests/test_overlay.py
+++ b/frameworks/template/tests/test_overlay.py
@@ -16,7 +16,7 @@ overlay_nostrict = pytest.mark.skipif(os.environ.get("SECURITY") == "strict",
     reason="overlay tests currently broken in strict")
 
 @pytest.fixture(scope='module', autouse=True)
-def configure_package(configure_universe):
+def configure_package(configure_security):
     try:
         sdk_install.uninstall(PACKAGE_NAME)
         sdk_utils.gc_frameworks()

--- a/frameworks/template/tests/test_sanity.py
+++ b/frameworks/template/tests/test_sanity.py
@@ -11,7 +11,7 @@ from tests.config import (
 FOLDERED_SERVICE_NAME = sdk_utils.get_foldered_name(PACKAGE_NAME)
 
 @pytest.fixture(scope='module', autouse=True)
-def configure_package(configure_universe):
+def configure_package(configure_security):
     try:
         sdk_install.uninstall(FOLDERED_SERVICE_NAME, package_name=PACKAGE_NAME)
         sdk_utils.gc_frameworks()

--- a/test.sh
+++ b/test.sh
@@ -39,11 +39,11 @@ function usage()
     for framework in $FRAMEWORK_LIST; do
         echo "       $framework"
     done
-    exit 1
 }
 
 if [ "$#" -eq "0" ]; then
     usage
+    exit 1
 fi
 
 if [ -z "$CLUSTER_URL" ]; then
@@ -92,6 +92,7 @@ case $key in
     ;;
     -s)
     security="strict"
+    [[ $CLUSTER_URL == https* ]] || echo "CLUSTER_URL must be https in strict mode" && exit 1
     ;;
     -p)
     ssh_path="$2"
@@ -99,6 +100,7 @@ case $key in
     ;;
     *)
     usage
+    exit 1
             # unknown option
     ;;
 esac
@@ -107,6 +109,7 @@ done
 
 if [ -z "$1" ]; then
     usage
+    exit 1
 fi
 
 framework=$1

--- a/testing/sdk_repository.py
+++ b/testing/sdk_repository.py
@@ -1,32 +1,25 @@
 import json
+import logging
 import os
 import random
 import string
 
 import shakedown
 
+log = logging.getLogger(__name__)
+
 
 def add_universe_repos():
-    """Add the universe package repositories defined in $STUB_UNIVERSE_URL.
-
-    This should generally be used in conjunction with remove_universe_repos()
-    as a fixture in a framework's conftest.py:
-
-    @pytest.fixture(scope='session')
-    def configure_universe():
-        stub_urls = {}
-        try:
-            stub_urls = repository.add_universe_repos()
-            yield # let the test session execute
-        finally:
-            repository.remove_universe_repos(stub_urls)
-    """
     stub_urls = {}
+
+    log.info('Adding universe repos')
 
     # prepare needed universe repositories
     stub_universe_urls = os.environ.get('STUB_UNIVERSE_URL')
     if not stub_universe_urls:
         return stub_urls
+
+    log.info('Adding stub URLs: {}'.format(stub_universe_urls))
     for url in stub_universe_urls.split():
         print('url: {}'.format(url))
         package_name = 'testpkg-'
@@ -37,23 +30,48 @@ def add_universe_repos():
     current_universes, _, _ = shakedown.run_dcos_command('package repo list --json')
     for repo in json.loads(current_universes)['repositories']:
         if repo['uri'] in stub_urls.values():
+            log.info('Removing duplicate stub URL: {}'.format(repo['uri']))
             remove_package_cmd = 'package repo remove {}'.format(repo['name'])
             shakedown.run_dcos_command(remove_package_cmd)
 
     # add the needed universe repositories
     for name, url in stub_urls.items():
+        log.info('Adding stub URL: {}'.format(url))
         add_package_cmd = 'package repo add --index=0 {} {}'.format(name, url)
         shakedown.run_dcos_command(add_package_cmd)
+
+    log.info('Finished adding universe repos')
 
     return stub_urls
 
 
 def remove_universe_repos(stub_urls):
-    """Remove universe package repositories see add_universe_repos() for more info."""
+    log.info('Removing universe repos')
+
     # clear out the added universe repositores at testing end
     for name, url in stub_urls.items():
+        log.info('Removing stub URL: {}'.format(url))
         remove_package_cmd = 'package repo remove {}'.format(name)
         out, err, rc = shakedown.run_dcos_command(remove_package_cmd)
         if err and err.endswith('is not present in the list'):
             # tried to remove something that wasn't there, move on.
             pass
+
+    log.info('Finished removing universe repos')
+
+
+def universe_session():
+    """Add the universe package repositories defined in $STUB_UNIVERSE_URL.
+
+    This should generally be used as a fixture in a framework's conftest.py:
+
+    @pytest.fixture(scope='session')
+    def configure_universe():
+        yield from sdk_repository.universe_session()
+    """
+    stub_urls = {}
+    try:
+        stub_urls = add_universe_repos()
+        yield
+    finally:
+        remove_universe_repos(stub_urls)

--- a/testing/sdk_security.py
+++ b/testing/sdk_security.py
@@ -1,0 +1,239 @@
+import logging
+import os
+from typing import List, Tuple
+
+import requests
+import shakedown
+
+log = logging.getLogger(__name__)
+
+
+def grant(dcosurl: str, headers: dict, user: str, acl: str, description: str, action: str="create") -> None:
+    log.info('Granting permission to {user} for {acl}/{action} ({description})'.format(
+        user=user, acl=acl, action=action, description=description))
+
+    # TODO(kwood): INFINITY-2066 - Use dcos_test_utils instead of raw requests
+
+    # Create the ACL
+    create_endpoint = '{dcosurl}/acs/api/v1/acls/{acl}'.format(dcosurl=dcosurl, acl=acl)
+    r = requests.put(create_endpoint, headers=headers, json={'description': description}, verify=False)
+    # 201=created, 409=already exists
+    assert r.status_code == 201 or r.status_code == 409, '{} failed {}: {}'.format(
+        create_endpoint, r.status_code, r.text)
+
+    # Assign the user to the ACL
+    assign_endpoint = '{dcosurl}/acs/api/v1/acls/{acl}/users/{user}/{action}'.format(
+        dcosurl=dcosurl, acl=acl, user=user, action=action)
+    r = requests.put(assign_endpoint, headers=headers, verify=False)
+    # 204=success, 409=already exists
+    assert r.status_code == 204 or r.status_code == 409, '{} failed {}: {}'.format(
+        create_endpoint, r.status_code, r.text)
+
+
+def revoke(dcosurl: str, headers: dict, user: str, acl: str, description: str, action: str="create") -> None:
+    # TODO(kwood): INFINITY-2065 - implement security cleanup
+    # log.info("Want to delete {user}+{acl}".format(user=user, acl=acl))
+    pass
+
+
+def get_dcos_credentials() -> Tuple[str, dict]:
+    dcosurl, err, rc = shakedown.run_dcos_command('config show core.dcos_url')
+    assert not rc, "Cannot get core.dcos_url: {}".format(err)
+    token, err, rc = shakedown.run_dcos_command('config show core.dcos_acs_token')
+    assert not rc, "Cannot get dcos_acs_token: {}".format(err)
+    headers = {
+        'Content-Type': 'application/json',
+        'Authorization': 'token={}'.format(token.strip()),
+    }
+    return dcosurl.strip(), headers
+
+
+def get_permissions(service_account_name: str, role: str, linux_user: str) -> List[dict]:
+    return [
+        ## registration permissions
+        {
+            'user': service_account_name,
+            'acl': "dcos:mesos:master:framework:role:{}".format(role),
+            'description': "Register with the Mesos master with role={}".format(role),
+        },
+
+        ## task execution permissions
+        {
+            'user': service_account_name,
+            'acl': "dcos:mesos:master:task:user:{}".format(linux_user),
+            'description': "Execute Mesos tasks as user={}".format(linux_user)
+        },
+
+        # XXX 1.10 curerrently requires this mesos:agent permission as well as
+        # mesos:task permission.  unclear if this will be ongoing requirement.
+        # See DCOS-15682
+        {
+            'user': service_account_name,
+            'acl': "dcos:mesos:agent:task:user:{}".format(linux_user),
+            'description': "Execute Mesos tasks as user={}".format(linux_user)
+        },
+
+        # In order for the Spark Dispatcher to register with Mesos as
+        # root, we must launch the dispatcher task as root.  The other
+        # frameworks are launched as nobody, but then register as
+        # service.user, which defaults to root
+        {
+            'user': 'dcos_marathon',
+            'acl': "dcos:mesos:master:task:user:root",
+            'description': "Execute Mesos tasks as user=root"
+        },
+
+        # XXX see above
+        {
+            'user': 'dcos_marathon',
+            'acl': "dcos:mesos:agent:task:user:root",
+            'description': "Execute Mesos tasks as user=root"
+        },
+
+        ## resource permissions
+        {
+            'user': service_account_name,
+            'acl': "dcos:mesos:master:reservation:role:{}".format(role),
+            'description': "Reserve Mesos resources with role={}".format(role)
+        },
+        {
+            'user': service_account_name,
+            'acl': "dcos:mesos:master:reservation:principal:{}".format(service_account_name),
+            'description': "Reserve Mesos resources with principal={}".format(service_account_name),
+            'action': "delete",
+        },
+
+        ## volume permissions
+        {
+            'user': service_account_name,
+            'acl': "dcos:mesos:master:volume:role:{}".format(role),
+            'description': "Create Mesos volumes with role={}".format(role)
+        },
+        {
+            'user': service_account_name,
+            'acl': "dcos:mesos:master:volume:principal:{}".format(service_account_name),
+            'description': "Create Mesos volumes with principal={}".format(service_account_name),
+            'action': "delete",
+        }]
+
+
+def grant_permissions(linux_user: str, role_name: str, service_account_name: str) -> None:
+    dcosurl, headers = get_dcos_credentials()
+    log.info("Granting permissions to {account}".format(account=service_account_name))
+    permissions = get_permissions(service_account_name, role_name, linux_user)
+    for permission in permissions:
+        grant(dcosurl, headers, **permission)
+    log.info("Permission setup completed for {account}".format(account=service_account_name))
+
+
+def revoke_permissions(linux_user: str, role_name: str, service_account_name: str) -> None:
+    dcosurl, headers = get_dcos_credentials()
+    # log.info("Revoking permissions to {account}".format(account=service_account_name))
+    permissions = get_permissions(service_account_name, role_name, linux_user)
+    for permission in permissions:
+        revoke(dcosurl, headers, **permission)
+    # log.info("Permission cleanup completed for {account}".format(account=service_account_name))
+
+
+def create_service_account(service_account_name: str, secret_name: str) -> None:
+    log.info('Creating service account for account={account} secret={secret}'.format(
+        account=service_account_name,
+        secret=secret_name))
+
+    log.info('Install cli necessary for security')
+    out, err, rc = shakedown.run_dcos_command('package install dcos-enterprise-cli --package-version=1.0.7')
+    assert not rc, 'Failed to install dcos-enterprise cli extension: {err}'.format(err=err)
+
+    log.info('Create keypair')
+    out, err, rc = shakedown.run_dcos_command('security org service-accounts keypair private-key.pem public-key.pem')
+    assert not rc, 'Failed to create keypair for testing service account: {err}'.format(err=err)
+
+    log.info('Create service account')
+    out, err, rc = shakedown.run_dcos_command(
+        'security org service-accounts delete "{account}"'.format(account=service_account_name))
+    out, err, rc = shakedown.run_dcos_command(
+        'security org service-accounts create -p public-key.pem -d "My service account" "{account}"'.format(
+            account=service_account_name))
+    assert not rc, 'Failed to create service account "{account}": {err}'.format(
+            account=service_account_name, err=err)
+
+    log.info('Create secret')
+    out, err, rc = shakedown.run_dcos_command('security secrets delete "{secret}"'.format(secret=secret_name))
+    out, err, rc = shakedown.run_dcos_command(
+        'security secrets create-sa-secret --strict private-key.pem "{account}" "{secret}"'.format(
+            account=service_account_name, secret=secret_name))
+    assert not rc, 'Failed to create secret "{secret}" for service account "{account}": {err}'.format(
+            account=service_account_name,
+            secret=secret_name,
+            err=err)
+
+    log.info('Service account created for account={account} secret={secret}'.format(
+        account=service_account_name,
+        secret=secret_name))
+
+
+def delete_service_account(service_account_name: str, secret_name: str) -> None:
+    # TODO(kwood): INFINITY-2065 - implement security cleanup
+    # log.info("Want to delete service account {}".format(service_account_name))
+    pass
+
+
+def setup_security(framework_name: str) -> None:
+    log.info('Setting up strict-mode security')
+    create_service_account(service_account_name='service-acct', secret_name='secret')
+    grant_permissions(
+        linux_user='nobody',
+        role_name='{}-role'.format(framework_name),
+        service_account_name='service-acct'
+    )
+    grant_permissions(
+        linux_user='nobody',
+        role_name='test__integration__{}-role'.format(framework_name),
+        service_account_name='service-acct'
+    )
+    grant_permissions(
+        linux_user='root',
+        role_name='{}-role'.format(framework_name),
+        service_account_name='service-acct'
+    )
+    grant_permissions(
+        linux_user='root',
+        role_name='test__integration__{}-role'.format(framework_name),
+        service_account_name='service-acct'
+    )
+    log.info('Finished setting up strict-mode security')
+
+
+def cleanup_security(framework_name: str) -> None:
+    # log.info('Cleaning up strict-mode security')
+    revoke_permissions(
+        linux_user='root',
+        role_name='test__integration__{}-role'.format(framework_name),
+        service_account_name='service-acct'
+    )
+    revoke_permissions(
+        linux_user='root',
+        role_name='{}-role'.format(framework_name),
+        service_account_name='service-acct'
+    )
+    delete_service_account(service_account_name='service-acct', secret_name='secret')
+    # log.info('Finished cleaning up strict-mode security')
+
+
+def security_session(framework_name: str) -> None:
+    """Create a service account and configure permissions for strict-mode tests.
+
+    This should generally be used as a fixture in a framework's conftest.py:
+
+    @pytest.fixture(scope='session')
+    def configure_security(configure_universe):
+        yield from sdk_security.security_session(framework_name)
+    """
+    try:
+        security_mode = os.environ.get('SECURITY')
+        if security_mode == 'strict':
+            setup_security(framework_name)
+        yield
+    finally:
+        if security_mode == 'strict':
+            cleanup_security(framework_name)


### PR DESCRIPTION
Moves service account creation and permission setting to a `pytest` fixture.

Two follow-up tickets:
- INFINITY-2066: Move sdk_security.py to dcos_test_utils for API calls
- INFINITY-2065: Implement security cleanup in pytest fixtures

--------------------
Edit 07/27 - previous notes and questions from WIP review below...

Some notes:
1. Only configured for `cassandra` right now
2. Has a few TODOs marked in the source
3. Doesn't detect if running in `strict` mode (see question 6 below)

I have a bunch of questions:

1. What should I use instead of straight `requests` calls? Is there an easily available library? Preferably something that understands what ACLs and USERs are.
2. Is there a prefered Exception class to use throughout? If not I'll make something like `sdk_security.SecurityException()`
3. Is there a better way to get the `dcosurl` and `token` than calling the `dcoscli` directly?
4. Have I understood the vocabulary and named variables correctly (`acl`, `user`, `role`, etc)?
5. Ideally, I'd like to have tests describe the permissions they need instead of using a generic security model for all tests, but I'm thinking that needs to be a separate block of work. Agree?
6. What's the best way to detect if we're in `strict` mode? Should I just rely on the `SECURITY` envvar, or is there something more authoritative?
