### PR TITLE
Refactor shakedown.wait_for calls into retrying

### DIFF
--- a/frameworks/elastic/tests/config.py
+++ b/frameworks/elastic/tests/config.py
@@ -102,7 +102,7 @@ def check_plugin_installed(plugin_name, service_name=SERVICE_NAME):
 
 
 @retrying.retry(
-    wait_fixed=10000
+    wait_fixed=10000,
     stop_max_delay=DEFAULT_ELASTIC_TIMEOUT*1000)
 def check_plugin_uninstalled(plugin_name, service_name=SERVICE_NAME):
     curl_api = _curl_api(service_name, "GET")

--- a/frameworks/elastic/tests/config.py
+++ b/frameworks/elastic/tests/config.py
@@ -61,7 +61,8 @@ def as_json(fn):
 
 @retrying.retry(
     wait_fixed=10000,
-    stop_max_delay=DEFAULT_KIBANA_TIMEOUT*1000)
+    stop_max_delay=DEFAULT_KIBANA_TIMEOUT*1000,
+    retry_on_result=lambda res: res is False)
 def check_kibana_adminrouter_integration(path):
     dcos_token = shakedown.dcos_acs_token()
     curl_cmd = "curl -I -k -H \"Authorization: token={}\" -s {}/{}".format(
@@ -72,7 +73,8 @@ def check_kibana_adminrouter_integration(path):
 
 @retrying.retry(
     wait_fixed=10000,
-    stop_max_delay=DEFAULT_ELASTIC_TIMEOUT*1000)
+    stop_max_delay=DEFAULT_ELASTIC_TIMEOUT*1000,
+    retry_on_result=lambda res: res is False)
 def check_elasticsearch_index_health(index_name, color, service_name=SERVICE_NAME):
     curl_api = _curl_api(service_name, "GET")
     result = _get_elasticsearch_index_health(curl_api, index_name)
@@ -81,7 +83,8 @@ def check_elasticsearch_index_health(index_name, color, service_name=SERVICE_NAM
 
 @retrying.retry(
     wait_fixed=10000,
-    stop_max_delay=DEFAULT_ELASTIC_TIMEOUT*1000)
+    stop_max_delay=DEFAULT_ELASTIC_TIMEOUT*1000,
+    retry_on_result=lambda res: res is False)
 def wait_for_expected_nodes_to_exist(service_name=SERVICE_NAME, task_count=DEFAULT_TASK_COUNT):
     curl_api = _curl_api(service_name, "GET")
     result = _get_elasticsearch_cluster_health(curl_api)
@@ -94,7 +97,8 @@ def wait_for_expected_nodes_to_exist(service_name=SERVICE_NAME, task_count=DEFAU
 
 @retrying.retry(
     wait_fixed=10000,
-    stop_max_delay=DEFAULT_ELASTIC_TIMEOUT*1000)
+    stop_max_delay=DEFAULT_ELASTIC_TIMEOUT*1000,
+    retry_on_result=lambda res: res is False)
 def check_plugin_installed(plugin_name, service_name=SERVICE_NAME):
     curl_api = _curl_api(service_name, "GET")
     result = _get_hosts_with_plugin(curl_api, plugin_name)
@@ -103,7 +107,8 @@ def check_plugin_installed(plugin_name, service_name=SERVICE_NAME):
 
 @retrying.retry(
     wait_fixed=10000,
-    stop_max_delay=DEFAULT_ELASTIC_TIMEOUT*1000)
+    stop_max_delay=DEFAULT_ELASTIC_TIMEOUT*1000,
+    retry_on_result=lambda res: res is False)
 def check_plugin_uninstalled(plugin_name, service_name=SERVICE_NAME):
     curl_api = _curl_api(service_name, "GET")
     result = _get_hosts_with_plugin(curl_api, plugin_name)
