### PR TITLE
[INFINITY-2131][INFINITY-2003][Cassandra] Fix C* strict tests

### DIFF
--- a/frameworks/cassandra/tests/config.py
+++ b/frameworks/cassandra/tests/config.py
@@ -1,3 +1,5 @@
+""" Utilties specific to Cassandra tests """
+
 import os
 
 import sdk_hosts
@@ -25,7 +27,7 @@ def _get_test_job(name, cmd, restart_policy='NEVER'):
             'docker': { 'image': 'cassandra:3.0.13' },
             'cpus': 1,
             'mem': 512,
-            'user': 'root',
+            'user': 'nobody',
             'restart': { 'policy': restart_policy }
         }
     }

--- a/frameworks/cassandra/tests/test_backup_and_restore.py
+++ b/frameworks/cassandra/tests/test_backup_and_restore.py
@@ -14,8 +14,8 @@ DELETE_DATA_JOB = get_delete_data_job(node_address=FOLDERED_NODE_ADDRESS)
 VERIFY_DELETION_JOB = get_verify_deletion_job(node_address=FOLDERED_NODE_ADDRESS)
 TEST_JOBS = [WRITE_DATA_JOB, VERIFY_DATA_JOB, DELETE_DATA_JOB, VERIFY_DELETION_JOB]
 
-no_strict = pytest.mark.skipif(os.environ.get("SECURITY") == "strict",
-        reason="backup/restore tests broken in strict")
+no_strict_for_azure = pytest.mark.skipif(os.environ.get("SECURITY") == "strict",
+        reason="backup/restore doesn't work in strict as user needs to be root")
 
 @pytest.fixture(scope='module', autouse=True)
 def configure_package(configure_universe):
@@ -46,7 +46,7 @@ def configure_package(configure_universe):
 # use e.g. "TEST_TYPES=sanity and not aws and not azure":
 
 @pytest.mark.azure
-@no_strict
+@no_strict_for_azure
 @pytest.mark.sanity
 def test_backup_and_restore_to_azure():
     client_id = os.getenv('AZURE_CLIENT_ID')
@@ -72,7 +72,6 @@ def test_backup_and_restore_to_azure():
 
 
 @pytest.mark.aws
-@no_strict
 @pytest.mark.sanity
 def test_backup_and_restore_to_s3():
     key_id = os.getenv('AWS_ACCESS_KEY_ID')

--- a/frameworks/cassandra/tests/test_overlay.py
+++ b/frameworks/cassandra/tests/test_overlay.py
@@ -23,6 +23,7 @@ TEST_JOBS = [WRITE_DATA_JOB, VERIFY_DATA_JOB, DELETE_DATA_JOB, VERIFY_DELETION_J
 
 @pytest.fixture(scope='module', autouse=True)
 def configure_package(configure_universe):
+    successfully_installed = False
     try:
         sdk_install.uninstall(PACKAGE_NAME)
         sdk_utils.gc_frameworks()
@@ -32,16 +33,19 @@ def configure_package(configure_universe):
             DEFAULT_TASK_COUNT,
             additional_options=sdk_networks.ENABLE_VIRTUAL_NETWORKS_OPTIONS)
 
+        successfully_installed = True
+
         tmp_dir = tempfile.mkdtemp(prefix='cassandra-test')
         for job in TEST_JOBS:
             sdk_jobs.install_job(job, tmp_dir=tmp_dir)
 
         yield # let the test session execute
     finally:
-        sdk_install.uninstall(PACKAGE_NAME)
+        if successfully_installed:
+            sdk_install.uninstall(PACKAGE_NAME)
 
-        for job in TEST_JOBS:
-            sdk_jobs.remove_job(job)
+            for job in TEST_JOBS:
+                sdk_jobs.remove_job(job)
 
 
 @pytest.mark.sanity

--- a/frameworks/cassandra/tests/test_recovery.py
+++ b/frameworks/cassandra/tests/test_recovery.py
@@ -11,6 +11,8 @@ import sdk_plan
 import sdk_tasks
 import sdk_utils
 
