### PR TITLE
INFINITY-2174 Fix more metronome flakes

### DIFF
--- a/testing/sdk_jobs.py
+++ b/testing/sdk_jobs.py
@@ -8,6 +8,7 @@ SHOULD ALSO BE APPLIED TO sdk_jobs IN ANY OTHER PARTNER REPOS
 import json
 import logging
 import os
+import re
 import tempfile
 import traceback
 
@@ -71,14 +72,13 @@ class InstallJobContext(object):
 def run_job(job_dict, timeout_seconds=600, raise_on_failure=True):
     job_name = job_dict['id']
 
-    sdk_cmd.run_cli('job run {}'.format(job_name))
-
-    def wait_for_run_id():
-        runs = json.loads(sdk_cmd.run_cli('job show runs {} --json'.format(job_name)))
-        if len(runs) > 0:
-            return runs[0]['id']
-        return ''
-    run_id = shakedown.wait_for(wait_for_run_id, noisy=True, timeout_seconds=timeout_seconds, ignore_exceptions=False)
+    run_id_pattern = re.match('^Run ID: (.*)$', sdk_cmd.run_cli('job run {}'.format(job_name)))
+    if run_id_pattern is None:
+        # CLI command and output was already logged via run_cli() call
+        raise Exception(
+            'Unable to extract Run ID from "job run" output. Bad CLI version?: {}'.format(
+                sdk_cmd.run_cli('--version')))
+    run_id = run_id_pattern.group(1)
 
     def fun():
         # catch errors from CLI: ensure that the only error raised is our own:

--- a/testing/sdk_metrics.py
+++ b/testing/sdk_metrics.py
@@ -86,11 +86,11 @@ def check_metrics_presence(emitted_metrics, expected_metrics):
     for metric in expected_metrics:
         if metric not in emitted_metrics:
             metrics_exist = False
-            log.error("Metric {} is not being emitted by {}".format(metric, service_name))
+            log.error("Unable to find metric {}".format(metric))
             # don't short-circuit to log if multiple metrics are missing
 
     if not metrics_exist:
-        log.info("Metrics emitted: {},\nMetrics expected: {}".format(service_metrics, expected_metrics))
+        log.info("Metrics emitted: {},\nMetrics expected: {}".format(emitted_metrics, expected_metrics))
 
     log.info("Expected metrics exist: {}".format(metrics_exist))
     return metrics_exist
@@ -98,7 +98,7 @@ def check_metrics_presence(emitted_metrics, expected_metrics):
 
 def wait_for_service_metrics(package_name, service_name, task_name, timeout, expected_metrics_exist):
     """Checks that the service is emitting the expected metrics.
-    The assumption is that if the expected metrics are being emitted then so 
+    The assumption is that if the expected metrics are being emitted then so
     are the rest of the metrics.
 
     Arguments:


### PR DESCRIPTION
`job show runs` no longer returns the just-started job if it finished too quickly(???).
Get around this by extracting the ID directly from the `job run` output.

For example:

```
》dcos job run test.cassandra.verify-deletion
Run ID: 20170907163128RQ9AC
  0
》dcos job show runs test.cassandra.verify-deletion --json
[]
  0
》[2.2s/10m] spinning...
...
```