### PR TITLE
Optionally override target GitHub repo for release

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -313,6 +313,7 @@ The following are optional:
 - `S3_RELEASE_BUCKET` (default: `downloads.mesosphere.io`): The S3 bucket to upload the release artifacts into.
 - `HTTP_RELEASE_SERVER` (default: `https://downloads.mesosphere.com`): The HTTP base URL for paths within the above bucket.
 - `RELEASE_DIR_PATH` (default: `<package-name>/assets`): The path prefix within `S3_RELEASE_BUCKET` and `HTTP_RELEASE_SERVER` to place the release artifacts. Artifacts will be stored in a `<package-version>` subdirectory within this path.
+- `RELEASE_UNIVERSE_REPO` (default: `mesosphere/universe`): The GitHub repository to submit the automated PR to.
 - `DRY_RUN`: Refrain from actually transferring/uploading anything in S3, and from actually creating a GitHub PR.
 
 ## Test Tools

--- a/tools/README.md
+++ b/tools/README.md
@@ -314,6 +314,7 @@ The following are optional:
 - `HTTP_RELEASE_SERVER` (default: `https://downloads.mesosphere.com`): The HTTP base URL for paths within the above bucket.
 - `RELEASE_DIR_PATH` (default: `<package-name>/assets`): The path prefix within `S3_RELEASE_BUCKET` and `HTTP_RELEASE_SERVER` to place the release artifacts. Artifacts will be stored in a `<package-version>` subdirectory within this path.
 - `RELEASE_UNIVERSE_REPO` (default: `mesosphere/universe`): The GitHub repository to submit the automated PR to.
+- `RELEASE_BRANCH` (default: `version-3.x`): The target release branch for the automated PR.
 - `DRY_RUN`: Refrain from actually transferring/uploading anything in S3, and from actually creating a GitHub PR.
 
 ## Test Tools

--- a/tools/release_builder.py
+++ b/tools/release_builder.py
@@ -39,6 +39,7 @@ class UniverseReleaseBuilder(object):
         self._dry_run = os.environ.get('DRY_RUN', '')
         self._force_upload = os.environ.get('FORCE_ARTIFACT_UPLOAD', '').lower() == 'true'
         self._beta_release = beta_release.lower() == 'true'
+        self._release_universe_repo=os.environ.get('RELEASE_UNIVERSE_REPO', 'mesosphere/universe')
 
         name_match = re.match('.+/stub-universe-(.+).(zip|json)$', stub_universe_url)
         if not name_match:
@@ -307,7 +308,7 @@ Artifact output: {}
         # check out the repo, create a new local branch:
         ret = os.system(' && '.join([
             'cd {}'.format(scratchdir),
-            'git clone --depth 1 --branch version-3.x git@github.com:mesosphere/universe',
+            'git clone --depth 1 --branch version-3.x git@github.com:{}'.format(self._release_universe_repo),
             'cd universe',
             'git config --local user.email jenkins@mesosphere.com',
             'git config --local user.name release_builder.py',
@@ -422,7 +423,7 @@ Artifact output: {}
         conn.set_debuglevel(999)
         conn.request(
             'POST',
-            '/repos/mesosphere/universe/pulls',
+            '/repos/{}/pulls'.format(self._release_universe_repo),
             body=json.dumps(payload).encode('utf-8'),
             headers=headers)
         return conn.getresponse()

--- a/tools/release_builder.py
+++ b/tools/release_builder.py
@@ -40,6 +40,7 @@ class UniverseReleaseBuilder(object):
         self._force_upload = os.environ.get('FORCE_ARTIFACT_UPLOAD', '').lower() == 'true'
         self._beta_release = beta_release.lower() == 'true'
         self._release_universe_repo=os.environ.get('RELEASE_UNIVERSE_REPO', 'mesosphere/universe')
+        self._release_branch=os.environ.get('RELEASE_BRANCH', 'version-3.x')
 
         name_match = re.match('.+/stub-universe-(.+).(zip|json)$', stub_universe_url)
         if not name_match:
@@ -308,7 +309,7 @@ Artifact output: {}
         # check out the repo, create a new local branch:
         ret = os.system(' && '.join([
             'cd {}'.format(scratchdir),
-            'git clone --depth 1 --branch version-3.x git@github.com:{}'.format(self._release_universe_repo),
+            'git clone --depth 1 --branch {} git@github.com:{} universe'.format(self._release_branch, self._release_universe_repo),
             'cd universe',
             'git config --local user.email jenkins@mesosphere.com',
             'git config --local user.name release_builder.py',
@@ -417,7 +418,7 @@ Artifact output: {}
             payload = {
                 'title': self._pr_title,
                 'head': branch,
-                'base': 'version-3.x',
+                'base': self._release_branch,
                 'body': commitmsg_file.read()}
         conn = http.client.HTTPSConnection('api.github.com')
         conn.set_debuglevel(999)


### PR DESCRIPTION
When an org maintains their own universe fork this allows them to use `release_builder.py` to submit automated PR's to it.