@@ -120,7 +125,8 @@ def _get_hosts_with_plugin(curl_api, plugin_name):
 
 @retrying.retry(
     wait_fixed=10000,
-    stop_max_delay=120*1000)
+    stop_max_delay=120*1000,
+    retry_on_result=lambda res: res is False)
 def get_elasticsearch_master(service_name=SERVICE_NAME):
     # just in case, re-fetch the _curl_api in case the elasticsearch master is moved:
     exit_status, output = shakedown.run_command_on_master(

--- a/frameworks/elastic/tests/config.py
+++ b/frameworks/elastic/tests/config.py
@@ -2,6 +2,7 @@ import json
 import logging
 from functools import wraps
 
+import retrying
 import shakedown
 
 import sdk_cmd
@@ -58,60 +59,55 @@ def as_json(fn):
     return wrapper
 
 
+@retrying.retry(
+    wait_fixed=10000,
+    stop_max_delay=DEFAULT_KIBANA_TIMEOUT*1000)
 def check_kibana_adminrouter_integration(path):
     dcos_token = shakedown.dcos_acs_token()
     curl_cmd = "curl -I -k -H \"Authorization: token={}\" -s {}/{}".format(
         dcos_token, shakedown.dcos_url().rstrip('/'), path.lstrip('/'))
-
-    def fun():
-        exit_status, output = shakedown.run_command_on_master(curl_cmd)
-        return output and "HTTP/1.1 200" in output
-
-    return shakedown.wait_for(fun, timeout_seconds=DEFAULT_KIBANA_TIMEOUT, noisy=True)
+    exit_status, output = shakedown.run_command_on_master(curl_cmd)
+    return output and "HTTP/1.1 200" in output
 
 
+@retrying.retry(
+    wait_fixed=10000,
+    stop_max_delay=DEFAULT_ELASTIC_TIMEOUT*1000)
 def check_elasticsearch_index_health(index_name, color, service_name=SERVICE_NAME):
     curl_api = _curl_api(service_name, "GET")
-
-    def fun():
-        result = _get_elasticsearch_index_health(curl_api, index_name)
-        return result and result["status"] == color
-
-    return shakedown.wait_for(fun, timeout_seconds=DEFAULT_ELASTIC_TIMEOUT)
+    result = _get_elasticsearch_index_health(curl_api, index_name)
+    return result and result["status"] == color
 
 
+@retrying.retry(
+    wait_fixed=10000,
+    stop_max_delay=DEFAULT_ELASTIC_TIMEOUT*1000)
 def wait_for_expected_nodes_to_exist(service_name=SERVICE_NAME, task_count=DEFAULT_TASK_COUNT):
     curl_api = _curl_api(service_name, "GET")
-
-    def expected_nodes():
-        result = _get_elasticsearch_cluster_health(curl_api)
-        if result is None:
-            return False
-        node_count = result["number_of_nodes"]
-        log.info('Waiting for {} healthy nodes, got {}'.format(task_count, node_count))
-        return node_count == task_count
-
-    return shakedown.wait_for(expected_nodes, timeout_seconds=DEFAULT_ELASTIC_TIMEOUT)
+    result = _get_elasticsearch_cluster_health(curl_api)
+    if result is None:
+        return False
+    node_count = result["number_of_nodes"]
+    log.info('Waiting for {} healthy nodes, got {}'.format(task_count, node_count))
+    return node_count == task_count
 
 
+@retrying.retry(
+    wait_fixed=10000,
+    stop_max_delay=DEFAULT_ELASTIC_TIMEOUT*1000)
 def check_plugin_installed(plugin_name, service_name=SERVICE_NAME):
     curl_api = _curl_api(service_name, "GET")
-
-    def fun():
-        result = _get_hosts_with_plugin(curl_api, plugin_name)
-        return result is not None and len(result) == DEFAULT_TASK_COUNT
-
-    return shakedown.wait_for(fun, timeout_seconds=DEFAULT_ELASTIC_TIMEOUT)
+    result = _get_hosts_with_plugin(curl_api, plugin_name)
+    return result is not None and len(result) == DEFAULT_TASK_COUNT
 
 
+@retrying.retry(
+    wait_fixed=10000
+    stop_max_delay=DEFAULT_ELASTIC_TIMEOUT*1000)
 def check_plugin_uninstalled(plugin_name, service_name=SERVICE_NAME):
     curl_api = _curl_api(service_name, "GET")
-
-    def fun():
-        result = _get_hosts_with_plugin(curl_api, plugin_name)
-        return result is not None and result == []
-
-    return shakedown.wait_for(fun, timeout_seconds=DEFAULT_ELASTIC_TIMEOUT)
+    result = _get_hosts_with_plugin(curl_api, plugin_name)
+    return result is not None and result == []
 
 
 def _get_hosts_with_plugin(curl_api, plugin_name):
@@ -122,16 +118,16 @@ def _get_hosts_with_plugin(curl_api, plugin_name):
         return None
 
 
+@retrying.retry(
+    wait_fixed=10000,
+    stop_max_delay=120*1000)
 def get_elasticsearch_master(service_name=SERVICE_NAME):
     # just in case, re-fetch the _curl_api in case the elasticsearch master is moved:
-    def get_master():
-        exit_status, output = shakedown.run_command_on_master("{}/_cat/master'".format(_curl_api(service_name, "GET")))
-        if exit_status and len(output.split()) > 0:
-            return output.split()[-1]
-
-        return False
-
-    return shakedown.wait_for(get_master)
+    exit_status, output = shakedown.run_command_on_master(
+        "{}/_cat/master'".format(_curl_api(service_name, "GET")))
+    if exit_status and len(output.split()) > 0:
+        return output.split()[-1]
+    return False
 
 
 def verify_commercial_api_status(is_enabled, service_name=SERVICE_NAME):

--- a/frameworks/hdfs/tests/config.py
+++ b/frameworks/hdfs/tests/config.py
@@ -58,7 +58,8 @@ def get_active_name_node(service_name):
 
 @retrying.retry(
     wait_fixed=10000,
-    stop_max_delay=DEFAULT_HDFS_TIMEOUT*1000)
+    stop_max_delay=DEFAULT_HDFS_TIMEOUT*1000,
+    retry_on_results=lambda res: not res)
 def get_name_node_status(service_name, name_node):
     rc, output = run_hdfs_command(service_name, "./bin/hdfs haadmin -getServiceState {}".format(name_node))
     if not rc:

--- a/frameworks/hdfs/tests/config.py
+++ b/frameworks/hdfs/tests/config.py
@@ -59,7 +59,7 @@ def get_active_name_node(service_name):
 @retrying.retry(
     wait_fixed=10000,
     stop_max_delay=DEFAULT_HDFS_TIMEOUT*1000,
-    retry_on_results=lambda res: not res)
+    retry_on_result=lambda res: not res)
 def get_name_node_status(service_name, name_node):
     rc, output = run_hdfs_command(service_name, "./bin/hdfs haadmin -getServiceState {}".format(name_node))
     if not rc:

