### PR TITLE
sleep_seconds=10, ignore_exceptions=False

### DIFF
--- a/frameworks/elastic/tests/config.py
+++ b/frameworks/elastic/tests/config.py
@@ -65,7 +65,8 @@ def check_kibana_adminrouter_integration(path):
         exit_status, output = shakedown.run_command_on_master(curl_cmd)
         return output and "HTTP/1.1 200" in output
 
-    return shakedown.wait_for(fun, timeout_seconds=DEFAULT_KIBANA_TIMEOUT, noisy=True)
+    return shakedown.wait_for(fun, timeout_seconds=DEFAULT_KIBANA_TIMEOUT, noisy=True,
+        sleep_seconds=10, ignore_exceptions=False)
 
 
 def check_elasticsearch_index_health(index_name, color, service_name=PACKAGE_NAME):
@@ -74,7 +75,8 @@ def check_elasticsearch_index_health(index_name, color, service_name=PACKAGE_NAM
         result = _get_elasticsearch_index_health(curl_api, index_name)
         return result and result["status"] == color
 
-    return shakedown.wait_for(fun, timeout_seconds=DEFAULT_ELASTIC_TIMEOUT)
+    return shakedown.wait_for(fun, timeout_seconds=DEFAULT_ELASTIC_TIMEOUT,
+        sleep_seconds=10, ignore_exceptions=False)
 
 
 def wait_for_expected_nodes_to_exist(service_name=PACKAGE_NAME, task_count=DEFAULT_TASK_COUNT):
@@ -87,7 +89,8 @@ def wait_for_expected_nodes_to_exist(service_name=PACKAGE_NAME, task_count=DEFAU
         log.info('Waiting for {} healthy nodes, got {}'.format(task_count, node_count))
         return node_count == task_count
 
-    return shakedown.wait_for(expected_nodes, timeout_seconds=DEFAULT_ELASTIC_TIMEOUT)
+    return shakedown.wait_for(expected_nodes, timeout_seconds=DEFAULT_ELASTIC_TIMEOUT,
+        sleep_seconds=10, ignore_exceptions=False)
 
 
 def check_plugin_installed(plugin_name, service_name=PACKAGE_NAME):
@@ -96,7 +99,8 @@ def check_plugin_installed(plugin_name, service_name=PACKAGE_NAME):
         result = _get_hosts_with_plugin(curl_api, plugin_name)
         return result is not None and len(result) == DEFAULT_TASK_COUNT
 
-    return shakedown.wait_for(fun, timeout_seconds=DEFAULT_ELASTIC_TIMEOUT)
+    return shakedown.wait_for(fun, timeout_seconds=DEFAULT_ELASTIC_TIMEOUT,
+        sleep_seconds=10, ignore_exceptions=False)
 
 
 def check_plugin_uninstalled(plugin_name, service_name=PACKAGE_NAME):
@@ -105,7 +109,8 @@ def check_plugin_uninstalled(plugin_name, service_name=PACKAGE_NAME):
         result = _get_hosts_with_plugin(curl_api, plugin_name)
         return result is not None and result == []
 
-    return shakedown.wait_for(fun, timeout_seconds=DEFAULT_ELASTIC_TIMEOUT)
+    return shakedown.wait_for(fun, timeout_seconds=DEFAULT_ELASTIC_TIMEOUT,
+        sleep_seconds=10, ignore_exceptions=False)
 
 
 def _get_hosts_with_plugin(curl_api, plugin_name):
@@ -126,7 +131,7 @@ def get_elasticsearch_master(service_name=PACKAGE_NAME):
 
         return False
 
-    return shakedown.wait_for(get_master)
+    return shakedown.wait_for(get_master, sleep_seconds=10, ignore_exceptions=False)
 
 
 def verify_commercial_api_status(is_enabled, service_name=PACKAGE_NAME):

--- a/frameworks/elastic/tests/test_overlay.py
+++ b/frameworks/elastic/tests/test_overlay.py
@@ -55,7 +55,8 @@ def test_indexing(default_populated_index):
         observed_name = doc["_source"]["name"]
         return observed_name == "Loren"
 
-    return shakedown.wait_for(fun, timeout_seconds=config.DEFAULT_ELASTIC_TIMEOUT)
+    return shakedown.wait_for(fun, timeout_seconds=config.DEFAULT_ELASTIC_TIMEOUT,
+        sleep_seconds=10, ignore_exceptions=False)
 
 
 @pytest.mark.sanity

--- a/frameworks/hdfs/tests/config.py
+++ b/frameworks/hdfs/tests/config.py
@@ -62,7 +62,8 @@ def get_name_node_status(svc_name, name_node):
 
         return output.strip()
 
-    return shakedown.wait_for(lambda: get_status(), timeout_seconds=DEFAULT_HDFS_TIMEOUT)
+    return shakedown.wait_for(lambda: get_status(), timeout_seconds=DEFAULT_HDFS_TIMEOUT,
+        sleep_seconds=10, ignore_exceptions=False)
 
 
 def run_hdfs_command(svc_name, command):

--- a/frameworks/hdfs/tests/test_overlay.py
+++ b/frameworks/hdfs/tests/test_overlay.py
@@ -114,4 +114,5 @@ def wait_for_failover_to_complete(namenode):
         status = config.get_name_node_status(config.PACKAGE_NAME, namenode)
         return status == "active"
 
-    shakedown.wait_for(lambda: failover_detection(), timeout_seconds=config.DEFAULT_HDFS_TIMEOUT)
+    shakedown.wait_for(lambda: failover_detection(), timeout_seconds=config.DEFAULT_HDFS_TIMEOUT,
+        sleep_seconds=10, ignore_exceptions=False)

--- a/frameworks/helloworld/tests/test_canary_strategy.py
+++ b/frameworks/helloworld/tests/test_canary_strategy.py
@@ -41,7 +41,7 @@ def configure_package(configure_security):
 def test_canary_init():
     def fn():
         return sdk_cmd.run_cli('hello-world pod list')
-    assert json.loads(shakedown.wait_for(fn, noisy=True)) == []
+    assert json.loads(shakedown.wait_for(fn, noisy=True, sleep_seconds=10, ignore_exceptions=False)) == []
 
     pl = sdk_plan.wait_for_plan_status(config.PACKAGE_NAME, 'deploy', 'WAITING')
     log.info(pl)

--- a/frameworks/helloworld/tests/test_sanity.py
+++ b/frameworks/helloworld/tests/test_sanity.py
@@ -189,7 +189,8 @@ def test_state_properties_get():
         stdout = sdk_cmd.run_cli('hello-world --name={} state properties'.format(FOLDERED_SERVICE_NAME))
         return len(json.loads(stdout)) > 0
 
-    shakedown.wait_for(lambda: check_for_nonempty_properties(), timeout_seconds=30)
+    shakedown.wait_for(lambda: check_for_nonempty_properties(), timeout_seconds=30,
+        sleep_seconds=10, ignore_exceptions=False)
 
     stdout = sdk_cmd.run_cli('hello-world --name={} state properties'.format(FOLDERED_SERVICE_NAME))
     jsonobj = json.loads(stdout)
@@ -232,7 +233,8 @@ def test_state_refresh_disable_cache():
                 return True
         return False
 
-    shakedown.wait_for(lambda: check_cache_refresh_fails_409conflict(), timeout_seconds=120.)
+    shakedown.wait_for(lambda: check_cache_refresh_fails_409conflict(), timeout_seconds=120.,
+        sleep_seconds=10, ignore_exceptions=False)
 
     marathon_config = sdk_marathon.get_config(FOLDERED_SERVICE_NAME)
     del marathon_config['env']['DISABLE_STATE_CACHE']
@@ -246,7 +248,8 @@ def test_state_refresh_disable_cache():
     def check_cache_refresh():
         return sdk_cmd.run_cli('hello-world --name={} state refresh_cache'.format(FOLDERED_SERVICE_NAME))
 
-    stdout = shakedown.wait_for(lambda: check_cache_refresh(), timeout_seconds=120.)
+    stdout = shakedown.wait_for(lambda: check_cache_refresh(), timeout_seconds=120.,
+        sleep_seconds=10, ignore_exceptions=False)
     assert "Received cmd: refresh" in stdout
 
 
@@ -281,7 +284,7 @@ def test_lock():
         timestamp = marathon_client.get_app(FOLDERED_SERVICE_NAME).get("lastTaskFailure", {}).get("timestamp", None)
         return timestamp != old_timestamp
 
-    shakedown.wait_for(lambda: fn())
+    shakedown.wait_for(lambda: fn(), sleep_seconds=10, ignore_exceptions=False)
 
     # Verify ZK is unchanged
     zk_config_new = shakedown.get_zk_node_data(zk_path)

--- a/frameworks/helloworld/tests/test_sidecar.py
+++ b/frameworks/helloworld/tests/test_sidecar.py
@@ -95,7 +95,7 @@ def test_toxic_sidecar_doesnt_trigger_recovery():
     log.info(recovery_plan)
     sdk_plan.start_plan(config.PACKAGE_NAME, 'sidecar-toxic')
 
-    shakedown.wait_for(ToxicSidecarCheck(), timeout_seconds=10 * 60)
+    shakedown.wait_for(ToxicSidecarCheck(), timeout_seconds=10 * 60, sleep_seconds=10, ignore_exceptions=False)
 
     # Restart the scheduler and wait for it to come up.
     sdk_marathon.restart_app(config.PACKAGE_NAME)

--- a/frameworks/helloworld/tests/test_taskcfg.py
+++ b/frameworks/helloworld/tests/test_taskcfg.py
@@ -44,7 +44,7 @@ def test_deploy():
         return False
 
     try:
-        shakedown.wait_for(lambda: fn(), timeout_seconds=wait_time)
+        shakedown.wait_for(lambda: fn(), timeout_seconds=wait_time, sleep_seconds=10, ignore_exceptions=False)
     except shakedown.TimeoutExpired:
         log.info('Timeout reached as expected')
 

--- a/frameworks/kafka/tests/test_sanity.py
+++ b/frameworks/kafka/tests/test_sanity.py
@@ -60,7 +60,7 @@ def test_endpoints_address():
         if len(ret['address']) == config.DEFAULT_BROKER_COUNT:
             return ret
         return False
-    endpoints = shakedown.wait_for(fun)
+    endpoints = shakedown.wait_for(fun, sleep_seconds=10, ignore_exceptions=False)
     # NOTE: do NOT closed-to-extension assert len(endpoints) == _something_
     assert len(endpoints['address']) == config.DEFAULT_BROKER_COUNT
     assert len(endpoints['dns']) == config.DEFAULT_BROKER_COUNT
@@ -364,4 +364,4 @@ def test_suppress():
         response.raise_for_status()
         return response.text == "true"
 
-    shakedown.wait_for(fun)
+    shakedown.wait_for(fun, sleep_seconds=10, ignore_exceptions=False)

--- a/frameworks/kafka/tests/test_utils.py
+++ b/frameworks/kafka/tests/test_utils.py
@@ -30,7 +30,7 @@ def broker_count_check(count, service_name=config.SERVICE_NAME):
             pass
         return False
 
-    shakedown.wait_for(fun)
+    shakedown.wait_for(fun, sleep_seconds=10, ignore_exceptions=False)
 
 
 def restart_broker_pods(service_name=config.SERVICE_NAME):

--- a/testing/sdk_install.py
+++ b/testing/sdk_install.py
@@ -80,7 +80,9 @@ def install(
             shakedown.wait_for(
                 lambda: sdk_api.is_suppressed(service_name),
                 noisy=True,
-                timeout_seconds=5 * 60)
+                timeout_seconds=5 * 60,
+                sleep_seconds=10,
+                ignore_exceptions=False)
 
     log.info('Installed {}/{} after {}'.format(
         package_name, service_name, shakedown.pretty_duration(time.time() - start)))

--- a/testing/sdk_jobs.py
+++ b/testing/sdk_jobs.py
@@ -73,7 +73,8 @@ def run_job(job_dict, timeout_seconds=600, raise_on_failure=True):
         if len(runs) > 0:
             return runs[0]['id']
         return ''
-    run_id = shakedown.wait_for(wait_for_run_id, noisy=True, timeout_seconds=timeout_seconds, ignore_exceptions=False)
+    run_id = shakedown.wait_for(wait_for_run_id, noisy=True, timeout_seconds=timeout_seconds,
+        sleep_seconds=10, ignore_exceptions=False)
 
     def fun():
         # catch errors from CLI: ensure that the only error raised is our own:
@@ -93,7 +94,8 @@ def run_job(job_dict, timeout_seconds=600, raise_on_failure=True):
         if raise_on_failure and run_id in failed_ids:
             raise Exception('Job {} with id {} has failed, exiting early'.format(job_name, run_id))
         return run_id in successful_ids
-    shakedown.wait_for(fun, noisy=True, timeout_seconds=timeout_seconds, ignore_exceptions=False)
+    shakedown.wait_for(fun, noisy=True, timeout_seconds=timeout_seconds,
+        sleep_seconds=10, ignore_exceptions=False)
 
     return run_id
 

--- a/testing/sdk_marathon.py
+++ b/testing/sdk_marathon.py
@@ -12,7 +12,7 @@ def get_config(app_name):
     # Be permissive of flakes when fetching the app content:
     def fn():
         return sdk_cmd.request('get', api_url('apps/{}'.format(app_name)), retry=False, log_args=False)
-    config = shakedown.wait_for(lambda: fn()).json()['app']
+    config = shakedown.wait_for(lambda: fn(), sleep_seconds=10, ignore_exceptions=False).json()['app']
 
     # The configuration JSON that marathon returns doesn't match the configuration JSON it accepts,
     # so we have to remove some offending fields to make it re-submittable, since it's not possible to

--- a/testing/sdk_metrics.py
+++ b/testing/sdk_metrics.py
@@ -80,4 +80,4 @@ def wait_for_any_metrics(package_name, service_name, task_name, timeout):
         # there are 2 generic metrics that are always emitted
         return len(service_metrics) > 2
 
-    shakedown.wait_for(metrics_exist, timeout)
+    shakedown.wait_for(metrics_exist, timeout_seconds=timeout, sleep_seconds=10, ignore_exceptions=False)

--- a/testing/sdk_plan.py
+++ b/testing/sdk_plan.py
@@ -25,7 +25,7 @@ def get_plan(service_name, plan):
             return output.json()
         except:
             return False
-    return shakedown.wait_for(fn)
+    return shakedown.wait_for(fn, sleep_seconds=10, ignore_exceptions=False)
 
 
 def start_plan(service_name, plan, parameters=None):
@@ -93,7 +93,8 @@ def wait_for_plan_status(service_name, plan_name, status, timeout_seconds=TIMEOU
             return plan
         else:
             return False
-    return shakedown.wait_for(fn, noisy=True, timeout_seconds=timeout_seconds)
+    return shakedown.wait_for(fn, noisy=True, timeout_seconds=timeout_seconds,
+        sleep_seconds=10, ignore_exceptions=False)
 
 
 def wait_for_phase_status(service_name, plan_name, phase_name, status, timeout_seconds=TIMEOUT_SECONDS):
@@ -106,7 +107,8 @@ def wait_for_phase_status(service_name, plan_name, phase_name, status, timeout_s
             return plan
         else:
             return False
-    return shakedown.wait_for(fn, noisy=True, timeout_seconds=timeout_seconds)
+    return shakedown.wait_for(fn, noisy=True, timeout_seconds=timeout_seconds,
+        sleep_seconds=10, ignore_exceptions=False)
 
 
 def wait_for_step_status(service_name, plan_name, phase_name, step_name, status, timeout_seconds=TIMEOUT_SECONDS):
@@ -119,7 +121,8 @@ def wait_for_step_status(service_name, plan_name, phase_name, step_name, status,
             return plan
         else:
             return False
-    return shakedown.wait_for(fn, noisy=True, timeout_seconds=timeout_seconds)
+    return shakedown.wait_for(fn, noisy=True, timeout_seconds=timeout_seconds,
+        sleep_seconds=10, ignore_exceptions=False)
 
 
 def recovery_plan_is_empty(service_name):

--- a/testing/sdk_tasks.py
+++ b/testing/sdk_tasks.py
@@ -31,7 +31,8 @@ def check_running(service_name, expected_task_count, timeout_seconds=DEFAULT_TIM
             sorted(other_tasks)))
         return len(running_task_names) >= expected_task_count
 
-    shakedown.wait_for(lambda: fn(), noisy=True, timeout_seconds=timeout_seconds)
+    shakedown.wait_for(lambda: fn(), noisy=True, timeout_seconds=timeout_seconds,
+        sleep_seconds=10, ignore_exceptions=False)
 
 
 def get_task_ids(service_name, task_prefix):
@@ -58,7 +59,8 @@ def check_tasks_updated(service_name, prefix, old_task_ids, timeout_seconds=DEFA
             all_updated = False
         return all_updated
 
-    shakedown.wait_for(lambda: fn(), noisy=True, timeout_seconds=timeout_seconds)
+    shakedown.wait_for(lambda: fn(), noisy=True, timeout_seconds=timeout_seconds,
+        sleep_seconds=10, ignore_exceptions=False)
 
 
 def check_tasks_not_updated(service_name, prefix, old_task_ids):
@@ -85,7 +87,8 @@ def kill_task_with_pattern(pattern, agent_host=None, timeout_seconds=DEFAULT_TIM
         return exit_status
 
     # might not be able to connect to the agent on first try so we repeat until we can
-    shakedown.wait_for(lambda: fn(), noisy=True, timeout_seconds=timeout_seconds)
+    shakedown.wait_for(lambda: fn(), noisy=True, timeout_seconds=timeout_seconds,
+        sleep_seconds=10, ignore_exceptions=False)
 
     if exit_status != 0:
         raise RuntimeError('Failed to kill task with pattern "{}", exit status: {}'.format(pattern, exit_status))

--- a/testing/sdk_upgrade.py
+++ b/testing/sdk_upgrade.py
@@ -281,4 +281,5 @@ def _add_last_repo(repo_name, repo_url, prev_version, default_repo_package_name)
 
 
 def _wait_for_new_default_version(prev_version, default_repo_package_name):
-    shakedown.wait_for(lambda: _get_pkg_version(default_repo_package_name) != prev_version, noisy=True)
+    shakedown.wait_for(lambda: _get_pkg_version(default_repo_package_name) != prev_version, noisy=True,
+        sleep_seconds=10, ignore_exceptions=False)


### PR DESCRIPTION
INFINITY-2324 - Add ignore_exceptions=False to shakedown.wait_for() calls

`shakedown.wait_for()` is hiding exceptions. All we see in the logs is a loop followed by a timeout, but not enough to diagnose the underlying issues. (Also increased sleep_seconds while touching all those lines to help with all the noise in the logs. Could probably do a much longer sleep...)