+TIMEOUT_SECONDS = 20 * 60
+
 from tests.config import (
     PACKAGE_NAME,
     DEFAULT_TASK_COUNT
@@ -42,6 +44,7 @@ def test_node_replace_replaces_seed_node():
 
 
 @pytest.mark.sanity
+@pytest.mark.local
 @sdk_utils.dcos_1_9_or_higher  # dcos task exec not supported < 1.9
 def test_node_replace_replaces_node():
     pod_to_replace = 'node-2'
@@ -58,7 +61,7 @@ def test_node_replace_replaces_node():
     # start replace and wait for it to finish
     cmd.run_cli('cassandra pod replace {}'.format(pod_to_replace))
     sdk_plan.wait_for_kicked_off_recovery(PACKAGE_NAME)
-    sdk_plan.wait_for_completed_recovery(PACKAGE_NAME)
+    sdk_plan.wait_for_completed_recovery(PACKAGE_NAME, timeout_seconds=TIMEOUT_SECONDS)
 
 
 @pytest.mark.sanity

--- a/frameworks/cassandra/tests/test_recovery.py
+++ b/frameworks/cassandra/tests/test_recovery.py
@@ -11,7 +11,7 @@ import sdk_plan
 import sdk_tasks
 import sdk_utils
 
-TIMEOUT_SECONDS = 20 * 60
+RECOVERY_TIMEOUT_SECONDS = 20 * 60
 
 from tests.config import (
     PACKAGE_NAME,
@@ -40,7 +40,7 @@ def test_node_replace_replaces_seed_node():
     # start replace and wait for it to finish
     cmd.run_cli('cassandra pod replace {}'.format(pod_to_replace))
     sdk_plan.wait_for_kicked_off_recovery(PACKAGE_NAME)
-    sdk_plan.wait_for_completed_recovery(PACKAGE_NAME)
+    sdk_plan.wait_for_completed_recovery(PACKAGE_NAME, timeout_seconds=RECOVERY_TIMEOUT_SECONDS)
 
 
 @pytest.mark.sanity
@@ -61,7 +61,7 @@ def test_node_replace_replaces_node():
     # start replace and wait for it to finish
     cmd.run_cli('cassandra pod replace {}'.format(pod_to_replace))
     sdk_plan.wait_for_kicked_off_recovery(PACKAGE_NAME)
-    sdk_plan.wait_for_completed_recovery(PACKAGE_NAME, timeout_seconds=TIMEOUT_SECONDS)
+    sdk_plan.wait_for_completed_recovery(PACKAGE_NAME, timeout_seconds=RECOVERY_TIMEOUT_SECONDS)
 
 
 @pytest.mark.sanity

--- a/testing/sdk_install.py
+++ b/testing/sdk_install.py
@@ -162,7 +162,7 @@ def get_package_options(additional_options={}):
     if os.environ.get('SECURITY', '') == 'strict':
         # strict mode requires correct principal and secret to perform install.
         # see also: tools/setup_permissions.sh and tools/create_service_account.sh
-        return _merge_dictionary(additional_options, {
+        return _merge_dictionaries(additional_options, {
             'service': {
                 'principal': 'service-acct',
                 'secret_name': 'secret',
@@ -173,7 +173,7 @@ def get_package_options(additional_options={}):
         return additional_options
 
 
-def _merge_dictionary(dict1, dict2):
+def _merge_dictionaries(dict1, dict2):
     if (not isinstance(dict2, dict)):
         return dict1
     ret = {}
@@ -182,7 +182,7 @@ def _merge_dictionary(dict1, dict2):
     for k, v in dict2.items():
         if (k in dict1 and isinstance(dict1[k], dict)
                 and isinstance(dict2[k], collections.Mapping)):
-            ret[k] = _merge_dictionary(dict1[k], dict2[k])
+            ret[k] = _merge_dictionaries(dict1[k], dict2[k])
         else:
             ret[k] = dict2[k]
     return ret

--- a/testing/sdk_jobs.py
+++ b/testing/sdk_jobs.py
@@ -71,7 +71,7 @@ def run_job(job_dict, timeout_seconds=600, raise_on_failure=True):
         if len(runs) > 0:
             return runs[0]['id']
         return ''
-    run_id = shakedown.wait_for(wait_for_run_id, noisy=True, timeout_seconds=60, ignore_exceptions=False)
+    run_id = shakedown.wait_for(wait_for_run_id, noisy=True, timeout_seconds=timeout_seconds, ignore_exceptions=False)
 
     def fun():
         # catch errors from CLI: ensure that the only error raised is our own:

--- a/testing/sdk_plan.py
+++ b/testing/sdk_plan.py
@@ -5,6 +5,7 @@ import sdk_api
 import sdk_utils
 import shakedown
 
+TIMEOUT_SECONDS = 15 * 60
 
 def get_deployment_plan(service_name):
     return get_plan(service_name, "deploy")
@@ -26,43 +27,47 @@ def start_plan(service_name, plan, parameters=None):
         json=parameters if parameters is not None else {})
 
 
-def wait_for_completed_recovery(service_name, timeout_seconds=15 * 60):
+def wait_for_completed_recovery(service_name, timeout_seconds=TIMEOUT_SECONDS):
     return wait_for_completed_plan(service_name, 'recovery', timeout_seconds)
 
 
-def wait_for_in_progress_recovery(service_name, timeout_seconds=15 * 60):
+def wait_for_in_progress_recovery(service_name, timeout_seconds=TIMEOUT_SECONDS):
     return wait_for_in_progress_plan(service_name, 'recovery', timeout_seconds)
 
 
-def wait_for_kicked_off_recovery(service_name, timeout_seconds=15 * 60):
+def wait_for_kicked_off_deployment(service_name, timeout_seconds=TIMEOUT_SECONDS):
+    return wait_for_kicked_off_plan(service_name, 'deploy', timeout_seconds)
+
+
+def wait_for_kicked_off_recovery(service_name, timeout_seconds=TIMEOUT_SECONDS):
     return wait_for_kicked_off_plan(service_name, 'recovery', timeout_seconds)
 
 
-def wait_for_completed_deployment(service_name, timeout_seconds=15 * 60):
+def wait_for_completed_deployment(service_name, timeout_seconds=TIMEOUT_SECONDS):
     return wait_for_completed_plan(service_name, 'deploy', timeout_seconds)
 
 
-def wait_for_completed_plan(service_name, plan_name, timeout_seconds=15 * 60):
+def wait_for_completed_plan(service_name, plan_name, timeout_seconds=TIMEOUT_SECONDS):
     return wait_for_plan_status(service_name, plan_name, 'COMPLETE', timeout_seconds)
 
 
-def wait_for_completed_phase(service_name, plan_name, phase_name, timeout_seconds=15 * 60):
+def wait_for_completed_phase(service_name, plan_name, phase_name, timeout_seconds=TIMEOUT_SECONDS):
     return wait_for_phase_status(service_name, plan_name, phase_name, 'COMPLETE', timeout_seconds)
 
 
-def wait_for_completed_step(service_name, plan_name, phase_name, step_name, timeout_seconds=15 * 60):
+def wait_for_completed_step(service_name, plan_name, phase_name, step_name, timeout_seconds=TIMEOUT_SECONDS):
     return wait_for_step_status(service_name, plan_name, phase_name, step_name, 'COMPLETE', timeout_seconds)
 
 
-def wait_for_kicked_off_plan(service_name, plan_name, timeout_seconds=15 * 60):
+def wait_for_kicked_off_plan(service_name, plan_name, timeout_seconds=TIMEOUT_SECONDS):
     return wait_for_plan_status(service_name, plan_name, ['STARTING', 'IN_PROGRESS'], timeout_seconds)
 
 
-def wait_for_in_progress_plan(service_name, plan_name, timeout_seconds=15 * 60):
+def wait_for_in_progress_plan(service_name, plan_name, timeout_seconds=TIMEOUT_SECONDS):
     return wait_for_plan_status(service_name, plan_name, 'IN_PROGRESS', timeout_seconds)
 
 
-def wait_for_plan_status(service_name, plan_name, status, timeout_seconds=15 * 60):
+def wait_for_plan_status(service_name, plan_name, status, timeout_seconds=TIMEOUT_SECONDS):
     '''Wait for a plan to have one of the specified statuses'''
     if isinstance(status, str):
         statuses = [status, ]
@@ -80,7 +85,7 @@ def wait_for_plan_status(service_name, plan_name, status, timeout_seconds=15 * 6
     return shakedown.wait_for(fn, noisy=True, timeout_seconds=timeout_seconds)
 
 
-def wait_for_phase_status(service_name, plan_name, phase_name, status, timeout_seconds=15 * 60):
+def wait_for_phase_status(service_name, plan_name, phase_name, status, timeout_seconds=TIMEOUT_SECONDS):
     def fn():
         plan = get_plan(service_name, plan_name)
         phase = get_phase(plan, phase_name)
@@ -93,7 +98,7 @@ def wait_for_phase_status(service_name, plan_name, phase_name, status, timeout_s
     return shakedown.wait_for(fn, noisy=True, timeout_seconds=timeout_seconds)
 
 
-def wait_for_step_status(service_name, plan_name, phase_name, step_name, status, timeout_seconds=15 * 60):
+def wait_for_step_status(service_name, plan_name, phase_name, step_name, status, timeout_seconds=TIMEOUT_SECONDS):
     def fn():
         plan = get_plan(service_name, plan_name)
         step = get_step(get_phase(plan, phase_name), step_name)

--- a/tools/setup_permissions.sh
+++ b/tools/setup_permissions.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-SERVICE_ACCOUNT_NAME=service-acct
 LINUX_USER=$1
 ROLE=$2
+SERVICE_ACCOUNT_NAME=${3:-service-acct}
 
 if [ -n "$CLUSTER_URL" ]
 then


### PR DESCRIPTION
This fixes the C* tests by setting the user properly for a strict mode cluster. Previously the jobs were failing because the writer couldn't be successful writing as "root".

This also:
- fixes a few utility names and prevents an exception from being thrown if it tries to remove C* jobs but none exist if the installation wasn't successful.
- extends the timeout for a node replace test as that commit got dropped in 
https://github.com/mesosphere/dcos-commons/pull/1370

This passes all C* strict clusters:
- 1.8: https://teamcity.mesosphere.io/viewLog.html?buildId=727876&tab=buildResultsDiv&buildTypeId=DcosIo_DcosCommons_Cassandra_DcOs18Strict
- 1.9: https://teamcity.mesosphere.io/viewLog.html?buildId=727875&tab=buildResultsDiv&buildTypeId=DcosIo_DcosCommons_Cassandra_DcOs19Strict
- master: https://teamcity.mesosphere.io/viewLog.html?buildId=727956&tab=buildResultsDiv&buildTypeId=DcosIo_DcosCommons_Cassandra_DcOsMasterStrict