--- a/frameworks/hdfs/tests/config.py
+++ b/frameworks/hdfs/tests/config.py
@@ -1,8 +1,8 @@
+import retrying
 import shakedown
 
 import sdk_cmd
 import sdk_plan
-import sdk_utils
 import sdk_tasks
 
 PACKAGE_NAME = 'beta-hdfs'
@@ -56,15 +56,14 @@ def get_active_name_node(service_name):
     raise Exception("Failed to determine active name node")
 
 
+@retrying.retry(
+    wait_fixed=10000,
+    stop_max_delay=DEFAULT_HDFS_TIMEOUT*1000)
 def get_name_node_status(service_name, name_node):
-    def get_status():
-        rc, output = run_hdfs_command(service_name, "./bin/hdfs haadmin -getServiceState {}".format(name_node))
-        if not rc:
-            return rc
-
-        return output.strip()
-
-    return shakedown.wait_for(lambda: get_status(), timeout_seconds=DEFAULT_HDFS_TIMEOUT)
+    rc, output = run_hdfs_command(service_name, "./bin/hdfs haadmin -getServiceState {}".format(name_node))
+    if not rc:
+        return rc
+    return output.strip()
 
 
 def run_hdfs_command(service_name, command):

--- a/frameworks/hdfs/tests/test_overlay.py
+++ b/frameworks/hdfs/tests/test_overlay.py
@@ -1,5 +1,6 @@
 from xml.etree import ElementTree
 
+import retrying
 import pytest
 import sdk_cmd
 import sdk_hosts
@@ -105,13 +106,13 @@ def test_integrity_on_name_node_failure():
     config.check_healthy(service_name=config.SERVICE_NAME)
 
 
+@retrying.retry(
+    wait_fixed=10000,
+    stop_max_delay=config.DEFAULT_HDFS_TIMEOUT*1000)
 def wait_for_failover_to_complete(namenode):
     """
     Inspects the name node logs to make sure ZK signals a complete failover.
     The given namenode is the one to become active after the failover is complete.
     """
-    def failover_detection():
-        status = config.get_name_node_status(config.SERVICE_NAME, namenode)
-        return status == "active"
-
-    shakedown.wait_for(lambda: failover_detection(), timeout_seconds=config.DEFAULT_HDFS_TIMEOUT)
+    status = config.get_name_node_status(config.SERVICE_NAME, namenode)
+    return status == "active"

--- a/frameworks/helloworld/tests/test_sanity.py
+++ b/frameworks/helloworld/tests/test_sanity.py
@@ -219,9 +219,9 @@ def wait_for_refresh_cache_fails_409conflict():
     """
     try:
         sdk_cmd.svc_cli(
-            config.PACKAGE_NAME, config.FOLDERED_SERVICE_NAME, 'state refresh_cache')
-    except Exception as e:
-        if "failed: 409 Conflict" in e.args[0]:
+            config.PACKAGE_NAME, FOLDERED_SERVICE_NAME, 'state refresh_cache')
+    except Exception as ex:
+        if "failed: 409 Conflict" in ex.args[0]:
             return True
     return False
 

--- a/frameworks/helloworld/tests/test_sanity.py
+++ b/frameworks/helloworld/tests/test_sanity.py
@@ -191,7 +191,7 @@ def wait_for_nonempty_properties():
     """'suppressed' could be missing if the scheduler recently started,
     loop for a bit just in case
     """
-        jsonobj = sdk_cmd.svc_cli(config.PACKAGE_NAME, config.FOLDERED_SERVICE_NAME, 'state properties', json=True)
+    jsonobj = sdk_cmd.svc_cli(config.PACKAGE_NAME, config.FOLDERED_SERVICE_NAME, 'state properties', json=True)
     assert len(jsonobj) > 0
 
 

--- a/frameworks/helloworld/tests/test_sidecar.py
+++ b/frameworks/helloworld/tests/test_sidecar.py
@@ -1,13 +1,13 @@
 import logging
 
 import pytest
+import retrying
 
 import sdk_cmd
 import sdk_install
 import sdk_marathon
 import sdk_plan
 import sdk_utils
-import shakedown
 from tests import config
 
 log = logging.getLogger(__name__)
@@ -54,34 +54,30 @@ def test_sidecar_parameterized():
     run_plan('sidecar-parameterized', {'PLAN_PARAMETER': 'parameterized'})
 
 
-class ToxicSidecarCheck:
+@retrying.retry(
+    wait_fixed=10000,
+    stop_max_delay=600000)
+def wait_for_toxic_sidecar_check():
     """
     Since the sidecar task fails too quickly, we check for the contents of
     the file generated in hello-container-path/toxic-output instead
 
     Note that we only check the output of hello-0.
-    """
-    @staticmethod
-    def get_cmd_output_pair():
-        """
-        In DC/OS prior to version 1.10, task exec does not run the command in the MESOS_SANDBOX directory and this
+
+    In DC/OS prior to version 1.10, task exec does not run the command in the MESOS_SANDBOX directory and this
         causes the check of the file contents to fail. Here we simply rely on the existence of the file.
