### PR TITLE
[INFINITY-2359] Disable kafka tls in stable

### DIFF
--- a/frameworks/kafka/docs/configure.md
+++ b/frameworks/kafka/docs/configure.md
@@ -232,15 +232,6 @@ Configure the port number that the brokers listen on. If the port is set to a pa
 *   **In DC/OS CLI options.json**: `broker-port`: integer (default: `9092`)
 *   **DC/OS web interface**: `BROKER_PORT`: `integer`
 
-### TLS Broker Port
-
-Configure the port number that brokers listen on with a TLS connection. The default value is `9093`. Same rules apply as for [Broker Port](#broker-port).
-
-This setting requires [TLS](#tls) to be enabled, otherwise it is ignored.
-
-*   **In DC/OS CLI options.json**: `broker-port_tls`: integer (default: `9093`)
-*   **DC/OS web interface**: `BROKER_PORT_TLS`: `integer`
-
 ## Configure Broker Placement Strategy <!-- replace this with a discussion of PLACEMENT_CONSTRAINTS? -->
 
 `ANY` allows brokers to be placed on any node with sufficient resources, while `NODE` ensures that all brokers within a given Kafka cluster are never colocated on the same node. This is an option that cannot be changed once the Kafka cluster is started: it can only be configured via the DC/OS CLI `--options` flag when the Kafka instance is created.
@@ -326,60 +317,6 @@ To configure it:
 ```
 
 This configuration option cannot be changed after installation.
-
-## TLS
-
-It is possible to expose Kafka over a secure TLS connection.
-
-**DC/OS CLI options.json**:
-```
-{
-    "service": {
-        "tls": true
-    }
-}
-```
-
-Once the TLS is enabled, Kafka will use secure TLS connections for inter-node communication. Additional TLS port named `broker-tls` will be available for clients connecting to the service. Only the [`TLS version 1.2`](https://www.ietf.org/rfc/rfc5246.txt) is supported. The non-TLS `broker` port will still be available.
-
-Enabling the TLS is possible only in `permissive` or `strict` cluster security modes. Both modes **require** a [service account](https://docs.mesosphere.com/service-docs/kafka/kafka-auth/). Additionally, the service account **must have** the `dcos:superuser` permission. If the permission is missing the Kafka scheduler will not abe able to provision the TLS artifacts.
-
-There is a performance impact with TLS connections that should be considered:
-
-* the initial TLS handshake
-
-* encryption and decryption of messages sent over the socket
-
-It is possible to use the Kafka CLI utility to test the performance impact of TLS by comparing the output of following commands:
-
-```
-export KAFKA_TOPIC_NAME=tls-test
-export KAFKA_MSG_COUNT=100000
-dcos kafka topic create ${KAFKA_TOPIC_NAME}
-
-# Test no TLS
-dcos kafka topic producer_test ${KAFKA_TOPIC_NAME} ${KAFKA_MSG_COUNT}
-
-# Test TLS
-dcos kafka topic producer_test_tls ${KAFKA_TOPIC_NAME} ${KAFKA_MSG_COUNT}
-```
-
-For more information about the TLS in the SDK see [the TLS documentation](https://mesosphere.github.io/dcos-commons/developer-guide.html#tls).
-
-### TLS and plaintext
-
-It is possible to keep both TLS and plaintext ports opened at the same time and have clients accessing both of them. To keep the plaintext port open use the following TLS configuration:
-
-```
-{
-    "service": {
-        "tls": true,
-        "tls_allow_plaintext": true
-    }
-}
-```
-
-The plaintext port will be disabled by default when the TLS is enabled.
 
 ## Recovery and Health Checks
 

--- a/frameworks/kafka/docs/connecting-clients.md
+++ b/frameworks/kafka/docs/connecting-clients.md
@@ -69,8 +69,6 @@ The response, for both the CLI and the REST API is as below.
 
 This JSON array contains a list of valid brokers that the client can use to connect to the Kafka cluster. For availability reasons, it is best to specify multiple brokers in configuration of the client. Use the VIP to address any one of the Kafka brokers in the cluster. [Learn more about load balancing and VIPs in DC/OS](https://docs.mesosphere.com/1.9/networking/).
 
-When [the TLS][15] is enabled you can request details for `broker-tls` port. To verify a TLS connection from a client the [DC/OS trust bundle with a CA certificate](https://docs.mesosphere.com/1.9/networking/tls-ssl/get-cert/) is required.
-
 # Configuring the Kafka Client Library
 
 ## Adding the Kafka Client Library to Your Application
@@ -178,5 +176,3 @@ The following code connects to a DC/OS-hosted Kafka instance using `bin/kafka-co
 
  [13]: https://docs.mesosphere.com/1.9/security/users-groups/
  [14]: https://docs.mesosphere.com/1.9/security/iam-api/
- [15]: https://docs.mesosphere.com/service-docs/kafka/configure/#tls
-

--- a/frameworks/kafka/tests/test_tls.py
+++ b/frameworks/kafka/tests/test_tls.py
@@ -68,6 +68,7 @@ def kafka_service_tls(service_account):
 @pytest.mark.smoke
 @pytest.mark.sanity
 @sdk_utils.dcos_1_10_or_higher
+@pytest.mark.skip(reason="TLS not supported in stable.")
 def test_tls_endpoints(kafka_service_tls):
     endpoints = sdk_networks.get_and_test_endpoints("", config.PACKAGE_NAME, 2)
     assert BROKER_TLS_ENDPOINT in endpoints
@@ -83,6 +84,7 @@ def test_tls_endpoints(kafka_service_tls):
 @pytest.mark.smoke
 @pytest.mark.sanity
 @sdk_utils.dcos_1_10_or_higher
+@pytest.mark.skip(reason="TLS not supported in stable.")
 def test_producer_over_tls(kafka_service_tls):
     service_cli('topic create {}'.format(config.DEFAULT_TOPIC_NAME))
 

--- a/frameworks/kafka/universe/config.json
+++ b/frameworks/kafka/universe/config.json
@@ -40,16 +40,6 @@
             "type": "boolean",
             "default":  false
           },
-          "tls": {
-            "description": "Enable TLS support (requires Enterprise DC/OS running in strict security mode).",
-            "type": "boolean",
-            "default": false
-          },
-          "tls_allow_plaintext": {
-            "description": "Keep the plaintext port open when the TLS is enabled. (Allows clients to connect using a non-encrypted connection and takes effect only if the TLS is enabled.)",
-            "type": "boolean",
-            "default": false
-          },
           "virtual_network_name": {
             "description": "The name of the virtual network to join",
             "type": "string",
@@ -130,11 +120,6 @@
             "description": "Port for broker to listen on",
             "type": "integer",
             "default": 0
-          },
-          "port_tls": {
-            "description": "Port for broker to listen on for TLS connections, if the TLS is enabled",
-            "type": "integer",
-            "default":  0
           },
           "kill_grace_period": {
             "description": "The number of seconds of grace to await a clean shutdown following SIGTERM before sending SIGKILL, default: `30`",


### PR DESCRIPTION
This removes the Kafka TLS settings from the stable branch. I've simply removed them from config.json and the docs. The overall plumbing still exists.