### PR TITLE
INFINITY-2292 Better resource strings

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultResourceSpec.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultResourceSpec.java
@@ -96,7 +96,7 @@ public class DefaultResourceSpec implements ResourceSpec {
     @Override
     public String toString() {
         return String.format(
-                "name: %s, value: %s, role: %s, preReservedRole: %s, principal: %s",
+                "name: %s, value: %s, role: %s, pre-reserved-role: %s, principal: %s",
                 getName(),
                 TextFormat.shortDebugString(getValue()),
                 getRole(),

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultVolumeSpec.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultVolumeSpec.java
@@ -2,7 +2,6 @@ package com.mesosphere.sdk.specification;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.protobuf.TextFormat;
 import com.mesosphere.sdk.offer.Constants;
 import com.mesosphere.sdk.specification.validation.ValidationUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
@@ -93,12 +92,9 @@ public class DefaultVolumeSpec extends DefaultResourceSpec implements VolumeSpec
 
     @Override
     public String toString() {
-        return String.format(
-                "name: '%s', value: '%s', type: '%s', role: '%s', principal: '%s'",
-                getName(),
-                TextFormat.shortDebugString(getValue()),
+        return String.format("%s, type: '%s', container-path: '%s'",
+                super.toString(),
                 getType(),
-                getRole(),
-                getPrincipal());
+                getContainerPath());
     }
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/NamedVIPSpec.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/NamedVIPSpec.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.mesosphere.sdk.specification.validation.ValidationUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import org.apache.mesos.Protos;
 import org.apache.mesos.Protos.DiscoveryInfo;
 
@@ -65,7 +64,11 @@ public class NamedVIPSpec extends PortSpec {
 
     @Override
     public String toString() {
-        return ReflectionToStringBuilder.toString(this);
+        return String.format("%s, vip-name: %s, vip-port: %s, protocol: %s",
+                super.toString(),
+                getVipName(),
+                getVipPort(),
+                getProtocol());
     }
 
     @Override

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/PortSpec.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/PortSpec.java
@@ -3,7 +3,6 @@ package com.mesosphere.sdk.specification;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.protobuf.TextFormat;
 import com.mesosphere.sdk.offer.Constants;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
@@ -92,17 +91,12 @@ public class PortSpec extends DefaultResourceSpec {
 
     @Override
     public String toString() {
-        return String.format(
-                "name: %s, portName: %s, networkNames: %s, value: %s," +
-                        " role: %s, preReservedRole: %s, principal: %s, envKey: %s",
-                getName(),
+        return String.format("%s, port-name: %s, network-names: %s, env-key: %s, visibility: %s",
+                super.toString(),
                 getPortName(),
                 getNetworkNames(),
-                TextFormat.shortDebugString(getValue()),
-                getRole(),
-                getPreReservedRole(),
-                getPrincipal(),
-                getEnvKey());
+                getEnvKey(),
+                getVisibility());
     }
 
     @Override


### PR DESCRIPTION
These strings may be used in e.g. config validation errors. Clean them up:
- Subtypes can just prepend the parent type's info
- Ensure subtypes have all fields filled in, and follow json naming while we're at it