-        """
-        if sdk_utils.dcos_version_less_than("1.10"):
-            cmd = "task ls hello-0-server hello-container-path/toxic-output"
-            output = ""
-        else:
-            cmd = "task exec hello-0-server cat hello-container-path/toxic-output"
-            output = "I'm addicted to you / Don't you know that you're toxic?"
+    """
+    if sdk_utils.dcos_version_less_than("1.10"):
+        cmd = "task ls hello-0-server hello-container-path/toxic-output"
+        expected_output = ""
+    else:
+        cmd = "task exec hello-0-server cat hello-container-path/toxic-output"
+        expected_output = "I'm addicted to you / Don't you know that you're toxic?"
 
-        return cmd, output
+    output = sdk_cmd.run_cli(cmd).strip()
+    logging.info("Checking for toxic output returned: %s", output)
 
-    def __call__(self):
-        cmd, expected_output = self.get_cmd_output_pair()
-        output = sdk_cmd.run_cli(cmd).strip()
-        logging.info("Checking for toxic output returned: %s", output)
-
-        return output == expected_output
+    assert output == expected_output
 
 
 @pytest.mark.sanity
@@ -94,7 +90,7 @@ def test_toxic_sidecar_doesnt_trigger_recovery():
     assert(len(recovery_plan['phases']) == 0)
     log.info(recovery_plan)
     sdk_plan.start_plan(config.SERVICE_NAME, 'sidecar-toxic')
-    shakedown.wait_for(ToxicSidecarCheck(), timeout_seconds=10 * 60)
+    wait_for_toxic_sidecar_check()
 
     # Restart the scheduler and wait for it to come up.
     sdk_marathon.restart_app(config.SERVICE_NAME)

--- a/frameworks/kafka/tests/test_sanity.py
+++ b/frameworks/kafka/tests/test_sanity.py
@@ -53,9 +53,9 @@ def configure_package(configure_security):
     wait_fixed=10000,
     stop_max_delay=120000,
     retry_on_result=lambda res: res is False)
-def wait_for_endpoints():
+def wait_for_endpoints(foldered_service_name):
     ret = sdk_cmd.svc_cli(
-        config.PACKAGE_NAME, sdk_utils.get_foldered_name(config.SERVICE_NAME),
+        config.PACKAGE_NAME, foldered_service_name,
         'endpoints {}'.format(config.DEFAULT_TASK_NAME), json=True)
     if len(ret['address']) == config.DEFAULT_BROKER_COUNT:
         return ret
@@ -65,7 +65,8 @@ def wait_for_endpoints():
 @pytest.mark.smoke
 @pytest.mark.sanity
 def test_endpoints_address():
-    endpoints = wait_for_endpoints()
+    foldered_name = sdk_utils.get_foldered_name(config.SERVICE_NAME)
+    endpoints = wait_for_endpoints(foldered_name)
     # NOTE: do NOT closed-to-extension assert len(endpoints) == _something_
     assert len(endpoints['address']) == config.DEFAULT_BROKER_COUNT
     assert len(endpoints['dns']) == config.DEFAULT_BROKER_COUNT

--- a/frameworks/kafka/tests/test_utils.py
+++ b/frameworks/kafka/tests/test_utils.py
@@ -1,23 +1,20 @@
 import logging
 
+import retrying
+
 import sdk_cmd
 import sdk_tasks
-import shakedown
 from tests import config
 
 log = logging.getLogger(__name__)
 
 
+@retrying.retry(
+    wait_fixed=10000,
+    stop_max_delay=120000,
+    retry_on_result=lambda res: res is False)
 def broker_count_check(count, service_name=config.SERVICE_NAME):
-    def fun():
-        try:
-            if len(sdk_cmd.svc_cli(config.PACKAGE_NAME, service_name, 'broker list', json=True)) == count:
-                return True
-        except:
-            pass
-        return False
-
-    shakedown.wait_for(fun)
+    return len(sdk_cmd.svc_cli(config.PACKAGE_NAME, service_name, 'broker list', json=True)) == count
 
 
 def restart_broker_pods(service_name=config.SERVICE_NAME):

--- a/frameworks/kafka/tests/test_utils.py
+++ b/frameworks/kafka/tests/test_utils.py
@@ -10,7 +10,7 @@ log = logging.getLogger(__name__)
 
 
 @retrying.retry(
-    wait_fixed=10000,
+    wait_fixed=1000,
     stop_max_delay=120000,
     retry_on_result=lambda res: res is False)
 def broker_count_check(count, service_name=config.SERVICE_NAME):

--- a/testing/sdk_install.py
+++ b/testing/sdk_install.py
@@ -43,13 +43,6 @@ def retried_shakedown_install(
         expected_running_tasks=expected_running_tasks)
 
 
