### PR TITLE
Use -t and -i to make the docker attach behave as a normal shell script.

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -160,5 +160,7 @@ docker run --rm \
     -v $(pwd):/build \
     -v $ssh_path:/ssh/key \
     -w /build \
+    -t \
+    -i \
     mesosphere/dcos-commons:latest \
     bash test-runner.sh


### PR DESCRIPTION
With this change, ctrl + c will exit test.sh and kill the container.

ctrl + q + p to simply detach.