### PR TITLE
[INFINITY-2137] Flaky kafka pod replace test

### DIFF
--- a/frameworks/kafka/tests/test_utils.py
+++ b/frameworks/kafka/tests/test_utils.py
@@ -46,6 +46,7 @@ def restart_broker_pods(service_name=SERVICE_NAME):
         broker_id = sdk_tasks.get_task_ids(service_name,'{}-{}-{}'.format(DEFAULT_POD_TYPE, i, DEFAULT_TASK_NAME))
         restart_info = service_cli('pod restart {}-{}'.format(DEFAULT_POD_TYPE, i), service_name=service_name)
         sdk_tasks.check_tasks_updated(service_name, '{}-{}-{}'.format(DEFAULT_POD_TYPE, i, DEFAULT_TASK_NAME), broker_id)
+        sdk_tasks.check_running(service_name, DEFAULT_BROKER_COUNT)
         assert len(restart_info) == 2
         assert restart_info['tasks'][0] == '{}-{}-{}'.format(DEFAULT_POD_TYPE, i, DEFAULT_TASK_NAME)
 


### PR DESCRIPTION
The restarting all pods test was not waiting to see the pods reached `RUNNING`. Fixed.