### PR TITLE
[INFINITY-1921] Fix type error (str -> int) in hello-world secrets soak tests

### DIFF
--- a/frameworks/helloworld/tests/test_soak.py
+++ b/frameworks/helloworld/tests/test_soak.py
@@ -23,9 +23,9 @@ NUM_WORLD = 3
 if "FRAMEWORK_NAME" in os.environ:
     FRAMEWORK_NAME = os.environ["FRAMEWORK_NAME"]
 if "NUM_HELLO" in os.environ:
-    NUM_HELLO = os.environ["NUM_HELLO"]
+    NUM_HELLO = int(os.environ["NUM_HELLO"])
 if "NUM_WORLD" in os.environ:
-    NUM_WORLD = os.environ["NUM_WORLD"]
+    NUM_WORLD = int(os.environ["NUM_WORLD"])
 
 
 @pytest.mark.soak_upgrade


### PR DESCRIPTION
Encountered this error in soak tests:
`TypeError: '>=' not supported between instances of 'int' and 'str'`

Needed to convert string to int.