### PR TITLE
[INFINITY-2100] Improve stability of test_xpack_toggle_with_kibana

### DIFF
--- a/frameworks/elastic/tests/config.py
+++ b/frameworks/elastic/tests/config.py
@@ -11,6 +11,7 @@ import sdk_tasks
 import sdk_utils
 
 PACKAGE_NAME = 'elastic'
+KIBANA_PACKAGE_NAME = 'kibana'
 
 DEFAULT_TASK_COUNT = 7
 DEFAULT_ELASTIC_TIMEOUT = 10 * 60

--- a/frameworks/elastic/tests/test_shakedown.py
+++ b/frameworks/elastic/tests/test_shakedown.py
@@ -1,22 +1,19 @@
-import json
 import pytest
-import shakedown
 
 import sdk_cmd as cmd
-import sdk_hosts
 import sdk_install
-import sdk_marathon
 import sdk_metrics
-import sdk_tasks
 import sdk_upgrade
-import sdk_utils
 from tests.config import *
 
 FOLDERED_SERVICE_NAME = sdk_utils.get_foldered_name(PACKAGE_NAME)
 
+
 @pytest.fixture(scope='module', autouse=True)
 def configure_package(configure_universe):
     try:
+        sdk_utils.out("Ensure elasticsearch and kibana are uninstalled...")
+        sdk_install.uninstall(KIBANA_PACKAGE_NAME)
         sdk_install.uninstall(FOLDERED_SERVICE_NAME, package_name=PACKAGE_NAME)
         sdk_utils.gc_frameworks()
 
@@ -27,8 +24,10 @@ def configure_package(configure_universe):
             service_name=FOLDERED_SERVICE_NAME,
             additional_options={"service": {"name": FOLDERED_SERVICE_NAME}})
 
-        yield # let the test session execute
+        yield  # let the test session execute
     finally:
+        sdk_utils.out("Clean up elasticsearch and kibana...")
+        sdk_install.uninstall(KIBANA_PACKAGE_NAME)
         sdk_install.uninstall(FOLDERED_SERVICE_NAME, package_name=PACKAGE_NAME)
 
 
@@ -76,28 +75,29 @@ def test_metrics():
     sdk_metrics.wait_for_any_metrics(FOLDERED_SERVICE_NAME, "data-0-node", DEFAULT_ELASTIC_TIMEOUT)
 
 
+@pytest.mark.focus
 @pytest.mark.sanity
+@pytest.mark.timeout(60 * 60)
 def test_xpack_toggle_with_kibana(default_populated_index):
-    # Verify disabled by default
+    sdk_utils.out("\n***** Verify X-Pack disabled by default in elasticsearch")
     verify_commercial_api_status(False, service_name=FOLDERED_SERVICE_NAME)
-    enable_xpack(service_name=FOLDERED_SERVICE_NAME)
 