-@retry(
-    wait_fixed=10000,
-    stop_max_delay=300000)
-def wait_for_suppressed_service(service_name):
-    assert sdk_api.is_suppressed(service_name)
-
-
 def install(
         package_name,
         service_name,
@@ -81,14 +74,6 @@ def install(
         log.info("Waiting for {}/{} to finish deployment plan...".format(
             package_name, service_name))
         sdk_plan.wait_for_completed_deployment(service_name, timeout_seconds)
-
-        # given the above wait for plan completion, here we just wait up to 5 minutes
-        if shakedown.dcos_version_less_than("1.9"):
-            log.info("Skipping `is_suppressed` check for %s/%s as this is only suppored starting in version 1.9",
-                     package_name, service_name)
-        else:
-            log.info("Waiting for %s/%s to be suppressed...", package_name, service_name)
-            wait_for_suppressed_service(service_name)
 
     log.info('Installed {}/{} after {}'.format(
         package_name, service_name, shakedown.pretty_duration(time.time() - start)))

--- a/testing/sdk_jobs.py
+++ b/testing/sdk_jobs.py
@@ -77,7 +77,7 @@ def run_job(job_dict, timeout_seconds=600, raise_on_failure=True):
     run_id = json.loads(sdk_cmd.run_cli('job run {} --json'.format(job_name)))['id']
 
     @retrying.retry(
-        wait_fixed=10000,
+        wait_fixed=1000,
         stop_max_delay=timeout_seconds*1000,
         retry_on_exception=lambda ex: False,
         retry_on_result=lambda res: not res)

--- a/testing/sdk_jobs.py
+++ b/testing/sdk_jobs.py
@@ -73,20 +73,8 @@ class InstallJobContext(object):
 def run_job(job_dict, timeout_seconds=600, raise_on_failure=True):
     job_name = job_dict['id']
 
-    sdk_cmd.run_cli('job run {}'.format(job_name))
-
-    @retrying.retry(
-        wait_fixed=10000,
-        stop_max_delay=timeout_seconds*1000,
-        retry_on_exception=lambda ex: False,
-        retry_on_result=lambda res: not res)
-    def wait_for_run_id():
-        runs = json.loads(sdk_cmd.run_cli('job show runs {} --json'.format(job_name)))
-        if len(runs) > 0:
-            return runs[0]['id']
-        return ''
-
-    run_id = wait_for_run_id()
+    # start job run, get run ID to be polled against:
+    run_id = json.loads(sdk_cmd.run_cli('job run {} --json'.format(job_name)))['id']
 
     @retrying.retry(
         wait_fixed=10000,

--- a/testing/sdk_marathon.py
+++ b/testing/sdk_marathon.py
@@ -16,7 +16,7 @@ log = logging.getLogger(__name__)
 
 
 @retrying.retry(
-    wait_fixed=10000,
+    wait_fixed=1000,
     stop_max_delay=120000)
 def wait_for_app(app_name):
     return sdk_cmd.request('get', api_url('apps/{}'.format(app_name)), retry=False, log_args=False)

--- a/testing/sdk_metrics.py
+++ b/testing/sdk_metrics.py
@@ -109,7 +109,7 @@ def wait_for_service_metrics(package_name, service_name, task_name, timeout, exp
     expected_metrics_exist -- serivce-specific callback that checks for service-specific metrics
     """
     @retrying.retry(
-        wait_fixed=5000,
+        wait_fixed=1000,
         stop_max_delay=timeout*1000,
         retry_on_result=lambda res: res is False)
     def check_for_service_metrics():

--- a/testing/sdk_metrics.py
+++ b/testing/sdk_metrics.py
@@ -10,6 +10,7 @@ SHOULD ALSO BE APPLIED TO sdk_metrics IN ANY OTHER PARTNER REPOS
 import json
 import logging
 
+import retrying
 import shakedown
 
 import sdk_cmd
@@ -119,3 +120,16 @@ def wait_for_service_metrics(package_name, service_name, task_name, timeout, exp
             return False
 
     shakedown.wait_for(check_for_service_metrics, timeout)
+
+
+def wait_for_any_metrics(package_name, service_name, task_name, timeout):
+    @retrying.retry(
+        wait_fixed=5000,
+        stop_max_delay=timeout*1000)
+    def wait_for_metrics_to_exist():
+        log.info("verifying metrics exist for {}".format(service_name))
+        service_metrics = get_metrics(package_name, service_name, task_name)
+        # there are 2 generic metrics that are always emitted
+        assert len(service_metrics) > 2
+
+    wait_for_metrics_to_exist()

--- a/testing/sdk_metrics.py
+++ b/testing/sdk_metrics.py
@@ -108,6 +108,10 @@ def wait_for_service_metrics(package_name, service_name, task_name, timeout, exp
     task_name -- the name of the task whose agent to run metrics commands from
     expected_metrics_exist -- serivce-specific callback that checks for service-specific metrics
     """
+    @retrying.retry(
+        wait_fixed=5000,
+        stop_max_delay=120000,
+        retry_on_result=lambda res: res is False)
     def check_for_service_metrics():
         try:
             log.info("verifying metrics exist for {}".format(service_name))
@@ -120,16 +124,3 @@ def wait_for_service_metrics(package_name, service_name, task_name, timeout, exp
             return False
 
     shakedown.wait_for(check_for_service_metrics, timeout)
-
-
-def wait_for_any_metrics(package_name, service_name, task_name, timeout):
-    @retrying.retry(
-        wait_fixed=5000,
-        stop_max_delay=timeout*1000)
-    def wait_for_metrics_to_exist():
-        log.info("verifying metrics exist for {}".format(service_name))
-        service_metrics = get_metrics(package_name, service_name, task_name)
-        # there are 2 generic metrics that are always emitted
-        assert len(service_metrics) > 2
-
-    wait_for_metrics_to_exist()

--- a/testing/sdk_metrics.py
+++ b/testing/sdk_metrics.py
@@ -110,7 +110,7 @@ def wait_for_service_metrics(package_name, service_name, task_name, timeout, exp
     """
     @retrying.retry(
         wait_fixed=5000,
-        stop_max_delay=120000,
+        stop_max_delay=timeout*1000,
         retry_on_result=lambda res: res is False)
     def check_for_service_metrics():
         try:
@@ -123,4 +123,4 @@ def wait_for_service_metrics(package_name, service_name, task_name, timeout, exp
             log.error("Caught exception trying to get metrics: {}".format(e))
             return False
 
-    shakedown.wait_for(check_for_service_metrics, timeout)
+    check_for_service_metrics()

--- a/testing/sdk_plan.py
+++ b/testing/sdk_plan.py
@@ -109,7 +109,7 @@ def wait_for_plan_status(service_name, plan_name, status, timeout_seconds=TIMEOU
 def wait_for_phase_status(service_name, plan_name, phase_name, status, timeout_seconds=TIMEOUT_SECONDS):
     @retrying.retry(
         wait_fixed=5000,
-        stop_max_delay=timeout_seconds=1000,
+        stop_max_delay=timeout_seconds*1000,
         retry_on_result=lambda res: res is False)
     def fn():
         plan = get_plan(service_name, plan_name)

--- a/testing/sdk_plan.py
+++ b/testing/sdk_plan.py
@@ -94,7 +94,7 @@ def wait_for_plan_status(service_name, plan_name, status, timeout_seconds=TIMEOU
         wait_fixed=5000,
         stop_max_delay=timeout_seconds*1000,
         retry_on_result=lambda res: res is False)
-    def fn():
+    def wait_for_status():
         plan = get_plan(service_name, plan_name)
         log.info('Waiting for {} plan to have {} status:\nFound:\n{}'.format(
             plan_name, status, plan_string(plan_name, plan)))
@@ -103,7 +103,7 @@ def wait_for_plan_status(service_name, plan_name, status, timeout_seconds=TIMEOU
         else:
             return False
 
-    return fn()
+    return wait_for_status()
 
 
 def wait_for_phase_status(service_name, plan_name, phase_name, status, timeout_seconds=TIMEOUT_SECONDS):

--- a/testing/sdk_plan.py
+++ b/testing/sdk_plan.py
@@ -27,7 +27,7 @@ def get_recovery_plan(service_name):
 
 
 @retrying.retry(
-    wait_fixed=5000,
+    wait_fixed=1000,
     stop_max_delay=120000,
     retry_on_result=lambda res: not res)
 def get_plan(service_name, plan):

--- a/testing/sdk_plan.py
+++ b/testing/sdk_plan.py
@@ -28,7 +28,8 @@ def get_recovery_plan(service_name):
 
 @retrying.retry(
     wait_fixed=5000,
-    stop_max_delay=120000)
+    stop_max_delay=120000,
+    retry_on_result=lambda res: not res)
 def get_plan(service_name, plan):
     return sdk_api.get(service_name, '/v1/plans/{}'.format(plan)).json()
 

--- a/testing/sdk_plan.py
+++ b/testing/sdk_plan.py
@@ -92,10 +92,10 @@ def wait_for_plan_status(service_name, plan_name, status, timeout_seconds=TIMEOU
         statuses = status
 
     @retrying.retry(
-        wait_fixed=5000,
+        wait_fixed=1000,  # some plans are short; use high-res polling
         stop_max_delay=timeout_seconds*1000,
         retry_on_result=lambda res: res is False)
-    def wait_for_status():
+    def wait_for_plan():
         plan = get_plan(service_name, plan_name)
         log.info('Waiting for {} plan to have {} status:\nFound:\n{}'.format(
             plan_name, status, plan_string(plan_name, plan)))
@@ -104,15 +104,15 @@ def wait_for_plan_status(service_name, plan_name, status, timeout_seconds=TIMEOU
         else:
             return False
 
-    return wait_for_status()
+    return wait_for_plan()
 
 
 def wait_for_phase_status(service_name, plan_name, phase_name, status, timeout_seconds=TIMEOUT_SECONDS):
     @retrying.retry(
-        wait_fixed=5000,
+        wait_fixed=1000,  # some phases are short; use high-res polling
         stop_max_delay=timeout_seconds*1000,
         retry_on_result=lambda res: res is False)
-    def fn():
+    def wait_for_phase():
         plan = get_plan(service_name, plan_name)
         phase = get_phase(plan, phase_name)
         log.info('Waiting for {}.{} phase to have {} status:\n{}'.format(
@@ -122,15 +122,15 @@ def wait_for_phase_status(service_name, plan_name, phase_name, status, timeout_s
         else:
             return False
 
-    return fn()
+    return wait_for_phase()
 
 
 def wait_for_step_status(service_name, plan_name, phase_name, step_name, status, timeout_seconds=TIMEOUT_SECONDS):
     @retrying.retry(
-        wait_fixed=5000,
+        wait_fixed=1000,  # some steps are short; use high-res polling
         stop_max_delay=timeout_seconds*1000,
         retry_on_result=lambda res: res is False)
-    def fn():
+    def wait_for_step():
         plan = get_plan(service_name, plan_name)
         step = get_step(get_phase(plan, phase_name), step_name)
         log.info('Waiting for {}.{}.{} step to have {} status:\n{}'.format(
@@ -140,7 +140,7 @@ def wait_for_step_status(service_name, plan_name, phase_name, step_name, status,
         else:
             return False
 
-    return fn()
+    return wait_for_step()
 
 
 def recovery_plan_is_empty(service_name):

--- a/testing/sdk_tasks.py
+++ b/testing/sdk_tasks.py
@@ -22,7 +22,7 @@ def check_running(service_name, expected_task_count, timeout_seconds=DEFAULT_TIM
         wait_fixed=5000,
         stop_max_delay=timeout_seconds*1000,
         retry_on_result=lambda res: res is False)
-    def fn():
+    def wait_for_running():
         try:
             tasks = shakedown.get_service_tasks(service_name)
         except dcos.errors.DCOSHTTPException:
@@ -42,7 +42,7 @@ def check_running(service_name, expected_task_count, timeout_seconds=DEFAULT_TIM
             sorted(other_tasks)))
         return len(running_task_names) >= expected_task_count
 
-    fn()
+    wait_for_running()
 
 
 def get_task_ids(service_name, task_prefix):
@@ -59,7 +59,7 @@ def check_tasks_updated(service_name, prefix, old_task_ids, timeout_seconds=DEFA
         wait_fixed=5000,
         stop_max_delay=timeout_seconds*1000,
         retry_on_result=lambda res: res is False)
-    def fn():
+    def wait_for_update():
         try:
             task_ids = get_task_ids(service_name, prefix)
         except dcos.errors.DCOSHTTPException:
@@ -94,7 +94,7 @@ def check_tasks_updated(service_name, prefix, old_task_ids, timeout_seconds=DEFA
             old_remaining_set,
             newly_launched_set))
 
-    fn()
+    wait_for_update()
 
 
 def check_tasks_not_updated(service_name, prefix, old_task_ids):

--- a/testing/sdk_tasks.py
+++ b/testing/sdk_tasks.py
@@ -56,7 +56,7 @@ def check_tasks_updated(service_name, prefix, old_task_ids, timeout_seconds=DEFA
     # and checking that the deploy/upgrade/repair plan has completed. Each serves a part in the bigger
     # atomic test, that the plan completed properly where properly includes that no old tasks remain.
     @retrying.retry(
-        wait_fixed=5000,
+        wait_fixed=1000,
         stop_max_delay=timeout_seconds*1000,
         retry_on_result=lambda res: res is False)
     def wait_for_update():
@@ -107,13 +107,12 @@ def check_tasks_not_updated(service_name, prefix, old_task_ids):
 
 
 def kill_task_with_pattern(pattern, agent_host=None, timeout_seconds=DEFAULT_TIMEOUT_SECONDS):
-    exit_status = 0
 
     @retrying.retry(
-        wait_fixed=5000,
+        wait_fixed=1000,
         stop_max_delay=timeout_seconds*1000,
-        retry_on_result=lambda res: res is False or res is 0)
-    def fn():
+        retry_on_result=lambda res: res is False)
+    def retry_kill():
         command = (
             "sudo kill -9 "
             "$(ps ax | grep {} | grep -v grep | tr -s ' ' | sed 's/^ *//g' | "
@@ -126,7 +125,4 @@ def kill_task_with_pattern(pattern, agent_host=None, timeout_seconds=DEFAULT_TIM
         return exit_status
 
     # might not be able to connect to the agent on first try so we repeat until we can
-    fn()
-
-    if exit_status != 0:
-        raise RuntimeError('Failed to kill task with pattern "{}", exit status: {}'.format(pattern, exit_status))
+    retry_kill()

--- a/testing/sdk_tasks.py
+++ b/testing/sdk_tasks.py
@@ -8,6 +8,7 @@ SHOULD ALSO BE APPLIED TO sdk_tasks IN ANY OTHER PARTNER REPOS
 import logging
 
 import dcos.errors
+import retrying
 import sdk_plan
 import shakedown
 
@@ -17,6 +18,10 @@ log = logging.getLogger(__name__)
 
 
 def check_running(service_name, expected_task_count, timeout_seconds=DEFAULT_TIMEOUT_SECONDS):
+    @retrying.retry(
+        wait_fixed=5000,
+        stop_max_delay=timeout_seconds*1000,
+        retry_on_result=lambda res: res is False)
     def fn():
         try:
             tasks = shakedown.get_service_tasks(service_name)
@@ -37,7 +42,7 @@ def check_running(service_name, expected_task_count, timeout_seconds=DEFAULT_TIM
             sorted(other_tasks)))
         return len(running_task_names) >= expected_task_count
 
-    shakedown.wait_for(lambda: fn(), noisy=True, timeout_seconds=timeout_seconds)
+    fn()
 
 
 def get_task_ids(service_name, task_prefix):
@@ -50,6 +55,10 @@ def check_tasks_updated(service_name, prefix, old_task_ids, timeout_seconds=DEFA
     # TODO: strongly consider merging the use of checking that tasks have been replaced (this method)
     # and checking that the deploy/upgrade/repair plan has completed. Each serves a part in the bigger
     # atomic test, that the plan completed properly where properly includes that no old tasks remain.
+    @retrying.retry(
+        wait_fixed=5000,
+        stop_max_delay=timeout_seconds*1000,
+        retry_on_result=lambda res: res is False)
     def fn():
         try:
             task_ids = get_task_ids(service_name, prefix)
@@ -85,7 +94,7 @@ def check_tasks_updated(service_name, prefix, old_task_ids, timeout_seconds=DEFA
             old_remaining_set,
             newly_launched_set))
 
-    shakedown.wait_for(lambda: fn(), noisy=True, timeout_seconds=timeout_seconds)
+    fn()
 
 
 def check_tasks_not_updated(service_name, prefix, old_task_ids):
@@ -99,6 +108,11 @@ def check_tasks_not_updated(service_name, prefix, old_task_ids):
 
 def kill_task_with_pattern(pattern, agent_host=None, timeout_seconds=DEFAULT_TIMEOUT_SECONDS):
     exit_status = 0
+
+    @retrying.retry(
+        wait_fixed=5000,
+        stop_max_delay=timeout_seconds*1000,
+        retry_on_result=lambda res: res is False or res is 0)
     def fn():
         command = (
             "sudo kill -9 "
@@ -112,7 +126,7 @@ def kill_task_with_pattern(pattern, agent_host=None, timeout_seconds=DEFAULT_TIM
         return exit_status
 
     # might not be able to connect to the agent on first try so we repeat until we can
-    shakedown.wait_for(lambda: fn(), noisy=True, timeout_seconds=timeout_seconds)
+    fn()
 
     if exit_status != 0:
         raise RuntimeError('Failed to kill task with pattern "{}", exit status: {}'.format(pattern, exit_status))

--- a/testing/sdk_upgrade.py
+++ b/testing/sdk_upgrade.py
@@ -123,13 +123,6 @@ def _get_universe_url():
     assert False, "Unable to find 'Universe' in list of repos: {}".format(repositories)
 
 
-@retrying.retry(
-    wait_fixed=10000,
-    stop_max_delay=300000)
-def wait_for_suppressed_service(service_name):
-    assert sdk_api.is_suppressed(service_name)
-
-
 def _upgrade_or_downgrade(
         package_name,
         to_package_version,
@@ -173,14 +166,6 @@ def _upgrade_or_downgrade(
         log.info("Waiting for {}/{} to finish deployment plan...".format(
             package_name, service_name))
         sdk_plan.wait_for_completed_deployment(service_name, timeout_seconds)
-
-        # given the above wait for plan completion, here we just wait up to 5 minutes
-        if shakedown.dcos_version_less_than("1.9"):
-            log.info("Skipping `is_suppressed` check for %s/%s as this is only suppored starting in version 1.9",
-                     package_name, service_name)
-        else:
-            log.info("Waiting for %s/%s to be suppressed...", package_name, service_name)
-            wait_for_suppressed_service(service_name)
 
 
 def _get_pkg_version(package_name):

--- a/testing/sdk_upgrade.py
+++ b/testing/sdk_upgrade.py
@@ -193,7 +193,7 @@ def _add_last_repo(repo_name, repo_url, prev_version, default_repo_package_name)
 
 
 @retrying.retry(
-    wait_fixed=5000,
+    wait_fixed=1000,
     stop_max_delay=120000)
 def _wait_for_new_default_version(prev_version, default_repo_package_name):
     assert _get_pkg_version(default_repo_package_name) != prev_version

--- a/testing/sdk_upgrade.py
+++ b/testing/sdk_upgrade.py
@@ -7,6 +7,7 @@ SHOULD ALSO BE APPLIED TO sdk_upgrade IN ANY OTHER PARTNER REPOS
 import json
 import logging
 import re
+import retrying
 import shakedown
 import tempfile
 
@@ -191,5 +192,8 @@ def _add_last_repo(repo_name, repo_url, prev_version, default_repo_package_name)
     _wait_for_new_default_version(prev_version, default_repo_package_name)
 
 
+@retrying.retry(
+    wait_fixed=5000,
+    stop_max_delay=120000)
 def _wait_for_new_default_version(prev_version, default_repo_package_name):
-    shakedown.wait_for(lambda: _get_pkg_version(default_repo_package_name) != prev_version, noisy=True)
+    assert _get_pkg_version(default_repo_package_name) != prev_version

--- a/testing/sdk_upgrade.py
+++ b/testing/sdk_upgrade.py
@@ -123,6 +123,13 @@ def _get_universe_url():
     assert False, "Unable to find 'Universe' in list of repos: {}".format(repositories)
 
 
+@retrying.retry(
+    wait_fixed=10000,
+    stop_max_delay=300000)
+def wait_for_suppressed_service(service_name):
+    assert sdk_api.is_suppressed(service_name)
+
+
 def _upgrade_or_downgrade(
         package_name,
         to_package_version,
@@ -166,6 +173,14 @@ def _upgrade_or_downgrade(
         log.info("Waiting for {}/{} to finish deployment plan...".format(
             package_name, service_name))
         sdk_plan.wait_for_completed_deployment(service_name, timeout_seconds)
+
+        # given the above wait for plan completion, here we just wait up to 5 minutes
+        if shakedown.dcos_version_less_than("1.9"):
+            log.info("Skipping `is_suppressed` check for %s/%s as this is only suppored starting in version 1.9",
+                     package_name, service_name)
+        else:
+            log.info("Waiting for %s/%s to be suppressed...", package_name, service_name)
+            wait_for_suppressed_service(service_name)
 
 
 def _get_pkg_version(package_name):


### PR DESCRIPTION
`shakedown.wait_for`:
retries all exceptions by default (and suppresses exceptions)
retries for 2 minutes by default
retries with 1 second polling by default
evaluates the function to only return if predicate() by default. This quite confusing as there is no strong typing so this can be True/False, empty string, empty list, empty set, etc
prints spinning...

`retrying.retry`:
retries all exceptions by default (does not suppress unless you implement your own suppression)
retries with infinite timeout by default
retries with 0 second polling by default
does not retry on ANY return value by default. If you want retrying.retry to consider the result, then you must supply retry_on_result

Rather than trying to adjust the shakedown polling function to log more useful information, its more direct if individual tests and invocations of a retry loop can define their own logging or print statements