### PR TITLE
Make event bus asynchronous

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/AbstractScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/AbstractScheduler.java
@@ -1,6 +1,7 @@
 package com.mesosphere.sdk.scheduler;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.eventbus.AsyncEventBus;
 import com.google.common.eventbus.EventBus;
 import com.google.protobuf.TextFormat;
 import com.mesosphere.sdk.offer.OfferUtils;
@@ -35,7 +36,7 @@ public abstract class AbstractScheduler implements Scheduler {
     protected final OfferQueue offerQueue = new OfferQueue();
     protected SchedulerDriver driver;
     protected DefaultReconciler reconciler;
-    protected final EventBus eventBus = new EventBus();
+    protected final EventBus eventBus = new AsyncEventBus(Executors.newSingleThreadExecutor());
 
     private Object inProgressLock = new Object();
     private Set<Protos.OfferID> offersInProgress = new HashSet<>();


### PR DESCRIPTION
I stress tested suppress/revive yesterday.  Ran it for many hours with `hello-world` at different `SLEEP_DURATION`s.  Found a deadlock.  Long story short it's a deadlock through the `MesosToSchedulerDriverAdapter`.  TaskStatus updates or offers at the same time a revive/suppress attempt is made can generate the condition below.  So I've made the event bus asynchronous which will break the cycle.  I'm stress testing again overnight.

```
Java stack information for the threads listed above:
===================================================
"Thread-13542":
	at com.mesosphere.sdk.scheduler.SuppressReviveManager.transitionState(SuppressReviveManager.java:121)
	- waiting to lock <0x00000000e06e18d8> (a java.lang.Object)
	at com.mesosphere.sdk.scheduler.SuppressReviveManager.handleTaskStatus(SuppressReviveManager.java:103)
	at sun.reflect.GeneratedMethodAccessor281.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at com.google.common.eventbus.EventSubscriber.handleEvent(EventSubscriber.java:74)
	at com.google.common.eventbus.SynchronizedEventSubscriber.handleEvent(SynchronizedEventSubscriber.java:47)
	- locked <0x00000000e101fb10> (a com.google.common.eventbus.SynchronizedEventSubscriber)
	at com.google.common.eventbus.EventBus.dispatch(EventBus.java:322)
	at com.google.common.eventbus.EventBus.dispatchQueuedEvents(EventBus.java:304)
	at com.google.common.eventbus.EventBus.post(EventBus.java:275)
	at com.mesosphere.sdk.scheduler.DefaultScheduler.statusUpdate(DefaultScheduler.java:783)
	at com.mesosphere.mesos.HTTPAdapter.MesosToSchedulerDriverAdapter.received(MesosToSchedulerDriverAdapter.java:228)
	- locked <0x00000000e06c8768> (a com.mesosphere.mesos.HTTPAdapter.MesosToSchedulerDriverAdapter)
"pool-8-thread-1":
	at com.mesosphere.mesos.HTTPAdapter.MesosToSchedulerDriverAdapter.reviveOffers(MesosToSchedulerDriverAdapter.java:620)
	- waiting to lock <0x00000000e06c8768> (a com.mesosphere.mesos.HTTPAdapter.MesosToSchedulerDriverAdapter)
	at com.mesosphere.sdk.scheduler.SuppressReviveManager.setOfferMode(SuppressReviveManager.java:208)
	- locked <0x00000000e06e18c8> (a java.lang.Object)
	at com.mesosphere.sdk.scheduler.SuppressReviveManager.revive(SuppressReviveManager.java:196)
	- locked <0x00000000e06e18c8> (a java.lang.Object)
	at com.mesosphere.sdk.scheduler.SuppressReviveManager.transitionState(SuppressReviveManager.java:134)
	- locked <0x00000000e06e18d8> (a java.lang.Object)
	at com.mesosphere.sdk.scheduler.SuppressReviveManager.suppressOrRevive(SuppressReviveManager.java:182)
	at com.mesosphere.sdk.scheduler.SuppressReviveManager.access$000(SuppressReviveManager.java:25)
	at com.mesosphere.sdk.scheduler.SuppressReviveManager$1.run(SuppressReviveManager.java:74)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:748)

Found 1 deadlock.
```