### PR TITLE
Give "principal" in additional options, to install a previous version.

### DIFF
--- a/testing/sdk_install.py
+++ b/testing/sdk_install.py
@@ -193,6 +193,7 @@ def get_package_options(additional_options={}):
         return _merge_dictionaries(additional_options, {
             'service': {
                 'service_account': 'service-acct',
+                'principal': 'service-acct',
                 'secret_name': 'secret',
                 'mesos_api_version': 'V0'
             }


### PR DESCRIPTION
New version uses `service_account` instead of `principal` in config.json.