### PR TITLE
[INFINITY-2317] Pass version in check of minimum dcos version

### DIFF
--- a/testing/sdk_utils.py
+++ b/testing/sdk_utils.py
@@ -40,7 +40,7 @@ def get_zk_path(service_name):
 
 @functools.lru_cache()
 def dcos_version_less_than(version):
-    return shakedown.dcos_version_less_than("1.10")
+    return shakedown.dcos_version_less_than(version)
 
 
 # WARNING: Any file that uses these must also "import shakedown" in the same file.


### PR DESCRIPTION
The `version` parameter should be passed to the `dcos_version_less_than()` function.

This would most likely affect the disabling of tests for 1.8.