### PR TITLE
login to cluster and configure cli

### DIFF
--- a/frameworks/cassandra/tests/conftest.py
+++ b/frameworks/cassandra/tests/conftest.py
@@ -1,10 +1,15 @@
 import pytest
+import sdk_login
 import sdk_repository
 import sdk_security
 
 
 @pytest.fixture(scope='session')
-def configure_universe():
+def configure_login():
+    yield from sdk_login.login_session()
+
+@pytest.fixture(scope='session')
+def configure_universe(configure_login):
     yield from sdk_repository.universe_session()
 
 @pytest.fixture(scope='session')

--- a/frameworks/elastic/tests/conftest.py
+++ b/frameworks/elastic/tests/conftest.py
@@ -1,10 +1,15 @@
 import pytest
+import sdk_login
 import sdk_repository
 import sdk_security
 
 
 @pytest.fixture(scope='session')
-def configure_universe():
+def configure_login():
+    yield from sdk_login.login_session()
+
+@pytest.fixture(scope='session')
+def configure_universe(configure_login):
     yield from sdk_repository.universe_session()
 
 @pytest.fixture(scope='session')

--- a/frameworks/hdfs/tests/conftest.py
+++ b/frameworks/hdfs/tests/conftest.py
@@ -1,10 +1,15 @@
 import pytest
+import sdk_login
 import sdk_repository
 import sdk_security
 
 
 @pytest.fixture(scope='session')
-def configure_universe():
+def configure_login():
+    yield from sdk_login.login_session()
+
+@pytest.fixture(scope='session')
+def configure_universe(configure_login):
     yield from sdk_repository.universe_session()
 
 @pytest.fixture(scope='session')

--- a/frameworks/helloworld/tests/conftest.py
+++ b/frameworks/helloworld/tests/conftest.py
@@ -1,10 +1,15 @@
 import pytest
+import sdk_login
 import sdk_repository
 import sdk_security
 
 
 @pytest.fixture(scope='session')
-def configure_universe():
+def configure_login():
+    yield from sdk_login.login_session()
+
+@pytest.fixture(scope='session')
+def configure_universe(configure_login):
     yield from sdk_repository.universe_session()
 
 @pytest.fixture(scope='session')

--- a/frameworks/kafka/tests/conftest.py
+++ b/frameworks/kafka/tests/conftest.py
@@ -1,10 +1,15 @@
 import pytest
+import sdk_login
 import sdk_repository
 import sdk_security
 
 
 @pytest.fixture(scope='session')
-def configure_universe():
+def configure_login():
+    yield from sdk_login.login_session()
+
+@pytest.fixture(scope='session')
+def configure_universe(configure_login):
     yield from sdk_repository.universe_session()
 
 @pytest.fixture(scope='session')

--- a/frameworks/template/tests/conftest.py
+++ b/frameworks/template/tests/conftest.py
@@ -1,10 +1,15 @@
 import pytest
+import sdk_login
 import sdk_repository
 import sdk_security
 
 
 @pytest.fixture(scope='session')
-def configure_universe():
+def configure_login():
+    yield from sdk_login.login_session()
+
+@pytest.fixture(scope='session')
+def configure_universe(configure_login):
     yield from sdk_repository.universe_session()
 
 @pytest.fixture(scope='session')

--- a/test-runner.sh
+++ b/test-runner.sh
@@ -53,9 +53,9 @@ for framework in $FRAMEWORK_LIST; do
     fi
 
     echo "Configuring dcoscli for cluster: $CLUSTER_URL"
+    # TODO(kwood): INFINITY-2183 - remove these once import issues are handled
     dcos config set core.dcos_url $CLUSTER_URL
     dcos config set core.ssl_verify false
-    /build/tools/dcos_login.py
 
     echo "Starting test for $framework at "`date`
     py.test -vv -s "${pytest_args[@]}" ${FRAMEWORK_DIR}/tests

