### PR TITLE
[INFINITY-2351] Require a minimum node count of 3

### DIFF
--- a/frameworks/cassandra/docs/limitations.md
+++ b/frameworks/cassandra/docs/limitations.md
@@ -5,6 +5,10 @@ feature_maturity: preview
 enterprise: 'no'
 ---
 
+## Node Count
+
+The DC/OS Cassandra Service must be deployed with at least 3 nodes.
+
 ## Rack-Aware Placement
 
 Apache Cassandra's Rack-Aware Replication is not supported at this time.

--- a/frameworks/cassandra/universe/config.json
+++ b/frameworks/cassandra/universe/config.json
@@ -85,7 +85,8 @@
         "count": {
           "type": "integer",
           "description": "The number of Cassandra nodes in the cluster.",
-          "default": 3
+          "default": 3,
+          "minimum": 3
         },
         "cpus": {
           "type": "number",


### PR DESCRIPTION
Our implementation does not support less than 2 seeds and 1 data node.