### PR TITLE
[INFINITY-2320] Skip task log collection in soak environment.

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -87,6 +87,10 @@ def get_rotating_task_log_lines(task_id: str, task_file: str):
 
 
 def get_task_logs_on_failure(test_name: str):
+    if os.environ.has_key("SOAK_SERVICE_NAME"):
+        # If running in soak, fetching all task logs doesn't really work.
+        log.info('Skipping log collection in soak environment.')
+        return
     for task_id in get_task_ids():
         for task_file in ('stderr', 'stdout'):
             for log_filename, log_lines in get_rotating_task_log_lines(task_id, task_file):


### PR DESCRIPTION
We use the continuous integration py.test setup in soak to run some tests.
When these fail in continuous integration, we collect all the cluster logs,
since they're all likely relevant to the failure.

In a soak cluster, however, there are a large (~20) frameworks and marathon
apps running, as well as many metronome jobs etc, most of which are not even
related to infinity, let alone the failure at hand.  Collecting all these
logs causes cascading failures with test failures taking longer than the
periodicity of the test execution.