### PR TITLE
[INFINITY-2135] Fix resource refinement on pod level volumes

### DIFF
--- a/frameworks/helloworld/src/main/dist/examples/pre-reserved.yml
+++ b/frameworks/helloworld/src/main/dist/examples/pre-reserved.yml
@@ -7,10 +7,14 @@ pods:
     pre-reserved-role: slave_public
     count: {{HELLO_COUNT}}
     placement: {{HELLO_PLACEMENT}}
+    volume:
+      path: pod-container-path
+      type: ROOT
+      size: {{HELLO_DISK}}
     tasks:
       server:
         goal: RUNNING
-        cmd: echo hello >> hello-container-path/output && sleep $SLEEP_DURATION
+        cmd: echo hello >> hello-container-path/output && echo hello >> pod-container-path/output && sleep $SLEEP_DURATION
         cpus: {{HELLO_CPUS}}
         memory: {{HELLO_MEM}}
         volume:
@@ -20,7 +24,7 @@ pods:
         env:
           SLEEP_DURATION: {{SLEEP_DURATION}}
         health-check:
-          cmd: stat hello-container-path/output
+          cmd: stat hello-container-path/output && stat pod-container-path/output
           interval: 5
           grace-period: 30
           delay: 0

--- a/frameworks/helloworld/tests/test_resource_refinement.py
+++ b/frameworks/helloworld/tests/test_resource_refinement.py
@@ -14,7 +14,13 @@ from tests.config import (
 def configure_package(configure_universe):
     try:
         sdk_install.uninstall(PACKAGE_NAME)
-        sdk_install.install(PACKAGE_NAME, DEFAULT_TASK_COUNT)
+        options = {
+            "service": {
+                "spec_file": "examples/pre-reserved.yml"
+            }
+        }
+
+        sdk_install.install(PACKAGE_NAME, DEFAULT_TASK_COUNT, additional_options=options)
 
         yield # let the test session execute
     finally:

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultResourceSet.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultResourceSet.java
@@ -2,7 +2,6 @@ package com.mesosphere.sdk.specification;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.mesosphere.sdk.offer.Constants;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.mesos.Protos;
@@ -120,19 +119,11 @@ public class DefaultResourceSet implements ResourceSet {
         public String preReservedRole;
 
         private Builder(String role, String preReservedRole, String principal) {
-            this.role = getRole(preReservedRole, role);
+            this.role = role;
             this.preReservedRole = preReservedRole;
             this.principal = principal;
             resources = new LinkedList<>();
             volumes = new LinkedList<>();
-        }
-
-        private String getRole(String preReservedRole, String role) {
-            if (preReservedRole == null || preReservedRole.equals(Constants.ANY_ROLE)) {
-                return role;
-            } else {
-                return preReservedRole + "/" + role;
-            }
         }
 
         private Builder addScalarResource(Double r, String resourceId) {


### PR DESCRIPTION
The role for all resources consuming pre-reserved resources should
conform to the `pre-reserved-role/service-role` pattern.  VolumeSpecs
generated from the pod level were not conformant.

For example the YAML below was generating a RESERVE operation with a role of `hello-world-role`, when it should have been `slave_public/hello-world-role`.

```yaml
  hello:
    pre-reserved-role: slave_public
    count: {{HELLO_COUNT}}
    placement: {{HELLO_PLACEMENT}}
    volume:
      path: pod-container-path
      type: ROOT
      size: {{HELLO_DISK}}
```
Additionally, the resource refinement test wasn't really exercising resource refinement, which is now fixed.