### PR TITLE
INFINITY-2326/2327 Cleanup of some startup warnings, and other minor logging improvements

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/api/ConfigResource.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/api/ConfigResource.java
@@ -3,13 +3,13 @@ package com.mesosphere.sdk.api;
 import java.util.Arrays;
 import java.util.UUID;
 
+import javax.inject.Singleton;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.core.Response;
 
 import com.mesosphere.sdk.api.types.PrettyJsonResource;
-import com.mesosphere.sdk.config.Configuration;
 import com.mesosphere.sdk.state.ConfigStore;
 import com.mesosphere.sdk.state.ConfigStoreException;
 import com.mesosphere.sdk.storage.StorageError.Reason;
@@ -26,14 +26,15 @@ import static com.mesosphere.sdk.api.ResponseUtils.jsonResponseBean;
  *
  * @param <T> The configuration type which is being stored by the framework.
  */
+@Singleton
 @Path("/v1/configurations")
-public class ConfigResource<T extends Configuration> extends PrettyJsonResource {
+public class ConfigResource<T extends ConfigStore<?>> extends PrettyJsonResource {
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
-    private final ConfigStore<T> configStore;
+    private final T configStore;
 
-    public ConfigResource(ConfigStore<T> configStore) {
+    public ConfigResource(T configStore) {
         this.configStore = configStore;
     }
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/api/EndpointsResource.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/api/EndpointsResource.java
@@ -130,7 +130,7 @@ public class EndpointsResource {
         Map<String, JSONObject> endpointsByName = new TreeMap<>();
         for (TaskInfo taskInfo : stateStore.fetchTasks()) {
             if (!taskInfo.hasDiscovery()) {
-                LOGGER.info("Task lacks any discovery information, no endpoints to report: {}",
+                LOGGER.debug("Task lacks any discovery information, no endpoints to report: {}",
                         taskInfo.getName());
                 continue;
             }
@@ -146,7 +146,7 @@ public class EndpointsResource {
             List<String> ipAddresses = reconcileIpAddresses(taskInfo.getName());
             for (Port port : discoveryInfo.getPorts().getPortsList()) {
                 if (port.getVisibility() != Constants.DISPLAYED_PORT_VISIBILITY) {
-                    LOGGER.info(
+                    LOGGER.debug(
                             "Port {} in task {} has {} visibility. {} is needed to be listed in endpoints.",
                             port.getName(), taskInfo.getName(), port.getVisibility(),
                             Constants.DISPLAYED_PORT_VISIBILITY);
@@ -221,7 +221,8 @@ public class EndpointsResource {
             String autoipHostPort,
             String ipHostPort) throws TaskException {
         if (Strings.isEmpty(taskInfoPort.getName())) {
-            // Older tasks may omit the port name in their DiscoveryInfo.
+            // Older tasks may omit the port name in their DiscoveryInfo. In practice this shouldn't happen because
+            // tasks that old should have been long updated/relaunched by the time this is invoked, but just in case...
             LOGGER.warn("Missing port name. Old task?: {}", TextFormat.shortDebugString(taskInfoPort));
             return;
         }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/api/PlansResource.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/api/PlansResource.java
@@ -15,6 +15,7 @@ import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.inject.Singleton;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -36,6 +37,7 @@ import static com.mesosphere.sdk.api.ResponseUtils.*;
 /**
  * API for management of Plan(s).
  */
+@Singleton
 @Path("/v1")
 public class PlansResource extends PrettyJsonResource {
 
@@ -183,7 +185,7 @@ public class PlansResource extends PrettyJsonResource {
      *
      * Interrupt differs from stop in the following ways:
      * A) Interrupt can be issued for a specific phase or for all phases within a plan.  Stop can only be
-     *    issued for a plan. 
+     *    issued for a plan.
      * B) Interrupt updates the underlying Phase/Step state. Stop not only updates the underlying state, but
      *    also restarts the Plan.
      */

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/api/PodResource.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/api/PodResource.java
@@ -13,6 +13,7 @@ import java.util.TreeSet;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import javax.inject.Singleton;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -41,6 +42,7 @@ import static com.mesosphere.sdk.api.ResponseUtils.jsonResponseBean;
 /**
  * A read-only API for accessing information about how to connect to the service.
  */
+@Singleton
 @Path("/v1/pod")
 public class PodResource extends PrettyJsonResource {
     private static final Logger LOGGER = LoggerFactory.getLogger(PodResource.class);

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/api/ConfigResourceTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/api/ConfigResourceTest.java
@@ -25,7 +25,7 @@ public class ConfigResourceTest {
 
     @Mock private ConfigStore<StringConfiguration> mockConfigStore;
 
-    private ConfigResource<StringConfiguration> resource;
+    private ConfigResource<ConfigStore<StringConfiguration>> resource;
 
     @Before
     public void beforeAll() {


### PR DESCRIPTION
- Annotations and generic type on ConfigResource: Fixing some jersey warnings emitted on scheduler startup.
- Downgrade of EndpointResource logs: Produces noise on every query, which is only really useful for service developers anyway
- Other log fixes: Nitpicks.