### PR TITLE
[INFINITY-2301] Verify service-specific metrics are being reported

### DIFF
--- a/frameworks/cassandra/tests/config.py
+++ b/frameworks/cassandra/tests/config.py
@@ -15,8 +15,15 @@ SERVICE_NAME = 'cassandra'
 DEFAULT_TASK_COUNT = 3
 DEFAULT_CASSANDRA_TIMEOUT = 600
 
-DEFAULT_NODE_ADDRESS = os.getenv('CASSANDRA_NODE_ADDRESS', sdk_hosts.autoip_host(SERVICE_NAME, 'node-0-server'))
+DEFAULT_NODE_ADDRESS = os.getenv(
+    'CASSANDRA_NODE_ADDRESS', sdk_hosts.autoip_host(SERVICE_NAME, 'node-0-server'))
 DEFAULT_NODE_PORT = os.getenv('CASSANDRA_NODE_PORT', '9042')
+
+EXPECTED_METRICS = [
+    "org.apache.cassandra.metrics.Table.CoordinatorReadLatency.system.hints.p999",
+    "org.apache.cassandra.metrics.Table.CompressionRatio.system_schema.indexes",
+    "org.apache.cassandra.metrics.ThreadPools.ActiveTasks.internal.MemtableReclaimMemory"
+]
 
 
 def _get_test_job(name, cmd, restart_policy='ON_FAILURE'):
@@ -25,11 +32,11 @@ def _get_test_job(name, cmd, restart_policy='ON_FAILURE'):
         'id': 'test.cassandra.' + name,
         'run': {
             'cmd': cmd,
-            'docker': { 'image': 'cassandra:3.0.13' },
+            'docker': {'image': 'cassandra:3.0.13'},
             'cpus': 1,
             'mem': 512,
             'user': 'nobody',
-            'restart': { 'policy': restart_policy }
+            'restart': {'policy': restart_policy}
         }
     }
 
