### PR TITLE
INFINITY-2304 cassandra tests: retry on failure

### DIFF
--- a/frameworks/cassandra/tests/config.py
+++ b/frameworks/cassandra/tests/config.py
@@ -16,9 +16,9 @@ DEFAULT_NODE_ADDRESS = os.getenv('CASSANDRA_NODE_ADDRESS', sdk_hosts.autoip_host
 DEFAULT_NODE_PORT = os.getenv('CASSANDRA_NODE_PORT', '9042')
 
 
-def _get_test_job(name, cmd, restart_policy='NEVER'):
+def _get_test_job(name, cmd, restart_policy='ON_FAILURE'):
     return {
-        'description': 'Integration test job: ' + name,
+        'description': '{} with restart policy {}'.format(name, restart_policy),
         'id': 'test.cassandra.' + name,
         'run': {
             'cmd': cmd,


### PR DESCRIPTION
Fix flakes such as:

```
I0824 23:10:39.743618 13789 executor.cpp:160] Starting task test_cassandra_delete-data_20170824231038Ct4vr.71daf3e1-8921-11e7-8c06-8a15a895e7e2
<stdin>:1:OperationTimedOut: errors={'10.0.0.175': 'Request timed out while waiting for schema agreement. See Session.execute[_async](timeout) and Cluster.max_schema_agreement_wait.'}, last_host=10.0.0.175
```

and:

```
I0824 23:21:45.697402  6594 executor.cpp:160] Starting task test_cassandra_verify-deletion_20170824232123MtB9C.f1f221b5-8922-11e7-8c06-8a15a895e7e2
Connection error: ('Unable to connect to any servers', {'9.0.6.2': error(None, "Tried connecting to [('9.0.6.2', 9042)]. Last error: timed out")})
W0824 23:21:45.697402  6591 logging.cpp:91] RAW: Received signal SIGTERM from process 6305 of user 0; exiting
```