### PR TITLE
[INFINITY-2364] Move from suppress/revive to decline/revive logic

### DIFF
--- a/frameworks/helloworld/tests/test_sanity.py
+++ b/frameworks/helloworld/tests/test_sanity.py
@@ -203,7 +203,7 @@ def test_state_properties_get():
     assert jsonobj[5] == "world-1-server:task-status"
 
     stdout = sdk_cmd.svc_cli(config.PACKAGE_NAME, foldered_name, 'state property suppressed')
-    assert stdout == "true\n"
+    assert stdout == "false\n"
 
 
 @pytest.mark.sanity

--- a/frameworks/kafka/tests/test_sanity.py
+++ b/frameworks/kafka/tests/test_sanity.py
@@ -347,20 +347,3 @@ def test_metrics():
         expected_metrics_exist
     )
 
-
-# --------- Suppressed -------------
-
-
-@pytest.mark.smoke
-@pytest.mark.sanity
-def test_suppress():
-    dcos_url = dcos.config.get_config_val('core.dcos_url')
-    suppressed_url = urllib.parse.urljoin(
-        dcos_url, 'service/{}/v1/state/properties/suppressed'.format(sdk_utils.get_foldered_name(config.SERVICE_NAME)))
-
-    def fun():
-        response = dcos.http.get(suppressed_url)
-        response.raise_for_status()
-        return response.text == "true"
-
-    shakedown.wait_for(fun)

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/Constants.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/Constants.java
@@ -70,8 +70,13 @@ public class Constants {
      */
     public static final DiscoveryInfo.Visibility DEFAULT_TASK_DISCOVERY_VISIBILITY = DiscoveryInfo.Visibility.CLUSTER;
 
-    private static final int TWO_WEEKS_SECONDS = Math.toIntExact(Duration.ofDays(14).getSeconds());
+    /**
+     * The duration in seconds to decline offers the scheduler does not need for the foreseeable future.
+     */
+    public static final int LONG_DECLINE_SECONDS = Math.toIntExact(Duration.ofDays(14).getSeconds());
 
-    public static final int LONG_DECLINE_SECONDS = TWO_WEEKS_SECONDS;
+    /**
+     * The duration in seconds to decline offers the scheduler does not need for a short time.
+     */
     public static final int SHORT_DECLINE_SECONDS = 5;
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/Constants.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/Constants.java
@@ -2,6 +2,8 @@ package com.mesosphere.sdk.offer;
 
 import org.apache.mesos.Protos.DiscoveryInfo;
 
+import java.time.Duration;
+
 /**
  * This class encapsulates constants of relevance to SDK Scheduler internals.
  *
@@ -67,4 +69,9 @@ public class Constants {
      * by the SDK.
      */
     public static final DiscoveryInfo.Visibility DEFAULT_TASK_DISCOVERY_VISIBILITY = DiscoveryInfo.Visibility.CLUSTER;
+
+    private static final int TWO_WEEKS_SECONDS = Math.toIntExact(Duration.ofDays(14).getSeconds());
+
+    public static final int LONG_DECLINE_SECONDS = TWO_WEEKS_SECONDS;
+    public static final int SHORT_DECLINE_SECONDS = 5;
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/OfferUtils.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/OfferUtils.java
@@ -14,10 +14,6 @@ import java.util.stream.Collectors;
  */
 public class OfferUtils {
     private static final Logger LOGGER = LoggerFactory.getLogger(OfferUtils.class);
-    private static final int TWO_WEEKS_S = 2 * 7 * 24 * 60 * 60;
-    private static final Protos.Filters filters = Protos.Filters.newBuilder()
-            .setRefuseSeconds(TWO_WEEKS_S)
-            .build();
 
     /**
      * Filters out accepted offers and returns back a list of unused offers.
@@ -54,14 +50,17 @@ public class OfferUtils {
      *
      * @param driver The {@link SchedulerDriver} that will receive the declineOffer() calls
      * @param unusedOffers The collection of Offers to decline
+     * @param refuseSeconds The number of seconds for which the offers should be refused
      */
-    public static void declineOffers(SchedulerDriver driver, Collection<Protos.Offer> unusedOffers) {
-        LOGGER.info("Declining {} unused offers:", unusedOffers.size());
+    public static void declineOffers(SchedulerDriver driver, Collection<Protos.Offer> unusedOffers, int refuseSeconds) {
+        LOGGER.info("Declining {} unused offers for {} seconds:", unusedOffers.size(), refuseSeconds);
+        final Protos.Filters filters = Protos.Filters.newBuilder()
+                .setRefuseSeconds(refuseSeconds)
+                .build();
         unusedOffers.forEach(offer -> {
             final Protos.OfferID offerId = offer.getId();
             LOGGER.info("  {}", offerId.getValue());
             driver.declineOffer(offerId, filters);
         });
     }
-
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/OfferUtils.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/OfferUtils.java
@@ -14,6 +14,10 @@ import java.util.stream.Collectors;
  */
 public class OfferUtils {
     private static final Logger LOGGER = LoggerFactory.getLogger(OfferUtils.class);
+    private static final int TWO_WEEKS_S = 2 * 7 * 24 * 60 * 60;
+    private static final Protos.Filters filters = Protos.Filters.newBuilder()
+            .setRefuseSeconds(TWO_WEEKS_S)
+            .build();
 
     /**
      * Filters out accepted offers and returns back a list of unused offers.
@@ -56,7 +60,7 @@ public class OfferUtils {
         unusedOffers.forEach(offer -> {
             final Protos.OfferID offerId = offer.getId();
             LOGGER.info("  {}", offerId.getValue());
-            driver.declineOffer(offerId);
+            driver.declineOffer(offerId, filters);
         });
     }
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/AbstractScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/AbstractScheduler.java
@@ -107,17 +107,18 @@ public abstract class AbstractScheduler implements Scheduler {
                 }
             }
 
-            // Task Reconciliation must complete before any Tasks may be launched.  It ensures that a Scheduler and
-            // Mesos have agreed upon the state of all Tasks of interest to the scheduler.
-            // http://mesos.apache.org/documentation/latest/reconciliation/
-            while (!reconciler.isReconciled()) {
-                LOGGER.info("Waiting for task reconciliation to complete.");
-                try {
-                    Thread.sleep(1000);
-                } catch (InterruptedException e) {
-                    LOGGER.debug("Waiting for task reconciliation interrupted.", e);
+            while (true) {
+                // Task Reconciliation must complete before any Tasks may be launched.  It ensures that a Scheduler and
+                // Mesos have agreed upon the state of all Tasks of interest to the scheduler.
+                // http://mesos.apache.org/documentation/latest/reconciliation/
+                while (!reconciler.isReconciled()) {
+                    LOGGER.info("Waiting for task reconciliation to complete.");
+                    try {
+                        Thread.sleep(1000);
+                    } catch (InterruptedException e) {
+                        LOGGER.debug("Waiting for task reconciliation interrupted.", e);
+                    }
                 }
-            }
 
             while (true) {
                 List<Protos.Offer> offers = offerQueue.takeAll();

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/AbstractScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/AbstractScheduler.java
@@ -2,6 +2,7 @@ package com.mesosphere.sdk.scheduler;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.TextFormat;
+import com.mesosphere.sdk.offer.Constants;
 import com.mesosphere.sdk.offer.OfferUtils;
 import com.mesosphere.sdk.reconciliation.DefaultReconciler;
 import com.mesosphere.sdk.scheduler.plan.PlanCoordinator;
@@ -162,7 +163,7 @@ public abstract class AbstractScheduler implements Scheduler {
             if (!queued) {
                 LOGGER.warn("Offer queue is full: Declining offer and removing from in progress: '{}'",
                         offer.getId().getValue());
-                OfferUtils.declineOffers(driver, Arrays.asList(offer));
+                OfferUtils.declineOffers(driver, Arrays.asList(offer), Constants.SHORT_DECLINE_SECONDS);
                 // Remove AFTER decline: Avoid race where we haven't declined yet but appear to be done
                 synchronized (inProgressLock) {
                     offersInProgress.remove(offer.getId());

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/AbstractScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/AbstractScheduler.java
@@ -1,8 +1,6 @@
 package com.mesosphere.sdk.scheduler;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.eventbus.AsyncEventBus;
-import com.google.common.eventbus.EventBus;
 import com.google.protobuf.TextFormat;
 import com.mesosphere.sdk.offer.OfferUtils;
 import com.mesosphere.sdk.reconciliation.DefaultReconciler;
@@ -39,7 +37,6 @@ public abstract class AbstractScheduler implements Scheduler {
     protected final OfferQueue offerQueue = new OfferQueue();
     protected SchedulerDriver driver;
     protected DefaultReconciler reconciler;
-    protected final EventBus eventBus = new AsyncEventBus(Executors.newSingleThreadExecutor());
 
     private Object inProgressLock = new Object();
     private Set<Protos.OfferID> offersInProgress = new HashSet<>();
@@ -129,7 +126,6 @@ public abstract class AbstractScheduler implements Scheduler {
                     LOGGER.info("  {}: {}", i + 1, TextFormat.shortDebugString(offers.get(i)));
                 }
                 executePlans(offers);
-                offers.forEach(offer -> eventBus.post(offer));
                 synchronized (inProgressLock) {
                     offersInProgress.removeAll(
                             offers.stream()
@@ -250,7 +246,7 @@ public abstract class AbstractScheduler implements Scheduler {
 
         // A SuppressReviveManager should be constructed only once.
         if (suppressReviveManager == null) {
-            suppressReviveManager = new SuppressReviveManager(driver, stateStore, eventBus, getPlanCoordinator());
+            suppressReviveManager = new SuppressReviveManager(driver, stateStore, getPlanCoordinator());
         }
 
         suppressReviveManager.start();

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/AbstractScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/AbstractScheduler.java
@@ -28,7 +28,7 @@ import java.util.stream.Collectors;
 public abstract class AbstractScheduler implements Scheduler {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractScheduler.class);
-    private SuppressReviveManager suppressReviveManager;
+    private ReviveManager reviveManager;
 
     protected final StateStore stateStore;
     protected final ConfigStore<ServiceSpec> configStore;
@@ -245,9 +245,9 @@ public abstract class AbstractScheduler implements Scheduler {
         reconciler.start();
         reconciler.reconcile(driver);
 
-        // A SuppressReviveManager should be constructed only once.
-        if (suppressReviveManager == null) {
-            suppressReviveManager = new SuppressReviveManager(driver, stateStore, getPlanCoordinator());
+        // A ReviveManager should be constructed only once.
+        if (reviveManager == null) {
+            reviveManager = new ReviveManager(driver, stateStore, getPlanCoordinator());
         }
 
         // The main plan execution loop should only be started once.

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/DefaultScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/DefaultScheduler.java
@@ -763,8 +763,8 @@ public class DefaultScheduler extends AbstractScheduler {
     }
 
     @Override
-    protected Collection<PlanManager> getPlanManagers() {
-        return planCoordinator.getPlanManagers();
+    protected PlanCoordinator getPlanCoordinator() {
+        return planCoordinator;
     }
 
     public boolean apiServerReady() {

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/DefaultScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/DefaultScheduler.java
@@ -759,7 +759,7 @@ public class DefaultScheduler extends AbstractScheduler {
                 unusedOffers.stream().map(offer -> offer.getId().getValue()).collect(Collectors.toList()));
 
         // Decline remaining offers.
-        OfferUtils.declineOffers(driver, unusedOffers);
+        OfferUtils.declineOffers(driver, unusedOffers, Constants.LONG_DECLINE_SECONDS);
     }
 
     @Override

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/DefaultScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/DefaultScheduler.java
@@ -779,8 +779,6 @@ public class DefaultScheduler extends AbstractScheduler {
                 status.getMessage(),
                 TextFormat.shortDebugString(status));
 
-        eventBus.post(status);
-
         // Store status, then pass status to PlanManager => Plan => Steps
         try {
             String taskName = StateStoreUtils.getTaskName(stateStore, status);

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/ReviveManager.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/ReviveManager.java
@@ -17,7 +17,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 /**
- * This class monitors a {@link PlanCoordinator} and suppresses or revives offers when appropriate.
+ * This class monitors a {@link PlanCoordinator} and revives offers when appropriate.
  */
 public class ReviveManager {
     public static final int REVIVE_INTERVAL_S = 5;

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SuppressReviveManager.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SuppressReviveManager.java
@@ -1,88 +1,64 @@
 package com.mesosphere.sdk.scheduler;
 
 import com.google.common.eventbus.EventBus;
-import com.google.common.eventbus.Subscribe;
-import com.mesosphere.sdk.offer.TaskException;
-import com.mesosphere.sdk.offer.TaskUtils;
-import com.mesosphere.sdk.scheduler.plan.Plan;
-import com.mesosphere.sdk.scheduler.plan.PlanManager;
-import com.mesosphere.sdk.scheduler.plan.PlanUtils;
-import com.mesosphere.sdk.specification.ServiceSpec;
-import com.mesosphere.sdk.state.ConfigStore;
+import com.mesosphere.sdk.scheduler.plan.PlanCoordinator;
+import com.mesosphere.sdk.scheduler.plan.PodInstanceRequirement;
+import com.mesosphere.sdk.scheduler.plan.Step;
 import com.mesosphere.sdk.state.StateStore;
 import com.mesosphere.sdk.state.StateStoreUtils;
-import org.apache.mesos.Protos;
 import org.apache.mesos.SchedulerDriver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
+import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 /**
- * This class monitors all plans and suppresses or revives offers when appropriate.
+ * This class monitors a {@link PlanCoordinator} and suppresses or revives offers when appropriate.
  */
 public class SuppressReviveManager {
-    public static final int SUPPRESSS_REVIVE_INTERVAL_S = 5;
-    public static final int SUPPRESSS_REVIVE_DELAY_S = 5;
+    public static final int REVIVE_INTERVAL_S = 5;
+    public static final int REVIVE_DELAY_S = 5;
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
-    private final ScheduledExecutorService plansMonitor = Executors.newScheduledThreadPool(1);
     private final SchedulerDriver driver;
-    private final Collection<PlanManager> planManagers;
+    private final PlanCoordinator planCoordinator;
+    private final ScheduledExecutorService monitor = Executors.newScheduledThreadPool(1);
     private final StateStore stateStore;
-
-    private final Object suppressReviveLock = new Object();
-
-    private final Object stateLock = new Object();
-    private final ConfigStore<ServiceSpec> configStore;
-    private AtomicReference<State> state = new AtomicReference<>(State.INITIAL);
-
-    /**
-     * The states of the suppress/revive state machine.
-     */
-    public enum State {
-        INITIAL,
-        WAITING_FOR_OFFER,
-        REVIVED,
-        SUPPRESSED
-    }
+    private Set<PodInstanceRequirement> candidates;
 
     public SuppressReviveManager(
-            StateStore stateStore,
-            ConfigStore<ServiceSpec> configStore,
             SchedulerDriver driver,
+            StateStore stateStore,
             EventBus eventBus,
-            Collection<PlanManager> planManagers) {
+            PlanCoordinator planCoordinator) {
         this(
-                stateStore,
-                configStore,
                 driver,
+                stateStore,
                 eventBus,
-                planManagers,
-                SUPPRESSS_REVIVE_DELAY_S,
-                SUPPRESSS_REVIVE_INTERVAL_S);
+                planCoordinator,
+                REVIVE_DELAY_S,
+                REVIVE_INTERVAL_S);
     }
 
     public SuppressReviveManager(
-            StateStore stateStore,
-            ConfigStore<ServiceSpec> configStore,
             SchedulerDriver driver,
+            StateStore stateStore,
             EventBus eventBus,
-            Collection<PlanManager> planManagers,
+            PlanCoordinator planCoordinator,
             int pollDelay,
             int pollInterval) {
 
-        this.stateStore = stateStore;
-        this.configStore = configStore;
         this.driver = driver;
-        this.planManagers = planManagers;
+        this.stateStore = stateStore;
+        this.planCoordinator = planCoordinator;
+        this.candidates = getRequirements(planCoordinator.getCandidates());
         eventBus.register(this);
-        plansMonitor.scheduleAtFixedRate(
+        monitor.scheduleAtFixedRate(
                 new Runnable() {
                     @Override
                     public void run() {
@@ -92,161 +68,61 @@ public class SuppressReviveManager {
                 pollDelay,
                 pollInterval,
                 TimeUnit.SECONDS);
+
         logger.info(
-                "Monitoring these plans for suppress/revive: {}",
-                planManagers.stream().map(planManager -> planManager.getPlan().getName()).collect(Collectors.toList()));
+                "Monitoring these plans for suppress/suppressOrRevive: {}",
+                planCoordinator.getPlanManagers().stream()
+                        .map(planManager -> planManager.getPlan().getName())
+                        .collect(Collectors.toList()));
     }
 
-    public void start() {
-        // This must be run on a separate thread to avoid deadlock with the MesosToSchedulerDriverAdapter
-        new Thread(new Runnable() {
-            @Override
-            public void run() {
-                transitionState(State.WAITING_FOR_OFFER);
-            }
-        }).start();
-    }
-
-    public State getState() {
-        return state.get();
-    }
-
-    @Subscribe
-    public void handleTaskStatus(Protos.TaskStatus taskStatus) {
-        logger.debug("Handling TaskStatus: {}", taskStatus);
-        if (TaskUtils.isRecoveryNeeded(taskStatus)) {
-            transitionState(State.WAITING_FOR_OFFER);
-        }
-    }
-
-    @Subscribe
-    public void handleOffer(Protos.Offer offer) {
-        logger.debug("Handling offer: {}", offer);
-        State state = this.state.get();
-        switch (state) {
-            case WAITING_FOR_OFFER:
-                transitionState(State.REVIVED);
-                break;
-            default:
-                logger.debug("State remains '{}' after receiving Offer: {}", state, offer);
-        }
-    }
-
-    private void transitionState(State target) {
-        synchronized (stateLock) {
-            State current = getState();
-
-            if (current.equals(target)) {
-                logger.debug("NOOP transition for state: '{}'", target);
-                return;
-            }
-
-            switch (target) {
-                case INITIAL:
-                    logger.error("Invalid state transition.  End state should never be INITIAL");
-                    return;
-                case WAITING_FOR_OFFER:
-                    switch (current) {
-                        case REVIVED:
-                            logger.debug("Already revived, no need to revive again and wait for offers.");
-                            target = State.REVIVED;
-                            break;
-                        default:
-                            revive();
-                    }
-                    break;
-                case REVIVED:
-                    switch (current) {
-                        case WAITING_FOR_OFFER:
-                            // The only acceptable transition
-                            break;
-                        default:
-                            logTransitionError(current, target);
-                            return;
-                    }
-                    break;
-                case SUPPRESSED:
-                    switch (current) {
-                        case REVIVED:
-                            suppress();
-                            break;
-                        case WAITING_FOR_OFFER:
-                            logTransitionWarning(current, target);
-                            return;
-                        default:
-                            logTransitionError(current, target);
-                            return;
-                    }
-                    break;
-            }
-
-            if (state.compareAndSet(current, target)) {
-                logger.debug("Transitioned from '{}' to '{}'", current, target);
-            } else {
-                logger.error("Failed to transitioned from '{}' to '{}'", current, target);
-                return;
-            }
-        }
-    }
-
-    private void logTransitionError(State start, State end) {
-        logger.error("Invalid transition from '{}' to '{}'.", start, end);
-    }
-
-    private void logTransitionWarning(State start, State end) {
-        logger.warn("Unexpected transition from '{}' to '{}'.", start, end);
+    private Set<PodInstanceRequirement> getRequirements(Collection<Step> steps) {
+        return steps.stream()
+                .filter(step -> step.getPodInstanceRequirement().isPresent())
+                .map(step -> step.getPodInstanceRequirement().get())
+                .collect(Collectors.toSet());
     }
 
     private void suppressOrRevive() {
-        boolean hasOperations = planManagers.stream()
-                .anyMatch(planManager -> PlanUtils.hasOperations(planManager.getPlan()));
-        if (hasOperations || hasTasksNeedingRecovery()) {
-            transitionState(State.WAITING_FOR_OFFER);
+        Set<PodInstanceRequirement> newCandidates = getRequirements(planCoordinator.getCandidates());
+        if (newCandidates.isEmpty()) {
+            logger.info("No candidates, suppressing offers");
+            suppress();
+            candidates = newCandidates;
+            return;
+        }
+
+        newCandidates.removeAll(candidates);
+
+        logger.info("Old candidates: {}", candidates);
+        logger.info("New candidates: {}", newCandidates);
+
+        if (newCandidates.isEmpty()) {
+            logger.info("No new candidates detected, no need to revive.");
         } else {
-            transitionState(State.SUPPRESSED);
+            candidates = newCandidates;
+            logger.info("Reviving offers");
+            revive();
         }
     }
 
     private void suppress() {
-        synchronized (suppressReviveLock) {
-            setOfferMode(true);
-        }
+        setOfferMode(true);
     }
 
     private void revive() {
-        synchronized (suppressReviveLock) {
-            setOfferMode(false);
-        }
+        setOfferMode(false);
     }
 
     private void setOfferMode(boolean suppressed) {
-        synchronized (suppressReviveLock) {
-            if (suppressed) {
-                logger.info("Suppressing offers.");
-                driver.suppressOffers();
-                StateStoreUtils.setSuppressed(stateStore, true);
-            } else {
-                logger.info("Reviving offers.");
-                driver.reviveOffers();
-                StateStoreUtils.setSuppressed(stateStore, false);
-            }
-        }
-    }
-
-    protected boolean hasTasksNeedingRecovery() {
-        Collection<Plan> plans = planManagers.stream()
-                .map(planManager -> planManager.getPlan())
-                .collect(Collectors.toList());
-        try {
-            return StateStoreUtils.fetchTasksNeedingRecovery(
-                    stateStore,
-                    configStore,
-                    PlanUtils.getLaunchableTasks(plans)).size() > 0;
-        } catch (TaskException e) {
-            logger.error("Failed to determine whether any tasks need recovery.", e);
-            // The safest course of action is to assume recovery is needed.  If it turns out not to be needed, we'll
-            // suppress offers again soon.
-            return true;
+        if (suppressed) {
+            logger.info("Suppressing offers.");
+            driver.suppressOffers();
+            StateStoreUtils.setSuppressed(stateStore, true);
+        } else {
+            logger.info("Reviving offers.");
+            driver.reviveOffers();
+            StateStoreUtils.setSuppressed(stateStore, false);
         }
     }
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SuppressReviveManager.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SuppressReviveManager.java
@@ -1,6 +1,5 @@
 package com.mesosphere.sdk.scheduler;
 
-import com.google.common.eventbus.EventBus;
 import com.mesosphere.sdk.scheduler.plan.PlanCoordinator;
 import com.mesosphere.sdk.scheduler.plan.PodInstanceRequirement;
 import com.mesosphere.sdk.scheduler.plan.Step;
@@ -34,12 +33,10 @@ public class SuppressReviveManager {
     public SuppressReviveManager(
             SchedulerDriver driver,
             StateStore stateStore,
-            EventBus eventBus,
             PlanCoordinator planCoordinator) {
         this(
                 driver,
                 stateStore,
-                eventBus,
                 planCoordinator,
                 REVIVE_DELAY_S,
                 REVIVE_INTERVAL_S);
@@ -48,7 +45,6 @@ public class SuppressReviveManager {
     public SuppressReviveManager(
             SchedulerDriver driver,
             StateStore stateStore,
-            EventBus eventBus,
             PlanCoordinator planCoordinator,
             int pollDelay,
             int pollInterval) {
@@ -57,7 +53,6 @@ public class SuppressReviveManager {
         this.stateStore = stateStore;
         this.planCoordinator = planCoordinator;
         this.candidates = getRequirements(planCoordinator.getCandidates());
-        eventBus.register(this);
         monitor.scheduleAtFixedRate(
                 new Runnable() {
                     @Override

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SuppressReviveManager.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SuppressReviveManager.java
@@ -20,8 +20,8 @@ import java.util.stream.Collectors;
  * This class monitors a {@link PlanCoordinator} and suppresses or revives offers when appropriate.
  */
 public class SuppressReviveManager {
-    public static final int REVIVE_INTERVAL_S = 5;
-    public static final int REVIVE_DELAY_S = 5;
+    public static final int SUPPRESS_REVIVE_INTERVAL_S = 5;
+    public static final int SUPPRESS_REVIVE_DELAY_S = 5;
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
     private final SchedulerDriver driver;
@@ -38,8 +38,8 @@ public class SuppressReviveManager {
                 driver,
                 stateStore,
                 planCoordinator,
-                REVIVE_DELAY_S,
-                REVIVE_INTERVAL_S);
+                SUPPRESS_REVIVE_DELAY_S,
+                SUPPRESS_REVIVE_INTERVAL_S);
     }
 
     public SuppressReviveManager(
@@ -81,7 +81,7 @@ public class SuppressReviveManager {
     private void suppressOrRevive() {
         Set<PodInstanceRequirement> newCandidates = getRequirements(planCoordinator.getCandidates());
         if (newCandidates.isEmpty()) {
-            logger.info("No candidates, suppressing offers");
+            logger.debug("No candidates found");
             suppress();
             candidates = newCandidates;
             return;
@@ -89,14 +89,13 @@ public class SuppressReviveManager {
 
         newCandidates.removeAll(candidates);
 
-        logger.info("Old candidates: {}", candidates);
-        logger.info("New candidates: {}", newCandidates);
+        logger.debug("Old candidates: {}", candidates);
+        logger.debug("New candidates: {}", newCandidates);
 
         if (newCandidates.isEmpty()) {
-            logger.info("No new candidates detected, no need to revive.");
+            logger.debug("No new candidates detected, no need to revive");
         } else {
             candidates = newCandidates;
-            logger.info("Reviving offers");
             revive();
         }
     }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/DefaultPlanCoordinator.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/DefaultPlanCoordinator.java
@@ -35,7 +35,8 @@ public class DefaultPlanCoordinator implements PlanCoordinator {
      * Returns the set of steps across all {@link PlanManager}s which are eligible for execution.  Execution normally
      * means that these steps are ready to be matched with offers and launch tasks.
      */
-    private List<Step> getCandidates() {
+    @Override
+    public List<Step> getCandidates() {
         // Assets that are being actively worked on
         final Set<PodInstanceRequirement> dirtiedAssets = new HashSet<>();
 
@@ -89,18 +90,6 @@ public class DefaultPlanCoordinator implements PlanCoordinator {
     @Override
     public Collection<OfferID> processOffers(final SchedulerDriver driver, final List<Offer> offersToProcess) {
         return planScheduler.resourceOffers(driver, offersToProcess, getCandidates());
-    }
-
-    @Override
-    public boolean hasOperations() {
-        boolean ret = false;
-        for (final PlanManager planManager : planManagers) {
-            LOGGER.debug("Plan: name={} status={}",
-                    planManager.getPlan().getName(),
-                    planManager.getPlan().getStatus());
-            ret = ret || PlanUtils.hasOperations(planManager.getPlan());
-        }
-        return ret;
     }
 
     @Override

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/PlanCoordinator.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/PlanCoordinator.java
@@ -12,6 +12,7 @@ import java.util.List;
  * its observers when this state changes.
  */
 public interface PlanCoordinator {
+
     /**
      * Provides offers to each {@link PlanManager} for processing. Keeps tracks of dirtied offers and assets.
      *
@@ -20,9 +21,9 @@ public interface PlanCoordinator {
     Collection<Protos.OfferID> processOffers(final SchedulerDriver driver, final List<Protos.Offer> offers);
 
     /**
-     * @return True if this {@link PlanCoordinator} has operations to perform.
+     * @return The {@link Step}s which are eligible for processing.
      */
-    boolean hasOperations();
+    List<Step> getCandidates();
 
     /**
      * @return The {@link PlanManager}s which the PlanCoordinator coordinates.

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/PodInstanceRequirement.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/PodInstanceRequirement.java
@@ -3,8 +3,13 @@ package com.mesosphere.sdk.scheduler.plan;
 import com.mesosphere.sdk.offer.TaskUtils;
 import com.mesosphere.sdk.scheduler.recovery.RecoveryType;
 import com.mesosphere.sdk.specification.PodInstance;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
-import java.util.*;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * A PodInstanceRequirement encapsulates a {@link PodInstance} and the names of tasks that should be launched in it.
@@ -66,7 +71,7 @@ public class PodInstanceRequirement {
 
     @Override
     public String toString() {
-        return getName();
+        return String.format("%s[%s]", getName(), recoveryType);
     }
 
     /**
@@ -86,6 +91,16 @@ public class PodInstanceRequirement {
                 .filter(t -> podInstanceRequirement.getTasksToLaunch().contains(t))
                 .count() > 0;
         return podConflicts && anyTaskConflicts;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return EqualsBuilder.reflectionEquals(this, o);
+    }
+
+    @Override
+    public int hashCode() {
+        return HashCodeBuilder.reflectionHashCode(this);
     }
 
     /**

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/uninstall/UninstallScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/uninstall/UninstallScheduler.java
@@ -140,8 +140,6 @@ public class UninstallScheduler extends AbstractScheduler {
                 status.getMessage(),
                 TextFormat.shortDebugString(status));
 
-        eventBus.post(status);
-
         try {
             stateStore.storeStatus(StateStoreUtils.getTaskName(stateStore, status), status);
             reconciler.update(status);

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/uninstall/UninstallScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/uninstall/UninstallScheduler.java
@@ -113,8 +113,23 @@ public class UninstallScheduler extends AbstractScheduler {
     }
 
     @Override
-    protected Collection<PlanManager> getPlanManagers() {
-        return Arrays.asList(uninstallPlanManager);
+    protected PlanCoordinator getPlanCoordinator() {
+        return new PlanCoordinator() {
+            @Override
+            public List<Step> getCandidates() {
+                return new ArrayList<>(uninstallPlanManager.getCandidates(Collections.emptyList()));
+            }
+
+            @Override
+            public Collection<Protos.OfferID> processOffers(SchedulerDriver driver, List<Protos.Offer> offers) {
+                return Collections.emptyList();
+            }
+
+            @Override
+            public Collection<PlanManager> getPlanManagers() {
+                return Arrays.asList(uninstallPlanManager);
+            }
+        };
     }
 
     @Override

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/uninstall/UninstallScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/uninstall/UninstallScheduler.java
@@ -109,7 +109,7 @@ public class UninstallScheduler extends AbstractScheduler {
 
         // Decline remaining offers.
         List<Protos.Offer> unusedOffers = OfferUtils.filterOutAcceptedOffers(localOffers, offersWithReservedResources);
-        OfferUtils.declineOffers(driver, unusedOffers);
+        OfferUtils.declineOffers(driver, unusedOffers, Constants.LONG_DECLINE_SECONDS);
     }
 
     @Override

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/OfferUtilsTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/OfferUtilsTest.java
@@ -75,7 +75,7 @@ public class OfferUtilsTest {
     public void testDeclineOffers() {
         final List<Protos.Offer> offers = getOffers(SUFFICIENT_CPUS, SUFFICIENT_MEM, SUFFICIENT_DISK);
         final List<Protos.OfferID> offerIds = offers.stream().map(Protos.Offer::getId).collect(Collectors.toList());
-        OfferUtils.declineOffers(mockSchedulerDriver, offers);
+        OfferUtils.declineOffers(mockSchedulerDriver, offers, Constants.LONG_DECLINE_SECONDS);
         verify(mockSchedulerDriver).declineOffer(eq(offerIds.get(0)), any());
         verify(mockSchedulerDriver).declineOffer(eq(offerIds.get(1)), any());
     }

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/OfferUtilsTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/OfferUtilsTest.java
@@ -15,6 +15,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.verify;
 
 public class OfferUtilsTest {
@@ -74,8 +76,8 @@ public class OfferUtilsTest {
         final List<Protos.Offer> offers = getOffers(SUFFICIENT_CPUS, SUFFICIENT_MEM, SUFFICIENT_DISK);
         final List<Protos.OfferID> offerIds = offers.stream().map(Protos.Offer::getId).collect(Collectors.toList());
         OfferUtils.declineOffers(mockSchedulerDriver, offers);
-        verify(mockSchedulerDriver).declineOffer(offerIds.get(0));
-        verify(mockSchedulerDriver).declineOffer(offerIds.get(1));
+        verify(mockSchedulerDriver).declineOffer(eq(offerIds.get(0)), any());
+        verify(mockSchedulerDriver).declineOffer(eq(offerIds.get(1)), any());
     }
 
     private List<Protos.Offer> getOffers(double cpus, double mem, double disk) {

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/DefaultSchedulerTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/DefaultSchedulerTest.java
@@ -992,8 +992,8 @@ public class DefaultSchedulerTest {
                 PlanTestUtils.getStepStatuses(plan));
         Awaitility.await()
                 .atMost(
-                        SuppressReviveManager.REVIVE_DELAY_S +
-                        SuppressReviveManager.REVIVE_INTERVAL_S + 1,
+                        SuppressReviveManager.SUPPRESS_REVIVE_DELAY_S +
+                        SuppressReviveManager.SUPPRESS_REVIVE_INTERVAL_S + 1,
                         TimeUnit.SECONDS)
                 .until(new Callable<Boolean>() {
                     @Override

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/DefaultSchedulerTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/DefaultSchedulerTest.java
@@ -694,11 +694,6 @@ public class DefaultSchedulerTest {
     }
 
     @Test
-    public void testSuppress() throws InterruptedException {
-        install();
-    }
-
-    @Test
     public void testTaskIpIsStoredOnInstall() throws InterruptedException {
         install();
 
@@ -992,13 +987,13 @@ public class DefaultSchedulerTest {
                 PlanTestUtils.getStepStatuses(plan));
         Awaitility.await()
                 .atMost(
-                        SuppressReviveManager.SUPPRESS_REVIVE_DELAY_S +
-                        SuppressReviveManager.SUPPRESS_REVIVE_INTERVAL_S + 1,
+                        ReviveManager.REVIVE_DELAY_S +
+                        ReviveManager.REVIVE_INTERVAL_S + 1,
                         TimeUnit.SECONDS)
                 .until(new Callable<Boolean>() {
                     @Override
                     public Boolean call() throws Exception {
-                        return StateStoreUtils.isSuppressed(stateStore);
+                        return defaultScheduler.planCoordinator.getCandidates().isEmpty();
                     }
                 });
 

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/ReviveManagerTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/ReviveManagerTest.java
@@ -5,7 +5,6 @@ import com.mesosphere.sdk.scheduler.plan.PlanCoordinator;
 import com.mesosphere.sdk.scheduler.plan.PodInstanceRequirement;
 import com.mesosphere.sdk.scheduler.plan.Status;
 import com.mesosphere.sdk.scheduler.plan.Step;
-import com.mesosphere.sdk.specification.*;
 import com.mesosphere.sdk.state.StateStore;
 import com.mesosphere.sdk.state.StateStoreUtils;
 import com.mesosphere.sdk.storage.MemPersister;
@@ -27,11 +26,11 @@ import java.util.concurrent.TimeUnit;
 import static org.mockito.Mockito.*;
 
 /**
- * This class tests {@link SuppressReviveManager}.
+ * This class tests {@link ReviveManager}.
  */
-public class SuppressReviveManagerTest {
+public class ReviveManagerTest {
     private StateStore stateStore;
-    private SuppressReviveManager manager;
+    private ReviveManager manager;
     @Mock private PlanCoordinator planCoordinator;
     @Mock SchedulerDriver driver;
 
@@ -43,31 +42,12 @@ public class SuppressReviveManagerTest {
         manager = null;
     }
 
-    @Test
-    public void suppressWhenWorkIsComplete() {
-        when(planCoordinator.getCandidates()).thenReturn(Collections.emptyList());
-        Assert.assertFalse(StateStoreUtils.isSuppressed(stateStore));
-        manager = getSuppressReviveManager(planCoordinator);
-        waitSuppressed(stateStore, manager, 5);
-    }
-
     @Test(expected = ConditionTimeoutException.class)
     public void stayRevivedWhenWorkIsIncomplete() {
         when(planCoordinator.getCandidates()).thenReturn(Arrays.asList(getStep(0)));
         Assert.assertFalse(StateStoreUtils.isSuppressed(stateStore));
         manager = getSuppressReviveManager(planCoordinator);
         waitSuppressed(stateStore, manager, 5);
-    }
-
-    @Test
-    public void suppressToRevivedWhenNewWorkAppears() {
-        when(planCoordinator.getCandidates()).thenReturn(Collections.emptyList());
-        Assert.assertFalse(StateStoreUtils.isSuppressed(stateStore));
-        manager = getSuppressReviveManager(planCoordinator);
-        waitSuppressed(stateStore, manager, 5);
-
-        when(planCoordinator.getCandidates()).thenReturn(Arrays.asList(getStep(0)));
-        waitRevived(stateStore, manager, 5);
     }
 
     @Test
@@ -82,8 +62,8 @@ public class SuppressReviveManagerTest {
         verify(driver, timeout(5000).atLeastOnce()).reviveOffers();
     }
 
-    private SuppressReviveManager getSuppressReviveManager(PlanCoordinator planCoordinator) {
-        return new SuppressReviveManager(
+    private ReviveManager getSuppressReviveManager(PlanCoordinator planCoordinator) {
+        return new ReviveManager(
                 driver,
                 stateStore,
                 planCoordinator,
@@ -168,11 +148,11 @@ public class SuppressReviveManagerTest {
         };
     }
 
-    private static void waitSuppressed(StateStore stateStore, SuppressReviveManager reviveManager, int seconds) {
+    private static void waitSuppressed(StateStore stateStore, ReviveManager reviveManager, int seconds) {
         waitStateStore(stateStore, true, seconds);
     }
 
-    private static void waitRevived(StateStore stateStore, SuppressReviveManager reviveManager, int seconds) {
+    private static void waitRevived(StateStore stateStore, ReviveManager reviveManager, int seconds) {
         waitStateStore(stateStore, false, seconds);
     }
 

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/SuppressReviveManagerTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/SuppressReviveManagerTest.java
@@ -1,6 +1,5 @@
 package com.mesosphere.sdk.scheduler;
 
-import com.google.common.eventbus.EventBus;
 import com.mesosphere.sdk.scheduler.plan.PlanCoordinator;
 import com.mesosphere.sdk.scheduler.plan.PodInstanceRequirement;
 import com.mesosphere.sdk.scheduler.plan.Step;
@@ -10,7 +9,6 @@ import com.mesosphere.sdk.state.StateStore;
 import com.mesosphere.sdk.state.StateStoreUtils;
 import com.mesosphere.sdk.storage.MemPersister;
 import com.mesosphere.sdk.testutils.TestConstants;
-import org.apache.mesos.Protos;
 import org.apache.mesos.SchedulerDriver;
 import org.awaitility.Awaitility;
 import org.awaitility.core.ConditionTimeoutException;
@@ -33,11 +31,6 @@ import static org.mockito.Mockito.*;
  */
 public class SuppressReviveManagerTest {
     private StateStore stateStore;
-
-    // This EventBus publishes events synchronously.  Changing this property would invalidate assertions in tests below.
-    // For example, asserting that a state transition does not occur after an event is safe now, that assertion would
-    // prove nothing if we put an asynchronous EventBus here.
-    private EventBus eventBus = new EventBus();
     private SuppressReviveManager manager;
 
     @Mock private SchedulerDriver driver;
@@ -113,7 +106,6 @@ public class SuppressReviveManagerTest {
         return new SuppressReviveManager(
                 driver,
                 stateStore,
-                eventBus,
                 planCoordinator,
                 0,
                 1);
@@ -137,29 +129,5 @@ public class SuppressReviveManagerTest {
                         return StateStoreUtils.isSuppressed(stateStore) == suppressed;
                     }
                 });
-    }
-
-    private void sendOffer() {
-        Protos.Offer offer = Protos.Offer.newBuilder()
-                .setId(TestConstants.OFFER_ID)
-                .setFrameworkId(TestConstants.FRAMEWORK_ID)
-                .setSlaveId(TestConstants.AGENT_ID)
-                .setHostname(TestConstants.HOSTNAME)
-                .build();
-
-        eventBus.post(offer);
-    }
-
-    private void sendFailedTaskStatus() {
-        sendTaskStatus(Protos.TaskState.TASK_FAILED);
-    }
-
-    private void sendTaskStatus(Protos.TaskState state) {
-        Protos.TaskStatus taskStatus = Protos.TaskStatus.newBuilder()
-                .setTaskId(TestConstants.TASK_ID)
-                .setState(state)
-                .build();
-
-        eventBus.post(taskStatus);
     }
 }

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/plan/DefaultPlanCoordinatorTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/plan/DefaultPlanCoordinatorTest.java
@@ -328,21 +328,4 @@ public class DefaultPlanCoordinatorTest extends DefaultCapabilitiesTestSuite {
         Assert.assertTrue(planB.getChildren().get(0).getChildren().get(0).getStatus().equals(Status.STARTING));
         Assert.assertTrue(planA.getChildren().get(0).getChildren().get(0).getStatus().equals(Status.PENDING));
     }
-
-    @Test
-    public void testHasOperations() throws Exception {
-        final Plan planA = new DeployPlanFactory(phaseFactory).getPlan(serviceSpecification);
-        final PlanManager planManagerA = new DefaultPlanManager(planA);
-        final DefaultPlanCoordinator coordinator = new DefaultPlanCoordinator(
-                Arrays.asList(planManagerA),
-                planScheduler);
-
-        Assert.assertFalse(coordinator.hasOperations());
-
-        planManagerA.getPlan().proceed();
-        Assert.assertTrue(coordinator.hasOperations());
-
-        planManagerA.getPlan().getChildren().get(0).getChildren().get(0).forceComplete();
-        Assert.assertFalse(coordinator.hasOperations());
-    }
 }

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/uninstall/UninstallSchedulerTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/uninstall/UninstallSchedulerTest.java
@@ -200,18 +200,6 @@ public class UninstallSchedulerTest extends DefaultCapabilitiesTestSuite {
     }
 
     @Test
-    public void testApiServerNotReadyDecline() throws InterruptedException {
-        UninstallScheduler uninstallScheduler =
-                new TestScheduler(TestConstants.SERVICE_NAME, stateStore, mockConfigStore, false);
-        uninstallScheduler.registered(mockSchedulerDriver, TestConstants.FRAMEWORK_ID, TestConstants.MASTER_INFO);
-
-        Protos.Offer offer = OfferTestUtils.getOffer(Collections.singletonList(RESERVED_RESOURCE_3));
-        uninstallScheduler.resourceOffers(mockSchedulerDriver, Collections.singletonList(offer));
-        uninstallScheduler.awaitOffersProcessed();
-        verify(mockSchedulerDriver, times(1)).declineOffer(any());
-    }
-
-    @Test
     public void testAllButDeregisteredPlanCompletes() throws Exception {
         // No framework ID is set yet, and there are no tasks, and no SchedulerDriver
         UninstallScheduler uninstallScheduler = new UninstallScheduler(

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/testutils/PodTestUtils.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/testutils/PodTestUtils.java
@@ -1,0 +1,206 @@
+package com.mesosphere.sdk.testutils;
+
+import com.mesosphere.sdk.offer.Constants;
+import com.mesosphere.sdk.offer.evaluate.placement.PlacementRule;
+import com.mesosphere.sdk.scheduler.plan.PodInstanceRequirement;
+import com.mesosphere.sdk.specification.*;
+import com.mesosphere.sdk.specification.util.RLimit;
+import org.apache.mesos.Protos;
+
+import java.net.URI;
+import java.util.*;
+
+/**
+ * Created by gabriel on 9/7/17.
+ */
+public class PodTestUtils {
+    public static ResourceSet getResourceSet() {
+        return new ResourceSet() {
+            @Override
+            public String getId() {
+                return TestConstants.RESOURCE_SET_ID;
+            }
+
+            @Override
+            public Collection<ResourceSpec> getResources() {
+                return Arrays.asList(new ResourceSpec() {
+                    @Override
+                    public Protos.Value getValue() {
+                        return Protos.Value.newBuilder()
+                                .setType(Protos.Value.Type.SCALAR)
+                                .setScalar(Protos.Value.Scalar.newBuilder()
+                                        .setValue(1.0))
+                                .build();
+                    }
+
+                    @Override
+                    public String getName() {
+                        return Constants.CPUS_RESOURCE_TYPE;
+                    }
+
+                    @Override
+                    public String getRole() {
+                        return TestConstants.ROLE;
+                    }
+
+                    @Override
+                    public String getPreReservedRole() {
+                        return TestConstants.PRE_RESERVED_ROLE;
+                    }
+
+                    @Override
+                    public String getPrincipal() {
+                        return TestConstants.PRINCIPAL;
+                    }
+                });
+            }
+
+            @Override
+            public Collection<VolumeSpec> getVolumes() {
+                return Collections.emptyList();
+            }
+        };
+    }
+
+    public static TaskSpec getTaskSpec() {
+        return new TaskSpec() {
+            @Override
+            public String getName() {
+                return TestConstants.TASK_NAME;
+            }
+
+            @Override
+            public GoalState getGoal() {
+                return GoalState.RUNNING;
+            }
+
+            @Override
+            public ResourceSet getResourceSet() {
+                return PodTestUtils.getResourceSet();
+            }
+
+            @Override
+            public Optional<CommandSpec> getCommand() {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<HealthCheckSpec> getHealthCheck() {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<ReadinessCheckSpec> getReadinessCheck() {
+                return Optional.empty();
+            }
+
+            @Override
+            public Collection<ConfigFileSpec> getConfigFiles() {
+                return Collections.emptyList();
+            }
+
+            @Override
+            public Optional<DiscoverySpec> getDiscovery() {
+                return Optional.empty();
+            }
+
+            @Override
+            public Integer getTaskKillGracePeriodSeconds() {
+                return null;
+            }
+
+            @Override
+            public Collection<TransportEncryptionSpec> getTransportEncryption() {
+                return Collections.emptyList();
+            }
+        };
+    }
+
+    public static PodSpec getPodSpec() {
+        return new PodSpec() {
+            @Override
+            public String getType() {
+                return TestConstants.POD_TYPE;
+            }
+
+            @Override
+            public Integer getCount() {
+                return 1;
+            }
+
+            @Override
+            public Optional<String> getImage() {
+                return Optional.empty();
+            }
+
+            @Override
+            public Collection<NetworkSpec> getNetworks() {
+                return Collections.emptyList();
+            }
+
+            @Override
+            public Collection<RLimit> getRLimits() {
+                return Collections.emptyList();
+            }
+
+            @Override
+            public Collection<URI> getUris() {
+                return Collections.emptyList();
+            }
+
+            @Override
+            public Optional<String> getUser() {
+                return Optional.empty();
+            }
+
+            @Override
+            public List<TaskSpec> getTasks() {
+                return Arrays.asList(getTaskSpec());
+            }
+
+            @Override
+            public Optional<PlacementRule> getPlacementRule() {
+                return Optional.empty();
+            }
+
+            @Override
+            public Collection<VolumeSpec> getVolumes() {
+                return Collections.emptyList();
+            }
+
+            @Override
+            public String getPreReservedRole() {
+                return TestConstants.PRE_RESERVED_ROLE;
+            }
+
+            @Override
+            public Collection<SecretSpec> getSecrets() {
+                return Collections.emptyList();
+            }
+
+            @Override
+            public Boolean getSharePidNamespace() {
+                return false;
+            }
+        };
+    }
+
+    public static PodInstance getPodInstance(int index) {
+        return new PodInstance() {
+            @Override
+            public PodSpec getPod() {
+                return getPodSpec();
+            }
+
+            @Override
+            public int getIndex() {
+                return index;
+            }
+        };
+    }
+
+    public static PodInstanceRequirement getPodInstanceRequirement(int index) {
+        List<String> tasksToLaunch = Arrays.asList(getTaskSpec().getName());
+        return PodInstanceRequirement.newBuilder(getPodInstance(index), tasksToLaunch).build();
+    }
+}

--- a/testing/sdk_install.py
+++ b/testing/sdk_install.py
@@ -75,17 +75,6 @@ def install(
             package_name, service_name))
         sdk_plan.wait_for_completed_deployment(service_name, timeout_seconds)
 
-        # given the above wait for plan completion, here we just wait up to 5 minutes
-        if shakedown.dcos_version_less_than("1.9"):
-            log.info("Skipping `is_suppressed` check for %s/%s as this is only suppored starting in version 1.9",
-                     package_name, service_name)
-        else:
-            log.info("Waiting for %s/%s to be suppressed...", package_name, service_name)
-            shakedown.wait_for(
-                lambda: sdk_api.is_suppressed(service_name),
-                noisy=True,
-                timeout_seconds=5 * 60)
-
     log.info('Installed {}/{} after {}'.format(
         package_name, service_name, shakedown.pretty_duration(time.time() - start)))
 

--- a/testing/sdk_upgrade.py
+++ b/testing/sdk_upgrade.py
@@ -166,17 +166,6 @@ def _upgrade_or_downgrade(
             package_name, service_name))
         sdk_plan.wait_for_completed_deployment(service_name, timeout_seconds)
 
-        # given the above wait for plan completion, here we just wait up to 5 minutes
-        if shakedown.dcos_version_less_than("1.9"):
-            log.info("Skipping `is_suppressed` check for %s/%s as this is only suppored starting in version 1.9",
-                     package_name, service_name)
-        else:
-            log.info("Waiting for %s/%s to be suppressed...", package_name, service_name)
-            shakedown.wait_for(
-                lambda: sdk_api.is_suppressed(service_name),
-                noisy=True,
-                timeout_seconds=5 * 60)
-
 
 def _get_pkg_version(package_name):
     return re.search(


### PR DESCRIPTION
Instead of suppressing offers when all work is complete, we now set a decline timeout of 2 weeks (a.k.a. forever) whenever we suppress any offer.  When we see *new* work (`PodInstanceRequirement`s) we assume that the offers we've declined forever may be useful to that work, and so we revive offers.

Pseudo-code algorithm is like this:
```
// We always start out revived
List<Requirement> currRequirements = getRequirements();

while (true) {
    List<Requirement> newRequirements = getRequirements() - currRequirements;
    if (newRequirements.isEmpty()) {
        print “No new work”;
    } else {
        currRequirements = newRequirements;
        revive();
    }
}

```

I've left out the `supress` portion of the logic in the pseudocode, but it's in the real code.  Basically if there's no work, suppress.

A natural question is why do we overwrite `currRequirements` with `newRequirements`?  Here's the invariant.  Anything that is in `currRequirements` has had revive called for it.  Any change with regard to `currRequirements` i.e. `newRequirements` implies that those requirements may need an offer which has been declined forever, so we need to revive.  We cannot maintain a cummulative list in `currRequirements` because we may see the same work twice.

e.g. 
```
1. `kafka-0-broker` fails    @ 10:30, it's new work!
2. `kafka-0-broker` recovers @ 10:35
3. `kafka-0-broker` fails    @ 11:00, it's new work!
...
```