### PR TITLE
[INFINITY-2187] Process TaskStatus messages synchronously

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/AbstractScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/AbstractScheduler.java
@@ -43,11 +43,6 @@ public abstract class AbstractScheduler implements Scheduler {
     private Object suppressReviveLock = new Object();
 
     /**
-     * Executor for handling TaskStatus updates in {@link #statusUpdate(SchedulerDriver, Protos.TaskStatus)}.
-     */
-    protected final ExecutorService statusExecutor = Executors.newSingleThreadExecutor();
-
-    /**
      * Executor for processing offers off the queue in {@code processOffers()}.
      */
     private final ExecutorService offerExecutor = Executors.newSingleThreadExecutor();

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/recovery/DefaultRecoveryPlanManager.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/recovery/DefaultRecoveryPlanManager.java
@@ -108,8 +108,8 @@ public class DefaultRecoveryPlanManager extends ChainedObserver implements PlanM
     public void update(Protos.TaskStatus status) {
         synchronized (planLock) {
             getPlan().update(status);
-            notifyObservers();
         }
+        notifyObservers();
     }
 
     protected void updatePlan(Collection<PodInstanceRequirement> dirtyAssets) {

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/uninstall/UninstallScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/uninstall/UninstallScheduler.java
@@ -182,20 +182,18 @@ public class UninstallScheduler extends AbstractScheduler {
 
     @Override
     public void statusUpdate(SchedulerDriver driver, Protos.TaskStatus status) {
-        statusExecutor.execute(() -> {
-            LOGGER.info("Received status update for taskId={} state={} message='{}'",
-                    status.getTaskId().getValue(),
-                    status.getState().toString(),
-                    status.getMessage());
+        LOGGER.info("Received status update for taskId={} state={} message='{}'",
+                status.getTaskId().getValue(),
+                status.getState().toString(),
+                status.getMessage());
 
-            try {
-                stateStore.storeStatus(status);
-                reconciler.update(status);
-            } catch (Exception e) {
-                LOGGER.warn("Failed to update TaskStatus received from Mesos. "
-                        + "This may be expected if Mesos sent stale status information: " + status, e);
-            }
-        });
+        try {
+            stateStore.storeStatus(status);
+            reconciler.update(status);
+        } catch (Exception e) {
+            LOGGER.warn("Failed to update TaskStatus received from Mesos. "
+                    + "This may be expected if Mesos sent stale status information: " + status, e);
+        }
     }
 
     @Override


### PR DESCRIPTION
Implicit acknowledgement of TaskStatus messages requires that exit from
the Scheduler `statusUpdate` function implies complete processing of the
message.  Processing on an async thread breaks this assumption.

It's also making the DefaultSchedulerTest.testConfigurationUpdate non-deterministic. 

NOTE:  The diff looks weird.  I just removed the executor service and stopped wrapping calls to `statusUpdate` with use of that service.