### PR TITLE
[INFINITY-2085] Default Executor does not support Absolute Path for Secrets

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultSecretSpec.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultSecretSpec.java
@@ -23,10 +23,10 @@ public class DefaultSecretSpec implements SecretSpec {
     private final String envKey;
 
     /** Regexp in @Pattern:
-     *      sub-pattern = ([.a-zA-Z0-9_-]*[/\\\\]*)*
+     *      sub-pattern = [.a-zA-Z0-9]+([.a-zA-Z0-9_-]*[/\\\\]*)*
      *      (sub-pattern)?  = either NULL, or sub-pattern.  So It can be Null.
      */
-    @Pattern(regexp = "(([.a-zA-Z0-9_-]*[/\\\\]*)*)?")
+    @Pattern(regexp = "([.a-zA-Z0-9]+([.a-zA-Z0-9_-]*[/\\\\]*)*)?")
     private final String filePath;
 
     @JsonCreator

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultSecretSpec.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultSecretSpec.java
@@ -25,6 +25,7 @@ public class DefaultSecretSpec implements SecretSpec {
     /** Regexp in @Pattern:
      *      sub-pattern = [.a-zA-Z0-9]+([.a-zA-Z0-9_-]*[/\\\\]*)*
      *      (sub-pattern)?  = either NULL, or sub-pattern.  So It can be Null.
+     *      No leading slash character is allowed!
      */
     @Pattern(regexp = "([.a-zA-Z0-9]+([.a-zA-Z0-9_-]*[/\\\\]*)*)?")
     private final String filePath;

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/config/validate/VerifySecretFilePathTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/config/validate/VerifySecretFilePathTest.java
@@ -22,7 +22,7 @@ public class VerifySecretFilePathTest {
         new DefaultSecretSpec( secretPath, envKey, " ");
     }
 
-    @Test
+    @Test(expected = Exception.class)
     public void testFilePathSlash()  {
         new DefaultSecretSpec( secretPath, envKey, "/path/to/file");
     }
@@ -32,7 +32,7 @@ public class VerifySecretFilePathTest {
         new DefaultSecretSpec( secretPath, envKey, "@?test");
     }
 
-    @Test
+    @Test(expected = Exception.class)
     public void testFilePathBeg() {
         new DefaultSecretSpec( secretPath, envKey, "-test");
     }


### PR DESCRIPTION
After switching to Default Executor, Absolute Path support for Secrets (supported only if there is a docker image) is dropped. All Secret files (similar to Volumes) are relative to the SANDBOX.


PS: We only have pod-level secrets. We do not have task-level secrets, dropped in the design phase