### PR TITLE
[INFINITY-2374] Disable tests that will not pass in open

### DIFF
--- a/frameworks/cassandra/tests/test_tls.py
+++ b/frameworks/cassandra/tests/test_tls.py
@@ -204,6 +204,8 @@ def _get_cqlsh_for_query(query: str):
 @pytest.mark.aws
 @pytest.mark.sanity
 @pytest.mark.tls
+@sdk_utils.dcos_1_10_or_higher
+@sdk_utils.dcos_ee_only
 def test_tls_connection(cassandra_service_tls, dcos_ca_bundle):
     """
     Tests writing, reading and deleting data over a secure TLS connection.

--- a/frameworks/helloworld/tests/test_secrets.py
+++ b/frameworks/helloworld/tests/test_secrets.py
@@ -74,6 +74,7 @@ def configure_package(configure_security):
 @pytest.mark.smoke
 @pytest.mark.secrets
 @sdk_utils.dcos_1_10_or_higher
+@sdk_utils.dcos_ee_only
 def test_secrets_basic():
     # 1) create Secrets
     # 2) install examples/secrets.yml
@@ -110,6 +111,7 @@ def test_secrets_basic():
 @pytest.mark.smoke
 @pytest.mark.secrets
 @sdk_utils.dcos_1_10_or_higher
+@sdk_utils.dcos_ee_only
 def test_secrets_verify():
     # 1) create Secrets
     # 2) install examples/secrets.yml
@@ -157,6 +159,7 @@ def test_secrets_verify():
 @pytest.mark.smoke
 @pytest.mark.secrets
 @sdk_utils.dcos_1_10_or_higher
+@sdk_utils.dcos_ee_only
 def test_secrets_update():
     # 1) create Secrets
     # 2) install examples/secrets.yml
@@ -213,6 +216,7 @@ def test_secrets_update():
 @pytest.mark.secrets
 @pytest.mark.smoke
 @sdk_utils.dcos_1_10_or_higher
+@sdk_utils.dcos_ee_only
 def test_secrets_config_update():
     # 1) install examples/secrets.yml
     # 2) create new Secrets, delete old Secrets
@@ -280,6 +284,7 @@ def test_secrets_config_update():
 @pytest.mark.smoke
 @pytest.mark.secrets
 @sdk_utils.dcos_1_10_or_higher
+@sdk_utils.dcos_ee_only
 def test_secrets_dcos_space():
     # 1) create secrets in hello-world/somePath, i.e. hello-world/somePath/secret1 ...
     # 2) Tasks with DCOS_SPACE hello-world/somePath

--- a/frameworks/helloworld/tests/test_tls.py
+++ b/frameworks/helloworld/tests/test_tls.py
@@ -99,6 +99,7 @@ def hello_world_service(service_account):
 @pytest.mark.tls
 @pytest.mark.sanity
 @sdk_utils.dcos_1_10_or_higher
+@sdk_utils.dcos_ee_only
 def test_java_truststore(hello_world_service):
     """
     Make an HTTP request from CLI to nginx exposed service.
@@ -127,6 +128,7 @@ def test_java_truststore(hello_world_service):
 @pytest.mark.tls
 @pytest.mark.sanity
 @sdk_utils.dcos_1_10_or_higher
+@sdk_utils.dcos_ee_only
 def test_tls_basic_artifacts(hello_world_service):
     task_id = sdk_tasks.get_task_ids(config.SERVICE_NAME, 'artifacts')[0]
     assert task_id
@@ -160,6 +162,7 @@ def test_tls_basic_artifacts(hello_world_service):
 @pytest.mark.tls
 @pytest.mark.sanity
 @sdk_utils.dcos_1_10_or_higher
+@sdk_utils.dcos_ee_only
 def test_java_keystore(hello_world_service):
     """
     Java `keystore-app` presents itself with provided TLS certificate
@@ -193,6 +196,7 @@ def test_java_keystore(hello_world_service):
 @pytest.mark.tls
 @pytest.mark.sanity
 @sdk_utils.dcos_1_10_or_higher
+@sdk_utils.dcos_ee_only
 def test_tls_nginx(hello_world_service):
     """
     Checks that NGINX exposes TLS service with correct PEM encoded end-entity
@@ -221,6 +225,7 @@ def test_tls_nginx(hello_world_service):
 @pytest.mark.tls
 @pytest.mark.sanity
 @sdk_utils.dcos_1_10_or_higher
+@sdk_utils.dcos_ee_only
 def test_changing_discovery_replaces_certificate_sans(hello_world_service):
     """
     Update service configuration to change discovery prefix of a task.

--- a/frameworks/kafka/tests/test_tls.py
+++ b/frameworks/kafka/tests/test_tls.py
@@ -62,6 +62,7 @@ def kafka_service_tls(service_account):
 @pytest.mark.smoke
 @pytest.mark.sanity
 @sdk_utils.dcos_1_10_or_higher
+@sdk_utils.dcos_ee_only
 def test_tls_endpoints(kafka_service_tls):
     endpoints = sdk_networks.get_and_test_endpoints(config.PACKAGE_NAME, config.SERVICE_NAME, "", 2)
     assert BROKER_TLS_ENDPOINT in endpoints
@@ -75,6 +76,7 @@ def test_tls_endpoints(kafka_service_tls):
 @pytest.mark.smoke
 @pytest.mark.sanity
 @sdk_utils.dcos_1_10_or_higher
+@sdk_utils.dcos_ee_only
 def test_producer_over_tls(kafka_service_tls):
     sdk_cmd.svc_cli(config.PACKAGE_NAME, config.SERVICE_NAME, 'topic create {}'.format(config.DEFAULT_TOPIC_NAME))
 

--- a/testing/sdk_utils.py
+++ b/testing/sdk_utils.py
@@ -66,6 +66,7 @@ def is_open_dcos():
     checking the envvar DCOS_ENTERPRISE.'''
     return os.environ.get('DCOS_ENTERPRISE', 'true').lower() != 'true'
 
+
 dcos_ee_only = pytest.mark.skipif(
     'sdk_utils.is_open_dcos',
     reason="Feature only supported in DC/OS EE.")

--- a/testing/sdk_utils.py
+++ b/testing/sdk_utils.py
@@ -10,6 +10,7 @@ import logging
 import dcos
 import shakedown
 import pytest
+import os
 
 log = logging.getLogger(__name__)
 
@@ -58,6 +59,16 @@ def is_test_failure(pytest_request):
             continue
         return True
     return False
+
+
+def is_open_dcos():
+    '''Determine if the tests are being run against open DC/OS. This is presently done by
+    checking the envvar DCOS_ENTERPRISE.'''
+    return os.environ.get('DCOS_ENTERPRISE', 'true').lower() != 'true'
+
+dcos_ee_only = pytest.mark.skipif(
+    'sdk_utils.is_open_dcos',
+    reason="Feature only supported in DC/OS EE.")
 
 
 # WARNING: Any file that uses these must also "import shakedown" in the same file.


### PR DESCRIPTION
Detect DC/OS Open and disable tests for features that do not work there.

Adds a `sdk_utils` pytest mark.
Disables TLS and secrets tests.