### PR TITLE
Default to attached cluster in test.sh

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -55,7 +55,7 @@ fi
 
 if [ -z "$CLUSTER_URL" ]; then
     echo "CLUSTER_URL not set. Trying to determine attached cluster"
-    CLUSTER_URL=$(dcos cluster list --attached --json | grep "url" | sed -e 's/.*"url": "\(.*\)".*/\1/')
+    CLUSTER_URL=$(dcos cluster list --attached --json | grep "url" | sed -e 's/.*"url": "\(http.*\)".*/\1/')
     if [ -z "$CLUSTER_URL" ]; then
         echo "Cluster not found. Create and configure one then set \$CLUSTER_URL."
         exit 1

--- a/test.sh
+++ b/test.sh
@@ -27,7 +27,8 @@ function usage()
     echo "-k passed to pytest directly [default NONE]"
     echo "-p PATH to cluster SSH key [default ${ssh_path}]"
     echo "-s run in strict mode (sets \$SECURITY=\"strict\")"
-    echo "Cluster must be created and \$CLUSTER_URL set"
+    echo "Cluster must be created and \$CLUSTER_URL set."
+    echo "    If it is not set, the currently attached cluster will be used"
     echo "AWS credentials must exist in the variables:"
     echo "      \$AWS_ACCESS_KEY_ID"
     echo "      \$AWS_SECRET_ACCESS_KEY"
@@ -53,8 +54,14 @@ fi
 
 
 if [ -z "$CLUSTER_URL" ]; then
-    echo "Cluster not found. Create and configure one then set \$CLUSTER_URL."
-    exit 1
+    echo "CLUSTER_URL not set. Trying to determine attached cluster"
+    CLUSTER_URL=$(dcos cluster list --attached --json | grep "url" | sed -e 's/.*"url": "\(.*\)".*/\1/')
+    if [ -z "$CLUSTER_URL" ]; then
+        echo "Cluster not found. Create and configure one then set \$CLUSTER_URL."
+        exit 1
+    else
+        echo "Using CLUSTER_URL=$CLUSTER_URL"
+    fi
 fi
 
 if [ -z "$AWS_ACCESS_KEY_ID" -o -z "$AWS_SECRET_ACCESS_KEY" ]; then


### PR DESCRIPTION
This PR removes the need for `CLUSTER_URL` to be set when running `test.sh` if `dcos` has already been attached to a cluster. If if `dcos` does not exist, then this should still raise an error indicating that the environment variable should be set.

I should add that this is more in keeping with my own way of working, and if there are objections, then I don't mind pulling this back.