### PR TITLE
[INFINITY-2082] Remove second scheduler used for testing locking before end of test

### DIFF
--- a/frameworks/helloworld/tests/test_sanity.py
+++ b/frameworks/helloworld/tests/test_sanity.py
@@ -271,6 +271,7 @@ def test_lock():
 
     # Scale to 2 instances
     labels = app["labels"]
+    original_labels = labels.copy()
     labels.pop("MARATHON_SINGLE_INSTANCE_APP")
     marathon_client.update_app(FOLDERED_SERVICE_NAME, {"labels": labels})
     shakedown.deployment_wait()
@@ -288,6 +289,5 @@ def test_lock():
     assert zk_config_old == zk_config_new
 
     # In order to prevent the second scheduler instance from obtaining a lock, we undo the "scale-up" operation
-    labels = app["labels"]
-    marathon_client.update_app(FOLDERED_SERVICE_NAME, {"labels": labels, "instances": 1})
+    marathon_client.update_app(FOLDERED_SERVICE_NAME, {"labels": original_labels, "instances": 1})
     shakedown.deployment_wait()

--- a/frameworks/helloworld/tests/test_sanity.py
+++ b/frameworks/helloworld/tests/test_sanity.py
@@ -284,6 +284,11 @@ def test_lock():
 
     shakedown.wait_for(lambda: fn())
 
+    # In order to prevent the second scheduler instance from obtaining a lock, we undo the "scale-up" operation
+    labels = app["labels"]
+    marathon_client.update_app(FOLDERED_SERVICE_NAME, {"labels": labels, "instances": 1})
+    shakedown.deployment_wait()
+
     # Verify ZK is unchanged
     zk_config_new = shakedown.get_zk_node_data(zk_path)
     assert zk_config_old == zk_config_new

--- a/frameworks/helloworld/tests/test_sanity.py
+++ b/frameworks/helloworld/tests/test_sanity.py
@@ -9,7 +9,6 @@ import sdk_cmd
 import sdk_install
 import sdk_marathon
 import sdk_tasks
-import sdk_test_upgrade
 import sdk_utils
 from tests.config import (
     PACKAGE_NAME,
@@ -32,9 +31,9 @@ def configure_package(configure_universe):
             PACKAGE_NAME,
             DEFAULT_TASK_COUNT,
             service_name=FOLDERED_SERVICE_NAME,
-            additional_options={"service": { "name": FOLDERED_SERVICE_NAME } })
+            additional_options={"service": {"name": FOLDERED_SERVICE_NAME}})
 
-        yield # let the test session execute
+        yield  # let the test session execute
     finally:
         sdk_install.uninstall(FOLDERED_SERVICE_NAME, package_name=PACKAGE_NAME)
 
@@ -61,7 +60,7 @@ def test_mesos_v1_api():
         PACKAGE_NAME,
         DEFAULT_TASK_COUNT,
         service_name=FOLDERED_SERVICE_NAME,
-        additional_options={"service": { "name": FOLDERED_SERVICE_NAME, "mesos_api_version": "V1"}}
+        additional_options={"service": {"name": FOLDERED_SERVICE_NAME, "mesos_api_version": "V1"}}
     )
     check_running(FOLDERED_SERVICE_NAME)
     sdk_install.uninstall(FOLDERED_SERVICE_NAME, package_name=PACKAGE_NAME)
@@ -71,7 +70,7 @@ def test_mesos_v1_api():
         PACKAGE_NAME,
         DEFAULT_TASK_COUNT,
         service_name=FOLDERED_SERVICE_NAME,
-        additional_options={"service": { "name": FOLDERED_SERVICE_NAME } })
+        additional_options={"service": {"name": FOLDERED_SERVICE_NAME}})
 
 
 @pytest.mark.sanity
@@ -242,7 +241,7 @@ def test_state_refresh_disable_cache():
 
     sdk_tasks.check_tasks_not_updated(FOLDERED_SERVICE_NAME, '', task_ids)
     check_running(FOLDERED_SERVICE_NAME)
-    shakedown.deployment_wait() # ensure marathon thinks the deployment is complete too
+    shakedown.deployment_wait()  # ensure marathon thinks the deployment is complete too
 
     # caching reenabled, refresh_cache should succeed (eventually, once scheduler is up):
     def check_cache_refresh():

--- a/frameworks/helloworld/tests/test_sanity.py
+++ b/frameworks/helloworld/tests/test_sanity.py
@@ -283,11 +283,11 @@ def test_lock():
 
     shakedown.wait_for(lambda: fn())
 
+    # Verify ZK is unchanged
+    zk_config_new = shakedown.get_zk_node_data(zk_path)
+    assert zk_config_old == zk_config_new
+
     # In order to prevent the second scheduler instance from obtaining a lock, we undo the "scale-up" operation
     labels = app["labels"]
     marathon_client.update_app(FOLDERED_SERVICE_NAME, {"labels": labels, "instances": 1})
     shakedown.deployment_wait()
-
-    # Verify ZK is unchanged
-    zk_config_new = shakedown.get_zk_node_data(zk_path)
-    assert zk_config_old == zk_config_new

--- a/frameworks/helloworld/tests/test_sanity.py
+++ b/frameworks/helloworld/tests/test_sanity.py
@@ -289,5 +289,5 @@ def test_lock():
     assert zk_config_old == zk_config_new
 
     # In order to prevent the second scheduler instance from obtaining a lock, we undo the "scale-up" operation
-    marathon_client.update_app(FOLDERED_SERVICE_NAME, {"labels": original_labels, "instances": 1})
+    marathon_client.update_app(FOLDERED_SERVICE_NAME, {"labels": original_labels, "instances": 1}, force=True)
     shakedown.deployment_wait()


### PR DESCRIPTION
As discussed with @benclarkwood, this addressed a flaky test. Due to the presence of a second scheduler, a timeout could occur in `test_sanity.test_lock_teardown`.

This removes the second scheduler before terminating the test.