### PR TITLE
[INFINITY-2264, INFINITY-2270] Suppress transition from REVIVED to WAITING_FOR_OFFER

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/TaskUtils.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/TaskUtils.java
@@ -93,7 +93,6 @@ public class TaskUtils {
     /**
      * Returns all the {@link TaskSpec} that have TLS configuration.
      *
-     * @param serviceSpec A ServiceSpec defining service.
      * @return A list of the task specs.
      */
     public static List<TaskSpec> getTasksWithTLS(PodInstanceRequirement podInstanceRequirement) {

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/AbstractScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/AbstractScheduler.java
@@ -7,6 +7,8 @@ import com.google.protobuf.TextFormat;
 import com.mesosphere.sdk.offer.OfferUtils;
 import com.mesosphere.sdk.reconciliation.DefaultReconciler;
 import com.mesosphere.sdk.scheduler.plan.PlanManager;
+import com.mesosphere.sdk.specification.ServiceSpec;
+import com.mesosphere.sdk.state.ConfigStore;
 import com.mesosphere.sdk.state.StateStore;
 import org.apache.mesos.Protos;
 import org.apache.mesos.Scheduler;
@@ -30,6 +32,7 @@ public abstract class AbstractScheduler implements Scheduler {
     private SuppressReviveManager suppressReviveManager;
 
     protected final StateStore stateStore;
+    protected final ConfigStore<ServiceSpec> configStore;
     // Mesos may call registered() multiple times in the lifespan of a Scheduler process, specifically when there's
     // master re-election. Avoid performing initialization multiple times, which would cause resourcesQueue to be stuck.
     private final AtomicBoolean isAlreadyRegistered = new AtomicBoolean(false);
@@ -54,8 +57,9 @@ public abstract class AbstractScheduler implements Scheduler {
     /**
      * Creates a new AbstractScheduler given a {@link StateStore}.
      */
-    protected AbstractScheduler(StateStore stateStore) {
+    protected AbstractScheduler(StateStore stateStore, ConfigStore<ServiceSpec> configStore) {
         this.stateStore = stateStore;
+        this.configStore = configStore;
         processOffers();
     }
 
@@ -215,7 +219,7 @@ public abstract class AbstractScheduler implements Scheduler {
         reconciler.start();
         reconciler.reconcile(driver);
         if (suppressReviveManager == null) {
-            suppressReviveManager = new SuppressReviveManager(stateStore, driver, eventBus, getPlanManagers());
+            suppressReviveManager = new SuppressReviveManager(stateStore, configStore, driver, eventBus, getPlanManagers());
         }
 
         suppressReviveManager.start();

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/AbstractScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/AbstractScheduler.java
@@ -219,7 +219,12 @@ public abstract class AbstractScheduler implements Scheduler {
         reconciler.start();
         reconciler.reconcile(driver);
         if (suppressReviveManager == null) {
-            suppressReviveManager = new SuppressReviveManager(stateStore, configStore, driver, eventBus, getPlanManagers());
+            suppressReviveManager = new SuppressReviveManager(
+                    stateStore,
+                    configStore,
+                    driver,
+                    eventBus,
+                    getPlanManagers());
         }
 
         suppressReviveManager.start();

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SuppressReviveManager.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SuppressReviveManager.java
@@ -131,7 +131,14 @@ public class SuppressReviveManager {
                     logger.error("Invalid state transition.  End state should never be INITIAL");
                     return;
                 case WAITING_FOR_OFFER:
-                    revive();
+                    switch (current) {
+                        case REVIVED:
+                            logger.debug("Already revived, no need to revive again and wait for offers.");
+                            target = State.REVIVED;
+                            break;
+                        default:
+                            revive();
+                    }
                     break;
                 case REVIVED:
                     switch (current) {

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SuppressReviveManager.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SuppressReviveManager.java
@@ -58,7 +58,14 @@ public class SuppressReviveManager {
             SchedulerDriver driver,
             EventBus eventBus,
             Collection<PlanManager> planManagers) {
-        this(stateStore, configStore, driver, eventBus, planManagers, SUPPRESSS_REVIVE_DELAY_S, SUPPRESSS_REVIVE_INTERVAL_S);
+        this(
+                stateStore,
+                configStore,
+                driver,
+                eventBus,
+                planManagers,
+                SUPPRESSS_REVIVE_DELAY_S,
+                SUPPRESSS_REVIVE_INTERVAL_S);
     }
 
     public SuppressReviveManager(
@@ -226,7 +233,7 @@ public class SuppressReviveManager {
         }
     }
 
-    private boolean hasTasksNeedingRecovery() {
+    protected boolean hasTasksNeedingRecovery() {
         Collection<Plan> plans = planManagers.stream()
                 .map(planManager -> planManager.getPlan())
                 .collect(Collectors.toList());

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/recovery/DefaultRecoveryPlanManager.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/recovery/DefaultRecoveryPlanManager.java
@@ -179,10 +179,10 @@ public class DefaultRecoveryPlanManager implements PlanManager {
     private List<PodInstanceRequirement> getRecoveryRequirements(Collection<PodInstanceRequirement> dirtyAssets)
             throws TaskException {
 
-        Collection<Protos.TaskInfo> failedTasks = StateStoreUtils.fetchTasksNeedingRecovery(stateStore, configStore);
-        failedTasks = failedTasks.stream()
-                .filter(taskInfo -> recoverableTaskNames.contains(taskInfo.getName()))
-                .collect(Collectors.toList());
+        Collection<Protos.TaskInfo> failedTasks = StateStoreUtils.fetchTasksNeedingRecovery(
+                stateStore,
+                configStore,
+                recoverableTaskNames);
         logger.info("Found tasks needing recovery: {}", getTaskNames(failedTasks));
 
         List<PodInstanceRequirement> failedPods = TaskUtils.getPodRequirements(

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/uninstall/UninstallScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/uninstall/UninstallScheduler.java
@@ -59,7 +59,7 @@ public class UninstallScheduler extends AbstractScheduler {
             ConfigStore<ServiceSpec> configStore,
             SchedulerFlags schedulerFlags,
             Optional<SecretsClient> secretsClient) {
-        super(stateStore);
+        super(stateStore, configStore);
         this.port = port;
         this.configStore = configStore;
         this.schedulerFlags = schedulerFlags;

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/state/StateStoreUtils.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/state/StateStoreUtils.java
@@ -17,12 +17,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Collectors;
 
 /**
@@ -52,14 +47,29 @@ public class StateStoreUtils {
     }
 
     /**
+     * Fetches and returns all {@link TaskInfo}s for tasks needing recovery and in the list of
+     * launchable Tasks.
+     *
+     * @return Terminated TaskInfos
+     */
+    public static Collection<TaskInfo> fetchTasksNeedingRecovery(
+            StateStore stateStore,
+            ConfigStore<ServiceSpec> configStore,
+            Set<String> launchableTaskNames) throws TaskException {
+
+        return StateStoreUtils.fetchTasksNeedingRecovery(stateStore, configStore).stream()
+                .filter(taskInfo -> launchableTaskNames.contains(taskInfo.getName()))
+                .collect(Collectors.toList());
+    }
+
+    /**
      * Fetches and returns all {@link TaskInfo}s for tasks needing recovery.
      *
      * @return Terminated TaskInfos
      */
     public static Collection<TaskInfo> fetchTasksNeedingRecovery(
             StateStore stateStore,
-            ConfigStore<ServiceSpec> configStore)
-            throws StateStoreException, TaskException {
+            ConfigStore<ServiceSpec> configStore) throws TaskException {
 
         Collection<TaskInfo> allInfos = stateStore.fetchTasks();
         Collection<TaskStatus> allStatuses = stateStore.fetchStatuses();

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/SuppressReviveManagerTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/SuppressReviveManagerTest.java
@@ -5,6 +5,8 @@ import com.mesosphere.sdk.scheduler.plan.Phase;
 import com.mesosphere.sdk.scheduler.plan.Plan;
 import com.mesosphere.sdk.scheduler.plan.PlanManager;
 import com.mesosphere.sdk.scheduler.plan.Status;
+import com.mesosphere.sdk.specification.ServiceSpec;
+import com.mesosphere.sdk.state.ConfigStore;
 import com.mesosphere.sdk.state.StateStore;
 import com.mesosphere.sdk.state.StateStoreUtils;
 import com.mesosphere.sdk.storage.MemPersister;
@@ -45,6 +47,8 @@ public class SuppressReviveManagerTest {
     @Mock private Phase completePhase;
     @Mock private Phase inProgressPhase;
 
+    @Mock private ConfigStore<ServiceSpec> configStore;
+
     @Before
     public void beforeEach() {
         stateStore = new StateStore(new MemPersister());
@@ -67,6 +71,7 @@ public class SuppressReviveManagerTest {
         when(planManager.getPlan()).thenReturn(completePlan);
         suppressReviveManager = new SuppressReviveManager(
                 stateStore,
+                configStore,
                 driver,
                 eventBus,
                 Arrays.asList(planManager));
@@ -79,6 +84,7 @@ public class SuppressReviveManagerTest {
         when(planManager.getPlan()).thenReturn(inprogressPlan);
         suppressReviveManager = new SuppressReviveManager(
                 stateStore,
+                configStore,
                 driver,
                 eventBus,
                 Arrays.asList(planManager));
@@ -134,6 +140,7 @@ public class SuppressReviveManagerTest {
     private SuppressReviveManager getSuppressReviveManager(PlanManager planManager) {
         return new SuppressReviveManager(
                 stateStore,
+                configStore,
                 driver,
                 eventBus,
                 Arrays.asList(planManager),

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/SuppressReviveManagerTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/SuppressReviveManagerTest.java
@@ -29,6 +29,10 @@ import static org.mockito.Mockito.when;
  */
 public class SuppressReviveManagerTest {
     private StateStore stateStore;
+
+    // This EventBus publishes events synchronously.  Changing this property would invalidate assertions in tests below.
+    // For example, asserting that a state transition does not occur after an event is safe now, that assertion would
+    // prove nothing if we put an asynchronous EventBus here.
     private EventBus eventBus = new EventBus();
     private SuppressReviveManager suppressReviveManager;
 
@@ -107,6 +111,13 @@ public class SuppressReviveManagerTest {
         waitStateStore(stateStore, false);
         sendOffer();
         waitRevived(stateStore, suppressReviveManager);
+    }
+
+    @Test
+    public void avoidRevivingFromRevivedState() {
+        reviveOnPlanInProgress();
+        sendFailedTaskStatus();
+        Assert.assertEquals(SuppressReviveManager.State.REVIVED, suppressReviveManager.getState());
     }
 
     private SuppressReviveManager getSuppressedManager() {


### PR DESCRIPTION
While testing we ran into this situation:

```
INFO  2017-08-22 01:44:32,946 [Thread-108] com.mesosphere.sdk.state.StateStore:storeStatus(198): Storing status 'TASK_KILLED' ...
...
INFO  2017-08-22 01:44:33,002 [pool-8-thread-1] com.mesosphere.sdk.scheduler.recovery.DefaultRecoveryPlanManager:getRecoveryRequirements(212): New pods needing recovery: []
...
INFO  2017-08-22 01:44:33,004 [pool-12-thread-1] com.mesosphere.sdk.scheduler.SuppressReviveManager:setOfferMode(210): Suppressing offers.
...
INFO  2017-08-22 01:44:37,241 [Thread-110] com.mesosphere.mesos.HTTPAdapter.MesosToSchedulerDriverAdapter:received(181): Received event of type: HEARTBEAT
INFO  2017-08-22 01:44:52,243 [Thread-111] com.mesosphere.mesos.HTTPAdapter.MesosToSchedulerDriverAdapter:received(181): Received event of type: HEARTBEAT
```

Because suppress/revive is now polling there's a possible race between notification of failure and detection of need to revive.  In short it needs to detect failures in the same way the RecoveryManager does to ensure reviving.  We should change plan updates to be less dependent on the Offer cycle, but that's out of scope at this late date.