--- a/test.sh
+++ b/test.sh
@@ -15,11 +15,12 @@ FRAMEWORK_LIST=$(ls $REPO_ROOT_DIR/frameworks | sort)
 
 function usage()
 {
-    echo "Usage: $0 [-m MARKEXPR] [-k EXPRESSION] [-p PATH] [-s] all|<framework-name>"
+    echo "Usage: $0 [-m MARKEXPR] [-k EXPRESSION] [-p PATH] [-s] [-o] all|<framework-name>"
     echo "-m passed to pytest directly [default -m \"sanity and not azure\"]"
     echo "-k passed to pytest directly [default NONE]"
     echo "-p PATH to cluster SSH key [default ~/.ssh/ccm.pem]"
     echo "-s run in strict mode (sets \$SECURITY=\"strict\")"
+    echo "-o Testing against an Open cluster not Enterprise"
     echo "Cluster must be created and \$CLUSTER_URL set"
     echo "AWS credentials must exist in the variables:"
     echo "      \$AWS_ACCESS_KEY_ID"
@@ -61,6 +62,7 @@ pytest_m="sanity and not azure"
 pytest_k=""
 azure_args=""
 ssh_path="${HOME}/.ssh/ccm.pem"
+DCOS_ENTERPRISE=True
 
 # If AZURE variables are given, change default -m and prepare args for docker
 if [ -n "$AZURE_DEV_CLIENT_ID" -a -n "$AZURE_DEV_CLIENT_SECRET" -a \
@@ -94,6 +96,10 @@ case $key in
     security="strict"
     [[ $CLUSTER_URL == https* ]] || echo "CLUSTER_URL must be https in strict mode" && exit 1
     ;;
+    -o)
+    DCOS_ENTERPRISE=False
+    shift # past argument
+    ;;
     -p)
     ssh_path="$2"
     shift # past argument
@@ -124,6 +130,7 @@ docker run --rm \
     -e CLUSTER_URL=$CLUSTER_URL \
     $azure_args \
     -e SECURITY=$security \
+    -e DCOS_ENTERPRISE=DCOS_ENTERPRISE \
     -e "PYTEST_K=$pytest_k" \
     -e "PYTEST_M=$pytest_m" \
     -e FRAMEWORK=$framework \

--- a/test.sh
+++ b/test.sh
@@ -130,7 +130,7 @@ docker run --rm \
     -e CLUSTER_URL=$CLUSTER_URL \
     $azure_args \
     -e SECURITY=$security \
-    -e DCOS_ENTERPRISE=DCOS_ENTERPRISE \
+    -e DCOS_ENTERPRISE=$DCOS_ENTERPRISE \
     -e "PYTEST_K=$pytest_k" \
     -e "PYTEST_M=$pytest_m" \
     -e FRAMEWORK=$framework \

--- a/testing/sdk_login.py
+++ b/testing/sdk_login.py
@@ -1,0 +1,81 @@
+import logging
+import os
+
+import requests
+import shakedown
+
+__CLI_LOGIN_OPEN_TOKEN = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6Ik9UQkVOakZFTWtWQ09VRTRPRVpGTlRNMFJrWXlRa015Tnprd1JrSkVRemRCTWpBM1FqYzVOZyJ9.eyJlbWFpbCI6ImFsYmVydEBiZWtzdGlsLm5ldCIsImVtYWlsX3ZlcmlmaWVkIjp0cnVlLCJpc3MiOiJodHRwczovL2Rjb3MuYXV0aDAuY29tLyIsInN1YiI6Imdvb2dsZS1vYXV0aDJ8MTA5OTY0NDk5MDExMTA4OTA1MDUwIiwiYXVkIjoiM3lGNVRPU3pkbEk0NVExeHNweHplb0dCZTlmTnhtOW0iLCJleHAiOjIwOTA4ODQ5NzQsImlhdCI6MTQ2MDE2NDk3NH0.OxcoJJp06L1z2_41_p65FriEGkPzwFB_0pA9ULCvwvzJ8pJXw9hLbmsx-23aY2f-ydwJ7LSibL9i5NbQSR2riJWTcW4N7tLLCCMeFXKEK4hErN2hyxz71Fl765EjQSO5KD1A-HsOPr3ZZPoGTBjE0-EFtmXkSlHb1T2zd0Z8T5Z2-q96WkFoT6PiEdbrDA-e47LKtRmqsddnPZnp0xmMQdTr2MjpVgvqG7TlRvxDcYc-62rkwQXDNSWsW61FcKfQ-TRIZSf2GS9F9esDF4b5tRtrXcBNaorYa9ql0XAWH5W_ct4ylRNl3vwkYKWa4cmPvOqT5Wlj9Tf0af4lNO40PQ'
+__CLI_LOGIN_EE_USERNAME = 'bootstrapuser'
+__CLI_LOGIN_EE_PASSWORD = 'deleteme'
+
+log = logging.getLogger(__name__)
+
+
+def get_acs_token(dcosurl: str, username: str, password: str, is_enterprise: bool) -> None:
+    if is_enterprise:
+        log.info('logging into {} as {}'.format(dcosurl, username))
+        payload = {'uid': username, 'password': password}
+    else:
+        log.info('logging into {} with default open token'.format(dcosurl))
+        payload = {'token': __CLI_LOGIN_OPEN_TOKEN}
+
+    headers = {'Content-Type': 'application/json',}
+    login_endpoint = '{dcosurl}/acs/api/v1/auth/login'.format(dcosurl=dcosurl)
+    r = requests.post(login_endpoint, headers=headers, json=payload, verify=False)
+    assert r.status_code == 200, '{} failed {}: {}'.format(login_endpoint, r.status_code, r.text)
+
+    return r.json()['token']
+
+
+def login(dcosurl: str, username: str, password: str, is_enterprise: bool, user_token: str) -> str:
+    if not user_token:
+        user_token = get_acs_token(dcosurl, username, password, is_enterprise)
+    return user_token
+
+
+def configure_cli(dcosurl: str, token: str) -> None
+    out, err, rc = shakedown.run_dcos_command('dcos config set core.dcos_url {}'.format(dcosurl))
+    assert rc, 'Failed to set core.dcos_url: {}'.format(err)
+    out, err, rc = shakedown.run_dcos_command('dcos config set core.ssl_verify false')
+    assert rc, 'Failed to set core.ssl_verify: {}'.format(err)
+    out, err, rc = shakedown.run_dcos_command('config set core.dcos_acs_token {}'.format(token))
+    assert rc, 'Failed to set core.dcos_acs_token: {}'.format(err)
+
+
+def logout(dcosurl: str):
+    pass
+
+
+def login_session() -> None:
+    """Login to DC/OS.
+
+    Behavior is determined by the following environment variables:
+    CLUSTER_URL: full URL to the test cluster
+    DCOS_LOGIN_USERNAME: the EE user (defaults to bootstrapuser)
+    DCOS_LOGIN_PASSWORD: the EE password (defaults to deleteme)
+    DCOS_ENTERPRISE: determine how to authenticate (defaults to false)
+    DCOS_ACS_TOKEN: bypass auth and use the user supplied token
+
+    This should generally be used as a fixture in a framework's conftest.py:
+
+    @pytest.fixture(scope='session')
+    def configure_login():
+        yield from sdk_login.login_session()
+    """
+    try:
+        cluster_url = os.environ.get('CLUSTER_URL')
+        dcos_login_username = os.environ.get('DCOS_LOGIN_USERNAME', __CLI_LOGIN_EE_USERNAME)
+        dcos_login_password = os.environ.get('DCOS_LOGIN_PASSWORD', __CLI_LOGIN_EE_PASSWORD)
+        dcos_enterprise = os.environ.get('DCOS_ENTERPRISE', False) and True
+        dcos_acs_token = os.environ.get('DCOS_ACS_TOKEN')
+        token = login(
+            dcosurl=cluster_url,
+            username=dcos_login_username,
+            password=dcos_login_password,
+            is_enterprise=dcos_enterprise,
+            user_token=dcos_acs_token
+        )
+        configure_cli(dcosurl, token)
+        yield
+    finally:
+        logout(dcosurl=cluster_url)

