### PR TITLE
INFINITY-2335 Documentation updates to reflect Cassandra endpoint rename

### DIFF
--- a/frameworks/cassandra/docs/connecting-clients.md
+++ b/frameworks/cassandra/docs/connecting-clients.md
@@ -19,7 +19,7 @@ Once the service is running, you may view information about its endpoints via ei
   - List endpoint types: `<dcos-url>/service/cassandra/v1/endpoints`
   - View endpoints for an endpoint type: `<dcos-url>/service/cassandra/v1/endpoints/<endpoint>`
 
-By default, the DC/OS Apache Cassandra Service exposes only the `native-client` endpoint type, which shows the locations for all Cassandra nodes in the cluster. If you have enabled the Thrift protocol in your service configuration, a `thrift-client` endpoint will also be listed. To see node addresses for use by native clients such as `cqlsh`, run `dcos beta-cassandra endpoints native-client`. A typical response will look like the following:
+By default, the DC/OS Apache Cassandra Service exposes only the `native-client` endpoint type, which shows the locations for all Cassandra nodes in the cluster. If you have enabled the Thrift protocol in your service configuration, a `thrift-client` endpoint will also be listed. To see node addresses for use by native clients, such as `cqlsh`, run `dcos beta-cassandra endpoints native-client`. A typical response will look like the following:
 
 ```json
 {
@@ -36,7 +36,7 @@ By default, the DC/OS Apache Cassandra Service exposes only the `native-client` 
 }
 ```
 
