### PR TITLE
[INFINITY-2038] Reenable DC configuration options

### DIFF
--- a/frameworks/cassandra/docs/limitations.md
+++ b/frameworks/cassandra/docs/limitations.md
@@ -5,6 +5,30 @@ feature_maturity: preview
 enterprise: 'no'
 ---
 
+* Data Center Name
+
+Data Center Name:
+
+The name of the data center cannot be changed after Cassandra installation. `service.data_center` and `service.rack` options are not allowed to be modified once Cassandra is installed. 
+
+```
+"service": {
+……
+      data_center": {
+          "description": "The name of the data center this cluster is running in",
+          "type": "string",
+          "default": "datacenter1"
+        },
+        "rack": {
+          "description": "The name of the rack this cluster is running on",
+          "type": "string",
+          "default": "rack1"
+        },
+……
+}
+```
+
+
 * Seed Node Replace
 
 While the Cassandra service supports a node replace operation via the command

--- a/frameworks/cassandra/src/main/dist/cassandra.yaml
+++ b/frameworks/cassandra/src/main/dist/cassandra.yaml
@@ -97,7 +97,7 @@ incremental_backups: false
 snapshot_before_compaction: false
 auto_snapshot: {{CASSANDRA_AUTO_SNAPSHOT}}
 cross_node_timeout: false
-endpoint_snitch: SimpleSnitch
+endpoint_snitch: GossipingPropertyFileSnitch
 roles_update_interval_in_ms: {{CASSANDRA_ROLES_UPDATE_INTERVAL_IN_MS}}
 permissions_update_interval_in_ms: {{CASSANDRA_PERMISSIONS_UPDATE_INTERVAL_IN_MS}}
 key_cache_keys_to_save: {{CASSANDRA_KEY_CACHE_KEYS_TO_SAVE}}

--- a/frameworks/cassandra/src/main/dist/svc.yml
+++ b/frameworks/cassandra/src/main/dist/svc.yml
@@ -67,6 +67,9 @@ pods:
           metrics:
             template: {{CONFIG_TEMPLATE_PATH}}/metrics-reporter-config.yaml
             dest: apache-cassandra-{{CASSANDRA_VERSION}}/conf/metrics-reporter-config.yaml
+          rack:
+            template: {{CONFIG_TEMPLATE_PATH}}/cassandra-rackdc.properties
+            dest: apache-cassandra-{{CASSANDRA_VERSION}}/conf/cassandra-rackdc.properties
           s3:
             template: {{CONFIG_TEMPLATE_PATH}}/s3config.json
             dest: s3config.json

