### PR TITLE
[INFINITY-1921] In hello-world secrets soak test, installed hello-world CLI

### DIFF
--- a/frameworks/helloworld/tests/test_soak.py
+++ b/frameworks/helloworld/tests/test_soak.py
@@ -38,6 +38,7 @@ def test_soak_secrets_update():
     test_soak_secrets_framework_alive()
 
     sdk_cmd.run_cli("package install --cli dcos-enterprise-cli")
+    sdk_cmd.run_cli("package install --cli hello-world")
     sdk_cmd.run_cli("security secrets update --value={} secrets/secret1".format(secret_content_alternative))
     sdk_cmd.run_cli("security secrets update --value={} secrets/secret2".format(secret_content_alternative))
     sdk_cmd.run_cli("security secrets update --value={} secrets/secret3".format(secret_content_alternative))


### PR DESCRIPTION
In hello-world secrets soak test, installed hello-world CLI because it is used by the test.

@mbdcos This should be the last fix -- I tested this fix in my own cluster and the test passed.