### PR TITLE
Fix inverted section mustache rendering

### DIFF
--- a/sdk/scheduler/build.gradle
+++ b/sdk/scheduler/build.gradle
@@ -97,7 +97,6 @@ dependencies {
     compile "org.glassfish.jersey.containers:jersey-container-jetty-http:${jerseyVer}"
     compile "org.glassfish.jersey.media:jersey-media-json-jackson:${jerseyVer}"
     compile "org.eclipse.jetty:jetty-servlet:${jettyServletVer}"
-    compile "com.github.spullara.mustache.java:compiler:${mustacheVer}"
     compile "org.hibernate:hibernate-validator:${hibernateValidatorVer}"
     compile "javax.el:javax.el-api:${elVer}"
     compile "org.glassfish.web:javax.el:${elVer}"

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/TemplateUtils.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/TemplateUtils.java
@@ -2,6 +2,7 @@ package com.mesosphere.sdk.specification.yaml;
 
 import java.io.StringReader;
 import java.io.StringWriter;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -74,9 +75,20 @@ public class TemplateUtils {
                 }
             });
         }
+
+        Map<String, Object> objEnv = new HashMap<>();
+        for (Map.Entry<String, String> entry : environment.entrySet()) {
+            if (StringUtils.equalsIgnoreCase(entry.getValue(), "false") ||
+                    StringUtils.equalsIgnoreCase(entry.getValue(), "true")) {
+                objEnv.put(entry.getKey(), Boolean.valueOf(entry.getValue()));
+            } else {
+                objEnv.put(entry.getKey(), entry.getValue());
+            }
+        }
+
         mustacheFactory
                 .compile(new StringReader(templateContent), templateName)
-                .execute(writer, environment);
+                .execute(writer, objEnv);
         return writer.toString();
     }
 

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/specification/yaml/TemplateUtilsTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/specification/yaml/TemplateUtilsTest.java
@@ -100,4 +100,58 @@ public class TemplateUtilsTest {
                 Collections.emptyMap(),
                 TemplateUtils.MissingBehavior.EXCEPTION));
     }
+
+    @Test
+    public void testApplyTrueEnvVarToSection() throws IOException {
+        String filename = "test-render-inverted.yml";
+        String yaml = getYamlContent(filename);
+        Assert.assertTrue(yaml.contains("ENABLED"));
+
+        Map<String, String> envMap = new HashMap<>();
+        envMap.put("ENABLED", String.valueOf(true));
+        String renderedYaml = TemplateUtils.applyEnvToMustache(
+                filename, yaml, envMap, TemplateUtils.MissingBehavior.EMPTY_STRING);
+
+        Assert.assertTrue(renderedYaml.contains("cmd: ./enabled true"));
+        Assert.assertFalse(renderedYaml.contains("cmd: ./disabled"));
+        Assert.assertFalse(renderedYaml.contains("ENABLED"));
+    }
+
+    @Test
+    public void testApplyFalseEnvVarToInvertedSection() throws IOException {
+        String filename = "test-render-inverted.yml";
+        String yaml = getYamlContent(filename);
+        Assert.assertTrue(yaml.contains("ENABLED"));
+
+        Map<String, String> envMap = new HashMap<>();
+        envMap.put("ENABLED", String.valueOf(false));
+        String renderedYaml = TemplateUtils.applyEnvToMustache(
+                filename, yaml, envMap, TemplateUtils.MissingBehavior.EMPTY_STRING);
+
+        Assert.assertTrue(renderedYaml.contains("cmd: ./disabled false"));
+        Assert.assertFalse(renderedYaml.contains("cmd: ./enabled"));
+        Assert.assertFalse(renderedYaml.contains("ENABLED"));
+    }
+
+    @Test
+    public void testApplyEmptyEnvVarToInvertedSection() throws IOException {
+        String filename = "test-render-inverted.yml";
+        String yaml = getYamlContent(filename);
+        Assert.assertTrue(yaml.contains("ENABLED"));
+
+        Map<String, String> envMap = new HashMap<>();
+        envMap.put("ENABLED", "");
+        String renderedYaml = TemplateUtils.applyEnvToMustache(
+                filename, yaml, envMap, TemplateUtils.MissingBehavior.EMPTY_STRING);
+
+        Assert.assertTrue(renderedYaml.contains("cmd: ./disabled"));
+        Assert.assertFalse(renderedYaml.contains("cmd: ./disabled false"));
+        Assert.assertFalse(renderedYaml.contains("cmd: ./enabled"));
+        Assert.assertFalse(renderedYaml.contains("ENABLED"));
+    }
+
+    private String getYamlContent(String fileName) throws IOException {
+        File file = new File(getClass().getClassLoader().getResource(fileName).getFile());
+        return FileUtils.readFileToString(file);
+    }
 }

--- a/sdk/scheduler/src/test/resources/test-render-inverted.yml
+++ b/sdk/scheduler/src/test/resources/test-render-inverted.yml
@@ -1,0 +1,15 @@
+name: test-render
+pods:
+  hello:
+    count: 1
+    tasks:
+      server:
+        goal: RUNNING
+        {{#ENABLED}}
+        cmd: ./enabled {{ENABLED}}
+        {{/ENABLED}}
+        {{^ENABLED}}
+        cmd: ./disabled {{ENABLED}}
+        {{/ENABLED}}
+        cpus: 1.0
+        memory: 256


### PR DESCRIPTION
The environment for mustache rendering should not consist entirely of
strings, but boolean objects in the case of "true" or "false" values