@@ -104,7 +111,8 @@ def run_backup_and_restore(
     write_data_job = get_write_data_job(node_address=job_node_address)
     verify_data_job = get_verify_data_job(node_address=job_node_address)
     delete_data_job = get_delete_data_job(node_address=job_node_address)
-    verify_deletion_job = get_verify_deletion_job(node_address=job_node_address)
+    verify_deletion_job = get_verify_deletion_job(
+        node_address=job_node_address)
 
     # Write data to Cassandra with a metronome job, then verify it was written
     # Note: Write job will fail if data already exists

--- a/frameworks/cassandra/tests/config.py
+++ b/frameworks/cassandra/tests/config.py
@@ -15,15 +15,8 @@ SERVICE_NAME = 'cassandra'
 DEFAULT_TASK_COUNT = 3
 DEFAULT_CASSANDRA_TIMEOUT = 600
 
-DEFAULT_NODE_ADDRESS = os.getenv(
-    'CASSANDRA_NODE_ADDRESS', sdk_hosts.autoip_host(SERVICE_NAME, 'node-0-server'))
+DEFAULT_NODE_ADDRESS = os.getenv('CASSANDRA_NODE_ADDRESS', sdk_hosts.autoip_host(SERVICE_NAME, 'node-0-server'))
 DEFAULT_NODE_PORT = os.getenv('CASSANDRA_NODE_PORT', '9042')
-
-EXPECTED_METRICS = [
-    "org.apache.cassandra.metrics.Table.CoordinatorReadLatency.system.hints.p999",
-    "org.apache.cassandra.metrics.Table.CompressionRatio.system_schema.indexes",
-    "org.apache.cassandra.metrics.ThreadPools.ActiveTasks.internal.MemtableReclaimMemory"
-]
 
 
 def _get_test_job(name, cmd, restart_policy='ON_FAILURE'):
@@ -111,8 +104,7 @@ def run_backup_and_restore(
     write_data_job = get_write_data_job(node_address=job_node_address)
     verify_data_job = get_verify_data_job(node_address=job_node_address)
     delete_data_job = get_delete_data_job(node_address=job_node_address)
-    verify_deletion_job = get_verify_deletion_job(
-        node_address=job_node_address)
+    verify_deletion_job = get_verify_deletion_job(node_address=job_node_address)
 
     # Write data to Cassandra with a metronome job, then verify it was written
     # Note: Write job will fail if data already exists

--- a/frameworks/cassandra/tests/test_sanity.py
+++ b/frameworks/cassandra/tests/test_sanity.py
@@ -93,9 +93,10 @@ def test_repair_cleanup_plans_complete():
 @pytest.mark.metrics
 @sdk_utils.dcos_1_9_or_higher
 def test_metrics():
-    sdk_metrics.wait_for_any_metrics(
+    sdk_metrics.wait_for_service_metrics(
         config.PACKAGE_NAME,
         config.get_foldered_service_name(),
         "node-0-server",
-        config.DEFAULT_CASSANDRA_TIMEOUT
+        config.DEFAULT_CASSANDRA_TIMEOUT,
+        config.EXPECTED_METRICS
     )

--- a/frameworks/cassandra/tests/test_sanity.py
+++ b/frameworks/cassandra/tests/test_sanity.py
@@ -103,7 +103,7 @@ def test_metrics():
     ]
 
     def expected_metrics_exist(emitted_metrics):
-        return sdk_metrics.check_metrics_presence(metric_names, expected_metrics)
+        return sdk_metrics.check_metrics_presence(emitted_metrics, expected_metrics)
 
     sdk_metrics.wait_for_service_metrics(
         config.PACKAGE_NAME,

--- a/frameworks/cassandra/tests/test_sanity.py
+++ b/frameworks/cassandra/tests/test_sanity.py
@@ -17,12 +17,14 @@ from tests import config
 def configure_package(configure_security):
     test_jobs = []
     try:
-        test_jobs = config.get_all_jobs(node_address=config.get_foldered_node_address())
+        test_jobs = config.get_all_jobs(
+            node_address=config.get_foldered_node_address())
         # destroy any leftover jobs first, so that they don't touch the newly installed service:
         for job in test_jobs:
             sdk_jobs.remove_job(job)
 
-        sdk_install.uninstall(config.PACKAGE_NAME, config.get_foldered_service_name())
+        sdk_install.uninstall(config.PACKAGE_NAME,
+                              config.get_foldered_service_name())
         sdk_upgrade.test_upgrade(
             config.PACKAGE_NAME,
             config.get_foldered_service_name(),
@@ -35,7 +37,8 @@ def configure_package(configure_security):
 
         yield  # let the test session execute
     finally:
-        sdk_install.uninstall(config.PACKAGE_NAME, config.get_foldered_service_name())
+        sdk_install.uninstall(config.PACKAGE_NAME,
+                              config.get_foldered_service_name())
 
         for job in test_jobs:
             sdk_jobs.remove_job(job)
@@ -93,10 +96,15 @@ def test_repair_cleanup_plans_complete():
 @pytest.mark.metrics
 @sdk_utils.dcos_1_9_or_higher
 def test_metrics():
+    expected_metrics = [
+        "org.apache.cassandra.metrics.Table.CoordinatorReadLatency.system.hints.p999",
+        "org.apache.cassandra.metrics.Table.CompressionRatio.system_schema.indexes",
+        "org.apache.cassandra.metrics.ThreadPools.ActiveTasks.internal.MemtableReclaimMemory"
+    ]
     sdk_metrics.wait_for_service_metrics(
         config.PACKAGE_NAME,
         config.get_foldered_service_name(),
         "node-0-server",
         config.DEFAULT_CASSANDRA_TIMEOUT,
-        config.EXPECTED_METRICS
+        expected_metrics
     )

--- a/frameworks/cassandra/tests/test_sanity.py
+++ b/frameworks/cassandra/tests/test_sanity.py
@@ -101,10 +101,14 @@ def test_metrics():
         "org.apache.cassandra.metrics.Table.CompressionRatio.system_schema.indexes",
         "org.apache.cassandra.metrics.ThreadPools.ActiveTasks.internal.MemtableReclaimMemory"
     ]
+
+    def expected_metrics_exist(emitted_metrics):
+        return sdk_metrics.check_metrics_presence(metric_names, expected_metrics)
+
     sdk_metrics.wait_for_service_metrics(
         config.PACKAGE_NAME,
         config.get_foldered_service_name(),
         "node-0-server",
         config.DEFAULT_CASSANDRA_TIMEOUT,
-        expected_metrics
+        expected_metrics_exist
     )

--- a/frameworks/elastic/tests/config.py
+++ b/frameworks/elastic/tests/config.py
@@ -27,9 +27,9 @@ DEFAULT_INDEX_NAME = 'customer'
 DEFAULT_INDEX_TYPE = 'entry'
 
 EXPECTED_METRICS = [
-    "elasticsearch.service_name.node.data-0-node.fs.total.total_in_bytes",
-    "elasticsearch.service_name.node.data-0-node.jvm.mem.pools.old.peak_used_in_bytes",
-    "elasticsearch.service_name.node.data-0-node.jvm.threads.count"
+    "node.data-0-node.fs.total.total_in_bytes",
+    "node.data-0-node.jvm.mem.pools.old.peak_used_in_bytes",
+    "node.data-0-node.jvm.threads.count"
 ]
 
 ENDPOINT_TYPES = (

--- a/frameworks/elastic/tests/config.py
+++ b/frameworks/elastic/tests/config.py
@@ -26,12 +26,6 @@ DEFAULT_KIBANA_TIMEOUT = 30 * 60
 DEFAULT_INDEX_NAME = 'customer'
 DEFAULT_INDEX_TYPE = 'entry'
 
-EXPECTED_METRICS = [
-    "node.data-0-node.fs.total.total_in_bytes",
-    "node.data-0-node.jvm.mem.pools.old.peak_used_in_bytes",
-    "node.data-0-node.jvm.threads.count"
-]
-
 ENDPOINT_TYPES = (
     'coordinator-http', 'coordinator-transport',
     'data-http', 'data-transport',

--- a/frameworks/elastic/tests/config.py
+++ b/frameworks/elastic/tests/config.py
@@ -67,80 +67,71 @@ def as_json(fn):
 def check_kibana_adminrouter_integration(path):
     dcos_token = shakedown.dcos_acs_token()
     curl_cmd = "curl -I -k -H \"Authorization: token={}\" -s {}/{}".format(
-<< << << < HEAD
         dcos_token, shakedown.dcos_url().rstrip('/'), path.lstrip('/'))
 
-
-== == == =
-        DCOS_TOKEN, shakedown.dcos_url().rstrip('/'), path.lstrip('/'))
-
->> >>>> > 9de226416... Verify service - specific metrics are being reported
     def fun():
-        exit_status, output=shakedown.run_command_on_master(curl_cmd)
+        exit_status, output = shakedown.run_command_on_master(curl_cmd)
         return output and "HTTP/1.1 200" in output
 
-    return shakedown.wait_for(fun, timeout_seconds = DEFAULT_KIBANA_TIMEOUT, noisy = True)
+    return shakedown.wait_for(fun, timeout_seconds=DEFAULT_KIBANA_TIMEOUT, noisy=True)
 
 
-def check_elasticsearch_index_health(index_name, color, service_name = SERVICE_NAME):
-    curl_api=_curl_api(service_name, "GET")
+def check_elasticsearch_index_health(index_name, color, service_name=SERVICE_NAME):
+    curl_api = _curl_api(service_name, "GET")
 
     def fun():
-        result=_get_elasticsearch_index_health(curl_api, index_name)
+        result = _get_elasticsearch_index_health(curl_api, index_name)
         return result and result["status"] == color
 
-    return shakedown.wait_for(fun, timeout_seconds = DEFAULT_ELASTIC_TIMEOUT)
+    return shakedown.wait_for(fun, timeout_seconds=DEFAULT_ELASTIC_TIMEOUT)
 
 
-def wait_for_expected_nodes_to_exist(service_name = SERVICE_NAME, task_count = DEFAULT_TASK_COUNT):
-    curl_api=_curl_api(service_name, "GET")
+def wait_for_expected_nodes_to_exist(service_name=SERVICE_NAME, task_count=DEFAULT_TASK_COUNT):
+    curl_api = _curl_api(service_name, "GET")
 
     def expected_nodes():
-        result=_get_elasticsearch_cluster_health(curl_api)
+        result = _get_elasticsearch_cluster_health(curl_api)
         if result is None:
             return False
-        node_count=result["number_of_nodes"]
-        log.info('Waiting for {} healthy nodes, got {}'.format(
-            task_count, node_count))
+        node_count = result["number_of_nodes"]
+        log.info('Waiting for {} healthy nodes, got {}'.format(task_count, node_count))
         return node_count == task_count
 
-    return shakedown.wait_for(expected_nodes, timeout_seconds = DEFAULT_ELASTIC_TIMEOUT)
+    return shakedown.wait_for(expected_nodes, timeout_seconds=DEFAULT_ELASTIC_TIMEOUT)
 
 
-def check_plugin_installed(plugin_name, service_name = SERVICE_NAME):
-    curl_api=_curl_api(service_name, "GET")
+def check_plugin_installed(plugin_name, service_name=SERVICE_NAME):
+    curl_api = _curl_api(service_name, "GET")
 
     def fun():
-        result=_get_hosts_with_plugin(curl_api, plugin_name)
+        result = _get_hosts_with_plugin(curl_api, plugin_name)
         return result is not None and len(result) == DEFAULT_TASK_COUNT
 
-    return shakedown.wait_for(fun, timeout_seconds = DEFAULT_ELASTIC_TIMEOUT)
+    return shakedown.wait_for(fun, timeout_seconds=DEFAULT_ELASTIC_TIMEOUT)
 
 
-def check_plugin_uninstalled(plugin_name, service_name = SERVICE_NAME):
-    curl_api=_curl_api(service_name, "GET")
+def check_plugin_uninstalled(plugin_name, service_name=SERVICE_NAME):
+    curl_api = _curl_api(service_name, "GET")
 
     def fun():
-        result=_get_hosts_with_plugin(curl_api, plugin_name)
+        result = _get_hosts_with_plugin(curl_api, plugin_name)
         return result is not None and result == []
 
-    return shakedown.wait_for(fun, timeout_seconds = DEFAULT_ELASTIC_TIMEOUT)
+    return shakedown.wait_for(fun, timeout_seconds=DEFAULT_ELASTIC_TIMEOUT)
 
 
 def _get_hosts_with_plugin(curl_api, plugin_name):
-    exit_status, output=shakedown.run_command_on_master(
-        "{}/_cat/plugins'".format(curl_api))
+    exit_status, output = shakedown.run_command_on_master("{}/_cat/plugins'".format(curl_api))
     if exit_status:
         return [host for host in output.split("\n") if plugin_name in host]
     else:
         return None
 
 
-def get_elasticsearch_master(service_name = SERVICE_NAME):
+def get_elasticsearch_master(service_name=SERVICE_NAME):
     # just in case, re-fetch the _curl_api in case the elasticsearch master is moved:
     def get_master():
-        exit_status, output=shakedown.run_command_on_master(
-            "{}/_cat/master'".format(_curl_api(service_name, "GET")))
+        exit_status, output = shakedown.run_command_on_master("{}/_cat/master'".format(_curl_api(service_name, "GET")))
         if exit_status and len(output.split()) > 0:
             return output.split()[-1]
 
@@ -149,8 +140,8 @@ def get_elasticsearch_master(service_name = SERVICE_NAME):
     return shakedown.wait_for(get_master)
 
 
-def verify_commercial_api_status(is_enabled, service_name = SERVICE_NAME):
-    query={
+def verify_commercial_api_status(is_enabled, service_name=SERVICE_NAME):
+    query = {
         "query": {
             "match": {
                 "name": "*"
@@ -200,15 +191,13 @@ def verify_xpack_license(service_name=SERVICE_NAME):
 
 @as_json
 def _get_elasticsearch_index_health(curl_api, index_name):
-    exit_status, output = shakedown.run_command_on_master(
-        "{}/_cluster/health/{}'".format(curl_api, index_name))
+    exit_status, output = shakedown.run_command_on_master("{}/_cluster/health/{}'".format(curl_api, index_name))
     return output
 
 
 @as_json
 def _get_elasticsearch_cluster_health(curl_api):
-    exit_status, output = shakedown.run_command_on_master(
-        "{}/_cluster/health'".format(curl_api))
+    exit_status, output = shakedown.run_command_on_master("{}/_cluster/health'".format(curl_api))
     return output
 
 
@@ -235,8 +224,7 @@ def graph_api(index_name, query, service_name=SERVICE_NAME):
 
 @as_json
 def get_xpack_license(service_name=SERVICE_NAME):
-    exit_status, output = shakedown.run_command_on_master(
-        "{}/_xpack/license'".format(_curl_api(service_name, "GET")))
+    exit_status, output = shakedown.run_command_on_master("{}/_xpack/license'".format(_curl_api(service_name, "GET")))
     return output
 
 
@@ -269,8 +257,7 @@ def _curl_api(service_name, method, role="master"):
 
 
 def _master_zero_http_port(service_name):
-    dns = sdk_cmd.svc_cli(PACKAGE_NAME, service_name,
-                          'endpoints master-http', json=True, print_output=False)['dns']
+    dns = sdk_cmd.svc_cli(PACKAGE_NAME, service_name, 'endpoints master-http', json=True, print_output=False)['dns']
     # 'dns' array will look something like this in CCM: [
     #   "master-0-node.elastic.[...]:1025",
     #   "master-1-node.elastic.[...]:1025",

--- a/frameworks/elastic/tests/config.py
+++ b/frameworks/elastic/tests/config.py
@@ -27,9 +27,9 @@ DEFAULT_INDEX_NAME = 'customer'
 DEFAULT_INDEX_TYPE = 'entry'
 
 EXPECTED_METRICS = [
-    "elasticsearch.elastic.node.data-0-node.fs.total.total_in_bytes",
-    "elasticsearch.elastic.node.data-0-node.jvm.mem.pools.old.peak_used_in_bytes",
-    "elasticsearch.elastic.node.data-0-node.jvm.threads.count"
+    "elasticsearch.service_name.node.data-0-node.fs.total.total_in_bytes",
+    "elasticsearch.service_name.node.data-0-node.jvm.mem.pools.old.peak_used_in_bytes",
+    "elasticsearch.service_name.node.data-0-node.jvm.threads.count"
 ]
 
 ENDPOINT_TYPES = (

--- a/frameworks/elastic/tests/test_sanity.py
+++ b/frameworks/elastic/tests/test_sanity.py
@@ -88,11 +88,12 @@ def test_indexing(default_populated_index):
 @pytest.mark.metrics
 @sdk_utils.dcos_1_9_or_higher
 def test_metrics():
-    sdk_metrics.wait_for_any_metrics(
+    sdk_metrics.wait_for_service_metrics(
         config.PACKAGE_NAME,
         sdk_utils.get_foldered_name(config.SERVICE_NAME),
         "data-0-node",
-        config.DEFAULT_ELASTIC_TIMEOUT
+        config.DEFAULT_ELASTIC_TIMEOUT,
+        config.EXPECTED_METRICS
     )
 
 

--- a/frameworks/elastic/tests/test_sanity.py
+++ b/frameworks/elastic/tests/test_sanity.py
@@ -19,8 +19,7 @@ log = logging.getLogger(__name__)
 def configure_package(configure_security):
     try:
         log.info("Ensure elasticsearch and kibana are uninstalled...")
-        sdk_install.uninstall(config.KIBANA_PACKAGE_NAME,
-                              config.KIBANA_PACKAGE_NAME)
+        sdk_install.uninstall(config.KIBANA_PACKAGE_NAME, config.KIBANA_PACKAGE_NAME)
         sdk_install.uninstall(config.PACKAGE_NAME,
                               sdk_utils.get_foldered_name(config.SERVICE_NAME))
 
@@ -35,18 +34,15 @@ def configure_package(configure_security):
         yield  # let the test session execute
     finally:
         log.info("Clean up elasticsearch and kibana...")
-        sdk_install.uninstall(config.KIBANA_PACKAGE_NAME,
-                              config.KIBANA_PACKAGE_NAME)
+        sdk_install.uninstall(config.KIBANA_PACKAGE_NAME, config.KIBANA_PACKAGE_NAME)
         sdk_install.uninstall(config.PACKAGE_NAME,
                               sdk_utils.get_foldered_name(config.SERVICE_NAME))
 
 
 @pytest.fixture(autouse=True)
 def pre_test_setup():
-    sdk_tasks.check_running(sdk_utils.get_foldered_name(
-        config.SERVICE_NAME), config.DEFAULT_TASK_COUNT)
-    config.wait_for_expected_nodes_to_exist(
-        service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
+    sdk_tasks.check_running(sdk_utils.get_foldered_name(config.SERVICE_NAME), config.DEFAULT_TASK_COUNT)
+    config.wait_for_expected_nodes_to_exist(service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
 
 
 @pytest.fixture
@@ -64,8 +60,7 @@ def default_populated_index():
 @pytest.mark.focus
 @pytest.mark.smoke
 def test_service_health():
-    assert shakedown.service_healthy(
-        sdk_utils.get_foldered_name(config.SERVICE_NAME))
+    assert shakedown.service_healthy(sdk_utils.get_foldered_name(config.SERVICE_NAME))
 
 
 @pytest.mark.sanity
@@ -112,8 +107,7 @@ def test_metrics():
 @pytest.mark.timeout(60 * 60)
 def test_xpack_toggle_with_kibana(default_populated_index):
     log.info("\n***** Verify X-Pack disabled by default in elasticsearch")
-    config.verify_commercial_api_status(
-        False, service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
+    config.verify_commercial_api_status(False, service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
 
     log.info("\n***** Test kibana with X-Pack disabled...")
     shakedown.install_package(config.KIBANA_PACKAGE_NAME, options_json={
@@ -126,16 +120,12 @@ def test_xpack_toggle_with_kibana(default_populated_index):
     config.check_kibana_adminrouter_integration(
         "service/{}/".format(config.KIBANA_PACKAGE_NAME))
     log.info("Uninstall kibana with X-Pack disabled")
-    sdk_install.uninstall(config.KIBANA_PACKAGE_NAME,
-                          config.KIBANA_PACKAGE_NAME)
+    sdk_install.uninstall(config.KIBANA_PACKAGE_NAME, config.KIBANA_PACKAGE_NAME)
 
     log.info("\n***** Set/verify X-Pack enabled in elasticsearch")
-    config.enable_xpack(
-        service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
-    config.verify_commercial_api_status(
-        True, service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
-    config.verify_xpack_license(
-        service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
+    config.enable_xpack(service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
+    config.verify_commercial_api_status(True, service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
+    config.verify_xpack_license(service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
 
     log.info("\n***** Write some data while enabled, disable X-Pack, and verify we can still read what we wrote.")
     config.create_document(
@@ -153,22 +143,16 @@ def test_xpack_toggle_with_kibana(default_populated_index):
             "xpack_enabled": True
         }})
     log.info("\n***** Installing Kibana w/X-Pack can take as much as 15 minutes for Marathon deployment ")
-    log.info(
-        "to complete due to a configured HTTP health check. (typical: 12 minutes)")
-    shakedown.deployment_wait(
-        app_id="/{}".format(config.KIBANA_PACKAGE_NAME), timeout=config.DEFAULT_KIBANA_TIMEOUT)
-    config.check_kibana_adminrouter_integration(
-        "service/{}/login".format(config.KIBANA_PACKAGE_NAME))
+    log.info("to complete due to a configured HTTP health check. (typical: 12 minutes)")
+    shakedown.deployment_wait(app_id="/{}".format(config.KIBANA_PACKAGE_NAME), timeout=config.DEFAULT_KIBANA_TIMEOUT)
+    config.check_kibana_adminrouter_integration("service/{}/login".format(config.KIBANA_PACKAGE_NAME))
     log.info("\n***** Uninstall kibana with X-Pack enabled")
-    sdk_install.uninstall(config.KIBANA_PACKAGE_NAME,
-                          config.KIBANA_PACKAGE_NAME)
+    sdk_install.uninstall(config.KIBANA_PACKAGE_NAME, config.KIBANA_PACKAGE_NAME)
 
     log.info("\n***** Disable X-Pack in elasticsearch.")
-    config.disable_xpack(
-        service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
+    config.disable_xpack(service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
     log.info("\n***** Verify we can still read what we wrote when X-Pack was enabled.")
-    config.verify_commercial_api_status(
-        False, service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
+    config.verify_commercial_api_status(False, service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
     doc = config.get_document(config.DEFAULT_INDEX_NAME, config.DEFAULT_INDEX_TYPE, 2,
                               service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
     assert doc["_source"]["name"] == "X-Pack"
@@ -206,12 +190,9 @@ def test_master_reelection():
 def test_master_node_replace():
     # Ideally, the pod will get placed on a different agent. This test will verify that the remaining two masters
     # find the replaced master at its new IP address. This requires a reasonably low TTL for Java DNS lookups.
-    master_ids = sdk_tasks.get_task_ids(
-        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'master-0')
-    cmd.svc_cli(config.PACKAGE_NAME, sdk_utils.get_foldered_name(
-        config.SERVICE_NAME), 'pod replace master-0')
-    sdk_tasks.check_tasks_updated(sdk_utils.get_foldered_name(
-        config.SERVICE_NAME), 'master-0', master_ids)
+    master_ids = sdk_tasks.get_task_ids(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'master-0')
+    cmd.svc_cli(config.PACKAGE_NAME, sdk_utils.get_foldered_name(config.SERVICE_NAME), 'pod replace master-0')
+    sdk_tasks.check_tasks_updated(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'master-0', master_ids)
     # pre_test_setup will verify that the cluster becomes healthy again.
 
 
@@ -219,28 +200,21 @@ def test_master_node_replace():
 @pytest.mark.sanity
 def test_plugin_install_and_uninstall(default_populated_index):
     plugin_name = 'analysis-phonetic'
-    marathon_config = sdk_marathon.get_config(
-        sdk_utils.get_foldered_name(config.SERVICE_NAME))
+    marathon_config = sdk_marathon.get_config(sdk_utils.get_foldered_name(config.SERVICE_NAME))
     marathon_config['env']['TASKCFG_ALL_ELASTICSEARCH_PLUGINS'] = plugin_name
-    sdk_marathon.update_app(sdk_utils.get_foldered_name(
-        config.SERVICE_NAME), marathon_config)
-    config.check_plugin_installed(
-        plugin_name, service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
+    sdk_marathon.update_app(sdk_utils.get_foldered_name(config.SERVICE_NAME), marathon_config)
+    config.check_plugin_installed(plugin_name, service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
 
-    marathon_config = sdk_marathon.get_config(
-        sdk_utils.get_foldered_name(config.SERVICE_NAME))
+    marathon_config = sdk_marathon.get_config(sdk_utils.get_foldered_name(config.SERVICE_NAME))
     marathon_config['env']['TASKCFG_ALL_ELASTICSEARCH_PLUGINS'] = ""
-    sdk_marathon.update_app(sdk_utils.get_foldered_name(
-        config.SERVICE_NAME), marathon_config)
-    config.check_plugin_uninstalled(
-        plugin_name, service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
+    sdk_marathon.update_app(sdk_utils.get_foldered_name(config.SERVICE_NAME), marathon_config)
+    config.check_plugin_uninstalled(plugin_name, service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
 
 
 @pytest.mark.recovery
 @pytest.mark.sanity
 def test_unchanged_scheduler_restarts_without_restarting_tasks():
-    initial_task_ids = sdk_tasks.get_task_ids(
-        sdk_utils.get_foldered_name(config.SERVICE_NAME), "master")
+    initial_task_ids = sdk_tasks.get_task_ids(sdk_utils.get_foldered_name(config.SERVICE_NAME), "master")
     shakedown.kill_process_on_host(sdk_marathon.get_scheduler_host(
         sdk_utils.get_foldered_name(config.SERVICE_NAME)), "elastic.scheduler.Main")
     sdk_tasks.check_tasks_not_updated(
@@ -251,16 +225,12 @@ def test_unchanged_scheduler_restarts_without_restarting_tasks():
 @pytest.mark.sanity
 def test_bump_node_counts():
     # Run this test last, as it changes the task count
-    marathon_config = sdk_marathon.get_config(
-        sdk_utils.get_foldered_name(config.SERVICE_NAME))
+    marathon_config = sdk_marathon.get_config(sdk_utils.get_foldered_name(config.SERVICE_NAME))
     data_nodes = int(marathon_config['env']['DATA_NODE_COUNT'])
     marathon_config['env']['DATA_NODE_COUNT'] = str(data_nodes + 1)
     ingest_nodes = int(marathon_config['env']['INGEST_NODE_COUNT'])
     marathon_config['env']['INGEST_NODE_COUNT'] = str(ingest_nodes + 1)
     coordinator_nodes = int(marathon_config['env']['COORDINATOR_NODE_COUNT'])
-    marathon_config['env']['COORDINATOR_NODE_COUNT'] = str(
-        coordinator_nodes + 1)
-    sdk_marathon.update_app(sdk_utils.get_foldered_name(
-        config.SERVICE_NAME), marathon_config)
-    sdk_tasks.check_running(sdk_utils.get_foldered_name(config.SERVICE_NAME),
-                            config.DEFAULT_TASK_COUNT + 3)
+    marathon_config['env']['COORDINATOR_NODE_COUNT'] = str(coordinator_nodes + 1)
+    sdk_marathon.update_app(sdk_utils.get_foldered_name(config.SERVICE_NAME), marathon_config)
+    sdk_tasks.check_running(sdk_utils.get_foldered_name(config.SERVICE_NAME), config.DEFAULT_TASK_COUNT + 3)

--- a/frameworks/elastic/tests/test_sanity.py
+++ b/frameworks/elastic/tests/test_sanity.py
@@ -92,8 +92,12 @@ def test_indexing(default_populated_index):
 @pytest.mark.metrics
 @sdk_utils.dcos_1_9_or_higher
 def test_metrics():
-    expected_metrics = [metric.replace("service_name", FOLDERED_SERVICE_NAME)
-                        for metric in config.EXPECTED_METRICS]
+    expected_metrics = [
+        "node.data-0-node.fs.total.total_in_bytes",
+        "node.data-0-node.jvm.mem.pools.old.peak_used_in_bytes",
+        "node.data-0-node.jvm.threads.count"
+    ]
+
     sdk_metrics.wait_for_service_metrics(
         config.PACKAGE_NAME,
         sdk_utils.get_foldered_name(config.SERVICE_NAME),

--- a/frameworks/hdfs/tests/config.py
+++ b/frameworks/hdfs/tests/config.py
@@ -18,9 +18,16 @@ TEST_FILE_2_NAME = "test_2"
 DEFAULT_HDFS_TIMEOUT = 5 * 60
 HDFS_POD_TYPES = {"journal", "name", "data"}
 
+EXPECTED_METRICS = [
+    "JournalNode.jvm.JvmMetrics.ThreadsRunnable",
+    "null.rpc.rpc.RpcQueueTimeNumOps",
+    "null.metricssystem.MetricsSystem.PublishAvgTime"
+]
+
 
 def write_data_to_hdfs(service_name, filename, content_to_write=TEST_CONTENT_SMALL):
-    write_command = "echo '{}' | ./bin/hdfs dfs -put - /{}".format(content_to_write, filename)
+    write_command = "echo '{}' | ./bin/hdfs dfs -put - /{}".format(
+        content_to_write, filename)
     rc, _ = run_hdfs_command(service_name, write_command)
     # rc being True is effectively it being 0...
     return rc
@@ -39,7 +46,8 @@ def delete_data_from_hdfs(service_name, filename):
 
 
 def write_lots_of_data_to_hdfs(service_name, filename):
-    write_command = "wget {} -qO- | ./bin/hdfs dfs -put /{}".format(TEST_CONTENT_LARGE_SOURCE, filename)
+    write_command = "wget {} -qO- | ./bin/hdfs dfs -put /{}".format(
+        TEST_CONTENT_LARGE_SOURCE, filename)
     rc, output = run_hdfs_command(service_name, write_command)
     return rc
 
@@ -58,7 +66,8 @@ def get_active_name_node(service_name):
 
 def get_name_node_status(service_name, name_node):
     def get_status():
-        rc, output = run_hdfs_command(service_name, "./bin/hdfs haadmin -getServiceState {}".format(name_node))
+        rc, output = run_hdfs_command(
+            service_name, "./bin/hdfs haadmin -getServiceState {}".format(name_node))
         if not rc:
             return rc
 
@@ -71,17 +80,20 @@ def run_hdfs_command(service_name, command):
     """
     Execute the command using the Docker client
     """
-    full_command = 'docker run -e HDFS_SERVICE_NAME={} mesosphere/hdfs-client:2.6.4 /bin/bash -c "/configure-hdfs.sh && {}"'.format(service_name, command)
+    full_command = 'docker run -e HDFS_SERVICE_NAME={} mesosphere/hdfs-client:2.6.4 /bin/bash -c "/configure-hdfs.sh && {}"'.format(
+        service_name, command)
 
     rc, output = shakedown.run_command_on_master(full_command)
     return rc, output
 
 
 def check_healthy(service_name, count=DEFAULT_TASK_COUNT, recovery_expected=False):
-    sdk_plan.wait_for_completed_deployment(service_name, timeout_seconds=25 * 60)
+    sdk_plan.wait_for_completed_deployment(
+        service_name, timeout_seconds=25 * 60)
     if recovery_expected:
         # TODO(elezar): See INFINITY-2109 where we need to better handle recovery health checks
-        sdk_plan.wait_for_kicked_off_recovery(service_name, timeout_seconds=25 * 60)
+        sdk_plan.wait_for_kicked_off_recovery(
+            service_name, timeout_seconds=25 * 60)
     sdk_plan.wait_for_completed_recovery(service_name, timeout_seconds=25 * 60)
     sdk_tasks.check_running(service_name, count)
 
@@ -89,9 +101,11 @@ def check_healthy(service_name, count=DEFAULT_TASK_COUNT, recovery_expected=Fals
 def expect_recovery(service_name):
     # TODO(elezar, nima) check_healthy also check for complete deployment, and this should not
     # affect the state of recovery.
-    check_healthy(service_name=service_name, count=DEFAULT_TASK_COUNT, recovery_expected=True)
+    check_healthy(service_name=service_name,
+                  count=DEFAULT_TASK_COUNT, recovery_expected=True)
 
 
 def get_pod_type_instances(pod_type_prefix, service_name=SERVICE_NAME):
-    pod_types = sdk_cmd.svc_cli(PACKAGE_NAME, service_name, 'pod list', json=True)
+    pod_types = sdk_cmd.svc_cli(
+        PACKAGE_NAME, service_name, 'pod list', json=True)
     return [pod_type for pod_type in pod_types if pod_type.startswith(pod_type_prefix)]

--- a/frameworks/hdfs/tests/config.py
+++ b/frameworks/hdfs/tests/config.py
@@ -26,8 +26,7 @@ EXPECTED_METRICS = [
 
 
 def write_data_to_hdfs(service_name, filename, content_to_write=TEST_CONTENT_SMALL):
-    write_command = "echo '{}' | ./bin/hdfs dfs -put - /{}".format(
-        content_to_write, filename)
+    write_command = "echo '{}' | ./bin/hdfs dfs -put - /{}".format(content_to_write, filename)
     rc, _ = run_hdfs_command(service_name, write_command)
     # rc being True is effectively it being 0...
     return rc
@@ -46,8 +45,7 @@ def delete_data_from_hdfs(service_name, filename):
 
 
 def write_lots_of_data_to_hdfs(service_name, filename):
-    write_command = "wget {} -qO- | ./bin/hdfs dfs -put /{}".format(
-        TEST_CONTENT_LARGE_SOURCE, filename)
+    write_command = "wget {} -qO- | ./bin/hdfs dfs -put /{}".format(TEST_CONTENT_LARGE_SOURCE, filename)
     rc, output = run_hdfs_command(service_name, write_command)
     return rc
 
@@ -66,8 +64,7 @@ def get_active_name_node(service_name):
 
 def get_name_node_status(service_name, name_node):
     def get_status():
-        rc, output = run_hdfs_command(
-            service_name, "./bin/hdfs haadmin -getServiceState {}".format(name_node))
+        rc, output = run_hdfs_command(service_name, "./bin/hdfs haadmin -getServiceState {}".format(name_node))
         if not rc:
             return rc
 
@@ -88,12 +85,10 @@ def run_hdfs_command(service_name, command):
 
 
 def check_healthy(service_name, count=DEFAULT_TASK_COUNT, recovery_expected=False):
-    sdk_plan.wait_for_completed_deployment(
-        service_name, timeout_seconds=25 * 60)
+    sdk_plan.wait_for_completed_deployment(service_name, timeout_seconds=25 * 60)
     if recovery_expected:
         # TODO(elezar): See INFINITY-2109 where we need to better handle recovery health checks
-        sdk_plan.wait_for_kicked_off_recovery(
-            service_name, timeout_seconds=25 * 60)
+        sdk_plan.wait_for_kicked_off_recovery(service_name, timeout_seconds=25 * 60)
     sdk_plan.wait_for_completed_recovery(service_name, timeout_seconds=25 * 60)
     sdk_tasks.check_running(service_name, count)
 
@@ -101,11 +96,9 @@ def check_healthy(service_name, count=DEFAULT_TASK_COUNT, recovery_expected=Fals
 def expect_recovery(service_name):
     # TODO(elezar, nima) check_healthy also check for complete deployment, and this should not
     # affect the state of recovery.
-    check_healthy(service_name=service_name,
-                  count=DEFAULT_TASK_COUNT, recovery_expected=True)
+    check_healthy(service_name=service_name, count=DEFAULT_TASK_COUNT, recovery_expected=True)
 
 
 def get_pod_type_instances(pod_type_prefix, service_name=SERVICE_NAME):
-    pod_types = sdk_cmd.svc_cli(
-        PACKAGE_NAME, service_name, 'pod list', json=True)
+    pod_types = sdk_cmd.svc_cli(PACKAGE_NAME, service_name, 'pod list', json=True)
     return [pod_type for pod_type in pod_types if pod_type.startswith(pod_type_prefix)]

--- a/frameworks/hdfs/tests/config.py
+++ b/frameworks/hdfs/tests/config.py
@@ -18,12 +18,6 @@ TEST_FILE_2_NAME = "test_2"
 DEFAULT_HDFS_TIMEOUT = 5 * 60
 HDFS_POD_TYPES = {"journal", "name", "data"}
 
-EXPECTED_METRICS = [
-    "JournalNode.jvm.JvmMetrics.ThreadsRunnable",
-    "null.rpc.rpc.RpcQueueTimeNumOps",
-    "null.metricssystem.MetricsSystem.PublishAvgTime"
-]
-
 
 def write_data_to_hdfs(service_name, filename, content_to_write=TEST_CONTENT_SMALL):
     write_command = "echo '{}' | ./bin/hdfs dfs -put - /{}".format(content_to_write, filename)

--- a/frameworks/hdfs/tests/test_sanity.py
+++ b/frameworks/hdfs/tests/test_sanity.py
@@ -357,12 +357,19 @@ def test_metrics():
         "null.metricssystem.MetricsSystem.PublishAvgTime"
     ]
 
+    def expected_metrics_exist(emitted_metrics):
+        # HDFS metric names need sanitation as they're dynamic.
+        # For eg: ip-10-0-0-139.null.rpc.rpc.RpcQueueTimeNumOps
+        # This is consistent across all HDFS metric names.
+        metric_names = set(['.'.join(metric_name.split(".")[1:]) for metric_name in emitted_metrics])
+        return sdk_metrics.check_metrics_presence(metric_names, expected_metrics)
+
     sdk_metrics.wait_for_service_metrics(
         config.PACKAGE_NAME,
         sdk_utils.get_foldered_name(config.SERVICE_NAME),
         "journal-0-node",
         config.DEFAULT_HDFS_TIMEOUT,
-        expected_metrics
+        expected_metrics_exist
     )
 
 

--- a/frameworks/hdfs/tests/test_sanity.py
+++ b/frameworks/hdfs/tests/test_sanity.py
@@ -150,8 +150,7 @@ def test_kill_all_journalnodes():
 
     for journal_pod in config.get_pod_type_instances("journal", sdk_utils.get_foldered_name(config.SERVICE_NAME)):
         sdk_cmd.svc_cli(
-            config.PACKAGE_NAME, sdk_utils.get_foldered_name(
-                config.SERVICE_NAME),
+            config.PACKAGE_NAME, sdk_utils.get_foldered_name(config.SERVICE_NAME),
             'pod restart {}'.format(journal_pod))
 
     config.expect_recovery(service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
@@ -170,8 +169,7 @@ def test_kill_all_namenodes():
 
     for name_pod in config.get_pod_type_instances("name", sdk_utils.get_foldered_name(config.SERVICE_NAME)):
         sdk_cmd.svc_cli(
-            config.PACKAGE_NAME, sdk_utils.get_foldered_name(
-                config.SERVICE_NAME),
+            config.PACKAGE_NAME, sdk_utils.get_foldered_name(config.SERVICE_NAME),
             'pod restart {}'.format(name_pod))
 
     config.expect_recovery(service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
@@ -190,8 +188,7 @@ def test_kill_all_datanodes():
 
     for data_pod in config.get_pod_type_instances("data", sdk_utils.get_foldered_name(config.SERVICE_NAME)):
         sdk_cmd.svc_cli(
-            config.PACKAGE_NAME, sdk_utils.get_foldered_name(
-                config.SERVICE_NAME),
+            config.PACKAGE_NAME, sdk_utils.get_foldered_name(config.SERVICE_NAME),
             'pod restart {}'.format(data_pod))
 
     config.expect_recovery(service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))

--- a/frameworks/hdfs/tests/test_sanity.py
+++ b/frameworks/hdfs/tests/test_sanity.py
@@ -20,7 +20,8 @@ log = logging.getLogger(__name__)
 @pytest.fixture(scope='module', autouse=True)
 def configure_package(configure_security):
     try:
-        sdk_install.uninstall(config.PACKAGE_NAME, sdk_utils.get_foldered_name(config.SERVICE_NAME))
+        sdk_install.uninstall(config.PACKAGE_NAME,
+                              sdk_utils.get_foldered_name(config.SERVICE_NAME))
 
         if shakedown.dcos_version_less_than("1.9"):
             # HDFS upgrade in 1.8 is not supported.
@@ -28,19 +29,22 @@ def configure_package(configure_security):
                 config.PACKAGE_NAME,
                 sdk_utils.get_foldered_name(config.SERVICE_NAME),
                 config.DEFAULT_TASK_COUNT,
-                additional_options={"service": {"name": sdk_utils.get_foldered_name(config.SERVICE_NAME)}},
+                additional_options={"service": {
+                    "name": sdk_utils.get_foldered_name(config.SERVICE_NAME)}},
                 timeout_seconds=30 * 60)
         else:
             sdk_upgrade.test_upgrade(
                 config.PACKAGE_NAME,
                 sdk_utils.get_foldered_name(config.SERVICE_NAME),
                 config.DEFAULT_TASK_COUNT,
-                additional_options={"service": {"name": sdk_utils.get_foldered_name(config.SERVICE_NAME)}},
+                additional_options={"service": {
+                    "name": sdk_utils.get_foldered_name(config.SERVICE_NAME)}},
                 timeout_seconds=30 * 60)
 
         yield  # let the test session execute
     finally:
-        sdk_install.uninstall(config.PACKAGE_NAME, sdk_utils.get_foldered_name(config.SERVICE_NAME))
+        sdk_install.uninstall(config.PACKAGE_NAME,
+                              sdk_utils.get_foldered_name(config.SERVICE_NAME))
 
 
 @pytest.fixture(autouse=True)
@@ -92,108 +96,154 @@ def check_properties(xml, expect):
 
 @pytest.mark.recovery
 def test_kill_journal_node():
-    journal_ids = sdk_tasks.get_task_ids(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal-0')
-    name_ids = sdk_tasks.get_task_ids(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name')
-    data_ids = sdk_tasks.get_task_ids(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data')
+    journal_ids = sdk_tasks.get_task_ids(
+        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal-0')
+    name_ids = sdk_tasks.get_task_ids(
+        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name')
+    data_ids = sdk_tasks.get_task_ids(
+        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data')
 
-    sdk_tasks.kill_task_with_pattern('journalnode', sdk_hosts.system_host(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal-0-node'))
-    config.expect_recovery(service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
-    sdk_tasks.check_tasks_updated(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal', journal_ids)
-    sdk_tasks.check_tasks_not_updated(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name', name_ids)
-    sdk_tasks.check_tasks_not_updated(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data', data_ids)
+    sdk_tasks.kill_task_with_pattern('journalnode', sdk_hosts.system_host(
+        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal-0-node'))
+    config.expect_recovery(
+        service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
+    sdk_tasks.check_tasks_updated(sdk_utils.get_foldered_name(
+        config.SERVICE_NAME), 'journal', journal_ids)
+    sdk_tasks.check_tasks_not_updated(
+        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name', name_ids)
+    sdk_tasks.check_tasks_not_updated(
+        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data', data_ids)
 
 
 @pytest.mark.sanity
 @pytest.mark.recovery
 def test_kill_name_node():
-    name_ids = sdk_tasks.get_task_ids(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name-0')
-    journal_ids = sdk_tasks.get_task_ids(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal')
-    data_ids = sdk_tasks.get_task_ids(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data')
+    name_ids = sdk_tasks.get_task_ids(
+        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name-0')
+    journal_ids = sdk_tasks.get_task_ids(
+        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal')
+    data_ids = sdk_tasks.get_task_ids(
+        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data')
 
     sdk_tasks.kill_task_with_pattern('namenode',
-        sdk_hosts.system_host(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name-0-node'))
-    config.expect_recovery(service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
-    sdk_tasks.check_tasks_updated(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name', name_ids)
-    sdk_tasks.check_tasks_not_updated(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal', journal_ids)
-    sdk_tasks.check_tasks_not_updated(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data', data_ids)
+                                     sdk_hosts.system_host(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name-0-node'))
+    config.expect_recovery(
+        service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
+    sdk_tasks.check_tasks_updated(sdk_utils.get_foldered_name(
+        config.SERVICE_NAME), 'name', name_ids)
+    sdk_tasks.check_tasks_not_updated(sdk_utils.get_foldered_name(
+        config.SERVICE_NAME), 'journal', journal_ids)
+    sdk_tasks.check_tasks_not_updated(
+        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data', data_ids)
 
 
 @pytest.mark.sanity
 @pytest.mark.recovery
 def test_kill_data_node():
-    data_ids = sdk_tasks.get_task_ids(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data-0')
-    journal_ids = sdk_tasks.get_task_ids(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal')
-    name_ids = sdk_tasks.get_task_ids(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name')
+    data_ids = sdk_tasks.get_task_ids(
+        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data-0')
+    journal_ids = sdk_tasks.get_task_ids(
+        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal')
+    name_ids = sdk_tasks.get_task_ids(
+        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name')
 
     sdk_tasks.kill_task_with_pattern('datanode',
-        sdk_hosts.system_host(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data-0-node'))
-    config.expect_recovery(service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
-    sdk_tasks.check_tasks_updated(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data', data_ids)
-    sdk_tasks.check_tasks_not_updated(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal', journal_ids)
-    sdk_tasks.check_tasks_not_updated(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name', name_ids)
+                                     sdk_hosts.system_host(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data-0-node'))
+    config.expect_recovery(
+        service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
+    sdk_tasks.check_tasks_updated(sdk_utils.get_foldered_name(
+        config.SERVICE_NAME), 'data', data_ids)
+    sdk_tasks.check_tasks_not_updated(sdk_utils.get_foldered_name(
+        config.SERVICE_NAME), 'journal', journal_ids)
+    sdk_tasks.check_tasks_not_updated(
+        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name', name_ids)
 
 
 @pytest.mark.sanity
 @pytest.mark.recovery
 def test_kill_scheduler():
-    sdk_tasks.kill_task_with_pattern('hdfs.scheduler.Main', shakedown.get_service_ips('marathon').pop())
-    config.check_healthy(service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
+    sdk_tasks.kill_task_with_pattern(
+        'hdfs.scheduler.Main', shakedown.get_service_ips('marathon').pop())
+    config.check_healthy(
+        service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
 
 
 @pytest.mark.sanity
 @pytest.mark.recovery
 def test_kill_all_journalnodes():
-    journal_ids = sdk_tasks.get_task_ids(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal')
-    data_ids = sdk_tasks.get_task_ids(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data')
+    journal_ids = sdk_tasks.get_task_ids(
+        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal')
+    data_ids = sdk_tasks.get_task_ids(
+        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data')
 
     for journal_pod in config.get_pod_type_instances("journal", sdk_utils.get_foldered_name(config.SERVICE_NAME)):
         sdk_cmd.svc_cli(
-            config.PACKAGE_NAME, sdk_utils.get_foldered_name(config.SERVICE_NAME),
+            config.PACKAGE_NAME, sdk_utils.get_foldered_name(
+                config.SERVICE_NAME),
             'pod restart {}'.format(journal_pod))
 
-    config.expect_recovery(service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
+    config.expect_recovery(
+        service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
 
     # name nodes fail and restart, so don't check those
-    sdk_tasks.check_tasks_updated(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal', journal_ids)
-    sdk_tasks.check_tasks_not_updated(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data', data_ids)
+    sdk_tasks.check_tasks_updated(sdk_utils.get_foldered_name(
+        config.SERVICE_NAME), 'journal', journal_ids)
+    sdk_tasks.check_tasks_not_updated(
+        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data', data_ids)
 
 
 @pytest.mark.sanity
 @pytest.mark.recovery
 def test_kill_all_namenodes():
-    journal_ids = sdk_tasks.get_task_ids(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal')
-    name_ids = sdk_tasks.get_task_ids(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name')
-    data_ids = sdk_tasks.get_task_ids(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data')
+    journal_ids = sdk_tasks.get_task_ids(
+        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal')
+    name_ids = sdk_tasks.get_task_ids(
+        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name')
+    data_ids = sdk_tasks.get_task_ids(
+        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data')
 
     for name_pod in config.get_pod_type_instances("name", sdk_utils.get_foldered_name(config.SERVICE_NAME)):
         sdk_cmd.svc_cli(
-            config.PACKAGE_NAME, sdk_utils.get_foldered_name(config.SERVICE_NAME),
+            config.PACKAGE_NAME, sdk_utils.get_foldered_name(
+                config.SERVICE_NAME),
             'pod restart {}'.format(name_pod))
 
-    config.expect_recovery(service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
+    config.expect_recovery(
+        service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
 
-    sdk_tasks.check_tasks_updated(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name', name_ids)
-    sdk_tasks.check_tasks_not_updated(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal', journal_ids)
-    sdk_tasks.check_tasks_not_updated(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data', data_ids)
+    sdk_tasks.check_tasks_updated(sdk_utils.get_foldered_name(
+        config.SERVICE_NAME), 'name', name_ids)
+    sdk_tasks.check_tasks_not_updated(sdk_utils.get_foldered_name(
+        config.SERVICE_NAME), 'journal', journal_ids)
+    sdk_tasks.check_tasks_not_updated(
+        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data', data_ids)
 
 
 @pytest.mark.sanity
 @pytest.mark.recovery
 def test_kill_all_datanodes():
-    journal_ids = sdk_tasks.get_task_ids(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal')
-    name_ids = sdk_tasks.get_task_ids(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name')
-    data_ids = sdk_tasks.get_task_ids(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data')
+    journal_ids = sdk_tasks.get_task_ids(
+        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal')
+    name_ids = sdk_tasks.get_task_ids(
+        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name')
+    data_ids = sdk_tasks.get_task_ids(
+        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data')
 
     for data_pod in config.get_pod_type_instances("data", sdk_utils.get_foldered_name(config.SERVICE_NAME)):
         sdk_cmd.svc_cli(
-            config.PACKAGE_NAME, sdk_utils.get_foldered_name(config.SERVICE_NAME),
+            config.PACKAGE_NAME, sdk_utils.get_foldered_name(
+                config.SERVICE_NAME),
             'pod restart {}'.format(data_pod))
 
-    config.expect_recovery(service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
+    config.expect_recovery(
+        service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
 
-    sdk_tasks.check_tasks_updated(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data', data_ids)
-    sdk_tasks.check_tasks_not_updated(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal', journal_ids)
-    sdk_tasks.check_tasks_not_updated(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name', name_ids)
+    sdk_tasks.check_tasks_updated(sdk_utils.get_foldered_name(
+        config.SERVICE_NAME), 'data', data_ids)
+    sdk_tasks.check_tasks_not_updated(sdk_utils.get_foldered_name(
+        config.SERVICE_NAME), 'journal', journal_ids)
+    sdk_tasks.check_tasks_not_updated(
+        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name', name_ids)
 
 
 @pytest.mark.sanity
@@ -207,102 +257,148 @@ def test_permanently_replace_namenodes():
 @pytest.mark.sanity
 @pytest.mark.recovery
 def test_permanent_and_transient_namenode_failures_0_1():
-    config.check_healthy(service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
-    name_0_ids = sdk_tasks.get_task_ids(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name-0')
-    name_1_ids = sdk_tasks.get_task_ids(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name-1')
-    journal_ids = sdk_tasks.get_task_ids(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal')
-    data_ids = sdk_tasks.get_task_ids(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data')
+    config.check_healthy(
+        service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
+    name_0_ids = sdk_tasks.get_task_ids(
+        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name-0')
+    name_1_ids = sdk_tasks.get_task_ids(
+        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name-1')
+    journal_ids = sdk_tasks.get_task_ids(
+        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal')
+    data_ids = sdk_tasks.get_task_ids(
+        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data')
 
-    sdk_cmd.svc_cli(config.PACKAGE_NAME, sdk_utils.get_foldered_name(config.SERVICE_NAME), 'pod replace name-0')
-    sdk_cmd.svc_cli(config.PACKAGE_NAME, sdk_utils.get_foldered_name(config.SERVICE_NAME), 'pod restart name-1')
+    sdk_cmd.svc_cli(config.PACKAGE_NAME, sdk_utils.get_foldered_name(
+        config.SERVICE_NAME), 'pod replace name-0')
+    sdk_cmd.svc_cli(config.PACKAGE_NAME, sdk_utils.get_foldered_name(
+        config.SERVICE_NAME), 'pod restart name-1')
 
-    config.expect_recovery(service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
+    config.expect_recovery(
+        service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
 
-    sdk_tasks.check_tasks_updated(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name-0', name_0_ids)
-    sdk_tasks.check_tasks_updated(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name-1', name_1_ids)
-    sdk_tasks.check_tasks_not_updated(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal', journal_ids)
-    sdk_tasks.check_tasks_not_updated(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data', data_ids)
+    sdk_tasks.check_tasks_updated(sdk_utils.get_foldered_name(
+        config.SERVICE_NAME), 'name-0', name_0_ids)
+    sdk_tasks.check_tasks_updated(sdk_utils.get_foldered_name(
+        config.SERVICE_NAME), 'name-1', name_1_ids)
+    sdk_tasks.check_tasks_not_updated(sdk_utils.get_foldered_name(
+        config.SERVICE_NAME), 'journal', journal_ids)
+    sdk_tasks.check_tasks_not_updated(
+        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data', data_ids)
 
 
 @pytest.mark.sanity
 @pytest.mark.recovery
 def test_permanent_and_transient_namenode_failures_1_0():
-    config.check_healthy(service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
-    name_0_ids = sdk_tasks.get_task_ids(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name-0')
-    name_1_ids = sdk_tasks.get_task_ids(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name-1')
-    journal_ids = sdk_tasks.get_task_ids(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal')
-    data_ids = sdk_tasks.get_task_ids(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data')
+    config.check_healthy(
+        service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
+    name_0_ids = sdk_tasks.get_task_ids(
+        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name-0')
+    name_1_ids = sdk_tasks.get_task_ids(
+        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name-1')
+    journal_ids = sdk_tasks.get_task_ids(
+        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal')
+    data_ids = sdk_tasks.get_task_ids(
+        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data')
 
-    sdk_cmd.svc_cli(config.PACKAGE_NAME, sdk_utils.get_foldered_name(config.SERVICE_NAME), 'pod replace name-1')
-    sdk_cmd.svc_cli(config.PACKAGE_NAME, sdk_utils.get_foldered_name(config.SERVICE_NAME), 'pod restart name-0')
+    sdk_cmd.svc_cli(config.PACKAGE_NAME, sdk_utils.get_foldered_name(
+        config.SERVICE_NAME), 'pod replace name-1')
+    sdk_cmd.svc_cli(config.PACKAGE_NAME, sdk_utils.get_foldered_name(
+        config.SERVICE_NAME), 'pod restart name-0')
 
-    config.expect_recovery(service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
+    config.expect_recovery(
+        service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
 
-    sdk_tasks.check_tasks_updated(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name-0', name_0_ids)
-    sdk_tasks.check_tasks_updated(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name-1', name_1_ids)
-    sdk_tasks.check_tasks_not_updated(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal', journal_ids)
-    sdk_tasks.check_tasks_not_updated(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data', data_ids)
+    sdk_tasks.check_tasks_updated(sdk_utils.get_foldered_name(
+        config.SERVICE_NAME), 'name-0', name_0_ids)
+    sdk_tasks.check_tasks_updated(sdk_utils.get_foldered_name(
+        config.SERVICE_NAME), 'name-1', name_1_ids)
+    sdk_tasks.check_tasks_not_updated(sdk_utils.get_foldered_name(
+        config.SERVICE_NAME), 'journal', journal_ids)
+    sdk_tasks.check_tasks_not_updated(
+        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data', data_ids)
 
 
 @pytest.mark.smoke
 def test_install():
-    config.check_healthy(service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
+    config.check_healthy(
+        service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
 
 
 @pytest.mark.sanity
 def test_bump_journal_cpus():
-    journal_ids = sdk_tasks.get_task_ids(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal')
-    name_ids = sdk_tasks.get_task_ids(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name')
+    journal_ids = sdk_tasks.get_task_ids(
+        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal')
+    name_ids = sdk_tasks.get_task_ids(
+        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name')
     log.info('journal ids: ' + str(journal_ids))
 
-    sdk_marathon.bump_cpu_count_config(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'JOURNAL_CPUS')
+    sdk_marathon.bump_cpu_count_config(
+        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'JOURNAL_CPUS')
 
-    sdk_tasks.check_tasks_updated(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal', journal_ids)
+    sdk_tasks.check_tasks_updated(sdk_utils.get_foldered_name(
+        config.SERVICE_NAME), 'journal', journal_ids)
     # journal node update should not cause any of the name nodes to crash
-    sdk_tasks.check_tasks_not_updated(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name', name_ids)
-    config.check_healthy(service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
+    sdk_tasks.check_tasks_not_updated(
+        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name', name_ids)
+    config.check_healthy(
+        service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
 
 
 @pytest.mark.sanity
 def test_bump_data_nodes():
-    data_ids = sdk_tasks.get_task_ids(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data')
+    data_ids = sdk_tasks.get_task_ids(
+        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data')
     log.info('data ids: ' + str(data_ids))
 
-    sdk_marathon.bump_task_count_config(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'DATA_COUNT')
+    sdk_marathon.bump_task_count_config(
+        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'DATA_COUNT')
 
     config.check_healthy(
         service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME),
         count=config.DEFAULT_TASK_COUNT + 1
     )
-    sdk_tasks.check_tasks_not_updated(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data', data_ids)
+    sdk_tasks.check_tasks_not_updated(
+        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data', data_ids)
 
 
 @pytest.mark.readiness_check
 @pytest.mark.sanity
 def test_modify_app_config():
     """This tests checks that the modification of the app config does not trigger a recovery."""
-    sdk_plan.wait_for_completed_recovery(sdk_utils.get_foldered_name(config.SERVICE_NAME))
-    old_recovery_plan = sdk_plan.get_plan(sdk_utils.get_foldered_name(config.SERVICE_NAME), "recovery")
+    sdk_plan.wait_for_completed_recovery(
+        sdk_utils.get_foldered_name(config.SERVICE_NAME))
+    old_recovery_plan = sdk_plan.get_plan(
+        sdk_utils.get_foldered_name(config.SERVICE_NAME), "recovery")
 
     app_config_field = 'TASKCFG_ALL_CLIENT_READ_SHORTCIRCUIT_STREAMS_CACHE_SIZE_EXPIRY_MS'
-    journal_ids = sdk_tasks.get_task_ids(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal')
-    name_ids = sdk_tasks.get_task_ids(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name')
+    journal_ids = sdk_tasks.get_task_ids(
+        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal')
+    name_ids = sdk_tasks.get_task_ids(
+        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name')
 
-    marathon_config = sdk_marathon.get_config(sdk_utils.get_foldered_name(config.SERVICE_NAME))
+    marathon_config = sdk_marathon.get_config(
+        sdk_utils.get_foldered_name(config.SERVICE_NAME))
     log.info('marathon config: ')
     log.info(marathon_config)
     expiry_ms = int(marathon_config['env'][app_config_field])
     marathon_config['env'][app_config_field] = str(expiry_ms + 1)
-    sdk_marathon.update_app(sdk_utils.get_foldered_name(config.SERVICE_NAME), marathon_config, timeout=15 * 60)
+    sdk_marathon.update_app(sdk_utils.get_foldered_name(
+        config.SERVICE_NAME), marathon_config, timeout=15 * 60)
 
     # All tasks should be updated because hdfs-site.xml has changed
-    config.check_healthy(service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
-    sdk_tasks.check_tasks_updated(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal', journal_ids)
-    sdk_tasks.check_tasks_updated(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name', name_ids)
-    sdk_tasks.check_tasks_updated(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data', journal_ids)
+    config.check_healthy(
+        service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
+    sdk_tasks.check_tasks_updated(sdk_utils.get_foldered_name(
+        config.SERVICE_NAME), 'journal', journal_ids)
+    sdk_tasks.check_tasks_updated(sdk_utils.get_foldered_name(
+        config.SERVICE_NAME), 'name', name_ids)
+    sdk_tasks.check_tasks_updated(sdk_utils.get_foldered_name(
+        config.SERVICE_NAME), 'data', journal_ids)
 
-    sdk_plan.wait_for_completed_recovery(sdk_utils.get_foldered_name(config.SERVICE_NAME))
-    new_recovery_plan = sdk_plan.get_plan(sdk_utils.get_foldered_name(config.SERVICE_NAME), "recovery")
+    sdk_plan.wait_for_completed_recovery(
+        sdk_utils.get_foldered_name(config.SERVICE_NAME))
+    new_recovery_plan = sdk_plan.get_plan(
+        sdk_utils.get_foldered_name(config.SERVICE_NAME), "recovery")
     assert old_recovery_plan == new_recovery_plan
 
 
@@ -310,63 +406,84 @@ def test_modify_app_config():
 def test_modify_app_config_rollback():
     app_config_field = 'TASKCFG_ALL_CLIENT_READ_SHORTCIRCUIT_STREAMS_CACHE_SIZE_EXPIRY_MS'
 
-    journal_ids = sdk_tasks.get_task_ids(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal')
-    data_ids = sdk_tasks.get_task_ids(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data')
+    journal_ids = sdk_tasks.get_task_ids(
+        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal')
+    data_ids = sdk_tasks.get_task_ids(
+        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data')
 
-    old_config = sdk_marathon.get_config(sdk_utils.get_foldered_name(config.SERVICE_NAME))
-    marathon_config = sdk_marathon.get_config(sdk_utils.get_foldered_name(config.SERVICE_NAME))
+    old_config = sdk_marathon.get_config(
+        sdk_utils.get_foldered_name(config.SERVICE_NAME))
+    marathon_config = sdk_marathon.get_config(
+        sdk_utils.get_foldered_name(config.SERVICE_NAME))
     log.info('marathon config: ')
     log.info(marathon_config)
     expiry_ms = int(marathon_config['env'][app_config_field])
     log.info('expiry ms: ' + str(expiry_ms))
     marathon_config['env'][app_config_field] = str(expiry_ms + 1)
-    sdk_marathon.update_app(sdk_utils.get_foldered_name(config.SERVICE_NAME), marathon_config, timeout=15 * 60)
+    sdk_marathon.update_app(sdk_utils.get_foldered_name(
+        config.SERVICE_NAME), marathon_config, timeout=15 * 60)
 
     # Wait for journal nodes to be affected by the change
-    sdk_tasks.check_tasks_updated(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal', journal_ids)
-    journal_ids = sdk_tasks.get_task_ids(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal')
+    sdk_tasks.check_tasks_updated(sdk_utils.get_foldered_name(
+        config.SERVICE_NAME), 'journal', journal_ids)
+    journal_ids = sdk_tasks.get_task_ids(
+        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal')
 
     log.info('old config: ')
     log.info(old_config)
     # Put the old config back (rollback)
-    sdk_marathon.update_app(sdk_utils.get_foldered_name(config.SERVICE_NAME), old_config)
+    sdk_marathon.update_app(sdk_utils.get_foldered_name(
+        config.SERVICE_NAME), old_config)
 
     # Wait for the journal nodes to return to their old configuration
-    sdk_tasks.check_tasks_updated(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal', journal_ids)
-    config.check_healthy(service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
+    sdk_tasks.check_tasks_updated(sdk_utils.get_foldered_name(
+        config.SERVICE_NAME), 'journal', journal_ids)
+    config.check_healthy(
+        service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
 
-    marathon_config = sdk_marathon.get_config(sdk_utils.get_foldered_name(config.SERVICE_NAME))
+    marathon_config = sdk_marathon.get_config(
+        sdk_utils.get_foldered_name(config.SERVICE_NAME))
     assert int(marathon_config['env'][app_config_field]) == expiry_ms
 
     # Data tasks should not have been affected
-    sdk_tasks.check_tasks_not_updated(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data', data_ids)
+    sdk_tasks.check_tasks_not_updated(
+        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data', data_ids)
 
 
 @pytest.mark.sanity
 @pytest.mark.metrics
-@pytest.mark.local
 @sdk_utils.dcos_1_9_or_higher
 def test_metrics():
-    sdk_metrics.wait_for_any_metrics(
+    sdk_metrics.wait_for_service_metrics(
         config.PACKAGE_NAME,
         sdk_utils.get_foldered_name(config.SERVICE_NAME),
         "journal-0-node",
-        config.DEFAULT_HDFS_TIMEOUT)
+        config.DEFAULT_HDFS_TIMEOUT,
+        config.EXPECTED_METRICS
+    )
 
 
 def replace_name_node(index):
-    config.check_healthy(service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
+    config.check_healthy(
+        service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
     name_node_name = 'name-' + str(index)
-    name_id = sdk_tasks.get_task_ids(sdk_utils.get_foldered_name(config.SERVICE_NAME), name_node_name)
-    journal_ids = sdk_tasks.get_task_ids(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal')
-    data_ids = sdk_tasks.get_task_ids(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data')
+    name_id = sdk_tasks.get_task_ids(
+        sdk_utils.get_foldered_name(config.SERVICE_NAME), name_node_name)
+    journal_ids = sdk_tasks.get_task_ids(
+        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal')
+    data_ids = sdk_tasks.get_task_ids(
+        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data')
 
     sdk_cmd.svc_cli(
         config.PACKAGE_NAME, sdk_utils.get_foldered_name(config.SERVICE_NAME),
         'pod replace {}'.format(name_node_name))
 
-    config.expect_recovery(service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
+    config.expect_recovery(
+        service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
 
-    sdk_tasks.check_tasks_updated(sdk_utils.get_foldered_name(config.SERVICE_NAME), name_node_name, name_id)
-    sdk_tasks.check_tasks_not_updated(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal', journal_ids)
-    sdk_tasks.check_tasks_not_updated(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data', data_ids)
+    sdk_tasks.check_tasks_updated(sdk_utils.get_foldered_name(
+        config.SERVICE_NAME), name_node_name, name_id)
+    sdk_tasks.check_tasks_not_updated(sdk_utils.get_foldered_name(
+        config.SERVICE_NAME), 'journal', journal_ids)
+    sdk_tasks.check_tasks_not_updated(
+        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data', data_ids)

--- a/frameworks/hdfs/tests/test_sanity.py
+++ b/frameworks/hdfs/tests/test_sanity.py
@@ -29,16 +29,14 @@ def configure_package(configure_security):
                 config.PACKAGE_NAME,
                 sdk_utils.get_foldered_name(config.SERVICE_NAME),
                 config.DEFAULT_TASK_COUNT,
-                additional_options={"service": {
-                    "name": sdk_utils.get_foldered_name(config.SERVICE_NAME)}},
+                additional_options={"service": {"name": sdk_utils.get_foldered_name(config.SERVICE_NAME)}},
                 timeout_seconds=30 * 60)
         else:
             sdk_upgrade.test_upgrade(
                 config.PACKAGE_NAME,
                 sdk_utils.get_foldered_name(config.SERVICE_NAME),
                 config.DEFAULT_TASK_COUNT,
-                additional_options={"service": {
-                    "name": sdk_utils.get_foldered_name(config.SERVICE_NAME)}},
+                additional_options={"service": {"name": sdk_utils.get_foldered_name(config.SERVICE_NAME)}},
                 timeout_seconds=30 * 60)
 
         yield  # let the test session execute
@@ -49,8 +47,7 @@ def configure_package(configure_security):
 
 @pytest.fixture(autouse=True)
 def pre_test_setup():
-    pass
-    #config.check_healthy(service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
+    config.check_healthy(service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
 
 
 @pytest.mark.sanity
@@ -96,85 +93,60 @@ def check_properties(xml, expect):
 
 @pytest.mark.recovery
 def test_kill_journal_node():
-    journal_ids = sdk_tasks.get_task_ids(
-        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal-0')
-    name_ids = sdk_tasks.get_task_ids(
-        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name')
-    data_ids = sdk_tasks.get_task_ids(
-        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data')
+    journal_ids = sdk_tasks.get_task_ids(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal-0')
+    name_ids = sdk_tasks.get_task_ids(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name')
+    data_ids = sdk_tasks.get_task_ids(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data')
 
     sdk_tasks.kill_task_with_pattern('journalnode', sdk_hosts.system_host(
         sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal-0-node'))
-    config.expect_recovery(
-        service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
-    sdk_tasks.check_tasks_updated(sdk_utils.get_foldered_name(
-        config.SERVICE_NAME), 'journal', journal_ids)
-    sdk_tasks.check_tasks_not_updated(
-        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name', name_ids)
-    sdk_tasks.check_tasks_not_updated(
-        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data', data_ids)
+    config.expect_recovery(service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
+    sdk_tasks.check_tasks_updated(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal', journal_ids)
+    sdk_tasks.check_tasks_not_updated(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name', name_ids)
+    sdk_tasks.check_tasks_not_updated(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data', data_ids)
 
 
 @pytest.mark.sanity
 @pytest.mark.recovery
 def test_kill_name_node():
-    name_ids = sdk_tasks.get_task_ids(
-        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name-0')
-    journal_ids = sdk_tasks.get_task_ids(
-        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal')
-    data_ids = sdk_tasks.get_task_ids(
-        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data')
+    name_ids = sdk_tasks.get_task_ids(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name-0')
+    journal_ids = sdk_tasks.get_task_ids(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal')
+    data_ids = sdk_tasks.get_task_ids(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data')
 
     sdk_tasks.kill_task_with_pattern('namenode',
                                      sdk_hosts.system_host(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name-0-node'))
-    config.expect_recovery(
-        service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
-    sdk_tasks.check_tasks_updated(sdk_utils.get_foldered_name(
-        config.SERVICE_NAME), 'name', name_ids)
-    sdk_tasks.check_tasks_not_updated(sdk_utils.get_foldered_name(
-        config.SERVICE_NAME), 'journal', journal_ids)
-    sdk_tasks.check_tasks_not_updated(
-        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data', data_ids)
+    config.expect_recovery(service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
+    sdk_tasks.check_tasks_updated(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name', name_ids)
+    sdk_tasks.check_tasks_not_updated(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal', journal_ids)
+    sdk_tasks.check_tasks_not_updated(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data', data_ids)
 
 
 @pytest.mark.sanity
 @pytest.mark.recovery
 def test_kill_data_node():
-    data_ids = sdk_tasks.get_task_ids(
-        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data-0')
-    journal_ids = sdk_tasks.get_task_ids(
-        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal')
-    name_ids = sdk_tasks.get_task_ids(
-        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name')
+    data_ids = sdk_tasks.get_task_ids(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data-0')
+    journal_ids = sdk_tasks.get_task_ids(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal')
+    name_ids = sdk_tasks.get_task_ids(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name')
 
     sdk_tasks.kill_task_with_pattern('datanode',
                                      sdk_hosts.system_host(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data-0-node'))
-    config.expect_recovery(
-        service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
-    sdk_tasks.check_tasks_updated(sdk_utils.get_foldered_name(
-        config.SERVICE_NAME), 'data', data_ids)
-    sdk_tasks.check_tasks_not_updated(sdk_utils.get_foldered_name(
-        config.SERVICE_NAME), 'journal', journal_ids)
-    sdk_tasks.check_tasks_not_updated(
-        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name', name_ids)
+    config.expect_recovery(service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
+    sdk_tasks.check_tasks_updated(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data', data_ids)
+    sdk_tasks.check_tasks_not_updated(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal', journal_ids)
+    sdk_tasks.check_tasks_not_updated(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name', name_ids)
 
 
 @pytest.mark.sanity
 @pytest.mark.recovery
 def test_kill_scheduler():
-    sdk_tasks.kill_task_with_pattern(
-        'hdfs.scheduler.Main', shakedown.get_service_ips('marathon').pop())
-    config.check_healthy(
-        service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
+    sdk_tasks.kill_task_with_pattern('hdfs.scheduler.Main', shakedown.get_service_ips('marathon').pop())
+    config.check_healthy(service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
 
 
 @pytest.mark.sanity
 @pytest.mark.recovery
 def test_kill_all_journalnodes():
-    journal_ids = sdk_tasks.get_task_ids(
-        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal')
-    data_ids = sdk_tasks.get_task_ids(
-        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data')
+    journal_ids = sdk_tasks.get_task_ids(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal')
+    data_ids = sdk_tasks.get_task_ids(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data')
 
     for journal_pod in config.get_pod_type_instances("journal", sdk_utils.get_foldered_name(config.SERVICE_NAME)):
         sdk_cmd.svc_cli(
@@ -182,25 +154,19 @@ def test_kill_all_journalnodes():
                 config.SERVICE_NAME),
             'pod restart {}'.format(journal_pod))
 
-    config.expect_recovery(
-        service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
+    config.expect_recovery(service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
 
     # name nodes fail and restart, so don't check those
-    sdk_tasks.check_tasks_updated(sdk_utils.get_foldered_name(
-        config.SERVICE_NAME), 'journal', journal_ids)
-    sdk_tasks.check_tasks_not_updated(
-        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data', data_ids)
+    sdk_tasks.check_tasks_updated(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal', journal_ids)
+    sdk_tasks.check_tasks_not_updated(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data', data_ids)
 
 
 @pytest.mark.sanity
 @pytest.mark.recovery
 def test_kill_all_namenodes():
-    journal_ids = sdk_tasks.get_task_ids(
-        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal')
-    name_ids = sdk_tasks.get_task_ids(
-        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name')
-    data_ids = sdk_tasks.get_task_ids(
-        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data')
+    journal_ids = sdk_tasks.get_task_ids(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal')
+    name_ids = sdk_tasks.get_task_ids(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name')
+    data_ids = sdk_tasks.get_task_ids(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data')
 
     for name_pod in config.get_pod_type_instances("name", sdk_utils.get_foldered_name(config.SERVICE_NAME)):
         sdk_cmd.svc_cli(
@@ -208,26 +174,19 @@ def test_kill_all_namenodes():
                 config.SERVICE_NAME),
             'pod restart {}'.format(name_pod))
 
-    config.expect_recovery(
-        service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
+    config.expect_recovery(service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
 
-    sdk_tasks.check_tasks_updated(sdk_utils.get_foldered_name(
-        config.SERVICE_NAME), 'name', name_ids)
-    sdk_tasks.check_tasks_not_updated(sdk_utils.get_foldered_name(
-        config.SERVICE_NAME), 'journal', journal_ids)
-    sdk_tasks.check_tasks_not_updated(
-        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data', data_ids)
+    sdk_tasks.check_tasks_updated(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name', name_ids)
+    sdk_tasks.check_tasks_not_updated(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal', journal_ids)
+    sdk_tasks.check_tasks_not_updated(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data', data_ids)
 
 
 @pytest.mark.sanity
 @pytest.mark.recovery
 def test_kill_all_datanodes():
-    journal_ids = sdk_tasks.get_task_ids(
-        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal')
-    name_ids = sdk_tasks.get_task_ids(
-        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name')
-    data_ids = sdk_tasks.get_task_ids(
-        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data')
+    journal_ids = sdk_tasks.get_task_ids(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal')
+    name_ids = sdk_tasks.get_task_ids(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name')
+    data_ids = sdk_tasks.get_task_ids(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data')
 
     for data_pod in config.get_pod_type_instances("data", sdk_utils.get_foldered_name(config.SERVICE_NAME)):
         sdk_cmd.svc_cli(
@@ -235,15 +194,11 @@ def test_kill_all_datanodes():
                 config.SERVICE_NAME),
             'pod restart {}'.format(data_pod))
 
-    config.expect_recovery(
-        service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
+    config.expect_recovery(service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
 
-    sdk_tasks.check_tasks_updated(sdk_utils.get_foldered_name(
-        config.SERVICE_NAME), 'data', data_ids)
-    sdk_tasks.check_tasks_not_updated(sdk_utils.get_foldered_name(
-        config.SERVICE_NAME), 'journal', journal_ids)
-    sdk_tasks.check_tasks_not_updated(
-        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name', name_ids)
+    sdk_tasks.check_tasks_updated(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data', data_ids)
+    sdk_tasks.check_tasks_not_updated(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal', journal_ids)
+    sdk_tasks.check_tasks_not_updated(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name', name_ids)
 
 
 @pytest.mark.sanity
@@ -257,148 +212,102 @@ def test_permanently_replace_namenodes():
 @pytest.mark.sanity
 @pytest.mark.recovery
 def test_permanent_and_transient_namenode_failures_0_1():
-    config.check_healthy(
-        service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
-    name_0_ids = sdk_tasks.get_task_ids(
-        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name-0')
-    name_1_ids = sdk_tasks.get_task_ids(
-        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name-1')
-    journal_ids = sdk_tasks.get_task_ids(
-        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal')
-    data_ids = sdk_tasks.get_task_ids(
-        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data')
+    config.check_healthy(service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
+    name_0_ids = sdk_tasks.get_task_ids(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name-0')
+    name_1_ids = sdk_tasks.get_task_ids(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name-1')
+    journal_ids = sdk_tasks.get_task_ids(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal')
+    data_ids = sdk_tasks.get_task_ids(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data')
 
-    sdk_cmd.svc_cli(config.PACKAGE_NAME, sdk_utils.get_foldered_name(
-        config.SERVICE_NAME), 'pod replace name-0')
-    sdk_cmd.svc_cli(config.PACKAGE_NAME, sdk_utils.get_foldered_name(
-        config.SERVICE_NAME), 'pod restart name-1')
+    sdk_cmd.svc_cli(config.PACKAGE_NAME, sdk_utils.get_foldered_name(config.SERVICE_NAME), 'pod replace name-0')
+    sdk_cmd.svc_cli(config.PACKAGE_NAME, sdk_utils.get_foldered_name(config.SERVICE_NAME), 'pod restart name-1')
 
-    config.expect_recovery(
-        service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
+    config.expect_recovery(service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
 
-    sdk_tasks.check_tasks_updated(sdk_utils.get_foldered_name(
-        config.SERVICE_NAME), 'name-0', name_0_ids)
-    sdk_tasks.check_tasks_updated(sdk_utils.get_foldered_name(
-        config.SERVICE_NAME), 'name-1', name_1_ids)
-    sdk_tasks.check_tasks_not_updated(sdk_utils.get_foldered_name(
-        config.SERVICE_NAME), 'journal', journal_ids)
-    sdk_tasks.check_tasks_not_updated(
-        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data', data_ids)
+    sdk_tasks.check_tasks_updated(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name-0', name_0_ids)
+    sdk_tasks.check_tasks_updated(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name-1', name_1_ids)
+    sdk_tasks.check_tasks_not_updated(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal', journal_ids)
+    sdk_tasks.check_tasks_not_updated(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data', data_ids)
 
 
 @pytest.mark.sanity
 @pytest.mark.recovery
 def test_permanent_and_transient_namenode_failures_1_0():
-    config.check_healthy(
-        service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
-    name_0_ids = sdk_tasks.get_task_ids(
-        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name-0')
-    name_1_ids = sdk_tasks.get_task_ids(
-        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name-1')
-    journal_ids = sdk_tasks.get_task_ids(
-        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal')
-    data_ids = sdk_tasks.get_task_ids(
-        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data')
+    config.check_healthy(service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
+    name_0_ids = sdk_tasks.get_task_ids(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name-0')
+    name_1_ids = sdk_tasks.get_task_ids(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name-1')
+    journal_ids = sdk_tasks.get_task_ids(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal')
+    data_ids = sdk_tasks.get_task_ids(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data')
 
-    sdk_cmd.svc_cli(config.PACKAGE_NAME, sdk_utils.get_foldered_name(
-        config.SERVICE_NAME), 'pod replace name-1')
-    sdk_cmd.svc_cli(config.PACKAGE_NAME, sdk_utils.get_foldered_name(
-        config.SERVICE_NAME), 'pod restart name-0')
+    sdk_cmd.svc_cli(config.PACKAGE_NAME, sdk_utils.get_foldered_name(config.SERVICE_NAME), 'pod replace name-1')
+    sdk_cmd.svc_cli(config.PACKAGE_NAME, sdk_utils.get_foldered_name(config.SERVICE_NAME), 'pod restart name-0')
 
-    config.expect_recovery(
-        service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
+    config.expect_recovery(service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
 
-    sdk_tasks.check_tasks_updated(sdk_utils.get_foldered_name(
-        config.SERVICE_NAME), 'name-0', name_0_ids)
-    sdk_tasks.check_tasks_updated(sdk_utils.get_foldered_name(
-        config.SERVICE_NAME), 'name-1', name_1_ids)
-    sdk_tasks.check_tasks_not_updated(sdk_utils.get_foldered_name(
-        config.SERVICE_NAME), 'journal', journal_ids)
-    sdk_tasks.check_tasks_not_updated(
-        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data', data_ids)
+    sdk_tasks.check_tasks_updated(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name-0', name_0_ids)
+    sdk_tasks.check_tasks_updated(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name-1', name_1_ids)
+    sdk_tasks.check_tasks_not_updated(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal', journal_ids)
+    sdk_tasks.check_tasks_not_updated(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data', data_ids)
 
 
 @pytest.mark.smoke
 def test_install():
-    config.check_healthy(
-        service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
+    config.check_healthy(service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
 
 
 @pytest.mark.sanity
 def test_bump_journal_cpus():
-    journal_ids = sdk_tasks.get_task_ids(
-        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal')
-    name_ids = sdk_tasks.get_task_ids(
-        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name')
+    journal_ids = sdk_tasks.get_task_ids(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal')
+    name_ids = sdk_tasks.get_task_ids(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name')
     log.info('journal ids: ' + str(journal_ids))
 
-    sdk_marathon.bump_cpu_count_config(
-        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'JOURNAL_CPUS')
+    sdk_marathon.bump_cpu_count_config(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'JOURNAL_CPUS')
 
-    sdk_tasks.check_tasks_updated(sdk_utils.get_foldered_name(
-        config.SERVICE_NAME), 'journal', journal_ids)
+    sdk_tasks.check_tasks_updated(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal', journal_ids)
     # journal node update should not cause any of the name nodes to crash
-    sdk_tasks.check_tasks_not_updated(
-        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name', name_ids)
-    config.check_healthy(
-        service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
+    sdk_tasks.check_tasks_not_updated(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name', name_ids)
+    config.check_healthy(service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
 
 
 @pytest.mark.sanity
 def test_bump_data_nodes():
-    data_ids = sdk_tasks.get_task_ids(
-        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data')
+    data_ids = sdk_tasks.get_task_ids(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data')
     log.info('data ids: ' + str(data_ids))
 
-    sdk_marathon.bump_task_count_config(
-        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'DATA_COUNT')
+    sdk_marathon.bump_task_count_config(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'DATA_COUNT')
 
     config.check_healthy(
         service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME),
         count=config.DEFAULT_TASK_COUNT + 1
     )
-    sdk_tasks.check_tasks_not_updated(
-        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data', data_ids)
+    sdk_tasks.check_tasks_not_updated(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data', data_ids)
 
 
 @pytest.mark.readiness_check
 @pytest.mark.sanity
 def test_modify_app_config():
     """This tests checks that the modification of the app config does not trigger a recovery."""
-    sdk_plan.wait_for_completed_recovery(
-        sdk_utils.get_foldered_name(config.SERVICE_NAME))
-    old_recovery_plan = sdk_plan.get_plan(
-        sdk_utils.get_foldered_name(config.SERVICE_NAME), "recovery")
+    sdk_plan.wait_for_completed_recovery(sdk_utils.get_foldered_name(config.SERVICE_NAME))
+    old_recovery_plan = sdk_plan.get_plan(sdk_utils.get_foldered_name(config.SERVICE_NAME), "recovery")
 
     app_config_field = 'TASKCFG_ALL_CLIENT_READ_SHORTCIRCUIT_STREAMS_CACHE_SIZE_EXPIRY_MS'
-    journal_ids = sdk_tasks.get_task_ids(
-        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal')
-    name_ids = sdk_tasks.get_task_ids(
-        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name')
+    journal_ids = sdk_tasks.get_task_ids(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal')
+    name_ids = sdk_tasks.get_task_ids(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name')
 
-    marathon_config = sdk_marathon.get_config(
-        sdk_utils.get_foldered_name(config.SERVICE_NAME))
+    marathon_config = sdk_marathon.get_config(sdk_utils.get_foldered_name(config.SERVICE_NAME))
     log.info('marathon config: ')
     log.info(marathon_config)
     expiry_ms = int(marathon_config['env'][app_config_field])
     marathon_config['env'][app_config_field] = str(expiry_ms + 1)
-    sdk_marathon.update_app(sdk_utils.get_foldered_name(
-        config.SERVICE_NAME), marathon_config, timeout=15 * 60)
+    sdk_marathon.update_app(sdk_utils.get_foldered_name(config.SERVICE_NAME), marathon_config, timeout=15 * 60)
 
     # All tasks should be updated because hdfs-site.xml has changed
-    config.check_healthy(
-        service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
-    sdk_tasks.check_tasks_updated(sdk_utils.get_foldered_name(
-        config.SERVICE_NAME), 'journal', journal_ids)
-    sdk_tasks.check_tasks_updated(sdk_utils.get_foldered_name(
-        config.SERVICE_NAME), 'name', name_ids)
-    sdk_tasks.check_tasks_updated(sdk_utils.get_foldered_name(
-        config.SERVICE_NAME), 'data', journal_ids)
+    config.check_healthy(service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
+    sdk_tasks.check_tasks_updated(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal', journal_ids)
+    sdk_tasks.check_tasks_updated(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'name', name_ids)
+    sdk_tasks.check_tasks_updated(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data', journal_ids)
 
-    sdk_plan.wait_for_completed_recovery(
-        sdk_utils.get_foldered_name(config.SERVICE_NAME))
-    new_recovery_plan = sdk_plan.get_plan(
-        sdk_utils.get_foldered_name(config.SERVICE_NAME), "recovery")
+    sdk_plan.wait_for_completed_recovery(sdk_utils.get_foldered_name(config.SERVICE_NAME))
+    new_recovery_plan = sdk_plan.get_plan(sdk_utils.get_foldered_name(config.SERVICE_NAME), "recovery")
     assert old_recovery_plan == new_recovery_plan
 
 
@@ -406,48 +315,36 @@ def test_modify_app_config():
 def test_modify_app_config_rollback():
     app_config_field = 'TASKCFG_ALL_CLIENT_READ_SHORTCIRCUIT_STREAMS_CACHE_SIZE_EXPIRY_MS'
 
-    journal_ids = sdk_tasks.get_task_ids(
-        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal')
-    data_ids = sdk_tasks.get_task_ids(
-        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data')
+    journal_ids = sdk_tasks.get_task_ids(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal')
+    data_ids = sdk_tasks.get_task_ids(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data')
 
-    old_config = sdk_marathon.get_config(
-        sdk_utils.get_foldered_name(config.SERVICE_NAME))
-    marathon_config = sdk_marathon.get_config(
-        sdk_utils.get_foldered_name(config.SERVICE_NAME))
+    old_config = sdk_marathon.get_config(sdk_utils.get_foldered_name(config.SERVICE_NAME))
+    marathon_config = sdk_marathon.get_config(sdk_utils.get_foldered_name(config.SERVICE_NAME))
     log.info('marathon config: ')
     log.info(marathon_config)
     expiry_ms = int(marathon_config['env'][app_config_field])
     log.info('expiry ms: ' + str(expiry_ms))
     marathon_config['env'][app_config_field] = str(expiry_ms + 1)
-    sdk_marathon.update_app(sdk_utils.get_foldered_name(
-        config.SERVICE_NAME), marathon_config, timeout=15 * 60)
+    sdk_marathon.update_app(sdk_utils.get_foldered_name(config.SERVICE_NAME), marathon_config, timeout=15 * 60)
 
     # Wait for journal nodes to be affected by the change
-    sdk_tasks.check_tasks_updated(sdk_utils.get_foldered_name(
-        config.SERVICE_NAME), 'journal', journal_ids)
-    journal_ids = sdk_tasks.get_task_ids(
-        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal')
+    sdk_tasks.check_tasks_updated(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal', journal_ids)
+    journal_ids = sdk_tasks.get_task_ids(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal')
 
     log.info('old config: ')
     log.info(old_config)
     # Put the old config back (rollback)
-    sdk_marathon.update_app(sdk_utils.get_foldered_name(
-        config.SERVICE_NAME), old_config)
+    sdk_marathon.update_app(sdk_utils.get_foldered_name(config.SERVICE_NAME), old_config)
 
     # Wait for the journal nodes to return to their old configuration
-    sdk_tasks.check_tasks_updated(sdk_utils.get_foldered_name(
-        config.SERVICE_NAME), 'journal', journal_ids)
-    config.check_healthy(
-        service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
+    sdk_tasks.check_tasks_updated(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal', journal_ids)
+    config.check_healthy(service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
 
-    marathon_config = sdk_marathon.get_config(
-        sdk_utils.get_foldered_name(config.SERVICE_NAME))
+    marathon_config = sdk_marathon.get_config(sdk_utils.get_foldered_name(config.SERVICE_NAME))
     assert int(marathon_config['env'][app_config_field]) == expiry_ms
 
     # Data tasks should not have been affected
-    sdk_tasks.check_tasks_not_updated(
-        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data', data_ids)
+    sdk_tasks.check_tasks_not_updated(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data', data_ids)
 
 
 @pytest.mark.sanity
@@ -464,26 +361,18 @@ def test_metrics():
 
 
 def replace_name_node(index):
-    config.check_healthy(
-        service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
+    config.check_healthy(service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
     name_node_name = 'name-' + str(index)
-    name_id = sdk_tasks.get_task_ids(
-        sdk_utils.get_foldered_name(config.SERVICE_NAME), name_node_name)
-    journal_ids = sdk_tasks.get_task_ids(
-        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal')
-    data_ids = sdk_tasks.get_task_ids(
-        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data')
+    name_id = sdk_tasks.get_task_ids(sdk_utils.get_foldered_name(config.SERVICE_NAME), name_node_name)
+    journal_ids = sdk_tasks.get_task_ids(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal')
+    data_ids = sdk_tasks.get_task_ids(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data')
 
     sdk_cmd.svc_cli(
         config.PACKAGE_NAME, sdk_utils.get_foldered_name(config.SERVICE_NAME),
         'pod replace {}'.format(name_node_name))
 
-    config.expect_recovery(
-        service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
+    config.expect_recovery(service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
 
-    sdk_tasks.check_tasks_updated(sdk_utils.get_foldered_name(
-        config.SERVICE_NAME), name_node_name, name_id)
-    sdk_tasks.check_tasks_not_updated(sdk_utils.get_foldered_name(
-        config.SERVICE_NAME), 'journal', journal_ids)
-    sdk_tasks.check_tasks_not_updated(
-        sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data', data_ids)
+    sdk_tasks.check_tasks_updated(sdk_utils.get_foldered_name(config.SERVICE_NAME), name_node_name, name_id)
+    sdk_tasks.check_tasks_not_updated(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'journal', journal_ids)
+    sdk_tasks.check_tasks_not_updated(sdk_utils.get_foldered_name(config.SERVICE_NAME), 'data', data_ids)

--- a/frameworks/hdfs/tests/test_sanity.py
+++ b/frameworks/hdfs/tests/test_sanity.py
@@ -351,12 +351,18 @@ def test_modify_app_config_rollback():
 @pytest.mark.metrics
 @sdk_utils.dcos_1_9_or_higher
 def test_metrics():
+    expected_metrics = [
+        "JournalNode.jvm.JvmMetrics.ThreadsRunnable",
+        "null.rpc.rpc.RpcQueueTimeNumOps",
+        "null.metricssystem.MetricsSystem.PublishAvgTime"
+    ]
+
     sdk_metrics.wait_for_service_metrics(
         config.PACKAGE_NAME,
         sdk_utils.get_foldered_name(config.SERVICE_NAME),
         "journal-0-node",
         config.DEFAULT_HDFS_TIMEOUT,
-        config.EXPECTED_METRICS
+        expected_metrics
     )
 
 

--- a/frameworks/kafka/tests/config.py
+++ b/frameworks/kafka/tests/config.py
@@ -9,3 +9,8 @@ DEFAULT_POD_TYPE = 'kafka'
 DEFAULT_TASK_NAME = 'broker'
 DEFAULT_KAFKA_TIMEOUT = 10 * 60
 DEFAULT_TOPIC_NAME = 'topic1'
+EXPECTED_METRICS = [
+    "kafka.network.RequestMetrics.ResponseQueueTimeMs.max",
+    "kafka.socket-server-metrics.io-ratio",
+    "kafka.controller.ControllerStats.LeaderElectionRateAndTimeMs.p95"
+]

--- a/frameworks/kafka/tests/config.py
+++ b/frameworks/kafka/tests/config.py
@@ -9,8 +9,3 @@ DEFAULT_POD_TYPE = 'kafka'
 DEFAULT_TASK_NAME = 'broker'
 DEFAULT_KAFKA_TIMEOUT = 10 * 60
 DEFAULT_TOPIC_NAME = 'topic1'
-EXPECTED_METRICS = [
-    "kafka.network.RequestMetrics.ResponseQueueTimeMs.max",
-    "kafka.socket-server-metrics.io-ratio",
-    "kafka.controller.ControllerStats.LeaderElectionRateAndTimeMs.p95"
-]

--- a/frameworks/kafka/tests/test_sanity.py
+++ b/frameworks/kafka/tests/test_sanity.py
@@ -354,12 +354,16 @@ def test_metrics():
         "kafka.socket-server-metrics.io-ratio",
         "kafka.controller.ControllerStats.LeaderElectionRateAndTimeMs.p95"
     ]
+
+    def expected_metrics_exist(emitted_metrics):
+        return sdk_metrics.check_metrics_presence(metric_names, expected_metrics)
+
     sdk_metrics.wait_for_service_metrics(
         config.PACKAGE_NAME,
         sdk_utils.get_foldered_name(config.SERVICE_NAME),
         "kafka-0-broker",
         config.DEFAULT_KAFKA_TIMEOUT,
-        expected_metrics
+        expected_metrics_exist
     )
 
 

--- a/frameworks/kafka/tests/test_sanity.py
+++ b/frameworks/kafka/tests/test_sanity.py
@@ -45,8 +45,7 @@ def configure_package(configure_security):
 
         yield  # let the test session execute
     finally:
-        sdk_install.uninstall(config.PACKAGE_NAME,
-                              sdk_utils.get_foldered_name(config.SERVICE_NAME))
+        sdk_install.uninstall(config.PACKAGE_NAME, sdk_utils.get_foldered_name(config.SERVICE_NAME))
 
 
 # --------- Endpoints -------------
@@ -143,8 +142,7 @@ def test_broker_list():
 def test_broker_invalid():
     try:
         sdk_cmd.svc_cli(
-            config.PACKAGE_NAME, sdk_utils.get_foldered_name(
-                config.SERVICE_NAME),
+            config.PACKAGE_NAME, sdk_utils.get_foldered_name(config.SERVICE_NAME),
             'broker get {}'.format(config.DEFAULT_BROKER_COUNT + 1), json=True)
         assert False, "Should have failed"
     except AssertionError as arg:
@@ -356,7 +354,7 @@ def test_metrics():
     ]
 
     def expected_metrics_exist(emitted_metrics):
-        return sdk_metrics.check_metrics_presence(metric_names, expected_metrics)
+        return sdk_metrics.check_metrics_presence(emitted_metrics, expected_metrics)
 
     sdk_metrics.wait_for_service_metrics(
         config.PACKAGE_NAME,

--- a/frameworks/kafka/tests/test_sanity.py
+++ b/frameworks/kafka/tests/test_sanity.py
@@ -78,8 +78,7 @@ def test_endpoints_address():
 @pytest.mark.sanity
 def test_endpoints_zookeeper_default():
     zookeeper = sdk_cmd.svc_cli(
-        config.PACKAGE_NAME, sdk_utils.get_foldered_name(config.SERVICE_NAME),
-        'endpoints zookeeper')
+        config.PACKAGE_NAME, sdk_utils.get_foldered_name(config.SERVICE_NAME), 'endpoints zookeeper')
     assert zookeeper.rstrip('\n') == 'master.mesos:2181/{}'.format(sdk_utils.get_zk_path(
         sdk_utils.get_foldered_name(config.SERVICE_NAME)))
 
@@ -98,8 +97,7 @@ def test_custom_zookeeper():
         config.PACKAGE_NAME, sdk_utils.get_foldered_name(config.SERVICE_NAME),
         'topic list', json=True) == [config.DEFAULT_TOPIC_NAME]
 
-    marathon_config = sdk_marathon.get_config(
-        sdk_utils.get_foldered_name(config.SERVICE_NAME))
+    marathon_config = sdk_marathon.get_config(sdk_utils.get_foldered_name(config.SERVICE_NAME))
     # should be using default path when this envvar is empty/unset:
     assert marathon_config['env']['KAFKA_ZOOKEEPER_URI'] == ''
 
@@ -107,13 +105,11 @@ def test_custom_zookeeper():
     zk_path = 'master.mesos:2181/{}/CUSTOMPATH'.format(sdk_utils.get_zk_path(
         sdk_utils.get_foldered_name(config.SERVICE_NAME)))
     marathon_config['env']['KAFKA_ZOOKEEPER_URI'] = zk_path
-    sdk_marathon.update_app(sdk_utils.get_foldered_name(
-        config.SERVICE_NAME), marathon_config)
+    sdk_marathon.update_app(sdk_utils.get_foldered_name(config.SERVICE_NAME), marathon_config)
 
     sdk_tasks.check_tasks_updated(
         sdk_utils.get_foldered_name(config.SERVICE_NAME), '{}-'.format(config.DEFAULT_POD_TYPE), broker_ids)
-    sdk_plan.wait_for_completed_deployment(
-        sdk_utils.get_foldered_name(config.SERVICE_NAME))
+    sdk_plan.wait_for_completed_deployment(sdk_utils.get_foldered_name(config.SERVICE_NAME))
 
     # wait for brokers to finish registering
     test_utils.broker_count_check(config.DEFAULT_BROKER_COUNT,
@@ -139,8 +135,7 @@ def test_custom_zookeeper():
 def test_broker_list():
     brokers = sdk_cmd.svc_cli(config.PACKAGE_NAME,
                               sdk_utils.get_foldered_name(config.SERVICE_NAME), 'broker list', json=True)
-    assert set(brokers) == set([str(i)
-                                for i in range(config.DEFAULT_BROKER_COUNT)])
+    assert set(brokers) == set([str(i) for i in range(config.DEFAULT_BROKER_COUNT)])
 
 
 @pytest.mark.smoke
@@ -164,15 +159,13 @@ def test_broker_invalid():
 @pytest.mark.smoke
 @pytest.mark.sanity
 def test_pods_restart():
-    test_utils.restart_broker_pods(
-        sdk_utils.get_foldered_name(config.SERVICE_NAME))
+    test_utils.restart_broker_pods(sdk_utils.get_foldered_name(config.SERVICE_NAME))
 
 
 @pytest.mark.smoke
 @pytest.mark.sanity
 def test_pod_replace():
-    test_utils.replace_broker_pod(
-        sdk_utils.get_foldered_name(config.SERVICE_NAME))
+    test_utils.replace_broker_pod(sdk_utils.get_foldered_name(config.SERVICE_NAME))
 
 
 # --------- Topics -------------
@@ -220,8 +213,7 @@ def test_topic_offsets_increase_with_writes():
         config.PACKAGE_NAME, sdk_utils.get_foldered_name(config.SERVICE_NAME),
         'topic producer_test {} {}'.format(config.DEFAULT_TOPIC_NAME, num_messages), json=True)
     assert len(write_info) == 1
-    assert write_info['message'].startswith(
-        'Output: {} records sent'.format(num_messages))
+    assert write_info['message'].startswith('Output: {} records sent'.format(num_messages))
 
     offset_info = sdk_cmd.svc_cli(
         config.PACKAGE_NAME, sdk_utils.get_foldered_name(config.SERVICE_NAME),
@@ -243,10 +235,8 @@ def test_decreasing_topic_partitions_fails():
         'topic partitions {} {}'.format(config.DEFAULT_TOPIC_NAME, config.DEFAULT_PARTITION_COUNT - 1), json=True)
 
     assert len(partition_info) == 1
-    assert partition_info['message'].startswith(
-        'Output: WARNING: If partitions are increased')
-    assert (
-        'The number of partitions for a topic can only be increased' in partition_info['message'])
+    assert partition_info['message'].startswith('Output: WARNING: If partitions are increased')
+    assert ('The number of partitions for a topic can only be increased' in partition_info['message'])
 
 
 @pytest.mark.sanity
@@ -256,10 +246,8 @@ def test_setting_topic_partitions_to_same_value_fails():
         'topic partitions {} {}'.format(config.DEFAULT_TOPIC_NAME, config.DEFAULT_PARTITION_COUNT), json=True)
 
     assert len(partition_info) == 1
-    assert partition_info['message'].startswith(
-        'Output: WARNING: If partitions are increased')
-    assert (
-        'The number of partitions for a topic can only be increased' in partition_info['message'])
+    assert partition_info['message'].startswith('Output: WARNING: If partitions are increased')
+    assert ('The number of partitions for a topic can only be increased' in partition_info['message'])
 
 
 @pytest.mark.sanity
@@ -269,10 +257,8 @@ def test_increasing_topic_partitions_succeeds():
         'topic partitions {} {}'.format(config.DEFAULT_TOPIC_NAME, config.DEFAULT_PARTITION_COUNT + 1), json=True)
 
     assert len(partition_info) == 1
-    assert partition_info['message'].startswith(
-        'Output: WARNING: If partitions are increased')
-    assert (
-        'The number of partitions for a topic can only be increased' not in partition_info['message'])
+    assert partition_info['message'].startswith('Output: WARNING: If partitions are increased')
+    assert ('The number of partitions for a topic can only be increased' not in partition_info['message'])
 
 
 @pytest.mark.sanity
@@ -301,8 +287,7 @@ def test_no_unavailable_partitions_exist():
 @pytest.mark.smoke
 @pytest.mark.sanity
 def test_help_cli():
-    sdk_cmd.svc_cli(config.PACKAGE_NAME, sdk_utils.get_foldered_name(
-        config.SERVICE_NAME), 'help')
+    sdk_cmd.svc_cli(config.PACKAGE_NAME, sdk_utils.get_foldered_name(config.SERVICE_NAME), 'help')
 
 
 @pytest.mark.smoke

--- a/frameworks/kafka/tests/test_sanity.py
+++ b/frameworks/kafka/tests/test_sanity.py
@@ -349,12 +349,17 @@ def test_pod_cli():
 @pytest.mark.metrics
 @sdk_utils.dcos_1_9_or_higher
 def test_metrics():
+    expected_metrics = [
+        "kafka.network.RequestMetrics.ResponseQueueTimeMs.max",
+        "kafka.socket-server-metrics.io-ratio",
+        "kafka.controller.ControllerStats.LeaderElectionRateAndTimeMs.p95"
+    ]
     sdk_metrics.wait_for_service_metrics(
         config.PACKAGE_NAME,
         sdk_utils.get_foldered_name(config.SERVICE_NAME),
         "kafka-0-broker",
         config.DEFAULT_KAFKA_TIMEOUT,
-        config.EXPECTED_METRICS
+        expected_metrics
     )
 
 

--- a/testing/sdk_api.py
+++ b/testing/sdk_api.py
@@ -1,3 +1,9 @@
+'''
+************************************************************************
+FOR THE TIME BEING WHATEVER MODIFICATIONS ARE APPLIED TO THIS FILE
+SHOULD ALSO BE APPLIED TO sdk_api IN ANY OTHER PARTNER REPOS
+************************************************************************
+'''
 import logging
 
 import dcos

--- a/testing/sdk_cmd.py
+++ b/testing/sdk_cmd.py
@@ -1,4 +1,10 @@
-'''Utilities relating to running commands and HTTP requests'''
+'''Utilities relating to running commands and HTTP requests
+
+************************************************************************
+FOR THE TIME BEING WHATEVER MODIFICATIONS ARE APPLIED TO THIS FILE
+SHOULD ALSO BE APPLIED TO sdk_cmd IN ANY OTHER PARTNER REPOS
+************************************************************************
+'''
 import json as jsonlib
 import logging
 

--- a/testing/sdk_hosts.py
+++ b/testing/sdk_hosts.py
@@ -1,5 +1,10 @@
-'''Utilities relating to mapping tasks and services to hostnames'''
+'''Utilities relating to mapping tasks and services to hostnames
 
+************************************************************************
+FOR THE TIME BEING WHATEVER MODIFICATIONS ARE APPLIED TO THIS FILE
+SHOULD ALSO BE APPLIED TO sdk_hosts IN ANY OTHER PARTNER REPOS
+************************************************************************
+'''
 
 SYSTEM_HOST_SUFFIX = 'mesos'
 AUTOIP_HOST_SUFFIX = 'autoip.dcos.thisdcos.directory'

--- a/testing/sdk_install.py
+++ b/testing/sdk_install.py
@@ -1,5 +1,10 @@
-'''Utilities relating to installing services'''
+'''Utilities relating to installing services
 
+************************************************************************
+FOR THE TIME BEING WHATEVER MODIFICATIONS ARE APPLIED TO THIS FILE
+SHOULD ALSO BE APPLIED TO sdk_install IN ANY OTHER PARTNER REPOS
+************************************************************************
+'''
 import collections
 import logging
 

--- a/testing/sdk_jobs.py
+++ b/testing/sdk_jobs.py
@@ -1,5 +1,10 @@
-'''Utilities relating to creation and verification of Metronome jobs'''
+'''Utilities relating to creation and verification of Metronome jobs
 
+************************************************************************
+FOR THE TIME BEING WHATEVER MODIFICATIONS ARE APPLIED TO THIS FILE
+SHOULD ALSO BE APPLIED TO sdk_jobs IN ANY OTHER PARTNER REPOS
+************************************************************************
+'''
 import json
 import logging
 import os

--- a/testing/sdk_marathon.py
+++ b/testing/sdk_marathon.py
@@ -1,4 +1,10 @@
-'''Utilities relating to interaction with Marathon'''
+'''Utilities relating to interaction with Marathon
+
+************************************************************************
+FOR THE TIME BEING WHATEVER MODIFICATIONS ARE APPLIED TO THIS FILE
+SHOULD ALSO BE APPLIED TO sdk_marathon IN ANY OTHER PARTNER REPOS
+************************************************************************
+'''
 import logging
 
 import shakedown

--- a/testing/sdk_metrics.py
+++ b/testing/sdk_metrics.py
@@ -89,7 +89,7 @@ def extract_metric_names(service_name, service_metrics):
     # For eg: ip-10-0-0-139.null.rpc.rpc.RpcQueueTimeNumOps
     # This is consistent across all HDFS metric names.
     if "hdfs" in service_name:
-        metric_names = ['-'.join(metric_name.split(".")[1:])
+        metric_names = ['.'.join(metric_name.split(".")[1:])
                         for metric_name in metric_names]
 
     return set(metric_names)

--- a/testing/sdk_metrics.py
+++ b/testing/sdk_metrics.py
@@ -37,8 +37,7 @@ def get_metrics(package_name, service_name, task_name):
     executor_id = task_to_check['executor_id']
 
     pod_name = '-'.join(task_name.split("-")[:2])
-    pod_info = sdk_cmd.svc_cli(
-        package_name, service_name, "pod info {}".format(pod_name), json=True)
+    pod_info = sdk_cmd.svc_cli(package_name, service_name, "pod info {}".format(pod_name), json=True)
     task_info = None
     for task in pod_info:
         if task["info"]["name"] == task_name:
@@ -52,8 +51,7 @@ def get_metrics(package_name, service_name, task_name):
 
     # Not related to functionality but consuming this
     # endpoint to verify downstream integrity
-    containers_url = "{}/system/v1/agent/{}/metrics/v0/containers".format(
-        shakedown.dcos_url(), agent_id)
+    containers_url = "{}/system/v1/agent/{}/metrics/v0/containers".format(shakedown.dcos_url(), agent_id)
     containers_response = sdk_cmd.request("GET", containers_url, retry=False)
     if containers_response.ok is None:
         log.info("Unable to fetch containers list")

--- a/testing/sdk_metrics.py
+++ b/testing/sdk_metrics.py
@@ -37,7 +37,8 @@ def get_metrics(package_name, service_name, task_name):
     executor_id = task_to_check['executor_id']
 
     pod_name = '-'.join(task_name.split("-")[:2])
-    pod_info = sdk_cmd.svc_cli(package_name, service_name, "pod info {}".format(pod_name), json=True)
+    pod_info = sdk_cmd.svc_cli(
+        package_name, service_name, "pod info {}".format(pod_name), json=True)
     task_info = None
     for task in pod_info:
         if task["info"]["name"] == task_name:
@@ -90,6 +91,14 @@ def extract_metric_names(service_name, service_metrics):
     # This is consistent across all HDFS metric names.
     if "hdfs" in service_name:
         metric_names = ['.'.join(metric_name.split(".")[1:])
+                        for metric_name in metric_names]
+
+    # Elastic metrics are also dynamic and based on the service name
+    # For eg: elasticsearch.test__integration__elastic.node.data-0-node.thread_pool.listener.completed
+    # To prevent this from breaking we drop the service name from the metric name
+    # => data-0-node.thread_pool.listener.completed
+    if "elastic" in service_name:
+        metric_names = ['.'.join(metric_name.split('.')[2:])
                         for metric_name in metric_names]
 
     return set(metric_names)

--- a/testing/sdk_networks.py
+++ b/testing/sdk_networks.py
@@ -1,3 +1,9 @@
+'''
+************************************************************************
+FOR THE TIME BEING WHATEVER MODIFICATIONS ARE APPLIED TO THIS FILE
+SHOULD ALSO BE APPLIED TO sdk_networks IN ANY OTHER PARTNER REPOS
+************************************************************************
+'''
 import json
 
 import shakedown

--- a/testing/sdk_plan.py
+++ b/testing/sdk_plan.py
@@ -1,4 +1,11 @@
-'''Utilities relating to interaction with service plans'''
+'''Utilities relating to interaction with service plans
+
+************************************************************************
+FOR THE TIME BEING WHATEVER MODIFICATIONS ARE APPLIED TO THIS FILE
+SHOULD ALSO BE APPLIED TO sdk_plan IN ANY OTHER PARTNER REPOS
+************************************************************************
+'''
+
 import logging
 
 import dcos

--- a/testing/sdk_repository.py
+++ b/testing/sdk_repository.py
@@ -1,3 +1,9 @@
+'''
+************************************************************************
+FOR THE TIME BEING WHATEVER MODIFICATIONS ARE APPLIED TO THIS FILE
+SHOULD ALSO BE APPLIED TO sdk_repository IN ANY OTHER PARTNER REPOS
+************************************************************************
+'''
 import json
 import logging
 import os

--- a/testing/sdk_security.py
+++ b/testing/sdk_security.py
@@ -1,3 +1,9 @@
+'''
+************************************************************************
+FOR THE TIME BEING WHATEVER MODIFICATIONS ARE APPLIED TO THIS FILE
+SHOULD ALSO BE APPLIED TO sdk_security IN ANY OTHER PARTNER REPOS
+************************************************************************
+'''
 import logging
 import os
 from typing import List, Tuple

--- a/testing/sdk_tasks.py
+++ b/testing/sdk_tasks.py
@@ -1,4 +1,10 @@
-'''Utilities relating to running commands and HTTP requests'''
+'''Utilities relating to running commands and HTTP requests
+
+************************************************************************
+FOR THE TIME BEING WHATEVER MODIFICATIONS ARE APPLIED TO THIS FILE
+SHOULD ALSO BE APPLIED TO sdk_tasks IN ANY OTHER PARTNER REPOS
+************************************************************************
+'''
 import logging
 
 import dcos.errors

--- a/testing/sdk_upgrade.py
+++ b/testing/sdk_upgrade.py
@@ -1,3 +1,9 @@
+'''
+************************************************************************
+FOR THE TIME BEING WHATEVER MODIFICATIONS ARE APPLIED TO THIS FILE
+SHOULD ALSO BE APPLIED TO sdk_upgrade IN ANY OTHER PARTNER REPOS
+************************************************************************
+'''
 import json
 import logging
 import re

--- a/testing/sdk_utils.py
+++ b/testing/sdk_utils.py
@@ -1,3 +1,9 @@
+'''
+************************************************************************
+FOR THE TIME BEING WHATEVER MODIFICATIONS ARE APPLIED TO THIS FILE
+SHOULD ALSO BE APPLIED TO sdk_utils IN ANY OTHER PARTNER REPOS
+************************************************************************
+'''
 import functools
 import logging
 


### PR DESCRIPTION
This checks each service for reporting a set of specific metrics, the logic being that if this set is reported by the service then the greater set of all metrics is being properly reported as well.

Some autopep8 cosmetic edits are also in this change set.