### PR TITLE
[INFINITY-2374] Disable tests that will not pass in open (#1567) (backport)

### DIFF
--- a/frameworks/helloworld/tests/test_secrets.py
+++ b/frameworks/helloworld/tests/test_secrets.py
@@ -74,6 +74,7 @@ def configure_package(configure_security):
 @pytest.mark.smoke
 @pytest.mark.secrets
 @sdk_utils.dcos_1_10_or_higher
+@sdk_utils.dcos_ee_only
 def test_secrets_basic():
     # 1) create Secrets
     # 2) install examples/secrets.yml
@@ -110,6 +111,7 @@ def test_secrets_basic():
 @pytest.mark.smoke
 @pytest.mark.secrets
 @sdk_utils.dcos_1_10_or_higher
+@sdk_utils.dcos_ee_only
 def test_secrets_verify():
     # 1) create Secrets
     # 2) install examples/secrets.yml
@@ -162,6 +164,7 @@ def test_secrets_verify():
 @pytest.mark.smoke
 @pytest.mark.secrets
 @sdk_utils.dcos_1_10_or_higher
+@sdk_utils.dcos_ee_only
 def test_secrets_update():
     # 1) create Secrets
     # 2) install examples/secrets.yml
@@ -222,6 +225,7 @@ def test_secrets_update():
 @pytest.mark.secrets
 @pytest.mark.smoke
 @sdk_utils.dcos_1_10_or_higher
+@sdk_utils.dcos_ee_only
 def test_secrets_config_update():
     # 1) install examples/secrets.yml
     # 2) create new Secrets, delete old Secrets
@@ -296,6 +300,7 @@ def test_secrets_config_update():
 @pytest.mark.smoke
 @pytest.mark.secrets
 @sdk_utils.dcos_1_10_or_higher
+@sdk_utils.dcos_ee_only
 def test_secrets_dcos_space():
     # 1) create secrets in hello-world/somePath, i.e. hello-world/somePath/secret1 ...
     # 2) Tasks with DCOS_SPACE hello-world/somePath

--- a/frameworks/helloworld/tests/test_tls.py
+++ b/frameworks/helloworld/tests/test_tls.py
@@ -100,6 +100,7 @@ def hello_world_service(service_account):
 @pytest.mark.tls
 @pytest.mark.sanity
 @sdk_utils.dcos_1_10_or_higher
+@sdk_utils.dcos_ee_only
 def test_java_truststore(hello_world_service):
     """
     Make an HTTP request from CLI to nginx exposed service.
@@ -128,6 +129,7 @@ def test_java_truststore(hello_world_service):
 @pytest.mark.tls
 @pytest.mark.sanity
 @sdk_utils.dcos_1_10_or_higher
+@sdk_utils.dcos_ee_only
 def test_tls_basic_artifacts(hello_world_service):
     task_id = sdk_tasks.get_task_ids(config.PACKAGE_NAME, 'artifacts')[0]
     assert task_id
@@ -161,6 +163,7 @@ def test_tls_basic_artifacts(hello_world_service):
 @pytest.mark.tls
 @pytest.mark.sanity
 @sdk_utils.dcos_1_10_or_higher
+@sdk_utils.dcos_ee_only
 def test_java_keystore(hello_world_service):
     """
     Java `keystore-app` presents itself with provided TLS certificate
@@ -194,6 +197,7 @@ def test_java_keystore(hello_world_service):
 @pytest.mark.tls
 @pytest.mark.sanity
 @sdk_utils.dcos_1_10_or_higher
+@sdk_utils.dcos_ee_only
 def test_tls_nginx(hello_world_service):
     """
     Checks that NGINX exposes TLS service with correct PEM encoded end-entity
@@ -222,6 +226,7 @@ def test_tls_nginx(hello_world_service):
 @pytest.mark.tls
 @pytest.mark.sanity
 @sdk_utils.dcos_1_10_or_higher
+@sdk_utils.dcos_ee_only
 def test_changing_discovery_replaces_certificate_sans(hello_world_service):
     """
     Update service configuration to change discovery prefix of a task.

--- a/frameworks/kafka/tests/test_tls.py
+++ b/frameworks/kafka/tests/test_tls.py
@@ -69,6 +69,7 @@ def kafka_service_tls(service_account):
 @pytest.mark.sanity
 @sdk_utils.dcos_1_10_or_higher
 @pytest.mark.skip(reason="TLS not supported in stable.")
+@sdk_utils.dcos_ee_only
 def test_tls_endpoints(kafka_service_tls):
     endpoints = sdk_networks.get_and_test_endpoints("", config.PACKAGE_NAME, 2)
     assert BROKER_TLS_ENDPOINT in endpoints
@@ -85,6 +86,7 @@ def test_tls_endpoints(kafka_service_tls):
 @pytest.mark.sanity
 @sdk_utils.dcos_1_10_or_higher
 @pytest.mark.skip(reason="TLS not supported in stable.")
+@sdk_utils.dcos_ee_only
 def test_producer_over_tls(kafka_service_tls):
     service_cli('topic create {}'.format(config.DEFAULT_TOPIC_NAME))
 

--- a/testing/sdk_utils.py
+++ b/testing/sdk_utils.py
@@ -4,6 +4,7 @@ import logging
 import dcos
 import shakedown
 import pytest
+import os
 
 log = logging.getLogger(__name__)
 
@@ -41,6 +42,17 @@ def get_zk_path(service_name):
 @functools.lru_cache()
 def dcos_version_less_than(version):
     return shakedown.dcos_version_less_than("1.10")
+
+
+def is_open_dcos():
+    '''Determine if the tests are being run against open DC/OS. This is presently done by
+    checking the envvar DCOS_ENTERPRISE.'''
+    return os.environ.get('DCOS_ENTERPRISE', 'true').lower() != 'true'
+
+
+dcos_ee_only = pytest.mark.skipif(
+    'sdk_utils.is_open_dcos',
+    reason="Feature only supported in DC/OS EE.")
 
 
 # WARNING: Any file that uses these must also "import shakedown" in the same file.


### PR DESCRIPTION
* Detect DC/OS Open and disable tests for features that do not work there.

* Bad python

* Disable C* TLS test in open