### PR TITLE
[DCOS-17876] Add $ to command line examples in HDFS docs

### DIFF
--- a/frameworks/hdfs/docs/api-reference.md
+++ b/frameworks/hdfs/docs/api-reference.md
@@ -19,8 +19,8 @@ If you are using open source DC/OS, follow these instructions to [pass your HTTP
 
 Once you have the authentication token, you can store it in an environment variable and reference it in your REST API calls:
 
-```
-export auth_token=uSeR_t0k3n
+```bash
+$ export auth_token=uSeR_t0k3n
 ```
 
 The `curl` examples in this document assume that an auth token has been stored in an environment variable named `auth_token`.
@@ -31,14 +31,14 @@ If you are using Enterprise DC/OS, the security mode of your installation may al
 The Plan API provides endpoints for monitoring and controlling service installation and configuration updates.
 
 ```bash
-curl -H "Authorization:token=$auth_token" <dcos_url>/service/hdfs/v1/plans/deploy
+$ curl -H "Authorization:token=$auth_token" <dcos_url>/service/hdfs/v1/plans/deploy
 ```
 ## Pause Installation
 
 The installation will pause after completing installation of the current node and wait for user input.
 
 ```bash
-curl -X POST -H "Authorization:token=$auth_token" <dcos_url>/service/hdfs/v1/plans/deploy/interrupt
+$ curl -X POST -H "Authorization:token=$auth_token" <dcos_url>/service/hdfs/v1/plans/deploy/interrupt
 ```
 
 ## Resume Installation
@@ -46,17 +46,17 @@ curl -X POST -H "Authorization:token=$auth_token" <dcos_url>/service/hdfs/v1/pla
 The REST API request below will resume installation at the next pending node.
 
 ```bash
-curl -X PUT <dcos_surl>/service/hdfs/v1/plans/deploy/continue
+$ curl -X PUT <dcos_surl>/service/hdfs/v1/plans/deploy/continue
 ```
 
 # Connection API
 
 ```bash
-curl -H "Authorization:token=$auth_token" dcos_url/service/hdfs/v1/endpoints/hdfs-site.xml
+$ curl -H "Authorization:token=$auth_token" dcos_url/service/hdfs/v1/endpoints/hdfs-site.xml
 ```
 
 ```bash
-curl -H "Authorization:token=$auth_token" <dcos_url>/service/hdfs/v1/endpoints/core-site.xml
+$ curl -H "Authorization:token=$auth_token" <dcos_url>/service/hdfs/v1/endpoints/core-site.xml
 ```
 
 You will see a response similar to the following:
@@ -290,13 +290,13 @@ The pod API provides endpoints for retrieving information about nodes, restartin
 A list of available node ids can be retrieved by sending a GET request to `/v1/pod`:
 
 CLI Example
-```
-dcos beta-hdfs pod list
+```bash
+$ dcos beta-hdfs pod list
 ```
 
 HTTP Example
-```
-curl  -H "Authorization:token=$auth_token" <dcos_url>/service/hdfs/v1/pod
+```bash
+$ curl  -H "Authorization:token=$auth_token" <dcos_url>/service/hdfs/v1/pod
 [
     "data-0",
     "data-1",
@@ -315,18 +315,18 @@ curl  -H "Authorization:token=$auth_token" <dcos_url>/service/hdfs/v1/pod
 
 You can retrieve node information by sending a GET request to `/v1/pod/<node-id>/info`:
 
-```
-curl  -H "Authorization:token=$auth_token" <dcos_url>/service/hdfs/v1/pod/<node-id>/info
+```bash
+$ curl  -H "Authorization:token=$auth_token" <dcos_url>/service/hdfs/v1/pod/<node-id>/info
 ```
 
 CLI Example
-```
-dcos beta-hdfs pod info journal-0
+```bash
+$ dcos beta-hdfs pod info journal-0
 ```
 
 HTTP Example
-```
-curl  -H "Authorization:token=$auth_token" <dcos_url>/service/hdfs/v1/pod/journal-0/info
+```bash
+$ curl  -H "Authorization:token=$auth_token" <dcos_url>/service/hdfs/v1/pod/journal-0/info
 [{
 	info: {
 		name: "journal-0-node",
@@ -725,13 +725,13 @@ curl  -H "Authorization:token=$auth_token" <dcos_url>/service/hdfs/v1/pod/journa
 The replace endpoint can be used to replace a node with an instance running on another agent node.
 
 CLI Example
-```
-dcos beta-hdfs pod replace <node-id>
+```bash
+$ dcos beta-hdfs pod replace <node-id>
 ```
 
 HTTP Example
-```
-curl -X POST -H "Authorization:token=$auth_token" <dcos_url>/service/hdfs/v1/pod/<node-id>/replace
+```bash
+$ curl -X POST -H "Authorization:token=$auth_token" <dcos_url>/service/hdfs/v1/pod/<node-id>/replace
 ```
 
 If the operation succeeds, a `200 OK` is returned.
@@ -741,13 +741,13 @@ If the operation succeeds, a `200 OK` is returned.
 The restart endpoint can be used to restart a node in place on the same agent node.
 
 CLI Example
-```
-dcos beta-hdfs pod restart <node-id>
+```bash
+$ dcos beta-hdfs pod restart <node-id>
 ```
 
 HTTP Example
 ```bash
-curl -X POST -H "Authorization:token=$auth_token" <dcos_url>/service/hdfs/v1/pod/<node-id>/restart
+$ curl -X POST -H "Authorization:token=$auth_token" <dcos_url>/service/hdfs/v1/pod/<node-id>/restart
 ```
 
 If the operation succeeds a `200 OK` is returned.
@@ -761,13 +761,13 @@ The configuration API provides an endpoint to view current and previous configur
 You can view the current target configuration by sending a GET request to `/v1/configurations/target`.
 
 CLI Example
-```
-dcos beta-hdfs config target
+```bash
+$ dcos beta-hdfs config target
 ```
 
 HTTP Example
-```
-curl -H "Authorization:token=$auth_token" <dcos_url>/service/hdfs/v1/configurations/target
+```bash
+$ curl -H "Authorization:token=$auth_token" <dcos_url>/service/hdfs/v1/configurations/target
 {
 	name: "hdfs",
 	role: "hdfs-role",
@@ -2025,13 +2025,13 @@ curl -H "Authorization:token=$auth_token" <dcos_url>/service/hdfs/v1/configurati
 You can list all configuration IDs by sending a GET request to `/v1/configurations`.
 
 CLI Example
-```
-dcos beta-hdfs config list
+```bash
+$ dcos beta-hdfs config list
 ```
 
 HTTP Example
-```
-curl -H "Authorization:token=$auth_token" <dcos_url>/service/hdfs/v1/configurations
+```bash
+$ curl -H "Authorization:token=$auth_token" <dcos_url>/service/hdfs/v1/configurations
 [
     "9a8d4308-ab9d-4121-b460-696ec3368ad6"
 ]
@@ -2042,13 +2042,13 @@ curl -H "Authorization:token=$auth_token" <dcos_url>/service/hdfs/v1/configurati
 You can view a specific configuration by sending a GET request to `/v1/configurations/<config-id>`.
 
 CLI Example
-```
-dcos hdfs config show 9a8d4308-ab9d-4121-b460-696ec3368ad6
+```bash
+$ dcos hdfs config show 9a8d4308-ab9d-4121-b460-696ec3368ad6
 ```
 
 HTTP Example
-```
-curl -H "Authorization:token=$auth_token" <dcos_url>/service/hdfs/v1/configurations/9a8d4308-ab9d-4121-b460-696ec3368ad6
+```bash
+$ curl -H "Authorization:token=$auth_token" <dcos_url>/service/hdfs/v1/configurations/9a8d4308-ab9d-4121-b460-696ec3368ad6
 {
     ... same format as target config above ...
 }
@@ -2057,6 +2057,6 @@ curl -H "Authorization:token=$auth_token" <dcos_url>/service/hdfs/v1/configurati
 # Service Status Info
 Send a GET request to the `/v1/state/properties/suppressed` endpoint to learn if HDFS is in a `suppressed` state and not receiving offers. If a service does not need offers, Mesos can "suppress" it so that other services are not starved for resources.
 You can use this request to troubleshoot: if you think HDFS should be receiving resource offers, but is not, you can use this API call to see if HDFS is suppressed.
-```
-curl -H "Authorization: token=$auth_token" "<dcos_url>/service/hdfs/v1/state/properties/suppressed"
+```bash
+$ curl -H "Authorization: token=$auth_token" "<dcos_url>/service/hdfs/v1/state/properties/suppressed"
 ```

--- a/frameworks/hdfs/docs/configure.md
+++ b/frameworks/hdfs/docs/configure.md
@@ -37,13 +37,13 @@ This configuration update strategy is analogous to the installation procedure ab
 
 Make the REST request below to view the current plan. See the REST API Authentication part of the REST API Reference section for information on how this request must be authenticated.
 
-```
-curl -v -H "Authorization: token=$(dcos config show core.dcos_acs_token)" "http://<dcos_url>/service/hdfs/v1/plans/deploy"
+```bash
+$ curl -v -H "Authorization: token=$(dcos config show core.dcos_acs_token)" "http://<dcos_url>/service/hdfs/v1/plans/deploy"
 ```
 
 The response will look similar to this:
 
-```
+```json
 {
 	phases: [{
 		id: "77708b6f-52db-4361-a56f-4d2bd9d6bf09",
@@ -138,14 +138,14 @@ The response will look similar to this:
 
 If you want to interrupt a configuration update that is in progress, enter the `interrupt` command.
 
-```
-curl -X -H "Authorization: token=$(dcos config show core.dcos_acs_token)" POST http:/<dcos_url>/service/hdfs/v1/plans/deploy/interrupt
+```bash
+$ curl -X -H "Authorization: token=$(dcos config show core.dcos_acs_token)" POST http:/<dcos_url>/service/hdfs/v1/plans/deploy/interrupt
 ```
 
 
 If you query the plan again, the response will look like this (notice `status: "Waiting"`):
 
-```
+```json
 {
 	phases: [{
 		id: "77708b6f-52db-4361-a56f-4d2bd9d6bf09",
@@ -242,13 +242,13 @@ If you query the plan again, the response will look like this (notice `status: "
 
 Enter the `continue` command to resume the update process.
 
-```
-curl -X -H "Authorization: token=$(dcos config show core.dcos_acs_token)" POST http://<dcos_url>/service/hdfs/v1/plans/deploy/continue
+```bash
+$ curl -X -H "Authorization: token=$(dcos config show core.dcos_acs_token)" POST http://<dcos_url>/service/hdfs/v1/plans/deploy/continue
 ```
 
 After you execute the continue operation, the plan will look like this:
 
-```
+```json
 {
 	phases: [{
 		id: "77708b6f-52db-4361-a56f-4d2bd9d6bf09",
@@ -349,7 +349,7 @@ The following describes the most commonly used features of DC/OS Apache HDFS and
 
 The service configuration object contains properties that MUST be specified during installation and CANNOT be modified after installation is in progress. This configuration object is similar across all DC/OS Infinity services. Service configuration example:
 
-```
+```json
 {
     "service": {
         "name": "hdfs",
@@ -388,7 +388,7 @@ The service configuration object contains properties that MUST be specified duri
 The node configuration objects correspond to the configuration for nodes in the HDFS cluster. Node configuration MUST be specified during installation and MAY be modified during configuration updates. All of the properties except `disk` and `disk_type` MAY be modified during the configuration update process.
 
 Example node configuration:
-```
+```json
 	"journal_node": {
 		"cpus": 0.5,
 		"mem": 4096,
@@ -477,7 +477,7 @@ Example node configuration:
 The HDFS file system network configuration, permissions, and compression is configured via the `hdfs` JSON object. Once these properties are set at installation time they can not be reconfigured.
 Example HDFS configuration:
 
-```
+```json
 {
     "hdfs": {
 		"name_node_rpc_port": 9001,

--- a/frameworks/hdfs/docs/configure.md
+++ b/frameworks/hdfs/docs/configure.md
@@ -343,7 +343,7 @@ After you execute the continue operation, the plan will look like this:
 
 # Configuration Options
 
-The following describes the most commonly used features of DC/OS Apache Cassandra and how to configure them via the DC/OS CLI and the DC/OS GUI. There are two methods of configuring a HDFS cluster. The configuration may be specified using a JSON file during installation via the DC/OS command line (See the Installation section) or via modification to the Service Scheduler’s DC/OS environment at runtime (See the Configuration Update section). Note that some configuration options may only be specified at installation time.
+The following describes the most commonly used features of DC/OS Apache HDFS and how to configure them via the DC/OS CLI and the DC/OS GUI. There are two methods of configuring an HDFS cluster. The configuration may be specified using a JSON file during installation via the DC/OS command line (See the Installation section) or via modification to the Service Scheduler’s DC/OS environment at runtime (See the Configuration Update section). Note that some configuration options may only be specified at installation time.
 
 ## Service Configuration
 

--- a/frameworks/hdfs/docs/connecting-clients.md
+++ b/frameworks/hdfs/docs/connecting-clients.md
@@ -15,7 +15,7 @@ Applications interface with HDFS like they would any POSIX file system. However,
 
 Executed the following command from the DC/OS CLI to retrieve the `hdfs-site.xml` file that client applications can use to connect to the cluster.
 
-```
+```bash
 $ dcos beta-hdfs --name=<service-name> endpoints hdfs-site.xml
 ...
 $ dcos beta-hdfs --name=<service-name> endpoints core-site.xml

--- a/frameworks/hdfs/docs/index.md
+++ b/frameworks/hdfs/docs/index.md
@@ -8,7 +8,7 @@ enterprise: 'no'
 
 
 
-Welcome to the documentation for the DC/OS Apache HDFS. DC/OS Apache HDFS is a managed service that makes it easy to deploy and manage an HA Apache HDFS cluster on Mesosphere DC/OS. Apache HDFS (Hadoop Distributed File System) is an open source distributed file system based on Google's GFS (Google File System) paper. It is a replicated and distributed file system interface for use with "big data" and "fast data" applications.
+Welcome to the documentation for DC/OS Apache HDFS. DC/OS Apache HDFS is a managed service that makes it easy to deploy and manage an HA Apache HDFS cluster on Mesosphere DC/OS. Apache HDFS (Hadoop Distributed File System) is an open source distributed file system based on Google's GFS (Google File System) paper. It is a replicated and distributed file system interface for use with "big data" and "fast data" applications.
 
 DC/OS HDFS offers the following benefits:
 

--- a/frameworks/hdfs/docs/install.md
+++ b/frameworks/hdfs/docs/install.md
@@ -27,7 +27,7 @@ The default installation may not be sufficient for a production deployment, but 
 Once you have installed Beta-HDFS, install the CLI.
 
 ```bash
-dcos package install beta-hdfs --cli
+$ dcos package install beta-hdfs --cli
 ```
 
 # Service Settings
@@ -52,8 +52,8 @@ Sample JSON options file named `sample-hdfs.json`:
 
 The command below creates a cluster using `sample-hdfs.json`:
 
-```
-dcos package install --options=sample-hdfs.json hdfs
+```bash
+$ dcos package install --options=sample-hdfs.json hdfs
 ```
 
 **Recommendation:** Store your custom configuration in source control.
@@ -70,8 +70,8 @@ Many of the other Infinity services currently support DC/OS Vagrant deployment. 
 
 Installing multiple HDFS clusters is identical to installing an HDFS cluster with a custom configuration, as described above. Use a JSON options file to specify a unique `name` for each installation:
 
-```
-cat hdfs1.json
+```bash
+$ cat hdfs1.json
 
 {
    "service": {
@@ -79,7 +79,7 @@ cat hdfs1.json
    }
 }
 
-dcos package install hdfs --options=hdfs1.json
+$ dcos package install hdfs --options=hdfs1.json
 ```
 
 Use the `--name` argument after install time to specify which HDFS instance to query. All `dcos hdfs` CLI commands accept the `--name` argument. If you do not specify a service name, the CLI assumes the default value, `hdfs`.
@@ -178,8 +178,8 @@ When the DC/OS HDFS service is initially installed, it generates an installation
 ## Viewing the Installation Plan
 The plan can be viewed from the API via the REST endpoint. A curl example is provided below. See the REST API Authentication part of the REST API Reference section for information on how this request must be authenticated.
 
-```
-curl -v -H "Authorization: token=$(dcos config show core.dcos_acs_token)" http://<dcos_url>/service/hdfs/v1/plans/deploy
+```bash
+$ curl -v -H "Authorization: token=$(dcos config show core.dcos_acs_token)" http://<dcos_url>/service/hdfs/v1/plans/deploy
 ```
 
 ## Plan Errors
@@ -201,15 +201,15 @@ The final phase of the installation is deployment of the distributed storage ser
 To pause installation, issue a REST API request as shown below. The installation will pause after completing installation of the current node and wait for user input.
 
 
-```
-curl -v -H "Authorization: token=$(dcos config show core.dcos_acs_token)" -X POST http://<dcos_url>/service/hdfs/v1/plans/deploy/interrupt
+```bash
+$ curl -v -H "Authorization: token=$(dcos config show core.dcos_acs_token)" -X POST http://<dcos_url>/service/hdfs/v1/plans/deploy/interrupt
 ```
 
 ## Resuming Installation
 If the installation has been paused, the REST API request below will resume installation at the next pending node.
 
-```
-curl -v -H "Authorization: token=$(dcos config show core.dcos_acs_token)" -X POST http://<dcos_url>/service/hdfs/v1/plans/deploy/continue
+```bash
+$ curl -v -H "Authorization: token=$(dcos config show core.dcos_acs_token)" -X POST http://<dcos_url>/service/hdfs/v1/plans/deploy/continue
 ```
 
 

--- a/frameworks/hdfs/docs/managing.md
+++ b/frameworks/hdfs/docs/managing.md
@@ -436,7 +436,7 @@ After you execute the continue operation, the plan will look like this:
 
 # Configuration Options
 
-The following describes the most commonly used features of Beta-HDFS and how to configure them via the DC/OS CLI and the DC/OS GUI. There are two methods of configuring a HDFS cluster. The configuration may be specified using a JSON file during installation via the DC/OS command line (See the Installation section) or via modification to the Service Scheduler’s DC/OS environment at runtime (See the Configuration Update section). Note that some configuration options may only be specified at installation time.
+The following describes the most commonly used features of Beta-HDFS and how to configure them via the DC/OS CLI and the DC/OS GUI. There are two methods of configuring an HDFS cluster. The configuration may be specified using a JSON file during installation via the DC/OS command line (See the Installation section) or via modification to the Service Scheduler’s DC/OS environment at runtime (See the Configuration Update section). Note that some configuration options may only be specified at installation time.
 
 ## Service Configuration
 

--- a/frameworks/hdfs/docs/managing.md
+++ b/frameworks/hdfs/docs/managing.md
@@ -31,8 +31,8 @@ Enterprise DC/OS 1.10 introduces a convenient command line option that allows fo
   + You can install just the subcommand CLI by running `dcos package install --cli beta-hdfs`.
   + If you are running an older version of the subcommand CLI that doesn't have the `update` command, uninstall and reinstall your CLI.
     ```bash
-    dcos package uninstall --cli beta-hdfs
-    dcos package install --cli beta-hdfs
+    $ dcos package uninstall --cli beta-hdfs
+    $ dcos package install --cli beta-hdfs
     ```
 
 ### Preparing configuration
@@ -130,13 +130,13 @@ This configuration update strategy is analogous to the installation procedure ab
 
 Make the REST request below to view the current plan. See the REST API Authentication part of the REST API Reference section for information on how this request must be authenticated.
 
-```
+```bash
 $ curl -v -H "Authorization: token=$(dcos config show core.dcos_acs_token)" "http://<dcos_url>/service/hdfs/v1/plans/deploy"
 ```
 
 The response will look similar to this:
 
-```
+```json
 {
 	phases: [{
 		id: "77708b6f-52db-4361-a56f-4d2bd9d6bf09",
@@ -231,14 +231,14 @@ The response will look similar to this:
 
 If you want to interrupt a configuration update that is in progress, enter the `interrupt` command.
 
-```
+```bash
 $ curl -X -H "Authorization: token=$(dcos config show core.dcos_acs_token)" POST http:/<dcos_url>/service/hdfs/v1/plans/deploy/interrupt
 ```
 
 
 If you query the plan again, the response will look like this (notice `status: "Waiting"`):
 
-```
+```json
 {
 	phases: [{
 		id: "77708b6f-52db-4361-a56f-4d2bd9d6bf09",
@@ -335,13 +335,13 @@ If you query the plan again, the response will look like this (notice `status: "
 
 Enter the `continue` command to resume the update process.
 
-```
+```bash
 $ curl -X -H "Authorization: token=$(dcos config show core.dcos_acs_token)" POST http://<dcos_url>/service/hdfs/v1/plans/deploy/continue
 ```
 
 After you execute the continue operation, the plan will look like this:
 
-```
+```json
 {
 	phases: [{
 		id: "77708b6f-52db-4361-a56f-4d2bd9d6bf09",
@@ -442,7 +442,7 @@ The following describes the most commonly used features of Beta-HDFS and how to 
 
 The service configuration object contains properties that MUST be specified during installation and CANNOT be modified after installation is in progress. This configuration object is similar across all DC/OS Infinity services. Service configuration example:
 
-```
+```json
 {
     "service": {
         "name": "hdfs",
@@ -481,7 +481,7 @@ The service configuration object contains properties that MUST be specified duri
 The node configuration objects correspond to the configuration for nodes in the HDFS cluster. Node configuration MUST be specified during installation and MAY be modified during configuration updates. All of the properties except `disk` and `disk_type` MAY be modified during the configuration update process.
 
 Example node configuration:
-```
+```json
 	"journal_node": {
 		"cpus": 0.5,
 		"mem": 4096,
@@ -1107,7 +1107,7 @@ $ dcos beta-hdfs pod status journal-0
 The HDFS file system network configuration, permissions, and compression is configured via the `hdfs` JSON object. Once these properties are set at installation time they can not be reconfigured.
 Example HDFS configuration:
 
-```
+```json
 {
     "hdfs": {
 		"name_node_rpc_port": 9001,
@@ -1350,13 +1350,13 @@ Once identified, make a note of which Journal Node is healthy.
 ## Fixing the unhealthy Journal Node
 
 1. SSH into the sandbox of the unhealthy Journal Node via
-```
-dcos task exec -it journal-0 /bin/bash
+```bash
+$ dcos task exec -it journal-0 /bin/bash
 ```
 
 2. In this sandbox, create the directory `journal-data/hdfs/current`:
 ```bash
-mkdir -p journal-data/hdfs/current
+$ mkdir -p journal-data/hdfs/current
 ```
 
 3. From the healthy Journal Node identified previously, copy the contents of the `VERSION` file into `journal-data/hdfs/current/VERSION`.
@@ -1366,10 +1366,10 @@ mkdir -p journal-data/hdfs/current
 
 5. Restart the unhealthy Journal Node via:
 ```bash
-dcos beta-hdfs pod restart journal-0
+$ dcos beta-hdfs pod restart journal-0
 ```
 
 6. Once the restarted Journal Node is up and running, confirm that it is now healthy again by inspecting the `stderr` log. You should see:
-```
+```bash
 INFO namenode.FileJournalManager: Finalizing edits file
 ```

--- a/frameworks/hdfs/docs/quick-start.md
+++ b/frameworks/hdfs/docs/quick-start.md
@@ -21,7 +21,7 @@ This tutorial will get you up and running in minutes with HDFS. You will install
 1.  Install the HDFS package.
 
     ```bash
-    dcos package install hdfs
+    $ dcos package install hdfs
     ```
 
     **Tip:** Type `dcos hdfs` to view the HDFS CLI options.
@@ -30,7 +30,7 @@ This tutorial will get you up and running in minutes with HDFS. You will install
 1.  Show the currently configured HDFS nodes.
 
     ```bash
-    dcos hdfs config list
+    $ dcos hdfs config list
     ```
 
     The output should resemble:
@@ -46,13 +46,13 @@ This tutorial will get you up and running in minutes with HDFS. You will install
 1.  [SSH](https://docs.mesosphere.com/1.9/administering-clusters/sshcluster/) to the leading master node.
 
     ```bash
-    dcos node ssh --leader --master-proxy
+    $ dcos node ssh --leader --master-proxy
     ```
 
 1.  Pull the HDFS Docker container down to your node and start an interactive pseudo-TTY session.
 
     ```bash
-    docker run -it mesosphere/hdfs-client:2.6.4 /bin/bash
+    $ docker run -it mesosphere/hdfs-client:2.6.4 /bin/bash
     ```
 
     The output should resemble:
@@ -76,13 +76,13 @@ This tutorial will get you up and running in minutes with HDFS. You will install
     By default, the client is configured to be configured to connect to an HDFS service named `hdfs` and no further client configuration is required. If you want to configure with a different name, run this command with name (`<hdfs-name>`) specified:
 
     ```bash
-    HDFS_SERVICE_NAME=<hdfs-name> ./configure-hdfs.sh
+    $ HDFS_SERVICE_NAME=<hdfs-name> ./configure-hdfs.sh
     ```
 
 1.  List the contents.
 
     ```bash
-    ./bin/hdfs dfs -ls /
+    $ ./bin/hdfs dfs -ls /
     ```
 
     The output should be empty.
@@ -90,13 +90,13 @@ This tutorial will get you up and running in minutes with HDFS. You will install
 1.  Create a file on HDFS.
 
     ```bash
-    echo "Test" | ./bin/hdfs dfs -put - /test.txt
+    $ echo "Test" | ./bin/hdfs dfs -put - /test.txt
     ```
 
 1.  List the contents again.
 
     ```bash
-    ./bin/hdfs dfs -ls /
+    $ ./bin/hdfs dfs -ls /
     ```
 
     The output should now resemble:
@@ -109,7 +109,7 @@ This tutorial will get you up and running in minutes with HDFS. You will install
 1.  Read the file to ensure data integrity.
 
     ```bash
-    ./bin/hdfs dfs -cat /test.txt
+    $ ./bin/hdfs dfs -cat /test.txt
     ```
 
     The output should resemble:
@@ -123,7 +123,7 @@ This tutorial will get you up and running in minutes with HDFS. You will install
     1.  Run this command to retrieve the `hdfs-site.xml` file.
 
         ```bash
-        dcos hdfs endpoints hdfs-site.xml
+        $ dcos hdfs endpoints hdfs-site.xml
         ```
 
         The output should resemble:
@@ -143,7 +143,7 @@ This tutorial will get you up and running in minutes with HDFS. You will install
     1.  Run this command to retrieve the `core-site.xml` file.
 
         ```bash
-        dcos hdfs endpoints core-site.xml
+        $ dcos hdfs endpoints core-site.xml
         ```
 
         The output should resemble:

--- a/frameworks/hdfs/docs/troubleshooting.md
+++ b/frameworks/hdfs/docs/troubleshooting.md
@@ -9,12 +9,12 @@ enterprise: 'no'
 The DC/OS Beta-HDFS Service is resilient to temporary node failures. However, if a DC/OS agent hosting an HDFS node is permanently lost, manual intervention is required to replace the failed node. The following command should be used to replace the node residing on the failed server.
 
 ```bash
-dcos beta-hdfs --name=<service-name> pod replace <node_id>
+$ dcos beta-hdfs --name=<service-name> pod replace <node_id>
 ```
 
 # Restarting a Node
 If you must forcibly restart a node, use the following command to restart the node on the same agent node where it currently resides. This will not result in an outage or loss of data.
 
 ```bash
-dcos beta-hdfs --name=<service-name> pod restart <node_id>
+$ dcos beta-hdfs --name=<service-name> pod restart <node_id>
 ```

--- a/frameworks/hdfs/docs/troubleshooting.md
+++ b/frameworks/hdfs/docs/troubleshooting.md
@@ -6,7 +6,7 @@ enterprise: 'no'
 ---
 
 # Replacing a Permanently Failed Node
-The DC/OS Beta-HDFS Service is resilient to temporary node failures. However, if a DC/OS agent hosting a HDFS node is permanently lost, manual intervention is required to replace the failed node. The following command should be used to replace the node residing on the failed server.
+The DC/OS Beta-HDFS Service is resilient to temporary node failures. However, if a DC/OS agent hosting an HDFS node is permanently lost, manual intervention is required to replace the failed node. The following command should be used to replace the node residing on the failed server.
 
 ```bash
 dcos beta-hdfs --name=<service-name> pod replace <node_id>

--- a/frameworks/hdfs/docs/uninstall.md
+++ b/frameworks/hdfs/docs/uninstall.md
@@ -13,7 +13,7 @@ If you are using DC/OS 1.10 and the installed service has a version greater than
 
 1. Uninstall the service. From the DC/OS CLI, enter `dcos package uninstall --app-id=<instancename> beta-hdfs`.
 
-For example, to uninstall a HDFS instance named `hdfs-dev`, run:
+For example, to uninstall an HDFS instance named `hdfs-dev`, run:
 
 ```bash
 dcos package uninstall --app-id=hdfs-dev beta-hdfs
@@ -27,7 +27,7 @@ If you are running DC/OS 1.9 or older, or a version of the service that is older
    For example, `dcos package uninstall --app-id=hdfs-dev beta-hdfs`.
 1. Clean up remaining reserved resources with the framework cleaner script, `janitor.py`. See [DC/OS documentation](https://docs.mesosphere.com/1.9/deploying-services/uninstall/#framework-cleaner) for more information about the framework cleaner script.
 
-For example, to uninstall a Kafka instance named `hdfs-dev`, run:
+For example, to uninstall an HDFS instance named `hdfs-dev`, run:
 
 ```bash
 $ MY_SERVICE_NAME=hdfs-dev

--- a/frameworks/hdfs/docs/uninstall.md
+++ b/frameworks/hdfs/docs/uninstall.md
@@ -16,7 +16,7 @@ If you are using DC/OS 1.10 and the installed service has a version greater than
 For example, to uninstall an HDFS instance named `hdfs-dev`, run:
 
 ```bash
-dcos package uninstall --app-id=hdfs-dev beta-hdfs
+$ dcos package uninstall --app-id=hdfs-dev beta-hdfs
 ```
 
 ### Older versions
@@ -24,14 +24,17 @@ dcos package uninstall --app-id=hdfs-dev beta-hdfs
 If you are running DC/OS 1.9 or older, or a version of the service that is older than 2.0.0-x, follow these steps:
 
 1. Stop the service. From the DC/OS CLI, enter `dcos package uninstall --app-id=<instancename> <packagename>`.
-   For example, `dcos package uninstall --app-id=hdfs-dev beta-hdfs`.
+   For example:
+   ```bash
+   $ dcos package uninstall --app-id=hdfs-dev beta-hdfs
+   ```
 1. Clean up remaining reserved resources with the framework cleaner script, `janitor.py`. See [DC/OS documentation](https://docs.mesosphere.com/1.9/deploying-services/uninstall/#framework-cleaner) for more information about the framework cleaner script.
 
 For example, to uninstall an HDFS instance named `hdfs-dev`, run:
 
 ```bash
 $ MY_SERVICE_NAME=hdfs-dev
-$ dcos package uninstall --app-id=$MY_SERVICE_NAME beta-hdfs`.
+$ dcos package uninstall --app-id=$MY_SERVICE_NAME beta-hdfs
 $ dcos node ssh --master-proxy --leader "docker run mesosphere/janitor /janitor.py \
     -r $MY_SERVICE_NAME-role \
     -p $MY_SERVICE_NAME-principal \


### PR DESCRIPTION
* Ensure all command line blocks are taged as `bash`
* Ensure all command line examples start with `$`

* Change incorrect reference to Apache Cassandra
* Change incorrect reference to Kafaka

* Other minor typo corrections.

I have another branch with similar changes to 0.30.X, but we can try a backport first.

