### PR TITLE
[INFINITY-2316] Fix removal of pod causes NPE

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/config/validate/TLSRequiresServiceAccount.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/config/validate/TLSRequiresServiceAccount.java
@@ -3,8 +3,12 @@ package com.mesosphere.sdk.config.validate;
 import com.mesosphere.sdk.offer.TaskUtils;
 import com.mesosphere.sdk.scheduler.SchedulerFlags;
 import com.mesosphere.sdk.specification.ServiceSpec;
+import org.apache.commons.lang3.StringUtils;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
 
 /**
  * A {@link TLSRequiresServiceAccount} checks whether the configuration contains provisioning of TLS artifacts
@@ -22,7 +26,7 @@ public class TLSRequiresServiceAccount implements ConfigValidator<ServiceSpec> {
     public Collection<ConfigValidationError> validate(Optional<ServiceSpec> oldConfig, ServiceSpec newConfig) {
         if (!TaskUtils.getTasksWithTLS(newConfig).isEmpty()) {
             try {
-                if (flags.getServiceAccountUid().equals("")) {
+                if (StringUtils.isBlank(flags.getServiceAccountUid())) {
                     return getConfigValidationErrors();
                 }
             } catch (Exception e) {

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/config/validate/PodSpecsCannotShrinkTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/config/validate/PodSpecsCannotShrinkTest.java
@@ -1,7 +1,10 @@
 package com.mesosphere.sdk.config.validate;
 
 import com.mesosphere.sdk.offer.InvalidRequirementException;
-import com.mesosphere.sdk.specification.*;
+import com.mesosphere.sdk.specification.DefaultServiceSpec;
+import com.mesosphere.sdk.specification.PodSpec;
+import com.mesosphere.sdk.specification.ServiceSpec;
+import com.mesosphere.sdk.specification.TaskSpec;
 import com.mesosphere.sdk.testutils.TestConstants;
 import org.junit.Assert;
 import org.junit.Before;
@@ -12,6 +15,8 @@ import org.mockito.MockitoAnnotations;
 import java.util.Arrays;
 import java.util.Optional;
 
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
 
 public class PodSpecsCannotShrinkTest {
@@ -22,17 +27,27 @@ public class PodSpecsCannotShrinkTest {
     @Mock
     private PodSpec mockPodSpec1;
     @Mock
+    private PodSpec mockPodSpec1WithHigherCount;
+    @Mock
     private PodSpec mockPodSpec11;
     @Mock
     private PodSpec mockPodSpec2;
     @Mock
     private PodSpec mockPodSpec22;
+    @Mock
+    private ServiceSpec mockDuplicatePodServiceSpec;
 
     @Before
     public void beforeEach() {
         MockitoAnnotations.initMocks(this);
         when(mockPodSpec1.getType()).thenReturn(TestConstants.POD_TYPE + "-A1");
         when(mockPodSpec1.getTasks()).thenReturn(Arrays.asList(taskSpec));
+        when(mockPodSpec1.getCount()).thenReturn(1);
+
+
+        when(mockPodSpec1WithHigherCount.getType()).thenReturn(TestConstants.POD_TYPE + "-A1");
+        when(mockPodSpec1WithHigherCount.getTasks()).thenReturn(Arrays.asList(taskSpec));
+        when(mockPodSpec1WithHigherCount.getCount()).thenReturn(100);
 
         when(mockPodSpec11.getType()).thenReturn(TestConstants.POD_TYPE + "-A2");
         when(mockPodSpec11.getTasks()).thenReturn(Arrays.asList(taskSpec));
@@ -178,5 +193,56 @@ public class PodSpecsCannotShrinkTest {
         Assert.assertEquals(0, VALIDATOR.validate(Optional.of(serviceSpec2), serviceSpec1).size());
         Assert.assertEquals(0, VALIDATOR.validate(Optional.of(serviceSpec1), serviceSpec1).size());
         Assert.assertEquals(0, VALIDATOR.validate(Optional.of(serviceSpec2), serviceSpec2).size());
+    }
+
+    @Test
+    public void testReducingPodCountIsInvalid() {
+        final ServiceSpec serviceWithManyPods = DefaultServiceSpec.newBuilder()
+                .name("svc1")
+                .role(TestConstants.ROLE)
+                .principal(TestConstants.PRINCIPAL)
+                .pods(Arrays.asList(mockPodSpec1WithHigherCount))
+                .build();
+
+        final ServiceSpec serviceWithFewPods = DefaultServiceSpec.newBuilder()
+                .name("svc1")
+                .role(TestConstants.ROLE)
+                .principal(TestConstants.PRINCIPAL)
+                .pods(Arrays.asList(mockPodSpec1))
+                .build();
+
+        assertThat(VALIDATOR.validate(Optional.of(serviceWithManyPods), serviceWithFewPods), hasSize(1));
+    }
+
+    @Test
+    public void testIncreasingPodCountIsValid() {
+        final ServiceSpec serviceWithManyPods = DefaultServiceSpec.newBuilder()
+                .name("svc1")
+                .role(TestConstants.ROLE)
+                .principal(TestConstants.PRINCIPAL)
+                .pods(Arrays.asList(mockPodSpec1WithHigherCount))
+                .build();
+
+        final ServiceSpec serviceWithFewPods = DefaultServiceSpec.newBuilder()
+                .name("svc1")
+                .role(TestConstants.ROLE)
+                .principal(TestConstants.PRINCIPAL)
+                .pods(Arrays.asList(mockPodSpec1))
+                .build();
+
+        assertThat(VALIDATOR.validate(Optional.of(serviceWithFewPods), serviceWithManyPods), is(empty()));
+    }
+
+    @Test
+    public void testDuplicatePodTypesAreInvalid() {
+        when(mockDuplicatePodServiceSpec.getPods()).thenReturn(Arrays.asList(mockPodSpec1, mockPodSpec1));
+
+        assertThat(VALIDATOR.validate(Optional.of(mockDuplicatePodServiceSpec), mockDuplicatePodServiceSpec), hasSize(1));
+
+    }
+
+    @Test
+    public void testOldConfigNotPresentIsValid() {
+        assertThat(VALIDATOR.validate(Optional.empty(), null), is(empty()));
     }
 }

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/config/validate/PreReservationCannotChangeTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/config/validate/PreReservationCannotChangeTest.java
@@ -1,0 +1,258 @@
+package com.mesosphere.sdk.config.validate;
+
+import com.mesosphere.sdk.specification.DefaultServiceSpec;
+import com.mesosphere.sdk.specification.PodSpec;
+import com.mesosphere.sdk.specification.ServiceSpec;
+import com.mesosphere.sdk.specification.TaskSpec;
+import com.mesosphere.sdk.testutils.TestConstants;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+
+
+public class PreReservationCannotChangeTest {
+    private static final ConfigValidator<ServiceSpec> VALIDATOR = new PreReservationCannotChange();
+
+    @Mock
+    private TaskSpec taskSpec;
+    @Mock
+    private PodSpec mockPodSpec1;
+    @Mock
+    private PodSpec mockPodSpec1WithNoRole;
+    @Mock
+    private PodSpec mockPodSpec1WithDifferentRole;
+    @Mock
+    private PodSpec mockPodSpec2;
+    @Mock
+    private PodSpec mockPodSpec2WithDifferentRole;
+
+    @Before
+    public void beforeEach() {
+        MockitoAnnotations.initMocks(this);
+        when(mockPodSpec1.getType()).thenReturn(TestConstants.POD_TYPE + "-A1");
+        when(mockPodSpec1.getTasks()).thenReturn(Arrays.asList(taskSpec));
+        when(mockPodSpec1.getPreReservedRole()).thenReturn("pre-reserved-role");
+
+        when(mockPodSpec1WithNoRole.getType()).thenReturn(TestConstants.POD_TYPE + "-A1");
+        when(mockPodSpec1WithNoRole.getTasks()).thenReturn(Arrays.asList(taskSpec));
+
+
+        when(mockPodSpec1WithDifferentRole.getType()).thenReturn(TestConstants.POD_TYPE + "-A1");
+        when(mockPodSpec1WithDifferentRole.getTasks()).thenReturn(Arrays.asList(taskSpec));
+        when(mockPodSpec1WithDifferentRole.getPreReservedRole()).thenReturn("pre-reserved-role-plus-difference");
+
+
+        when(mockPodSpec2.getType()).thenReturn(TestConstants.POD_TYPE + "-B1");
+        when(mockPodSpec2.getTasks()).thenReturn(Arrays.asList(taskSpec, taskSpec));
+        when(mockPodSpec2.getPreReservedRole()).thenReturn("pre-reserved-role");
+
+        when(mockPodSpec2WithDifferentRole.getType()).thenReturn(TestConstants.POD_TYPE + "-B1");
+        when(mockPodSpec2WithDifferentRole.getTasks()).thenReturn(Arrays.asList(taskSpec));
+        when(mockPodSpec2WithDifferentRole.getPreReservedRole()).thenReturn("pre-reserved-role-plus-difference");
+    }
+
+    @Test
+    public void testNoInitialPodPassesValidation() {
+        Optional<ServiceSpec> serviceSpec1 = Optional.empty();
+
+        assertThat(VALIDATOR.validate(serviceSpec1, null), is(empty()));
+    }
+
+
+    @Test
+    public void testMatchingServiceSpecsPassesValidation() {
+        Optional<ServiceSpec> serviceSpec1 = Optional.of(DefaultServiceSpec.newBuilder()
+                .name("svc1")
+                .role(TestConstants.ROLE)
+                .principal(TestConstants.PRINCIPAL)
+                .pods(Arrays.asList(mockPodSpec1, mockPodSpec2))
+                .build());
+        assertThat(VALIDATOR.validate(serviceSpec1, serviceSpec1.get()), is(empty()));
+    }
+
+    @Test
+    public void testSwappedPodsDoesPassesValidation() {
+        Optional<ServiceSpec> serviceSpec1 = Optional.of(DefaultServiceSpec.newBuilder()
+                .name("svc1")
+                .role(TestConstants.ROLE)
+                .principal(TestConstants.PRINCIPAL)
+                .pods(Arrays.asList(mockPodSpec1, mockPodSpec2))
+                .build());
+
+
+        final ServiceSpec serviceSpec2 = DefaultServiceSpec.newBuilder()
+                .name("svc1")
+                .role(TestConstants.ROLE)
+                .principal(TestConstants.PRINCIPAL)
+                .pods(Arrays.asList(mockPodSpec2, mockPodSpec1))
+                .build();
+
+        assertThat(VALIDATOR.validate(serviceSpec1, serviceSpec2), is(empty()));
+    }
+
+    @Test
+    public void testReplacedPodPassesValidation() {
+        Optional<ServiceSpec> serviceSpec1 = Optional.of(DefaultServiceSpec.newBuilder()
+                .name("svc1")
+                .role(TestConstants.ROLE)
+                .principal(TestConstants.PRINCIPAL)
+                .pods(Arrays.asList(mockPodSpec1))
+                .build());
+
+
+        final ServiceSpec serviceSpec2 = DefaultServiceSpec.newBuilder()
+                .name("svc1")
+                .role(TestConstants.ROLE)
+                .principal(TestConstants.PRINCIPAL)
+                .pods(Arrays.asList(mockPodSpec1))
+                .build();
+
+        assertThat(VALIDATOR.validate(serviceSpec1, serviceSpec2), is(empty()));
+    }
+
+    @Test
+    public void testFirstPodChangesReservedRoleFailsValidation() {
+        Optional<ServiceSpec> serviceSpec1 = Optional.of(DefaultServiceSpec.newBuilder()
+                .name("svc1")
+                .role(TestConstants.ROLE)
+                .principal(TestConstants.PRINCIPAL)
+                .pods(Arrays.asList(mockPodSpec1, mockPodSpec2))
+                .build());
+
+
+        final ServiceSpec serviceSpec2 = DefaultServiceSpec.newBuilder()
+                .name("svc1")
+                .role(TestConstants.ROLE)
+                .principal(TestConstants.PRINCIPAL)
+                .pods(Arrays.asList(mockPodSpec1WithDifferentRole, mockPodSpec2))
+                .build();
+
+        assertThat(VALIDATOR.validate(serviceSpec1, serviceSpec2), hasSize(1));
+    }
+
+    @Test
+    public void testSecondPodChangesReservedRoleFailsValidation() {
+        Optional<ServiceSpec> serviceSpec1 = Optional.of(DefaultServiceSpec.newBuilder()
+                .name("svc1")
+                .role(TestConstants.ROLE)
+                .principal(TestConstants.PRINCIPAL)
+                .pods(Arrays.asList(mockPodSpec1, mockPodSpec2))
+                .build());
+
+
+        final ServiceSpec serviceSpec2 = DefaultServiceSpec.newBuilder()
+                .name("svc1")
+                .role(TestConstants.ROLE)
+                .principal(TestConstants.PRINCIPAL)
+                .pods(Arrays.asList(mockPodSpec1, mockPodSpec2WithDifferentRole))
+                .build();
+
+        assertThat(VALIDATOR.validate(serviceSpec1, serviceSpec2), hasSize(1));
+    }
+
+
+    @Test
+    public void testFirstPodRemovalPassesValidation() {
+        Optional<ServiceSpec> serviceSpec1 = Optional.of(DefaultServiceSpec.newBuilder()
+                .name("svc1")
+                .role(TestConstants.ROLE)
+                .principal(TestConstants.PRINCIPAL)
+                .pods(Arrays.asList(mockPodSpec1, mockPodSpec2))
+                .build());
+
+        ServiceSpec serviceSpec2 = DefaultServiceSpec.newBuilder()
+                .name("svc2")
+                .role(TestConstants.ROLE)
+                .principal(TestConstants.PRINCIPAL)
+                .pods(Arrays.asList(mockPodSpec2))
+                .build();
+
+        assertThat(VALIDATOR.validate(serviceSpec1, serviceSpec2), is(empty()));
+    }
+
+    @Test
+    public void testSecondPodRemovalPassesValidation() {
+        Optional<ServiceSpec> serviceSpec1 = Optional.of(DefaultServiceSpec.newBuilder()
+                .name("svc1")
+                .role(TestConstants.ROLE)
+                .principal(TestConstants.PRINCIPAL)
+                .pods(Arrays.asList(mockPodSpec1, mockPodSpec2))
+                .build());
+
+        ServiceSpec serviceSpec2 = DefaultServiceSpec.newBuilder()
+                .name("svc2")
+                .role(TestConstants.ROLE)
+                .principal(TestConstants.PRINCIPAL)
+                .pods(Arrays.asList(mockPodSpec1))
+                .build();
+
+        assertThat(VALIDATOR.validate(serviceSpec1, serviceSpec2), is(empty()));
+    }
+
+
+    @Test
+    public void testRemovalOfPreReservedRoleFailsValidation() {
+        Optional<ServiceSpec> serviceSpec1 = Optional.of(DefaultServiceSpec.newBuilder()
+                .name("svc1")
+                .role(TestConstants.ROLE)
+                .principal(TestConstants.PRINCIPAL)
+                .pods(Arrays.asList(mockPodSpec1))
+                .build());
+        ServiceSpec serviceSpec2 = DefaultServiceSpec.newBuilder()
+                .name("svc2")
+                .role(TestConstants.ROLE)
+                .principal(TestConstants.PRINCIPAL)
+                .pods(Arrays.asList(mockPodSpec1WithNoRole))
+                .build();
+
+        assertThat(VALIDATOR.validate(serviceSpec1, serviceSpec2), hasSize(1));
+
+    }
+
+    @Test
+    public void testAdditionOfPreReservedRoleFailsValidation() {
+        Optional<ServiceSpec> serviceSpec1 = Optional.of(DefaultServiceSpec.newBuilder()
+                .name("svc1")
+                .role(TestConstants.ROLE)
+                .principal(TestConstants.PRINCIPAL)
+                .pods(Arrays.asList(mockPodSpec1WithNoRole))
+                .build());
+        ServiceSpec serviceSpec2 = DefaultServiceSpec.newBuilder()
+                .name("svc2")
+                .role(TestConstants.ROLE)
+                .principal(TestConstants.PRINCIPAL)
+                .pods(Arrays.asList(mockPodSpec1))
+                .build();
+
+        assertThat(VALIDATOR.validate(serviceSpec1, serviceSpec2), hasSize(1));
+
+    }
+
+    @Test
+    public void testMissingPreReservedRolesPassesValidation() {
+        Optional<ServiceSpec> serviceSpec1 = Optional.of(DefaultServiceSpec.newBuilder()
+                .name("svc1")
+                .role(TestConstants.ROLE)
+                .principal(TestConstants.PRINCIPAL)
+                .pods(Arrays.asList(mockPodSpec1WithNoRole))
+                .build());
+        ServiceSpec serviceSpec2 = DefaultServiceSpec.newBuilder()
+                .name("svc2")
+                .role(TestConstants.ROLE)
+                .principal(TestConstants.PRINCIPAL)
+                .pods(Arrays.asList(mockPodSpec1WithNoRole))
+                .build();
+
+        assertThat(VALIDATOR.validate(serviceSpec1, serviceSpec2), is(empty()));
+
+    }
+
+}

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/config/validate/ServiceNameCannotContainDoubleUnderscoresTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/config/validate/ServiceNameCannotContainDoubleUnderscoresTest.java
@@ -1,14 +1,14 @@
 package com.mesosphere.sdk.config.validate;
 
 import com.mesosphere.sdk.offer.InvalidRequirementException;
-import com.mesosphere.sdk.specification.*;
+import com.mesosphere.sdk.specification.ServiceSpec;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import java.util.*;
+import java.util.Optional;
 
 import static org.mockito.Mockito.when;
 
@@ -19,11 +19,18 @@ public class ServiceNameCannotContainDoubleUnderscoresTest {
     private static final ConfigValidator<ServiceSpec> VALIDATOR = new ServiceNameCannotContainDoubleUnderscores();
 
     // Avoid spec validator hell by just using a mock object:
-    @Mock private ServiceSpec mockServiceSpec;
+    @Mock
+    private ServiceSpec mockServiceSpec;
 
     @Before
     public void beforeEach() {
         MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void testTripleUnderscores() throws InvalidRequirementException {
+        when(mockServiceSpec.getName()).thenReturn("svc___1");
+        Assert.assertEquals(1, VALIDATOR.validate(Optional.empty(), mockServiceSpec).size());
     }
 
     @Test


### PR DESCRIPTION
Backport of #1510.

For the release notes: 
> Removal of a Pod could result in a null-pointer exception.