### PR TITLE
Decouple plan execution from the offer cycle

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/AbstractScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/AbstractScheduler.java
@@ -43,6 +43,7 @@ public abstract class AbstractScheduler implements Scheduler {
 
     private Object inProgressLock = new Object();
     private Set<Protos.OfferID> offersInProgress = new HashSet<>();
+    private AtomicBoolean processingOffers = new AtomicBoolean(false);
 
     /**
      * Executor for handling TaskStatus updates in {@link #statusUpdate(SchedulerDriver, Protos.TaskStatus)}.
@@ -50,7 +51,7 @@ public abstract class AbstractScheduler implements Scheduler {
     protected final ExecutorService statusExecutor = Executors.newSingleThreadExecutor();
 
     /**
-     * Executor for processing offers off the queue in {@code processOffers()}.
+     * Executor for processing offers off the queue in {@link #executePlansLoop()}.
      */
     private final ExecutorService offerExecutor = Executors.newSingleThreadExecutor();
 
@@ -60,7 +61,6 @@ public abstract class AbstractScheduler implements Scheduler {
     protected AbstractScheduler(StateStore stateStore, ConfigStore<ServiceSpec> configStore) {
         this.stateStore = stateStore;
         this.configStore = configStore;
-        processOffers();
     }
 
     @Override
@@ -93,16 +93,19 @@ public abstract class AbstractScheduler implements Scheduler {
         postRegister();
     }
 
-    private void processOffers() {
+    /**
+     * This method starts the main execution thread for the scheduler.  It drives the execution of plans including
+     * providing offers.
+     */
+    private void executePlansLoop() {
         offerExecutor.execute(() -> {
             while (true) {
-                // This is a blocking call which pulls as many elements from the offer queue as possible.
                 List<Protos.Offer> offers = offerQueue.takeAll();
                 LOGGER.info("Processing {} offer{}:", offers.size(), offers.size() == 1 ? "" : "s");
                 for (int i = 0; i < offers.size(); ++i) {
                     LOGGER.info("  {}: {}", i + 1, TextFormat.shortDebugString(offers.get(i)));
                 }
-                processOfferSet(offers);
+                executePlans(offers);
                 offers.forEach(offer -> eventBus.post(offer));
                 synchronized (inProgressLock) {
                     offersInProgress.removeAll(
@@ -230,9 +233,17 @@ public abstract class AbstractScheduler implements Scheduler {
         SchedulerUtils.hardExit(SchedulerErrorCode.ERROR);
     }
 
+    /**
+     * Registration can occur multiple times in a scheduler's lifecycle via both
+     * {@link Scheduler#registered(SchedulerDriver, Protos.FrameworkID, Protos.MasterInfo)} and
+     * {@link Scheduler#reregistered(SchedulerDriver, Protos.MasterInfo)} calls.
+     */
     protected void postRegister() {
+        // Task reconciliation should be started on all registrations.
         reconciler.start();
         reconciler.reconcile(driver);
+
+        // A SuppressReviveManager should be constructed only once.
         if (suppressReviveManager == null) {
             suppressReviveManager = new SuppressReviveManager(
                     stateStore,
@@ -243,13 +254,21 @@ public abstract class AbstractScheduler implements Scheduler {
         }
 
         suppressReviveManager.start();
+
+        // The main plan execution loop should only be started once.
+        if (processingOffers.compareAndSet(false, true)) {
+            executePlansLoop();
+        }
     }
 
     protected abstract void initialize(SchedulerDriver driver) throws InterruptedException;
 
     protected abstract boolean apiServerReady();
 
-    protected abstract void processOfferSet(List<Protos.Offer> offers);
+    /**
+     * The abstract scheduler will periodically call this method with a list of available offers, which may be empty.
+     */
+    protected abstract void executePlans(List<Protos.Offer> offers);
 
     protected abstract Collection<PlanManager> getPlanManagers();
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/DefaultScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/DefaultScheduler.java
@@ -722,7 +722,7 @@ public class DefaultScheduler extends AbstractScheduler {
         }
     }
 
-    protected void processOfferSet(List<Protos.Offer> offers) {
+    protected void executePlans(List<Protos.Offer> offers) {
         List<Protos.Offer> localOffers = new ArrayList<>(offers);
 
         // Coordinate amongst all the plans via PlanCoordinator.

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/OfferQueue.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/OfferQueue.java
@@ -5,11 +5,13 @@ import org.apache.mesos.Protos;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.Duration;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 /**
@@ -17,6 +19,7 @@ import java.util.stream.Collectors;
  */
 public class OfferQueue {
     private static final int DEFAULT_CAPACITY = 100;
+    private static final Duration DEFAULT_OFFER_WAIT = Duration.ofSeconds(5);
     private final Logger logger = LoggerFactory.getLogger(getClass());
     private final BlockingQueue<Protos.Offer> queue;
 
@@ -29,21 +32,34 @@ public class OfferQueue {
     }
 
     /**
-     * Calling this method is a blocking Operation. It returns all Offers currently in the queue. It always returns at
-     * least one Offer.
+     * Calling this method will wait for Offers for the provided duration.
+     * It returns all Offers currently in the queue if any are present and none otherwise.
      */
-    public List<Protos.Offer> takeAll() {
+    public List<Protos.Offer> takeAll(Duration duration) {
         List<Protos.Offer> offers = new LinkedList<>();
         try {
-            // The take() call is blocking, so waits for at least one Offer is returned.  The following drainTo() call
-            // will pull the remainder of Offers (including zero Offers) off the queue and return.
-            offers.add(queue.take());
+            // The poll() waits for one Offer or returns null if none is present within the timeout.  The following
+            // drainTo() call will pull the remainding of Offers (including zero Offers) off the queue and return.
+            Protos.Offer offer = queue.poll(duration.getSeconds(), TimeUnit.SECONDS);
+            if (offer != null) {
+                offers.add(offer);
+            }
+
             queue.drainTo(offers);
         } catch (InterruptedException e) {
             logger.warn("Interrupted while waiting for offer in queue.");
         }
 
         return offers;
+    }
+
+    /**
+     * Calling this method will wait for Offers for a static duration of {@link OfferQueue#DEFAULT_CAPACITY}.
+     * It returns all Offers currently in the queue if any are present and an empty list if the duration
+     * of {@link OfferQueue#DEFAULT_OFFER_WAIT} is reached.
+     */
+    public List<Protos.Offer> takeAll() {
+        return takeAll(DEFAULT_OFFER_WAIT);
     }
 
     /**

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/uninstall/UninstallScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/uninstall/UninstallScheduler.java
@@ -90,7 +90,7 @@ public class UninstallScheduler extends AbstractScheduler {
     }
 
     @Override
-    protected void processOfferSet(List<Protos.Offer> offers) {
+    protected void executePlans(List<Protos.Offer> offers) {
         List<Protos.Offer> localOffers = new ArrayList<>(offers);
         // Get candidate steps to be scheduled
         Collection<? extends Step> candidateSteps = uninstallPlanManager.getCandidates(Collections.emptyList());

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/OfferQueueTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/OfferQueueTest.java
@@ -5,6 +5,7 @@ import org.apache.mesos.Protos;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.UUID;
 
@@ -117,6 +118,13 @@ public class OfferQueueTest {
         offerQueue.remove(TestConstants.OFFER_ID);
         // Expect capacity to increase by one as we've removed one known offer
         Assert.assertEquals(remainingCapacity + 1, offerQueue.getRemainingCapacity());
+    }
+
+    @Test
+    public void testGetNoOffers() {
+        OfferQueue offerQueue = new OfferQueue();
+        List<Protos.Offer> offers = offerQueue.takeAll(Duration.ZERO);
+        Assert.assertTrue(offers.isEmpty());
     }
 
     private Protos.Offer getOffer() {


### PR DESCRIPTION
The work represented by plans is not solely accomplished by the consumption of offers.  In particular the leaf element of plans, a step, can return an `Optional<PodInstanceRequirement>` when it is started.

The execution of plans is today driven by the presence or absence of offers, however logically when no work requiring offers is present the scheduler should suppress offers.  However steps which do not require offers should still be processed.

In this change, we now no longer block plan execution on waiting for offers.  If offers are present they are consumed otherwise plan execution continues without them.

This is a pre-requisite for #1578 