--- a/frameworks/cassandra/universe/config.json
+++ b/frameworks/cassandra/universe/config.json
@@ -33,12 +33,12 @@
         "data_center": {
           "description": "The name of the data center this cluster is running in",
           "type": "string",
-          "default": "dc1"
+          "default": "datacenter1"
         },
         "rack": {
           "description": "The name of the rack this cluster is running on",
           "type": "string",
-          "default": "rac1"
+          "default": "rack1"
         },
         "remote_seeds": {
           "description": "A comma-separated list of seed nodes from other clusters in a multi-datacenter deployment",

--- a/frameworks/cassandra/universe/marathon.json.mustache
+++ b/frameworks/cassandra/universe/marathon.json.mustache
@@ -142,8 +142,8 @@
     "LIBMESOS_URI": "{{resource.assets.uris.libmesos-bundle-tar-gz}}",
     "CASSANDRA_DOCKER_IMAGE": "{{resource.assets.container.docker.cassandra}}",
     "JAVA_URI": "{{resource.assets.uris.jre-tar-gz}}",
-    "CASSANDRA_LOCATION_DATA_CENTER": "{{service.data_center}}",
-    "CASSANDRA_LOCATION_RACK": "{{service.rack}}",
+    "TASKCFG_ALL_CASSANDRA_LOCATION_DATA_CENTER": "{{service.data_center}}",
+    "TASKCFG_ALL_CASSANDRA_LOCATION_RACK": "{{service.rack}}",
     "BACKUP_RESTORE_STRATEGY": "{{service.backup_restore_strategy}}",
     "CONFIG_TEMPLATE_PATH": "cassandra-scheduler"
   },

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/config/validate/ServiceNameCannotContainDoubleUnderscores.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/config/validate/ServiceNameCannotContainDoubleUnderscores.java
@@ -13,7 +13,9 @@ public class ServiceNameCannotContainDoubleUnderscores implements ConfigValidato
     @Override
     public Collection<ConfigValidationError> validate(Optional<ServiceSpec> oldConfig, ServiceSpec newConfig) {
         if (newConfig.getName().contains("__")) {
-            return Arrays.asList(ConfigValidationError.valueError("ServiceName", newConfig.getName(),
+            return Arrays.asList(ConfigValidationError.valueError(
+                    "ServiceName",
+                    newConfig.getName(),
                     String.format("Service name may not contain double underscores: %s", newConfig.getName())));
         }
         return Collections.emptyList();

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/config/validate/TaskEnvCannotChange.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/config/validate/TaskEnvCannotChange.java
@@ -1,0 +1,139 @@
+package com.mesosphere.sdk.config.validate;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+import org.apache.logging.log4j.util.Strings;
+
+import com.mesosphere.sdk.specification.CommandSpec;
+import com.mesosphere.sdk.specification.PodSpec;
+import com.mesosphere.sdk.specification.ServiceSpec;
+import com.mesosphere.sdk.specification.TaskSpec;
+
+/**
+ * Customizable configuration validator which requires that a specified task environment variable cannot be changed
+ * after initial deployment.
+ */
+public class TaskEnvCannotChange implements ConfigValidator<ServiceSpec> {
+    private final String podType;
+    private final String taskName;
+    private final String envName;
+    private final Set<Rule> rules;
+
+    /**
+     * Variances to how enforcement should be performed. Omitting these rules results in disallowing any kind of change.
+     */
+    public enum Rule {
+        // Allow the env value to be changed only if it was originally missing or empty.
+        ALLOW_UNSET_TO_SET,
+
+        // Allow the env value to be cleared if it was originally set
+        ALLOW_SET_TO_UNSET
+    }
+
+    /**
+     * Creates a new validator restricting changes to an environment value.
+     *
+     * @param podType The type of the pod to enforce (see {@link PodSpec#getType()})
+     * @param taskName The name of the task to enforce (see {@link TaskSpec#getName()})
+     * @param envName The environment variable to restrict within the above pod/task
+     * @param rules A list of any allowances to be made in the enforcement
+     */
+    public TaskEnvCannotChange(String podType, String taskName, String envName, Rule... rules) {
+        this.podType = podType;
+        this.taskName = taskName;
+        this.envName = envName;
+        this.rules = new HashSet<>(Arrays.asList(rules));
+    }
+
+    @Override
+    public Collection<ConfigValidationError> validate(Optional<ServiceSpec> oldConfig, ServiceSpec newConfig) {
+        if (!oldConfig.isPresent()) {
+            return Collections.emptyList();
+        }
+
+        Optional<TaskSpec> oldTask = getTask(oldConfig.get(), podType, taskName);
+        if (!oldTask.isPresent()) {
+            // Maybe the pod or task was renamed? Lets avoid enforcing whether those are rename- able and assume it's OK
+            return Collections.emptyList();
+        }
+        if (!oldTask.get().getCommand().isPresent()) {
+            // Similar to above: assume that the command was recently added to this task.
+            return Collections.emptyList();
+        }
+
+        Optional<TaskSpec> newTask = getTask(newConfig, podType, taskName);
+        if (!newTask.isPresent()) {
+            throw new IllegalArgumentException(String.format("Unable to find requested pod=%s, task=%s in config: %s",
+                    podType, taskName, newConfig));
+        }
+        if (!newTask.get().getCommand().isPresent()) {
+            throw new IllegalArgumentException(String.format(
+                    "Requested pod=%s, task=%s in config lacks a command section: %s",
+                    podType, taskName, newTask.get()));
+        }
+
+        Optional<ConfigValidationError> error =
+                validateEnvChange(oldTask.get().getCommand().get(), newTask.get().getCommand().get());
+        return error.isPresent() ? Arrays.asList(error.get()) : Collections.emptyList();
+    }
+
+    private static Optional<TaskSpec> getTask(ServiceSpec serviceSpec, String podType, String taskName) {
+        for (PodSpec podSpec : serviceSpec.getPods()) {
+            if (!podSpec.getType().equals(podType)) {
+                continue;
+            }
+            for (TaskSpec taskSpec : podSpec.getTasks()) {
+                if (taskSpec.getName().equals(taskName)) {
+                    return Optional.of(taskSpec);
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
+    private Optional<ConfigValidationError> validateEnvChange(CommandSpec oldCommand, CommandSpec newCommand) {
+        final String oldEnvVal = oldCommand.getEnvironment().get(envName);
+        final String newEnvVal = newCommand.getEnvironment().get(envName);
+
+        if (Strings.isBlank(oldEnvVal)) {
+            if (Strings.isBlank(newEnvVal)) {
+                // <unset> to <unset> (no change)
+                return Optional.empty();
+            } else {
+                // <unset> to SomeVal (added)
+                if (rules.contains(Rule.ALLOW_UNSET_TO_SET)) {
+                    return Optional.empty();
+                }
+                return Optional.of(ConfigValidationError.transitionError(
+                        String.format("%s.%s.env.%s", podType, taskName, envName),
+                        oldEnvVal, newEnvVal,
+                        String.format("Env value %s cannot change from unset to set", envName)));
+            }
+        } else {
+            if (Strings.isBlank(newEnvVal)) {
+                // SomeVal to <unset> (removed)
+                if (rules.contains(Rule.ALLOW_SET_TO_UNSET)) {
+                    return Optional.empty();
+                }
+                return Optional.of(ConfigValidationError.transitionError(
+                        String.format("%s.%s.env.%s", podType, taskName, envName),
+                        oldEnvVal, newEnvVal,
+                        String.format("Env value %s cannot be unset after being set", envName)));
+            } else if (oldEnvVal.equals(newEnvVal)) {
+                // SomeVal to SomeVal (no change)
+                return Optional.empty();
+            } else {
+                // SomeVal to SomeVal2 (changed)
+                return Optional.of(ConfigValidationError.transitionError(
+                        String.format("%s.%s.env.%s", podType, taskName, envName),
+                        oldEnvVal, newEnvVal,
+                        String.format("Env value %s cannot change", envName)));
+            }
+        }
+    }
+}

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultServiceSpec.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultServiceSpec.java
@@ -49,7 +49,7 @@ public class DefaultServiceSpec implements ServiceSpec {
 
     @Valid
     @NotNull
-    @Size(min = 1, message = "Atleast one pod should be configured.")
+    @Size(min = 1, message = "At least one pod must be configured.")
     @UniquePodType(message = "Pod types must be unique")
     private List<PodSpec> pods;
 

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/config/validate/PodSpecsCannotChangeNetworkRegimeTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/config/validate/PodSpecsCannotChangeNetworkRegimeTest.java
@@ -14,7 +14,7 @@ import java.util.*;
 import static org.mockito.Mockito.when;
 
 /**
- * Created by Rand on 5/18/17.
+ * Tests for {@link PodSpecsCannotChangeNetworkRegime}.
  */
 public class PodSpecsCannotChangeNetworkRegimeTest {
     private static final ConfigValidator<ServiceSpec> VALIDATOR = new PodSpecsCannotChangeNetworkRegime();

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/config/validate/ServiceNameCannotContainDoubleUnderscoresTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/config/validate/ServiceNameCannotContainDoubleUnderscoresTest.java
@@ -1,0 +1,46 @@
+package com.mesosphere.sdk.config.validate;
+
+import com.mesosphere.sdk.offer.InvalidRequirementException;
+import com.mesosphere.sdk.specification.*;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.*;
+
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link ServiceNameCannotContainDoubleUnderscores}.
+ */
+public class ServiceNameCannotContainDoubleUnderscoresTest {
+    private static final ConfigValidator<ServiceSpec> VALIDATOR = new ServiceNameCannotContainDoubleUnderscores();
+
+    // Avoid spec validator hell by just using a mock object:
+    @Mock private ServiceSpec mockServiceSpec;
+
+    @Before
+    public void beforeEach() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void testDoubleUnderscores() throws InvalidRequirementException {
+        when(mockServiceSpec.getName()).thenReturn("svc__1");
+        Assert.assertEquals(1, VALIDATOR.validate(Optional.empty(), mockServiceSpec).size());
+    }
+
+    @Test
+    public void testSingleUnderscores() throws InvalidRequirementException {
+        when(mockServiceSpec.getName()).thenReturn("svc_1");
+        Assert.assertEquals(0, VALIDATOR.validate(Optional.empty(), mockServiceSpec).size());
+    }
+
+    @Test
+    public void testNoUnderscores() throws InvalidRequirementException {
+        when(mockServiceSpec.getName()).thenReturn("svc1");
+        Assert.assertEquals(0, VALIDATOR.validate(Optional.empty(), mockServiceSpec).size());
+    }
+}

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/config/validate/TaskEnvCannotChangeTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/config/validate/TaskEnvCannotChangeTest.java
@@ -1,0 +1,152 @@
+package com.mesosphere.sdk.config.validate;
+
+import com.mesosphere.sdk.config.validate.TaskEnvCannotChange.Rule;
+import com.mesosphere.sdk.offer.InvalidRequirementException;
+import com.mesosphere.sdk.specification.*;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import java.util.*;
+
+import org.mockito.*;
+
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests for {@link TaskEnvCannotChange}.
+ */
+public class TaskEnvCannotChangeTest {
+    private static final String POD_TYPE = "pod";
+    private static final String TASK_NAME = "task";
+    private static final String ENV_NAME = "SOME_ENV";
+
+    private ServiceSpec serviceEnvUnset;
+    private ServiceSpec serviceEnvEmpty;
+    private ServiceSpec serviceEnvValue;
+    private ServiceSpec serviceEnvValue2;
+
+    private static final ConfigValidator<ServiceSpec> VALIDATOR_NO_RULES =
+            new TaskEnvCannotChange(POD_TYPE, TASK_NAME, ENV_NAME);
+    private static final ConfigValidator<ServiceSpec> VALIDATOR_UNSET_TO_SET =
+            new TaskEnvCannotChange(POD_TYPE, TASK_NAME, ENV_NAME, Rule.ALLOW_UNSET_TO_SET);
+    private static final ConfigValidator<ServiceSpec> VALIDATOR_SET_TO_UNSET =
+            new TaskEnvCannotChange(POD_TYPE, TASK_NAME, ENV_NAME, Rule.ALLOW_SET_TO_UNSET);
+    private static final ConfigValidator<ServiceSpec> VALIDATOR_SET_TO_UNSET_TO_SET =
+            new TaskEnvCannotChange(POD_TYPE, TASK_NAME, ENV_NAME, Rule.ALLOW_UNSET_TO_SET, Rule.ALLOW_SET_TO_UNSET);
+
+    @Before
+    public void beforeEach() {
+        MockitoAnnotations.initMocks(this);
+        serviceEnvUnset = specWithEnv(null);
+        serviceEnvEmpty = specWithEnv("");
+        serviceEnvValue = specWithEnv("val");
+        serviceEnvValue2 = specWithEnv("val2");
+    }
+
+    private static ServiceSpec specWithEnv(String val) {
+        // Use mocks to avoid *Spec validation hell
+        CommandSpec mockCommand = mock(CommandSpec.class);
+        when(mockCommand.getEnvironment()).thenReturn(
+                val == null ? Collections.emptyMap() : Collections.singletonMap(ENV_NAME, val));
+
+        TaskSpec mockTask = mock(TaskSpec.class);
+        when(mockTask.getName()).thenReturn(TASK_NAME);
+        when(mockTask.getCommand()).thenReturn(Optional.of(mockCommand));
+
+        PodSpec mockPod = mock(PodSpec.class);
+        when(mockPod.getType()).thenReturn(POD_TYPE);
+        when(mockPod.getTasks()).thenReturn(Arrays.asList(mockTask));
+
+        ServiceSpec mockService = mock(ServiceSpec.class);
+        when(mockService.getPods()).thenReturn(Arrays.asList(mockPod));
+        return mockService;
+    }
+
+    @Test
+    public void testNoRules() throws InvalidRequirementException {
+        Assert.assertEquals(0, VALIDATOR_NO_RULES.validate(Optional.empty(), serviceEnvUnset).size());
+        Assert.assertEquals(0, VALIDATOR_NO_RULES.validate(Optional.empty(), serviceEnvEmpty).size());
+        Assert.assertEquals(0, VALIDATOR_NO_RULES.validate(Optional.empty(), serviceEnvValue).size());
+
+        Assert.assertEquals(0, VALIDATOR_NO_RULES.validate(Optional.of(serviceEnvUnset), serviceEnvUnset).size());
+        Assert.assertEquals(0, VALIDATOR_NO_RULES.validate(Optional.of(serviceEnvUnset), serviceEnvEmpty).size());
+        Assert.assertEquals(1, VALIDATOR_NO_RULES.validate(Optional.of(serviceEnvUnset), serviceEnvValue).size());
+
+        Assert.assertEquals(0, VALIDATOR_NO_RULES.validate(Optional.of(serviceEnvEmpty), serviceEnvUnset).size());
+        Assert.assertEquals(0, VALIDATOR_NO_RULES.validate(Optional.of(serviceEnvEmpty), serviceEnvEmpty).size());
+        Assert.assertEquals(1, VALIDATOR_NO_RULES.validate(Optional.of(serviceEnvEmpty), serviceEnvValue).size());
+
+        Assert.assertEquals(1, VALIDATOR_NO_RULES.validate(Optional.of(serviceEnvValue), serviceEnvUnset).size());
+        Assert.assertEquals(1, VALIDATOR_NO_RULES.validate(Optional.of(serviceEnvValue), serviceEnvEmpty).size());
+        Assert.assertEquals(0, VALIDATOR_NO_RULES.validate(Optional.of(serviceEnvValue), serviceEnvValue).size());
+
+        Assert.assertEquals(1, VALIDATOR_NO_RULES.validate(Optional.of(serviceEnvValue), serviceEnvValue2).size());
+        Assert.assertEquals(1, VALIDATOR_NO_RULES.validate(Optional.of(serviceEnvValue2), serviceEnvValue).size());
+    }
+
+    @Test
+    public void testAllowUnsetToSet() throws InvalidRequirementException {
+        Assert.assertEquals(0, VALIDATOR_UNSET_TO_SET.validate(Optional.empty(), serviceEnvUnset).size());
+        Assert.assertEquals(0, VALIDATOR_UNSET_TO_SET.validate(Optional.empty(), serviceEnvEmpty).size());
+        Assert.assertEquals(0, VALIDATOR_UNSET_TO_SET.validate(Optional.empty(), serviceEnvValue).size());
+
+        Assert.assertEquals(0, VALIDATOR_UNSET_TO_SET.validate(Optional.of(serviceEnvUnset), serviceEnvUnset).size());
+        Assert.assertEquals(0, VALIDATOR_UNSET_TO_SET.validate(Optional.of(serviceEnvUnset), serviceEnvEmpty).size());
+        Assert.assertEquals(0, VALIDATOR_UNSET_TO_SET.validate(Optional.of(serviceEnvUnset), serviceEnvValue).size());
+
+        Assert.assertEquals(0, VALIDATOR_UNSET_TO_SET.validate(Optional.of(serviceEnvEmpty), serviceEnvUnset).size());
+        Assert.assertEquals(0, VALIDATOR_UNSET_TO_SET.validate(Optional.of(serviceEnvEmpty), serviceEnvEmpty).size());
+        Assert.assertEquals(0, VALIDATOR_UNSET_TO_SET.validate(Optional.of(serviceEnvEmpty), serviceEnvValue).size());
+
+        Assert.assertEquals(1, VALIDATOR_UNSET_TO_SET.validate(Optional.of(serviceEnvValue), serviceEnvUnset).size());
+        Assert.assertEquals(1, VALIDATOR_UNSET_TO_SET.validate(Optional.of(serviceEnvValue), serviceEnvEmpty).size());
+        Assert.assertEquals(0, VALIDATOR_UNSET_TO_SET.validate(Optional.of(serviceEnvValue), serviceEnvValue).size());
+
+        Assert.assertEquals(1, VALIDATOR_UNSET_TO_SET.validate(Optional.of(serviceEnvValue), serviceEnvValue2).size());
+        Assert.assertEquals(1, VALIDATOR_UNSET_TO_SET.validate(Optional.of(serviceEnvValue2), serviceEnvValue).size());
+    }
+
+    @Test
+    public void testAllowSetToUnset() throws InvalidRequirementException {
+        Assert.assertEquals(0, VALIDATOR_SET_TO_UNSET.validate(Optional.empty(), serviceEnvUnset).size());
+        Assert.assertEquals(0, VALIDATOR_SET_TO_UNSET.validate(Optional.empty(), serviceEnvEmpty).size());
+        Assert.assertEquals(0, VALIDATOR_SET_TO_UNSET.validate(Optional.empty(), serviceEnvValue).size());
+
+        Assert.assertEquals(0, VALIDATOR_SET_TO_UNSET.validate(Optional.of(serviceEnvUnset), serviceEnvUnset).size());
+        Assert.assertEquals(0, VALIDATOR_SET_TO_UNSET.validate(Optional.of(serviceEnvUnset), serviceEnvEmpty).size());
+        Assert.assertEquals(1, VALIDATOR_SET_TO_UNSET.validate(Optional.of(serviceEnvUnset), serviceEnvValue).size());
+
+        Assert.assertEquals(0, VALIDATOR_SET_TO_UNSET.validate(Optional.of(serviceEnvEmpty), serviceEnvUnset).size());
+        Assert.assertEquals(0, VALIDATOR_SET_TO_UNSET.validate(Optional.of(serviceEnvEmpty), serviceEnvEmpty).size());
+        Assert.assertEquals(1, VALIDATOR_SET_TO_UNSET.validate(Optional.of(serviceEnvEmpty), serviceEnvValue).size());
+
+        Assert.assertEquals(0, VALIDATOR_SET_TO_UNSET.validate(Optional.of(serviceEnvValue), serviceEnvUnset).size());
+        Assert.assertEquals(0, VALIDATOR_SET_TO_UNSET.validate(Optional.of(serviceEnvValue), serviceEnvEmpty).size());
+        Assert.assertEquals(0, VALIDATOR_SET_TO_UNSET.validate(Optional.of(serviceEnvValue), serviceEnvValue).size());
+
+        Assert.assertEquals(1, VALIDATOR_SET_TO_UNSET.validate(Optional.of(serviceEnvValue), serviceEnvValue2).size());
+        Assert.assertEquals(1, VALIDATOR_SET_TO_UNSET.validate(Optional.of(serviceEnvValue2), serviceEnvValue).size());
+    }
+
+    @Test
+    public void testAllowSetToUnset_UnsetToSet() throws InvalidRequirementException {
+        Assert.assertEquals(0, VALIDATOR_SET_TO_UNSET_TO_SET.validate(Optional.empty(), serviceEnvUnset).size());
+        Assert.assertEquals(0, VALIDATOR_SET_TO_UNSET_TO_SET.validate(Optional.empty(), serviceEnvEmpty).size());
+        Assert.assertEquals(0, VALIDATOR_SET_TO_UNSET_TO_SET.validate(Optional.empty(), serviceEnvValue).size());
+
+        Assert.assertEquals(0, VALIDATOR_SET_TO_UNSET_TO_SET.validate(Optional.of(serviceEnvUnset), serviceEnvUnset).size());
+        Assert.assertEquals(0, VALIDATOR_SET_TO_UNSET_TO_SET.validate(Optional.of(serviceEnvUnset), serviceEnvEmpty).size());
+        Assert.assertEquals(0, VALIDATOR_SET_TO_UNSET_TO_SET.validate(Optional.of(serviceEnvUnset), serviceEnvValue).size());
+
+        Assert.assertEquals(0, VALIDATOR_SET_TO_UNSET_TO_SET.validate(Optional.of(serviceEnvEmpty), serviceEnvUnset).size());
+        Assert.assertEquals(0, VALIDATOR_SET_TO_UNSET_TO_SET.validate(Optional.of(serviceEnvEmpty), serviceEnvEmpty).size());
+        Assert.assertEquals(0, VALIDATOR_SET_TO_UNSET_TO_SET.validate(Optional.of(serviceEnvEmpty), serviceEnvValue).size());
+
+        Assert.assertEquals(0, VALIDATOR_SET_TO_UNSET_TO_SET.validate(Optional.of(serviceEnvValue), serviceEnvUnset).size());
+        Assert.assertEquals(0, VALIDATOR_SET_TO_UNSET_TO_SET.validate(Optional.of(serviceEnvValue), serviceEnvEmpty).size());
+        Assert.assertEquals(0, VALIDATOR_SET_TO_UNSET_TO_SET.validate(Optional.of(serviceEnvValue), serviceEnvValue).size());
+
+        Assert.assertEquals(1, VALIDATOR_SET_TO_UNSET_TO_SET.validate(Optional.of(serviceEnvValue), serviceEnvValue2).size());
+        Assert.assertEquals(1, VALIDATOR_SET_TO_UNSET_TO_SET.validate(Optional.of(serviceEnvValue2), serviceEnvValue).size());
+    }
+}


### PR DESCRIPTION
- Brings back the DC/rack config options
- Adds `ignore_dc` option to have cassandra allow renames if needed