### PR TITLE
[KAF-362] Add upgrade documentation for Kafka upgrade from 0.10.2.x to 0.11.0

### DIFF
--- a/frameworks/kafka/docs/upgrade.md
+++ b/frameworks/kafka/docs/upgrade.md
@@ -16,25 +16,23 @@ This document explains how to upgrade the DC/OS Kafka service from 0.10.2.x to 0
 
 - 0.11.0.0 clients can communicate with older brokers, such as 0.10.2.x brokers. However 0.11.0.0 clients are required for these new features. 
 
-The rolling [upgrade procedure](https://kafka.apache.org/documentation/#upgrade) (from 0.10.2.x to 0.11.0.0) is explained below. This procedure guarantees no downtime during the upgrade.
-
-
-1. Upgrade the code to the new version:
-   * Upgrade Kafka software to [0.11.0.0](https://archive.apache.org/dist/kafka/0.11.0.0/RELEASE_NOTES.html).
+The recommended Kafka rolling upgrade from `0.10.2.x` to `0.11.0.0` includes the following steps:
+1. Upgrade service the latest version of DC/OS Kafka package:
+   * Upgrade Kafka software to `0.11.0.0`.
+   * Do not update protocol and log versions, keep them same.
    * Restart the brokers one at a time.    
    * Wait until the entire cluster is upgraded.
 
 2. Change `inter.broker.protocol.version` to `0.11.0.0`:
-
    * In the `server.properties` file, change `inter.broker.protocol.version` to `0.11.0.0`.
    * Do not change log.message.format.version yet.
    * Restart the brokers one by one for the new protocol version to take affect.
 
 3. Change `log.message.format.version` to `0.11.0`:
-
    * In the server.properties files, change `log.message.format.version` to `0.11.0`.
    * Restart the brokers one by one for the new log format version to take affect.
 
+This is an overview of the rolling upgrade process to guarantee no downtime during the upgrade. The process for upgrading Kafka with DC/OS is documented in detail below.
 
 
 The new DC/OS Kafka package (with Kafka 0.11.0.0 version) that we will be upgrading to has the following default settings:
@@ -43,12 +41,14 @@ The new DC/OS Kafka package (with Kafka 0.11.0.0 version) that we will be upgrad
 * inter.broker.protocol.version = 0.11.0.0
 * log.message.format.version = 0.11.0
 
-The current DC/OS Kafka service (installed with Kafka 0.10.2.x version) will typically have the following configuration:
+The previous DC/OS Kafka package (with Kafka 0.10.2.x version) will have the following configuration:
 
 * Kafka Version = 0.10.2.1
 * inter.broker.protocol.version = 0.10.0.0
 * log.message.format.version = 0.10.0
 
+
+Here we assume that you already have a DC/OS Kafka service running, installed with the previous package version (with Kafka 0.10.2.x).  In order to guarantee no downtime during the upgrade process (upgrade service to the new DC/OS Kafka package with 0.11.0.0), follow the steps described below.  
 
 #### Step 1
 
@@ -105,7 +105,7 @@ The new service will be running the Kafka 0.11.0.0 with two specific customized 
 
 Since protocol and log versions have been updated (new protocol and log formats), you can not directly roll back to the previous package version.
 
-**Note**: Default settings for protocol and log versions are overwritten with these customized options (steps 1 through 3), even though  their values are same as the defaults of the new package. Pay attention to these customized options for further package updates since they will be preserved unless overwritten explicitly.
+**Note**: Default settings for protocol and log versions are overwritten with these customized options (steps 1 through 3), even though  their values are same as the defaults of the new package. Pay attention to these customized options for further package upgrades since they will be preserved unless overwritten explicitly.
 
     
     

--- a/frameworks/kafka/docs/upgrade.md
+++ b/frameworks/kafka/docs/upgrade.md
@@ -5,7 +5,7 @@ feature_maturity: preview
 enterprise: 'no'
 ---
 
-This document explains how to upgrade the DC/OS Kafka service from version 0.10.2.x to 0.11.0.0.
+This document explains how to upgrade the DC/OS Apache Kafka service from version `1.1.16-0.10.1.0-beta` to `2.0.0-0.11.0.0`.
 
 - Refer to the Kafka [upgrade](https://kafka.apache.org/documentation/#upgrade) documentation for more information.
 
@@ -15,7 +15,7 @@ This document explains how to upgrade the DC/OS Kafka service from version 0.10.
 
 # Overview
 
-This is an overview of the rolling upgrade process, which guarantees no downtime during the upgrade. The process for upgrading Kafka with DC/OS is documented in detail below.
+This is an overview of the rolling upgrade process. The process for upgrading Kafka with DC/OS is documented in detail below.
 
 1. Upgrade your package to the latest version of DC/OS Kafka service:
    * Upgrade Kafka software to `0.11.0.0`.
@@ -34,24 +34,24 @@ This is an overview of the rolling upgrade process, which guarantees no downtime
 
 # Detailed upgrade instructions
 
-The new DC/OS Kafka package (with Kafka version 0.11.0.0) that we will be upgrading to has the following default settings:
+The new DC/OS Kafka package `2.0.0-0.11.0.0` (with Kafka version 0.11.0.0) that we will be upgrading to has the following default settings:
 
 * Kafka Version = 0.11.0.0
 * inter.broker.protocol.version = 0.11.0.0
 * log.message.format.version = 0.11.0
 
-The previous DC/OS Kafka package (with Kafka version 0.10.2.x) has the following configuration:
+The beta DC/OS Kafka package `1.1.16-0.10.1.0-beta` (with Kafka 0.10.2.x) has the following configuration:
 
 * Kafka Version = 0.10.2.1
 * inter.broker.protocol.version = 0.10.0.0
 * log.message.format.version = 0.10.0
 
 
-Here, we assume that you already have a DC/OS Kafka service running, installed with the previous package version (Kafka 0.10.2.x). In order to guarantee no downtime during the upgrade process, follow the steps below.  
+Here, we assume that you already have a DC/OS Kafka service running, installed with the beta package version `1.1.16-0.10.1.0-beta` (with Kafka 0.10.2.x). In order to guarantee no downtime during the upgrade process, follow the steps below.  
 
 #### Step 1
 
-First, make a note of the existing protocol and log versions. Upgrade your service to the new package (with Kafka 0.11.0.0), but keep the existig protocol and log versions same by applying customized package update options. The following `options.json` file shows how protocol and log versions can be customized. Here, we assume that existing service uses 0.10.0 protocol/log versions. If you have changed protocol and log to another 0.10.x version, set them in options JSON file.
+First, make a note of the existing protocol and log versions. Upgrade your service to the new package version `2.0.0-0.11.0.0` (with Kafka 0.11.0.0), but keep the existig protocol and log versions same by applying customized package update options. The following `options.json` file shows how protocol and log versions can be customized. Here, we assume that existing service uses 0.10.0 protocol/log versions. If you have changed protocol and log to another 0.10.x version, set them in options JSON file.
    
     {
         "kafka": {
@@ -60,9 +60,9 @@ First, make a note of the existing protocol and log versions. Upgrade your servi
         }
     }
 
-Now, upgrade to the package that provides the new code, Kafka 0.11.0.0. 
+Now, upgrade to the package `2.0.0-0.11.0.0` that provides the new code, Kafka 0.11.0.0. 
 
-    $ dcos kafka update start --options=options.json --package-version=<new-kafka-package-with-0.11.0.0>
+    $ dcos kafka update start --options=options.json --package-version=2.0.0-0.11.0.0
 
 Since we updated with a customized options file, the protocol and log version are overwritten and not updated to the new package's default settings. The existing protocol and log version are specifically set in `options.json`. 
 
@@ -103,7 +103,7 @@ The new service will be running Kafka 0.11.0.0 with two customized options (`int
 
 Since protocol and log versions have been updated with new protocol and log formats, you can not directly roll back to the previous package version.
 
-**Note**: Default settings for protocol and log versions are overwritten with these customized options (steps 1 through 3), even though  their values are same as the defaults of the new package. Pay attention to these customized options for further package upgrades since they will be preserved unless overwritten explicitly.
+**Note**: Default settings for protocol and log versions are overwritten with these customized options (steps 1 through 3), even though  their values are same as the defaults of the new package version `2.0.0-0.11.0.0` . Pay attention to these customized options for further package upgrades since they will be preserved unless overwritten explicitly.
 
     
     

--- a/frameworks/kafka/docs/upgrade.md
+++ b/frameworks/kafka/docs/upgrade.md
@@ -1,25 +1,25 @@
 ---
-post_title: Upgrade Kafka from 0.10.2.1 to 0.11.0.0
+post_title: Upgrade Kafka from 0.10.2.x to 0.11.0.0
 menu_order: 10
 feature_maturity: preview
 enterprise: 'no'
 ---
 
-# Upgrade Kafka from 0.10.2.1 to 0.11.0.0
+This document explains how to upgrade the DC/OS Kafka service from version 0.10.2.x to 0.11.0.0.
 
-
-This document explains how to upgrade the DC/OS Kafka service from 0.10.2.x to 0.11.0.0 version. Refer to the Kafka [upgrade](https://kafka.apache.org/documentation/#upgrade) documentation for more information.
+- Refer to the Kafka [upgrade](https://kafka.apache.org/documentation/#upgrade) documentation for more information.
 
 - Information about the new message format in 0.11.0.0 is available [here](https://kafka.apache.org/documentation/#upgrade_11_message_format).
 
-- Kafka 0.11.0.0 introduces idempotent and transactional capabilities. These new 0.11.0.0 features require the new messaging format, and so will not work on older formats. 
+- 0.11.0.0 clients can communicate with older brokers, such as 0.10.2.x brokers. But Kafka 0.11.0.0 introduces idempotent and transactional capabilities. 0.11.0.0 clients are required for these new features. 
 
-- 0.11.0.0 clients can communicate with older brokers, such as 0.10.2.x brokers. However 0.11.0.0 clients are required for these new features. 
+# Overview
 
-The recommended Kafka rolling upgrade from `0.10.2.x` to `0.11.0.0` includes the following steps:
-1. Upgrade service the latest version of DC/OS Kafka package:
+This is an overview of the rolling upgrade process, which guarantees no downtime during the upgrade. The process for upgrading Kafka with DC/OS is documented in detail below.
+
+1. Upgrade your package to the latest version of DC/OS Kafka service:
    * Upgrade Kafka software to `0.11.0.0`.
-   * Do not update protocol and log versions, keep them same.
+   * Do not update protocol and log versions yet.
    * Restart the brokers one at a time.    
    * Wait until the entire cluster is upgraded.
 
@@ -29,30 +29,29 @@ The recommended Kafka rolling upgrade from `0.10.2.x` to `0.11.0.0` includes the
    * Restart the brokers one by one for the new protocol version to take affect.
 
 3. Change `log.message.format.version` to `0.11.0`:
-   * In the server.properties files, change `log.message.format.version` to `0.11.0`.
+   * In the `server.properties` files, change `log.message.format.version` to `0.11.0`.
    * Restart the brokers one by one for the new log format version to take affect.
 
-This is an overview of the rolling upgrade process to guarantee no downtime during the upgrade. The process for upgrading Kafka with DC/OS is documented in detail below.
+# Detailed upgrade instructions
 
-
-The new DC/OS Kafka package (with Kafka 0.11.0.0 version) that we will be upgrading to has the following default settings:
+The new DC/OS Kafka package (with Kafka version 0.11.0.0) that we will be upgrading to has the following default settings:
 
 * Kafka Version = 0.11.0.0
 * inter.broker.protocol.version = 0.11.0.0
 * log.message.format.version = 0.11.0
 
-The previous DC/OS Kafka package (with Kafka 0.10.2.x version) will have the following configuration:
+The previous DC/OS Kafka package (with Kafka version 0.10.2.x) has the following configuration:
 
 * Kafka Version = 0.10.2.1
 * inter.broker.protocol.version = 0.10.0.0
 * log.message.format.version = 0.10.0
 
 
-Here we assume that you already have a DC/OS Kafka service running, installed with the previous package version (with Kafka 0.10.2.x).  In order to guarantee no downtime during the upgrade process (upgrade service to the new DC/OS Kafka package with 0.11.0.0), follow the steps described below.  
+Here, we assume that you already have a DC/OS Kafka service running, installed with the previous package version (Kafka 0.10.2.x). In order to guarantee no downtime during the upgrade process, follow the steps below.  
 
 #### Step 1
 
-First, make a note of the existing protocol and log versions. Upgrade your service to the new package (with Kafka 0.11.0.0) but keep the existig protocol and log versions same. In order to only update to the new code, apply customized package update options. The following `options.json` file shows how protocol and log versions can be customized. Here we assume that existing service uses 0.10.0 protocol/log versions. If you have changed protocol and log to another 0.10.x version, set them in options JSON file.
+First, make a note of the existing protocol and log versions. Upgrade your service to the new package (with Kafka 0.11.0.0), but keep the existig protocol and log versions same by applying customized package update options. The following `options.json` file shows how protocol and log versions can be customized. Here, we assume that existing service uses 0.10.0 protocol/log versions. If you have changed protocol and log to another 0.10.x version, set them in options JSON file.
    
     {
         "kafka": {
@@ -65,16 +64,15 @@ Now, upgrade to the package that provides the new code, Kafka 0.11.0.0.
 
     $ dcos kafka update start --options=options.json --package-version=<new-kafka-package-with-0.11.0.0>
 
-Since we updated with a customized options file, protocol and log version are overwritten and not updated to the new package's default settings. The existing protocol and log version are specifically set in `options.json`. 
+Since we updated with a customized options file, the protocol and log version are overwritten and not updated to the new package's default settings. The existing protocol and log version are specifically set in `options.json`. 
 
-The Kafka service will be upgraded to the new package version. This will upgrade the code to the new 0.11.0.0 version. The brokers will now be upgraded and restarted serially, one at a time. `serial` is the default deployment plan strategy.
+The Kafka service will be upgraded to the version 0.11.0.0. The brokers will now be upgraded and restarted serially. `serial` is the default deployment plan strategy.
 
-**Note**: The goal in using customized options during package upgrade is to keep protocol and log versions same. We will enforce the new format to take affect gradually in the following steps.
-
+**Note**: The goal in using customized options during package upgrade is to keep the protocol and log versions the same. In the following steps, we will change protocol and log versions one at a time.
 
 #### Step 2
 
-Next, update the protocol version manually. Only change the value of `inter.broker.protocol.version` in the `options.json` file, and then perform an update operation. The brokers will be restarted one at a time, with the new `server.properties` file that has protocol version set to `0.11.0.0`. 
+Next, update the protocol version manually. Only change the value of `inter.broker.protocol.version` in the `options.json` file, and then perform an update operation. The brokers will be restarted one at a time with the new `server.properties` file with protocol version set to `0.11.0.0`. 
     
     {
         "kafka": {
@@ -88,7 +86,7 @@ Next, update the protocol version manually. Only change the value of `inter.brok
     
 #### Step 3    
     
-Once you verify that all brokers are restarted, update the log version. Change the log version to `0.11.0` and do another update operation. 
+Once you verify that all brokers are restarted, update the log version. Change the log version to `0.11.0` and perform another update operation. 
    
     {
         "kafka": {
@@ -101,9 +99,9 @@ Once you verify that all brokers are restarted, update the log version. Change t
     $ dcos kafka update start --options=options.json
     
     
-The new service will be running the Kafka 0.11.0.0 with two specific customized options (`inter.broker.protocol.version` and `log.message.format.version`). 
+The new service will be running Kafka 0.11.0.0 with two customized options (`inter.broker.protocol.version` and `log.message.format.version`). 
 
-Since protocol and log versions have been updated (new protocol and log formats), you can not directly roll back to the previous package version.
+Since protocol and log versions have been updated with new protocol and log formats, you can not directly roll back to the previous package version.
 
 **Note**: Default settings for protocol and log versions are overwritten with these customized options (steps 1 through 3), even though  their values are same as the defaults of the new package. Pay attention to these customized options for further package upgrades since they will be preserved unless overwritten explicitly.
 

--- a/frameworks/kafka/docs/upgrade.md
+++ b/frameworks/kafka/docs/upgrade.md
@@ -7,43 +7,52 @@ enterprise: 'no'
 
 # Upgrade Kafka from 0.10.2.1 to 0.11.0.0
 
-This document explains upgrading the DC/OS Kafka service from 0.10.2.x to 0.11.0.0 version. Please follow the Kafka [upgrade](https://kafka.apache.org/documentation/#upgrade) documentation for more information. Information about the new message format in 0.11.0 is available [here](https://kafka.apache.org/documentation/#upgrade_11_message_format). Kafka 0.11.0 introduces idempotent and transactional capabilies. These new 0.11.0 features requires the new messaging format, and so will not work on older formats. Please also note that 0.11.0 clients can communicate with older brokers, such as 0.10.2 brokers.  
 
-The rolling upgrade procedure (from 0.10.2.x to 0.11.0.0) is explained below. This is the recommended way of upgrading to 0.11.0.0 in order to guarantee no downtime while upgrading Kafka.
+This document explains how to upgrade the DC/OS Kafka service from 0.10.2.x to 0.11.0.0 version. Refer to the Kafka [upgrade](https://kafka.apache.org/documentation/#upgrade) documentation for more information.
+
+- Information about the new message format in 0.11.0.0 is available [here](https://kafka.apache.org/documentation/#upgrade_11_message_format).
+
+- Kafka 0.11.0.0 introduces idempotent and transactional capabilities. These new 0.11.0.0 features require the new messaging format, and so will not work on older formats. 
+
+- 0.11.0.0 clients can communicate with older brokers, such as 0.10.2.x brokers. However 0.11.0.0 clients are required for these new features. 
+
+The rolling [upgrade procedure](https://kafka.apache.org/documentation/#upgrade) (from 0.10.2.x to 0.11.0.0) is explained below. This procedure guarantees no downtime during the upgrade.
 
 
 1. Upgrade the code to the new version:
-   * Upgrade Kafka software to 0.11.0.0.
+   * Upgrade Kafka software to [0.11.0.0](https://archive.apache.org/dist/kafka/0.11.0.0/RELEASE_NOTES.html).
    * Restart the brokers one at a time.    
    * Wait until the entire cluster is upgraded.
 
-2. Change inter.broker.protocol.version to 0.11.0.0:
+2. Change `inter.broker.protocol.version` to `0.11.0.0`:
 
-   * Edit server.properties files and change inter.broker.protocol.version to 0.11.0.0.
-   * Do not change log.message.format.version
-   * Restart the brokers one by one for the new protocol version to take affect
+   * In the `server.properties` file, change `inter.broker.protocol.version` to `0.11.0.0`.
+   * Do not change log.message.format.version yet.
+   * Restart the brokers one by one for the new protocol version to take affect.
 
-3. Change log.message.format.version to 0.11.0:
+3. Change `log.message.format.version` to `0.11.0`:
 
-   * Edit server.properties files and change log.message.format.version to 0.11.0.
-   * Restart the brokers one by one for the new log format version to take affect
+   * In the server.properties files, change `log.message.format.version` to `0.11.0`.
+   * Restart the brokers one by one for the new log format version to take affect.
 
 
 
-The new DC/OS Kafka package that we will be upgrading to has the following default settings:
+The new DC/OS Kafka package (with Kafka 0.11.0.0 version) that we will be upgrading to has the following default settings:
 
 * Kafka Version = 0.11.0.0
 * inter.broker.protocol.version = 0.11.0.0
 * log.message.format.version = 0.11.0
 
-The current DC/OS Kafka service will typically have the following configuration:
+The current DC/OS Kafka service (installed with Kafka 0.10.2.x version) will typically have the following configuration:
 
 * Kafka Version = 0.10.2.1
 * inter.broker.protocol.version = 0.10.0.0
 * log.message.format.version = 0.10.0
 
 
-First, update your service to the new package version, but while doing that preserve the old protocol and log versions. In order to only update to the new code, apply customized package update options. The following `options.json` file shows how protocol and log versions can be customized. Here we assume that existing service use 0.10.0 protocol/log versions. If you have changed protocol and log to another 0.10.x version, please set them in options JSON file.
+#### Step 1
+
+First, make a note of the existing protocol and log versions. Upgrade your service to the new package (with Kafka 0.11.0.0) but keep the existig protocol and log versions same. In order to only update to the new code, apply customized package update options. The following `options.json` file shows how protocol and log versions can be customized. Here we assume that existing service uses 0.10.0 protocol/log versions. If you have changed protocol and log to another 0.10.x version, set them in options JSON file.
    
     {
         "kafka": {
@@ -52,16 +61,20 @@ First, update your service to the new package version, but while doing that pres
         }
     }
 
-Now, update to the package that provides the new code, Kafka 0.11.0.0, as follows. 
+Now, upgrade to the package that provides the new code, Kafka 0.11.0.0. 
 
-    $ dcos kafka update start --options=options.json --package-version=<new-kafka-package>
+    $ dcos kafka update start --options=options.json --package-version=<new-kafka-package-with-0.11.0.0>
 
-Since we update with a customized options file, protocol and log version are not changed to the pacakge's default settings 
+Since we updated with a customized options file, protocol and log version are overwritten and not updated to the new package's default settings. The existing protocol and log version are specifically set in `options.json`. 
 
-The default strategy for a deployment plan is `serial`; therefore, the brokers will be updated serially, one at a time.
+The Kafka service will be upgraded to the new package version. This will upgrade the code to the new 0.11.0.0 version. The brokers will now be upgraded and restarted serially, one at a time. `serial` is the default deployment plan strategy.
+
+**Note**: The goal in using customized options during package upgrade is to keep protocol and log versions same. We will enforce the new format to take affect gradually in the following steps.
 
 
-Next, update the protocol version. Only change the inter.broker.protocol.version in `options.json` file, and perform an update operation. The brokers will be restarted one at a time, with the new server.properties file that has protocol version set to 0.11.0.0. 
+#### Step 2
+
+Next, update the protocol version manually. Only change the value of `inter.broker.protocol.version` in the `options.json` file, and then perform an update operation. The brokers will be restarted one at a time, with the new `server.properties` file that has protocol version set to `0.11.0.0`. 
     
     {
         "kafka": {
@@ -73,7 +86,9 @@ Next, update the protocol version. Only change the inter.broker.protocol.version
    
     $ dcos kafka update start --options=options.json 
     
-Once you verify that all brokers are restarted, update the log version. Change the log version to 0.11.0 and do another update operation. 
+#### Step 3    
+    
+Once you verify that all brokers are restarted, update the log version. Change the log version to `0.11.0` and do another update operation. 
    
     {
         "kafka": {
@@ -86,7 +101,11 @@ Once you verify that all brokers are restarted, update the log version. Change t
     $ dcos kafka update start --options=options.json
     
     
-Finally, the new service will be running the Kafka 0.11.0 version with two specific customized options (inter.broker.protocol.version and log.message.format.version). Since protocol and log versions are updated (new protocol and log formats), you can not directly roll back to the previous package version. Please note that default settings for protocol and log versions are overwritten with these customized options (step 1 through 3), even though  their values are same as defaults of the new package. Pay attention to these customized options for further package updates since they will be preserved unless overwritten explicitly.
-    
+The new service will be running the Kafka 0.11.0.0 with two specific customized options (`inter.broker.protocol.version` and `log.message.format.version`). 
+
+Since protocol and log versions have been updated (new protocol and log formats), you can not directly roll back to the previous package version.
+
+**Note**: Default settings for protocol and log versions are overwritten with these customized options (steps 1 through 3), even though  their values are same as the defaults of the new package. Pay attention to these customized options for further package updates since they will be preserved unless overwritten explicitly.
+
     
     

--- a/frameworks/kafka/docs/upgrade.md
+++ b/frameworks/kafka/docs/upgrade.md
@@ -1,0 +1,92 @@
+---
+post_title: Upgrade Kafka from 0.10.2.1 to 0.11.0.0
+menu_order: 10
+feature_maturity: preview
+enterprise: 'no'
+---
+
+# Upgrade Kafka from 0.10.2.1 to 0.11.0.0
+
+This document explains upgrading the DC/OS Kafka service from 0.10.2.x to 0.11.0.0 version. Please follow the Kafka [upgrade](https://kafka.apache.org/documentation/#upgrade) documentation for more information. 
+
+The rolling upgrade procedure (from 0.10.2.x to 0.11.0.0) is explained below. This is the recommended way of upgrading to 0.11.0.0 in order to guarantee no downtime while upgrading Kafka.
+
+
+1. Upgrade the code to the new version:
+   * Upgrade Kafka software to 0.11.0.0.
+   * Restart the brokers one at a time.    
+   * Wait until the entire cluster is upgraded.
+
+2. Change inter.broker.protocol.version to 0.11.0.0:
+
+   * Edit server.properties files and change inter.broker.protocol.version to 0.11.0.0.
+   * Do not change log.message.format.version
+   * Restart the brokers one by one for the new protocol version to take affect
+
+3. Change log.message.format.version to 0.11.0:
+
+   * Edit server.properties files and change log.message.format.version to 0.11.0.
+   * Restart the brokers one by one for the new log format version to take affect
+
+
+
+The new DC/OS Kafka package that we will be upgrading to has the following default settings:
+
+* Kafka Version = 0.11.0.0
+* inter.broker.protocol.version = 0.11.0.0
+* log.message.format.version = 0.11.0
+
+The current DC/OS Kafka service will typically have the following configuration:
+
+* Kafka Version = 0.10.2.1
+* inter.broker.protocol.version = 0.10.0.0
+* log.message.format.version = 0.10.0
+
+
+First, update your service to the new package version, but while doing that preserve the old protocol and log versions. In order to only update to the new code, apply customized package update options. The following `options.json` file shows how protocol and log versions can be customized. Here we assume that existing service use 0.10.0 protocol/log versions. If you have changed protocol and log to another 0.10.x version, please set them in options JSON file.
+   
+    {
+        "kafka": {
+            "inter.broker.protocol.version": "0.10.0.0",
+            "log.message.format.version": "0.10.0"
+        }
+    }
+
+Now, update to the package that provides the new code, Kafka 0.11.0.0, as follows. 
+
+    $ dcos kafka update start --options=options.json --package-version=<new-kafka-package>
+
+Since we update with a customized options file, protocol and log version are not changed to the pacakge's default settings 
+
+The default strategy for a deployment plan is `serial`; therefore, the brokers will be updated serially, one at a time.
+
+
+Next, update the protocol version. Only change the inter.broker.protocol.version in `options.json` file, and perform an update operation. The brokers will be restarted one at a time, with the new server.properties file that has protocol version set to 0.11.0.0. 
+    
+    {
+        "kafka": {
+            "inter.broker.protocol.version": "0.11.0.0",
+            "log.message.format.version": "0.10.0"
+        }
+    }
+    
+   
+    $ dcos kafka update start --options=options.json 
+    
+Once you verify that all brokers are restarted, update the log version. Change the log version to 0.11.0 and do another update operation. 
+   
+    {
+        "kafka": {
+            "inter.broker.protocol.version": "0.11.0.0",
+            "log.message.format.version": "0.11.0"
+        }
+    }
+    
+   
+    $ dcos kafka update start --options=options.json
+    
+    
+    
+    
+    
+    

--- a/frameworks/kafka/docs/upgrade.md
+++ b/frameworks/kafka/docs/upgrade.md
@@ -7,7 +7,7 @@ enterprise: 'no'
 
 # Upgrade Kafka from 0.10.2.1 to 0.11.0.0
 
-This document explains upgrading the DC/OS Kafka service from 0.10.2.x to 0.11.0.0 version. Please follow the Kafka [upgrade](https://kafka.apache.org/documentation/#upgrade) documentation for more information. 
+This document explains upgrading the DC/OS Kafka service from 0.10.2.x to 0.11.0.0 version. Please follow the Kafka [upgrade](https://kafka.apache.org/documentation/#upgrade) documentation for more information. Information about the new message format in 0.11.0 is available [here](https://kafka.apache.org/documentation/#upgrade_11_message_format). Kafka 0.11.0 introduces idempotent and transactional capabilies. These new 0.11.0 features requires the new messaging format, and so will not work on older formats. Please also note that 0.11.0 clients can communicate with older brokers, such as 0.10.2 brokers.  
 
 The rolling upgrade procedure (from 0.10.2.x to 0.11.0.0) is explained below. This is the recommended way of upgrading to 0.11.0.0 in order to guarantee no downtime while upgrading Kafka.
 
@@ -86,7 +86,7 @@ Once you verify that all brokers are restarted, update the log version. Change t
     $ dcos kafka update start --options=options.json
     
     
-    
+Finally, the new service will be running the Kafka 0.11.0 version with two specific customized options (inter.broker.protocol.version and log.message.format.version). Since protocol and log versions are updated (new protocol and log formats), you can not directly roll back to the previous package version. Please note that default settings for protocol and log versions are overwritten with these customized options (step 1 through 3), even though  their values are same as defaults of the new package. Pay attention to these customized options for further package updates since they will be preserved unless overwritten explicitly.
     
     
     


### PR DESCRIPTION
Upgrading from 0.10 version to 0.11 version (See PR #1239)
(step 1) Update to 0.11 version but use an options.json file to set protocol/log version to 0.10
(step 2) Change protocol version to 0.11.0 and update again
(step 3) Change log version to 0.11.0 and update again

