### PR TITLE
Fix C* backup_restore_test failure

### DIFF
--- a/frameworks/cassandra/tests/test_backup_and_restore.py
+++ b/frameworks/cassandra/tests/test_backup_and_restore.py
@@ -10,28 +10,32 @@ from tests import config
 
 
 no_strict_for_azure = pytest.mark.skipif(os.environ.get("SECURITY") == "strict",
-        reason="backup/restore doesn't work in strict as user needs to be root")
+                                         reason="backup/restore doesn't work in strict as user needs to be root")
+
 
 @pytest.fixture(scope='module', autouse=True)
 def configure_package(configure_security):
     test_jobs = []
     try:
-        test_jobs = config.get_all_jobs(node_address=config.get_foldered_node_address())
-        sdk_install.uninstall(config.get_foldered_service_name(), package_name=config.PACKAGE_NAME)
+        test_jobs = config.get_all_jobs(
+            node_address=config.get_foldered_node_address())
+        sdk_install.uninstall(
+            config.get_foldered_service_name(), package_name=config.PACKAGE_NAME)
         # user=root because Azure CLI needs to run in root...
         sdk_install.install(
             config.PACKAGE_NAME,
             config.DEFAULT_TASK_COUNT,
             service_name=config.get_foldered_service_name(),
-            additional_options={"service": { "name": config.get_foldered_service_name(), "user": "root" } })
+            additional_options={"service": {"name": config.get_foldered_service_name(), "user": "root"}})
 
         tmp_dir = tempfile.mkdtemp(prefix='cassandra-test')
         for job in test_jobs:
             sdk_jobs.install_job(job, tmp_dir=tmp_dir)
 
-        yield # let the test session execute
+        yield  # let the test session execute
     finally:
-        sdk_install.uninstall(config.get_foldered_service_name(), package_name=config.PACKAGE_NAME)
+        sdk_install.uninstall(
+            config.get_foldered_service_name(), package_name=config.PACKAGE_NAME)
 
         # remove job definitions from metronome
         for job in test_jobs:
@@ -39,6 +43,7 @@ def configure_package(configure_security):
 
 # To disable these tests in local runs where you may lack the necessary credentials,
 # use e.g. "TEST_TYPES=sanity and not aws and not azure":
+
 
 @pytest.mark.azure
 @no_strict_for_azure
@@ -58,7 +63,7 @@ def test_backup_and_restore_to_azure():
         'CASSANDRA_KEYSPACES': '"testspace1 testspace2"',
     }
 
-    run_backup_and_restore(
+    config.run_backup_and_restore(
         config.get_foldered_service_name(),
         'backup-azure',
         'restore-azure',


### PR DESCRIPTION
Most of the changes are cosmetic due to pep8 auto styling.

Fixes failure: https://teamcity.mesosphere.io/viewLog.html?buildId=759181&tab=buildResultsDiv&buildTypeId=DcosIo_DcosCommons_Cassandra_CompleteIntegrationTest