### PR TITLE
[INFINITY-2384] PlansResource should log parameters on plan start.

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/api/PlansResource.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/api/PlansResource.java
@@ -110,7 +110,13 @@ public class PlansResource extends PrettyJsonResource {
             }
 
             plan.proceed();
-            return jsonOkResponse(getCommandResult("start"));
+
+            logger.info("Started plan {} with parameters {} by user request", planName, parameters);
+
+            return jsonOkResponse(getCommandResult(String.format("%s %s with parameters: %s",
+                    "start",
+                    planName,
+                    parameters.toString())));
         } else {
             return elementNotFoundResponse();
         }


### PR DESCRIPTION
Log the parameters supplied in start, and also return them in feedback to the user.

The CLI receives:
```
Mesospheres-MacBook-Pro-2:dcos-commons benwood$ dcos beta-cassandra --name=cassandra plan start backup-s3 -p TEST0=BANANA -p TEST1=PIE
{
  "message": "Received cmd: start backup-s3 with parameters: {TEST0=BANANA, TEST1=PIE}"
}
```

The scheduler logs show:
```
INFO  2017-09-08 02:37:42,184 [qtp202217792-38] com.mesosphere.sdk.api.PlansResource:startPlan(114): Started plan backup-s3 with parameters {TEST0=BANANA, TEST1=PIE} by user request
```