--- a/testing/sdk_login.py
+++ b/testing/sdk_login.py
@@ -33,7 +33,7 @@ def login(dcosurl: str, username: str, password: str, is_enterprise: bool, user_
     return user_token
 
 
-def configure_cli(dcosurl: str, token: str) -> None
+def configure_cli(dcosurl: str, token: str) -> None:
     out, err, rc = shakedown.run_dcos_command('dcos config set core.dcos_url {}'.format(dcosurl))
     assert rc, 'Failed to set core.dcos_url: {}'.format(err)
     out, err, rc = shakedown.run_dcos_command('dcos config set core.ssl_verify false')

--- a/testing/sdk_login.py
+++ b/testing/sdk_login.py
@@ -42,7 +42,7 @@ def login_session() -> None:
 
     Behavior is determined by the following environment variables:
     CLUSTER_URL: full URL to the test cluster
-    DCOS_ENTERPRISE: if set to any value assume an EE instance
+    DCOS_ENTERPRISE: testing EE if "True"
     DCOS_LOGIN_USERNAME: the EE user (defaults to bootstrapuser)
     DCOS_LOGIN_PASSWORD: the EE password (defaults to deleteme)
     DCOS_ACS_TOKEN: bypass auth and use the user supplied token
@@ -56,7 +56,7 @@ def login_session() -> None:
     cluster_url = os.environ.get('CLUSTER_URL')
     dcos_login_username = os.environ.get('DCOS_LOGIN_USERNAME', __CLI_LOGIN_EE_USERNAME)
     dcos_login_password = os.environ.get('DCOS_LOGIN_PASSWORD', __CLI_LOGIN_EE_PASSWORD)
-    dcos_enterprise = os.environ.get('DCOS_ENTERPRISE', False) and True
+    dcos_enterprise = os.environ.get('DCOS_ENTERPRISE', None) == 'True'
     dcos_acs_token = os.environ.get('DCOS_ACS_TOKEN')
     if not dcos_acs_token:
         dcos_acs_token = login(


### PR DESCRIPTION
Currently CLI configuration is left to the user or whatever script is calling tests. This is an essential part of running the test and is therefore now captures in test setup