-In general, the `.autoip.dcos.thisdcos.directory` endpoints will only work from within the same DC/OS cluster. From outside the cluster you can either use the direct IPs, or set up a proxy service that acts as a frontend to your DC/OS Apache Cassandra instance. If you use the IPs, keep in mind that they may change if nodes are moved between machines, whereas the `.autoip.dcos.thisdcos.directory` hosts will follow the nodes. For development and testing purposes, you can use [DC/OS Tunnel](https://docs.mesosphere.com/latest/administration/access-node/tunnel/) to access services from outside the cluster, but this option is not suitable for production use.
+In general, the `.autoip.dcos.thisdcos.directory` endpoints will only work from within the same DC/OS cluster. From outside the cluster you can either use the direct IPs or set up a proxy service that acts as a frontend to your DC/OS Apache Cassandra instance. If you use the IPs, keep in mind that they may change if nodes are moved between machines, whereas the `.autoip.dcos.thisdcos.directory` hosts will follow the nodes. For development and testing purposes, you can use [DC/OS Tunnel](https://docs.mesosphere.com/latest/administration/access-node/tunnel/) to access services from outside the cluster, but this option is not suitable for production use.
 
 # Connecting Clients to Endpoints
 

--- a/frameworks/cassandra/docs/connecting-clients.md
+++ b/frameworks/cassandra/docs/connecting-clients.md
@@ -19,7 +19,7 @@ Once the service is running, you may view information about its endpoints via ei
   - List endpoint types: `<dcos-url>/service/cassandra/v1/endpoints`
   - View endpoints for an endpoint type: `<dcos-url>/service/cassandra/v1/endpoints/<endpoint>`
 
-The DC/OS Apache Cassandra Service currently exposes only the `node` endpoint type, which shows the locations for all Cassandra nodes in the cluster. To see node addresses, run `dcos beta-cassandra endpoints node`. A typical response will look like the following:
+By default, the DC/OS Apache Cassandra Service exposes only the `native-client` endpoint type, which shows the locations for all Cassandra nodes in the cluster. If you have enabled the Thrift protocol in your service configuration, a `thrift-client` endpoint will also be listed. To see node addresses for use by native clients such as `cqlsh`, run `dcos beta-cassandra endpoints native-client`. A typical response will look like the following:
 
 ```json
 {
@@ -32,12 +32,11 @@ The DC/OS Apache Cassandra Service currently exposes only the `node` endpoint ty
     "node-2-server.cassandra.autoip.dcos.thisdcos.directory:9042",
     "node-0-server.cassandra.autoip.dcos.thisdcos.directory:9042",
     "node-1-server.cassandra.autoip.dcos.thisdcos.directory:9042"
-  ],
-  "vip": "node.cassandra.l4lb.thisdcos.directory:9042"
+  ]
 }
 ```
 
-In general, the `.autoip.dcos.thisdcos.directory` endpoints will only work from within the same DC/OS cluster. From outside the cluster you can either use the direct IPs, or set up a proxy service that acts as a frontend to your DC/OS Apache Cassandra instance. For development and testing purposes, you can use [DC/OS Tunnel](https://docs.mesosphere.com/latest/administration/access-node/tunnel/) to access services from outside the cluster, but this option is not suitable for production use.
+In general, the `.autoip.dcos.thisdcos.directory` endpoints will only work from within the same DC/OS cluster. From outside the cluster you can either use the direct IPs, or set up a proxy service that acts as a frontend to your DC/OS Apache Cassandra instance. If you use the IPs, keep in mind that they may change if nodes are moved between machines, whereas the `.autoip.dcos.thisdcos.directory` hosts will follow the nodes. For development and testing purposes, you can use [DC/OS Tunnel](https://docs.mesosphere.com/latest/administration/access-node/tunnel/) to access services from outside the cluster, but this option is not suitable for production use.
 
 # Connecting Clients to Endpoints
 

--- a/frameworks/cassandra/docs/quickstart.md
+++ b/frameworks/cassandra/docs/quickstart.md
@@ -17,8 +17,11 @@ You can also install DC/OS Apache Cassandra from [the DC/OS web interface](https
 1. Connect a client to the DC/OS Apache Cassandra service.
     ```
     dcos beta-cassandra endpoints
-    ["node"]
-    dcos beta-cassandra endpoints node
+    [
+      "native-client"
+    ]
+
+    dcos beta-cassandra endpoints native-client
     {
       "address": [
         "10.0.1.125:9042",
@@ -29,17 +32,16 @@ You can also install DC/OS Apache Cassandra from [the DC/OS web interface](https
         "node-1-server.cassandra.autoip.dcos.thisdcos.directory:9042",
         "node-0-server.cassandra.autoip.dcos.thisdcos.directory:9042",
         "node-2-server.cassandra.autoip.dcos.thisdcos.directory:9042"
-      ],
-      "vip": "node.cassandra.l4lb.thisdcos.directory:9042"
+      ]
     }
     ```
-1. Write some data to your cluster:
-```
-dcos node ssh --master-proxy --leader
-core@ip-10-0-6-153 ~ docker run -it cassandra:3.0.13 cqlsh node-0-server.cassandra.autoip.dcos.thisdcos.directory
-> CREATE KEYSPACE space1 WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : 3 };
-> USE space1;
-> CREATE TABLE testtable1 (key varchar, value varchar, PRIMARY KEY(key));
-> INSERT INTO space1.testtable1(key, value) VALUES('testkey1', 'testvalue1');
-> SELECT * FROM testtable1;
-```
+1. Write some data to your cluster using the `node-0-server` entry provided above. Note that in production use you will want to specify multiple node addresses to avoid disruption if a subset of addressed nodes are down:
+    ```
+    dcos node ssh --master-proxy --leader
+    core@ip-10-0-6-153 ~ docker run -it cassandra:3.0.13 cqlsh node-0-server.cassandra.autoip.dcos.thisdcos.directory
+    > CREATE KEYSPACE space1 WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : 3 };
+    > USE space1;
+    > CREATE TABLE testtable1 (key varchar, value varchar, PRIMARY KEY(key));
+    > INSERT INTO space1.testtable1(key, value) VALUES('testkey1', 'testvalue1');
+    > SELECT * FROM testtable1;
+    ```

--- a/frameworks/cassandra/docs/quickstart.md
+++ b/frameworks/cassandra/docs/quickstart.md
@@ -35,7 +35,9 @@ You can also install DC/OS Apache Cassandra from [the DC/OS web interface](https
       ]
     }
     ```
-1. Write some data to your cluster using the `node-0-server` entry provided above. Note that in production use you will want to specify multiple node addresses to avoid disruption if a subset of addressed nodes are down:
+1. Write some data to your cluster using the `node-0-server` entry provided above.
+
+**Note:** In production, you should specify multiple node addresses to avoid disruption if a subset of addressed nodes are down:
     ```
     dcos node ssh --master-proxy --leader
     core@ip-10-0-6-153 ~ docker run -it cassandra:3.0.13 cqlsh node-0-server.cassandra.autoip.dcos.thisdcos.directory


### PR DESCRIPTION
- `node` has been renamed to `native-client` to align with DSE
- Mention that an additional `thrift-client` endpoint is automatically exposed if Thrift is enabled (via `cassandra.start_rpc`)
- Fix indent for a code block in quick start
- Added caveat about IPs possibly changing if cassandra nodes are moved between machines
- Added note to quick start about specifying multiple addresses in production use (too much for quick start?)