### PR TITLE
[KAF-350] Ensure Graceful Shutdown is tested on 1.9+

### DIFF
--- a/frameworks/helloworld/tests/test_recovery.py
+++ b/frameworks/helloworld/tests/test_recovery.py
@@ -81,8 +81,9 @@ def test_pod_restart():
 
 
 @pytest.mark.recovery
+@sdk_utils.dcos_1_10_or_higher
 def test_pods_restart_graceful_shutdown():
-    world_ids = tasks.get_task_ids(PACKAGE_NAME, 'world-0')
+    world_ids = sdk_tasks.get_task_ids(PACKAGE_NAME, 'world-0')
 
     stdout = cmd.run_cli('hello-world pods restart world-0')
     jsonobj = json.loads(stdout)
@@ -91,7 +92,7 @@ def test_pods_restart_graceful_shutdown():
     assert len(jsonobj['tasks']) == 1
     assert jsonobj['tasks'][0] == 'world-0-server'
 
-    tasks.check_tasks_updated(PACKAGE_NAME, 'world', world_ids)
+    sdk_tasks.check_tasks_updated(PACKAGE_NAME, 'world', world_ids)
     check_running()
 
     # ensure the SIGTERM was sent via the "all clean" message in the world

--- a/frameworks/helloworld/tests/test_recovery.py
+++ b/frameworks/helloworld/tests/test_recovery.py
@@ -81,7 +81,7 @@ def test_pod_restart():
 
 
 @pytest.mark.recovery
-@sdk_utils.dcos_1_10_or_higher
+@sdk_utils.dcos_1_9_or_higher
 def test_pods_restart_graceful_shutdown():
     world_ids = sdk_tasks.get_task_ids(PACKAGE_NAME, 'world-0')
 

--- a/frameworks/kafka/tests/test_availability.py
+++ b/frameworks/kafka/tests/test_availability.py
@@ -43,7 +43,7 @@ def teardown_module(module):
 
 @pytest.mark.availability
 @pytest.mark.soak_availability
-@sdk_utils.dcos_1_10_or_higher
+@sdk_utils.dcos_1_9_or_higher
 def test_service_startup_rapid():
     max_restart_seconds = EXPECTED_KAFKA_STARTUP_SECONDS
     startup_padding_seconds = EXPECTED_DCOS_STARTUP_SECONDS

--- a/frameworks/kafka/tests/test_availability.py
+++ b/frameworks/kafka/tests/test_availability.py
@@ -43,6 +43,7 @@ def teardown_module(module):
 
 @pytest.mark.availability
 @pytest.mark.soak_availability
+@sdk_utils.dcos_1_10_or_higher
 def test_service_startup_rapid():
     max_restart_seconds = EXPECTED_KAFKA_STARTUP_SECONDS
     startup_padding_seconds = EXPECTED_DCOS_STARTUP_SECONDS


### PR DESCRIPTION
* Ensure graceful shutdown tests are marked to run only on dc/os 1.10+.
* Fix merge conflict on sdk_tasks -> tasks -> sdk_tasks (import change).

For reconciliation sake, see https://github.com/mesosphere/dcos-commons/pull/1331 for the list of tests introduced for the feature.