### PR TITLE
INFINITY-1975 Tweaks to Cassandra endpoints: rename node=>native-client, remove VIP, show thrift-client when enabled

### DIFF
--- a/frameworks/cassandra/src/main/dist/svc.yml
+++ b/frameworks/cassandra/src/main/dist/svc.yml
@@ -32,11 +32,14 @@ pods:
             port: {{TASKCFG_ALL_CASSANDRA_STORAGE_PORT}}
           ssl:
             port: {{TASKCFG_ALL_CASSANDRA_SSL_STORAGE_PORT}}
-          node:
+          native-client:
             port: {{TASKCFG_ALL_CASSANDRA_NATIVE_TRANSPORT_PORT}}
             advertise: true
-          rpc:
+          {{#TASKCFG_ALL_CASSANDRA_START_RPC}}
+          thrift-client:
             port: {{TASKCFG_ALL_CASSANDRA_RPC_PORT}}
+            advertise: true
+          {{/TASKCFG_ALL_CASSANDRA_START_RPC}}
       sidecar-resources:
         cpus: 1
         memory: 1024

--- a/frameworks/cassandra/src/main/dist/svc.yml
+++ b/frameworks/cassandra/src/main/dist/svc.yml
@@ -35,9 +35,6 @@ pods:
           node:
             port: {{TASKCFG_ALL_CASSANDRA_NATIVE_TRANSPORT_PORT}}
             advertise: true
-            vip:
-              prefix: node
-              port: 9042
           rpc:
             port: {{TASKCFG_ALL_CASSANDRA_RPC_PORT}}
       sidecar-resources:

--- a/frameworks/cassandra/tests/test_overlay.py
+++ b/frameworks/cassandra/tests/test_overlay.py
@@ -77,8 +77,8 @@ def test_functionality():
 @pytest.mark.overlay
 @sdk_utils.dcos_1_9_or_higher
 def test_endpoints():
-    endpoints = sdk_networks.get_and_test_endpoints("", config.PACKAGE_NAME, 1)  # tests that the correct number of endpoints are found, should just be "node"
-    assert "node" in endpoints, "Cassandra endpoints should contain only 'node', got {}".format(endpoints)
-    endpoints = sdk_networks.get_and_test_endpoints("node", config.PACKAGE_NAME, 3)
+    endpoints = sdk_networks.get_and_test_endpoints("", config.PACKAGE_NAME, 1)  # tests that the correct number of endpoints are found, should just be "native-client"
+    assert "native-client" in endpoints, "Cassandra endpoints should contain only 'native-client', got {}".format(endpoints)
+    endpoints = sdk_networks.get_and_test_endpoints("native-client", config.PACKAGE_NAME, 3)
     assert "address" in endpoints, "Endpoints missing address key"
     sdk_networks.check_endpoints_on_overlay(endpoints)

--- a/frameworks/cassandra/tests/test_overlay.py
+++ b/frameworks/cassandra/tests/test_overlay.py
@@ -79,6 +79,6 @@ def test_functionality():
 def test_endpoints():
     endpoints = sdk_networks.get_and_test_endpoints("", config.PACKAGE_NAME, 1)  # tests that the correct number of endpoints are found, should just be "native-client"
     assert "native-client" in endpoints, "Cassandra endpoints should contain only 'native-client', got {}".format(endpoints)
-    endpoints = sdk_networks.get_and_test_endpoints("native-client", config.PACKAGE_NAME, 3)
+    endpoints = sdk_networks.get_and_test_endpoints("native-client", config.PACKAGE_NAME, 2)
     assert "address" in endpoints, "Endpoints missing address key"
     sdk_networks.check_endpoints_on_overlay(endpoints)

--- a/frameworks/cassandra/tests/test_sanity.py
+++ b/frameworks/cassandra/tests/test_sanity.py
@@ -48,9 +48,9 @@ def test_service_health():
 @pytest.mark.sanity
 def test_endpoints():
     # check that we can reach the scheduler via admin router, and that returned endpoints are sanitized:
-    endpoints = json.loads(cmd.run_cli('cassandra --name={} endpoints node'.format(config.get_foldered_service_name())))
+    endpoints = json.loads(cmd.run_cli('cassandra --name={} endpoints native-client'.format(config.get_foldered_service_name())))
     assert endpoints['dns'][0] == sdk_hosts.autoip_host(config.get_foldered_service_name(), 'node-0-server', 9042)
-    assert endpoints['vip'] == sdk_hosts.vip_host(config.get_foldered_service_name(), 'node', 9042)
+    assert not 'vip' in endpoints
 
 
 @pytest.mark.sanity

--- a/frameworks/cassandra/universe/config.json
+++ b/frameworks/cassandra/universe/config.json
@@ -284,7 +284,7 @@
         },
         "start_rpc": {
           "type": "boolean",
-          "description": "If true Thrift RPC is enable. This is deprecated by may be necessary for legacy applications.",
+          "description": "If true Thrift RPC is enabled. This is deprecated but may be necessary for legacy applications.",
           "default": false
         },
         "rpc_port": {


### PR DESCRIPTION
- The cassandra VIP was previously only enabled because VIP presence == shown in `endpoints`. Now that the two are decoupled, the cassandra VIP should be removed.
- Renames the 'node' endpoint 'native-client'
- Enables display of a 'thrift-client' endpoint when thrift is enabled
- Refrains from reserving the thrift port when thrift isn't enabled