### PR TITLE
[INFINITY-2157] Reset to PENDING on TASK_LOST in DeploymentStep

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/DeploymentStep.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/DeploymentStep.java
@@ -162,7 +162,7 @@ public class DeploymentStep extends AbstractStep {
                 }
                 break;
             default:
-                logger.warn("Failed to process unexpected state: " + status.getState());
+                logger.error("Failed to process unexpected state: " + status.getState());
         }
 
         setStatus(getStatus(tasks));

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/DeploymentStep.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/DeploymentStep.java
@@ -136,6 +136,7 @@ public class DeploymentStep extends AbstractStep {
             case TASK_FAILED:
             case TASK_KILLED:
             case TASK_KILLING:
+            case TASK_LOST:
                 setTaskStatus(status.getTaskId(), Status.PENDING);
                 // Retry the step because something failed.
                 setStatus(Status.PENDING);


### PR DESCRIPTION
The deployment step should go back to PENDING on TASK_LOST.  I saw this in the wild and forced it back to PENDING with the `plan force-restart` command and it worked.  All other failure cases are handled this way, TASK_LOST should work the same way.