### PR TITLE
py.test install() skip marathon deployment wait.

### DIFF
--- a/testing/sdk_install.py
+++ b/testing/sdk_install.py
@@ -34,7 +34,8 @@ def retried_shakedown_install(
         options_json=merged_options,
         wait_for_completion=True,
         timeout_sec=timeout_seconds,
-        expected_running_tasks=expected_running_tasks)
+        expected_running_tasks=expected_running_tasks,
+        wait_for_marathon_deployment=False)
 
 
 def install(


### PR DESCRIPTION
Depends upon a change to shakedown; skip the marathon deployment
wait since it can fail in a way that is nearly identical to what we want to
retry.