-    # Test kibana with x-pack disabled...
-    sdk_install.uninstall("kibana")
-    shakedown.install_package("kibana", options_json={
+    sdk_utils.out("\n***** Test kibana with X-Pack disabled...")
+    shakedown.install_package(KIBANA_PACKAGE_NAME, options_json={
         "kibana": {
             "elasticsearch_url": "http://" + sdk_hosts.vip_host(FOLDERED_SERVICE_NAME, "coordinator", 9200)
         }})
-    shakedown.deployment_wait(app_id="/kibana", timeout=DEFAULT_KIBANA_TIMEOUT)
-    check_kibana_adminrouter_integration("service/kibana/")
-    sdk_install.uninstall("kibana")
+    shakedown.deployment_wait(app_id="/{}".format(KIBANA_PACKAGE_NAME), timeout=DEFAULT_KIBANA_TIMEOUT)
+    check_kibana_adminrouter_integration("service/{}/".format(KIBANA_PACKAGE_NAME))
+    sdk_utils.out("Uninstall kibana with X-Pack disabled")
+    sdk_install.uninstall(KIBANA_PACKAGE_NAME)
 
-    # Set/verify enabled
+    sdk_utils.out("\n***** Set/verify X-Pack enabled in elasticsearch")
+    enable_xpack(service_name=FOLDERED_SERVICE_NAME)    
     verify_commercial_api_status(True, service_name=FOLDERED_SERVICE_NAME)
     verify_xpack_license(service_name=FOLDERED_SERVICE_NAME)
 
-    # Write some data while enabled, disable X-Pack, and verify we can still read what we wrote.
-
+    sdk_utils.out("\n***** Write some data while enabled, disable X-Pack, and verify we can still read what we wrote.")
     create_document(
         DEFAULT_INDEX_NAME,
         DEFAULT_INDEX_TYPE,
@@ -105,20 +105,22 @@ def test_xpack_toggle_with_kibana(default_populated_index):
         {"name": "X-Pack", "role": "commercial plugin"},
         service_name=FOLDERED_SERVICE_NAME)
 
-    # Test kibana with x-pack enabled...
-    shakedown.install_package("kibana", options_json={
+    sdk_utils.out("\n***** Test kibana with X-Pack enabled...")
+    shakedown.install_package(KIBANA_PACKAGE_NAME, options_json={
         "kibana": {
             "elasticsearch_url": "http://" + sdk_hosts.vip_host(FOLDERED_SERVICE_NAME, "coordinator", 9200),
             "xpack_enabled": True
         }})
-    # Installing Kibana w/x-pack can take as much as 15 minutes for Marathon deployment to complete,
-    # due to a configured HTTP health check. (typical: 10 minutes)
-    shakedown.deployment_wait(app_id="/kibana", timeout=DEFAULT_KIBANA_TIMEOUT)
-    check_kibana_adminrouter_integration("service/kibana/login")
-    sdk_install.uninstall("kibana")
+    sdk_utils.out("\n***** Installing Kibana w/X-Pack can take as much as 15 minutes for Marathon deployment ")
+    sdk_utils.out("to complete due to a configured HTTP health check. (typical: 12 minutes)")
+    shakedown.deployment_wait(app_id="/{}".format(KIBANA_PACKAGE_NAME), timeout=DEFAULT_KIBANA_TIMEOUT)
+    check_kibana_adminrouter_integration("service/{}/login".format(KIBANA_PACKAGE_NAME))
+    sdk_utils.out("\n***** Uninstall kibana with X-Pack enabled")
+    sdk_install.uninstall(KIBANA_PACKAGE_NAME)
 
-    # Disable again
+    sdk_utils.out("\n***** Disable X-Pack in elasticsearch.")
     disable_xpack(service_name=FOLDERED_SERVICE_NAME)
+    sdk_utils.out("\n***** Verify we can still read what we wrote when X-Pack was enabled.")
     verify_commercial_api_status(False, service_name=FOLDERED_SERVICE_NAME)
     doc = get_document(DEFAULT_INDEX_NAME, DEFAULT_INDEX_TYPE, 2, service_name=FOLDERED_SERVICE_NAME)
     assert doc["_source"]["name"] == "X-Pack"
@@ -188,4 +190,3 @@ def test_bump_node_counts():
     config['env']['COORDINATOR_NODE_COUNT'] = str(coordinator_nodes + 1)
     sdk_marathon.update_app(FOLDERED_SERVICE_NAME, config)
     sdk_tasks.check_running(FOLDERED_SERVICE_NAME, DEFAULT_TASK_COUNT + 3)
-

--- a/testing/sdk_install.py
+++ b/testing/sdk_install.py
@@ -12,6 +12,8 @@ import sdk_api
 import sdk_plan
 import sdk_utils
 
+TIMEOUT_SECONDS = 15 * 60
+
 
 def install(
         package_name,
@@ -19,7 +21,7 @@ def install(
         service_name=None,
         additional_options={},
         package_version=None,
-        timeout_seconds=15 * 60,
+        timeout_seconds=TIMEOUT_SECONDS,
         wait_scheduler_idle=True):
     if not service_name:
         service_name = package_name
@@ -102,7 +104,7 @@ def uninstall(service_name, package_name=None, role=None, principal=None, zk=Non
             # service_name may already contain a leading slash:
             marathon_app_id = '/' + service_name.lstrip('/')
             sdk_utils.out('Waiting for no deployments for {}'.format(marathon_app_id))
-            shakedown.deployment_wait(600, marathon_app_id)
+            shakedown.deployment_wait(TIMEOUT_SECONDS, marathon_app_id)
 
             # wait for service to be gone according to marathon
             def marathon_dropped_service():
@@ -115,7 +117,7 @@ def uninstall(service_name, package_name=None, role=None, principal=None, zk=Non
                     sdk_utils.out('Found multiple apps with id {}'.format(marathon_app_id))
                 return len(matching_app_ids) == 0
             sdk_utils.out('Waiting for no {} Marathon app'.format(marathon_app_id))
-            shakedown.time_wait(marathon_dropped_service)
+            shakedown.time_wait(marathon_dropped_service, timeout_seconds=TIMEOUT_SECONDS)
 
         except (dcos.errors.DCOSException, ValueError) as e:
             sdk_utils.out('Got exception when uninstalling package: {}'.format(e))


### PR DESCRIPTION
- the default uninstall timeout of 120s is too short. Elastic and perhaps other FW's can take longer. Increasing to 15 minutes.
- Kibana should be uninstalled both as part of setup to make sure it's not already there, and teardown to make sure it isn't left around to potentially affect downstream tests.
- the default per-pytest timeout of 30 minutes is too short for test_xpack_toggle_with_kibana. Increasing to 1hr.
- The current test logic is not correct and I'm not sure how it ever works. In https://github.com/mesosphere/dcos-commons/blob/master/frameworks/elastic/tests/test_shakedown.py#L83-L86, we enable x-pack in elasticsearch, and then install kibana without x-pack and test integration between the two.