### PR TITLE
[INFINITY-2309] Fix handling of DeploymentStep status changes. (#1488) (backport)

### DIFF
--- a/frameworks/helloworld/tests/test_recovery.py
+++ b/frameworks/helloworld/tests/test_recovery.py
@@ -28,10 +28,8 @@ def configure_package(configure_security):
 def test_kill_hello_node():
     config.check_running()
     hello_ids = sdk_tasks.get_task_ids(config.PACKAGE_NAME, 'hello-0')
-    sdk_tasks.kill_task_with_pattern(
-        'hello', 'hello-0-server.hello-world.mesos')
-    sdk_tasks.check_tasks_updated(config.PACKAGE_NAME, 'hello', hello_ids)
-
+    sdk_tasks.kill_task_with_pattern('hello', 'hello-0-server.hello-world.mesos')
+    sdk_tasks.check_tasks_updated(config.PACKAGE_NAME, 'hello-0', hello_ids)
     config.check_running()
 
 
@@ -51,7 +49,7 @@ def test_pod_restart():
     assert len(jsonobj['tasks']) == 1
     assert jsonobj['tasks'][0] == 'hello-0-server'
 
-    sdk_tasks.check_tasks_updated(config.PACKAGE_NAME, 'hello', hello_ids)
+    sdk_tasks.check_tasks_updated(config.PACKAGE_NAME, 'hello-0', hello_ids)
     config.check_running()
 
     # check agent didn't move:
@@ -83,7 +81,7 @@ def test_pods_restart_graceful_shutdown():
     assert len(jsonobj['tasks']) == 1
     assert jsonobj['tasks'][0] == 'world-0-server'
 
-    sdk_tasks.check_tasks_updated(config.PACKAGE_NAME, 'world', world_ids)
+    sdk_tasks.check_tasks_updated(config.PACKAGE_NAME, 'world-0', world_ids)
     config.check_running()
 
     # ensure the SIGTERM was sent via the "all clean" message in the world
@@ -95,8 +93,8 @@ def test_pods_restart_graceful_shutdown():
     for s in stdout.split('\n'):
         if s.find('echo') < 0 and s.find('all clean') >= 0:
             clean_msg = s
-    
-    assert clean_msg != None
+
+    assert clean_msg is not None
 
 
 @pytest.mark.sanity

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/plan/DeploymentStepTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/plan/DeploymentStepTest.java
@@ -13,9 +13,7 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
+import java.util.*;
 
 import static org.mockito.Mockito.when;
 
@@ -42,6 +40,85 @@ public class DeploymentStepTest {
         when(podInstance.getName()).thenReturn(TestConstants.POD_TYPE + "-" + 0);
         taskName = TaskSpec.getInstanceName(podInstance, taskSpec);
         taskID = CommonIdUtils.toTaskId(taskName);
+    }
+
+    @Test
+    public void testGetStatusReturnsMinimumState() {
+        // No tasks
+        Map<Protos.TaskID, DeploymentStep.TaskStatusPair> tasks = new HashMap<>();
+        Assert.assertEquals(Status.PENDING, getPendingStep().getStatus(tasks));
+
+        // 1 PREPARED and 1 ERROR and 1 COMPLETE tasks
+        tasks = new HashMap<>();
+        tasks.put(CommonIdUtils.toTaskId("test1"),
+                new DeploymentStep.TaskStatusPair(null, Status.PREPARED));
+        tasks.put(CommonIdUtils.toTaskId("test2"),
+                new DeploymentStep.TaskStatusPair(null, Status.ERROR));
+        tasks.put(CommonIdUtils.toTaskId("test3"),
+                new DeploymentStep.TaskStatusPair(null, Status.COMPLETE));
+        Assert.assertEquals(Status.ERROR, getPendingStep().getStatus(tasks));
+
+
+        // 1 PREPARED and 2 PENDING tasks
+        tasks = new HashMap<>();
+        tasks.put(CommonIdUtils.toTaskId("test1"),
+                new DeploymentStep.TaskStatusPair(null, Status.PREPARED));
+        tasks.put(CommonIdUtils.toTaskId("test2"),
+                new DeploymentStep.TaskStatusPair(null, Status.PENDING));
+        tasks.put(CommonIdUtils.toTaskId("test3"),
+                new DeploymentStep.TaskStatusPair(null, Status.PENDING));
+        Assert.assertEquals(Status.PENDING, getPendingStep().getStatus(tasks));
+
+        // 2 PREPARED and 1 STARTING tasks
+        tasks = new HashMap<>();
+        tasks.put(CommonIdUtils.toTaskId("test1"),
+                new DeploymentStep.TaskStatusPair(null, Status.PREPARED));
+        tasks.put(CommonIdUtils.toTaskId("test2"),
+                new DeploymentStep.TaskStatusPair(null, Status.STARTING));
+        tasks.put(CommonIdUtils.toTaskId("test3"),
+                new DeploymentStep.TaskStatusPair(null, Status.PREPARED));
+        Assert.assertEquals(Status.PREPARED, getPendingStep().getStatus(tasks));
+
+        // 1 PENDING and 2 STARTING tasks
+        tasks = new HashMap<>();
+        tasks.put(CommonIdUtils.toTaskId("test1"),
+                new DeploymentStep.TaskStatusPair(null, Status.PENDING));
+        tasks.put(CommonIdUtils.toTaskId("test2"),
+                new DeploymentStep.TaskStatusPair(null, Status.STARTING));
+        tasks.put(CommonIdUtils.toTaskId("test3"),
+                new DeploymentStep.TaskStatusPair(null, Status.STARTING));
+        Assert.assertEquals(Status.PENDING, getPendingStep().getStatus(tasks));
+
+        // 2 STARTING and 1 COMPLETE task
+        tasks = new HashMap<>();
+        tasks.put(CommonIdUtils.toTaskId("test1"),
+                new DeploymentStep.TaskStatusPair(null, Status.STARTING));
+        tasks.put(CommonIdUtils.toTaskId("test2"),
+                new DeploymentStep.TaskStatusPair(null, Status.STARTING));
+        tasks.put(CommonIdUtils.toTaskId("test3"),
+                new DeploymentStep.TaskStatusPair(null, Status.COMPLETE));
+        Assert.assertEquals(Status.STARTING, getPendingStep().getStatus(tasks));
+
+        // 3 COMPLETE tasks
+        tasks = new HashMap<>();
+        tasks.put(CommonIdUtils.toTaskId("test1"),
+                new DeploymentStep.TaskStatusPair(null, Status.COMPLETE));
+        tasks.put(CommonIdUtils.toTaskId("test2"),
+                new DeploymentStep.TaskStatusPair(null, Status.COMPLETE));
+        tasks.put(CommonIdUtils.toTaskId("test3"),
+                new DeploymentStep.TaskStatusPair(null, Status.COMPLETE));
+        Assert.assertEquals(Status.COMPLETE, getPendingStep().getStatus(tasks));
+
+        // 2 COMPLETE and 1 IN_PROGRESS tasks (yes, IN_PROGRESS is not a valid status for a task
+        // but this is just testing the fallback logic).
+        tasks = new HashMap<>();
+        tasks.put(CommonIdUtils.toTaskId("test1"),
+                new DeploymentStep.TaskStatusPair(null, Status.COMPLETE));
+        tasks.put(CommonIdUtils.toTaskId("test2"),
+                new DeploymentStep.TaskStatusPair(null, Status.COMPLETE));
+        tasks.put(CommonIdUtils.toTaskId("test3"),
+                new DeploymentStep.TaskStatusPair(null, Status.IN_PROGRESS));
+        Assert.assertEquals(Status.PENDING, getPendingStep().getStatus(tasks));
     }
 
     @Test
@@ -114,7 +191,7 @@ public class DeploymentStepTest {
         Assert.assertEquals(endStatus, step.getStatus());
     }
 
-    private Step getPendingStep() {
+    private DeploymentStep getPendingStep() {
         return new DeploymentStep(
                 TEST_STEP_NAME,
                 Status.PENDING,

--- a/testing/sdk_utils.py
+++ b/testing/sdk_utils.py
@@ -40,7 +40,7 @@ def get_zk_path(service_name):
 
 @functools.lru_cache()
 def dcos_version_less_than(version):
-    return shakedown.dcos_version_less_than("1.10")
+    return shakedown.dcos_version_less_than(version)
 
 
 # WARNING: Any file that uses these must also "import shakedown" in the same file.


### PR DESCRIPTION
* Fix typo

* Only wait for world-0 on pod replacement

* Minior cleanup of check tasks updated

* Temporary state hack

* Modify DeploymentStep status calculation to be the "least" status of its consituent tasks.

* Add explicit order parameter to Status.java

* Add testing for getStatus()

* Add clear doc of why the logic is valid.

* Revert "Add explicit order parameter to Status.java"

This reverts commit 0a0f90f89ceb497b7a3ac69380b329c0820342ef.

* Explicitly handle all expected states.

* PMD fix

* Clarify comments