### PR TITLE
[DOCS-2102] Align ordering of all Mag7 docs

### DIFF
--- a/frameworks/cassandra/docs/api-reference.md
+++ b/frameworks/cassandra/docs/api-reference.md
@@ -1,7 +1,6 @@
 ---
 post_title: API Reference
 menu_order: 70
-feature_maturity: preview
 enterprise: 'no'
 ---
 

--- a/frameworks/cassandra/docs/cassandra-settings.md
+++ b/frameworks/cassandra/docs/cassandra-settings.md
@@ -3,7 +3,6 @@ post_title: Cassandra Settings
 nav_title: Cassandra Settings
 menu_order: 24
 post_excerpt: ""
-feature_maturity: preview
 enterprise: 'no'
 ---
 

--- a/frameworks/cassandra/docs/connecting-clients.md
+++ b/frameworks/cassandra/docs/connecting-clients.md
@@ -3,7 +3,6 @@ post_title: Connecting Clients
 nav_title: Connecting Clients
 menu_order: 50
 post_excerpt: ""
-feature_maturity: preview
 enterprise: 'no'
 ---
 

--- a/frameworks/cassandra/docs/disaster-recovery.md
+++ b/frameworks/cassandra/docs/disaster-recovery.md
@@ -3,7 +3,6 @@ post_title: Disaster Recovery
 nav_title: Disaster Recovery
 menu_order: 80
 post_excerpt: ""
-feature_maturity: preview
 enterprise: 'no'
 ---
 

--- a/frameworks/cassandra/docs/index.md
+++ b/frameworks/cassandra/docs/index.md
@@ -2,7 +2,6 @@
 post_title: Overview
 menu_order: 10
 post_excerpt: ""
-feature_maturity: preview
 enterprise: 'no'
 ---
 

--- a/frameworks/cassandra/docs/install.md
+++ b/frameworks/cassandra/docs/install.md
@@ -3,7 +3,6 @@ post_title: Installing and Customizing
 nav_title: Installing and Customizing
 menu_order: 20
 post_excerpt: ""
-feature_maturity: preview
 enterprise: 'no'
 ---
 

--- a/frameworks/cassandra/docs/limitations.md
+++ b/frameworks/cassandra/docs/limitations.md
@@ -1,6 +1,6 @@
 ---
 post_title: Limitations
-menu_order: 80
+menu_order: 100
 enterprise: 'no'
 ---
 

--- a/frameworks/cassandra/docs/managing.md
+++ b/frameworks/cassandra/docs/managing.md
@@ -3,7 +3,6 @@ post_title: Managing
 nav_title: Managing
 menu_order: 60
 post_excerpt: ""
-feature_maturity: preview
 enterprise: 'no'
 ---
 

--- a/frameworks/cassandra/docs/node-settings.md
+++ b/frameworks/cassandra/docs/node-settings.md
@@ -3,7 +3,6 @@ post_title: Node Settings
 nav_title: Node Settings
 menu_order: 27
 post_excerpt: ""
-feature_maturity: preview
 enterprise: 'no'
 ---
 

--- a/frameworks/cassandra/docs/quick-start.md
+++ b/frameworks/cassandra/docs/quick-start.md
@@ -3,7 +3,6 @@ post_title: Quick Start
 nav_title: Quick Start
 menu_order: 40
 post_excerpt: ""
-feature_maturity: preview
 enterprise: 'no'
 ---
 

--- a/frameworks/cassandra/docs/release-notes.md
+++ b/frameworks/cassandra/docs/release-notes.md
@@ -1,6 +1,6 @@
 ---
 post_title: Release Notes
-menu_order: 40
+menu_order: 120
 enterprise: 'no'
 ---
 

--- a/frameworks/cassandra/docs/service-settings.md
+++ b/frameworks/cassandra/docs/service-settings.md
@@ -3,7 +3,6 @@ post_title: Service Settings
 nav_title: Service Settings
 menu_order: 21
 post_excerpt: ""
-feature_maturity: preview
 enterprise: 'no'
 ---
 

--- a/frameworks/cassandra/docs/support.md
+++ b/frameworks/cassandra/docs/support.md
@@ -3,7 +3,6 @@ post_title: Supported Versions
 nav_title: Supported Versions
 menu_order: 110
 post_excerpt: ""
-feature_maturity: preview
 enterprise: 'no'
 ---
 

--- a/frameworks/cassandra/docs/troubleshooting.md
+++ b/frameworks/cassandra/docs/troubleshooting.md
@@ -3,7 +3,6 @@ post_title: Troubleshooting
 nav_title: Troubleshooting
 menu_order: 90
 post_excerpt: ""
-feature_maturity: preview
 enterprise: 'no'
 ---
 

--- a/frameworks/cassandra/docs/uninstall.md
+++ b/frameworks/cassandra/docs/uninstall.md
@@ -1,7 +1,6 @@
 ---
 post_title: Uninstall
 menu_order: 30
-feature_maturity: preview
 enterprise: 'no'
 ---
 

--- a/frameworks/cassandra/docs/upgrade.md
+++ b/frameworks/cassandra/docs/upgrade.md
@@ -1,7 +1,6 @@
 ---
 post_title: Upgrade
 menu_order: 130
-feature_maturity: preview
 enterprise: 'no'
 ---
 

--- a/frameworks/elastic/docs/api-reference.md
+++ b/frameworks/elastic/docs/api-reference.md
@@ -1,7 +1,6 @@
 ---
 post_title: API Reference
 menu_order: 70
-feature_maturity: preview
 enterprise: 'no'
 ---
 

--- a/frameworks/elastic/docs/connecting-clients.md
+++ b/frameworks/elastic/docs/connecting-clients.md
@@ -1,7 +1,6 @@
 ---
 post_title: Connecting Clients
 menu_order: 50
-feature_maturity: preview
 enterprise: 'no'
 ---
 

--- a/frameworks/elastic/docs/disaster-recovery.md
+++ b/frameworks/elastic/docs/disaster-recovery.md
@@ -1,7 +1,6 @@
 ---
 post_title: Disaster Recovery
 menu_order: 80
-feature_maturity: preview
 enterprise: 'no'
 ---
 

--- a/frameworks/elastic/docs/elastic-x-pack.md
+++ b/frameworks/elastic/docs/elastic-x-pack.md
@@ -1,7 +1,6 @@
 ---
 post_title: X-Pack
 menu_order: 21
-feature_maturity: preview
 enterprise: 'no'
 ---
 

--- a/frameworks/elastic/docs/index.md
+++ b/frameworks/elastic/docs/index.md
@@ -2,7 +2,6 @@
 post_title: Version 1.0.8-5.2.2
 menu_order: 10
 post_excerpt: ""
-feature_maturity: preview
 enterprise: 'no'
 ---
 

--- a/frameworks/elastic/docs/install.md
+++ b/frameworks/elastic/docs/install.md
@@ -1,7 +1,6 @@
 ---
 post_title: Install and Customize
 menu_order: 20
-feature_maturity: preview
 enterprise: 'no'
 ---
 

--- a/frameworks/elastic/docs/limitations.md
+++ b/frameworks/elastic/docs/limitations.md
@@ -1,6 +1,6 @@
 ---
 post_title: Limitations
-menu_order: 50
+menu_order: 100
 enterprise: 'no'
 ---
 

--- a/frameworks/elastic/docs/managing.md
+++ b/frameworks/elastic/docs/managing.md
@@ -1,7 +1,6 @@
 ---
 post_title: Managing
 menu_order: 60
-feature_maturity: preview
 enterprise: 'no'
 ---
 

--- a/frameworks/elastic/docs/quick-start.md
+++ b/frameworks/elastic/docs/quick-start.md
@@ -1,7 +1,6 @@
 ---
 post_title: Quick Start
 menu_order: 40
-feature_maturity: preview
 enterprise: 'no'
 ---
 

--- a/frameworks/elastic/docs/release-notes.md
+++ b/frameworks/elastic/docs/release-notes.md
@@ -1,6 +1,6 @@
 ---
 post_title: Release Notes
-menu_order: 40
+menu_order: 120
 enterprise: 'no'
 ---
 

--- a/frameworks/elastic/docs/support.md
+++ b/frameworks/elastic/docs/support.md
@@ -3,7 +3,6 @@ post_title: Supported Versions
 nav_title: Supported Versions
 menu_order: 110
 post_excerpt: ""
-feature_maturity: preview
 enterprise: 'no'
 ---
 

--- a/frameworks/elastic/docs/troubleshooting.md
+++ b/frameworks/elastic/docs/troubleshooting.md
@@ -1,7 +1,6 @@
 ---
 post_title: Troubleshooting
 menu_order: 90
-feature_maturity: preview
 enterprise: 'no'
 ---
 

--- a/frameworks/elastic/docs/uninstall.md
+++ b/frameworks/elastic/docs/uninstall.md
@@ -1,7 +1,6 @@
 ---
 post_title: Uninstall
 menu_order: 30
-feature_maturity: preview
 enterprise: 'no'
 ---
 

--- a/frameworks/elastic/docs/upgrade.md
+++ b/frameworks/elastic/docs/upgrade.md
@@ -1,7 +1,6 @@
 ---
 post_title: Upgrade
 menu_order: 130
-feature_maturity: preview
 enterprise: 'no'
 ---
 

--- a/frameworks/hdfs/docs/api-reference.md
+++ b/frameworks/hdfs/docs/api-reference.md
@@ -1,7 +1,6 @@
 ---
 post_title: API Reference
 menu_order: 70
-feature_maturity: preview
 enterprise: 'no'
 ---
 

--- a/frameworks/hdfs/docs/connecting-clients.md
+++ b/frameworks/hdfs/docs/connecting-clients.md
@@ -1,7 +1,6 @@
 ---
 post_title: Connecting Clients
 menu_order: 50
-feature_maturity: preview
 enterprise: 'no'
 ---
 

--- a/frameworks/hdfs/docs/index.md
+++ b/frameworks/hdfs/docs/index.md
@@ -2,7 +2,6 @@
 post_title: Version HDFS_1.3.0-2.6.0-cdh5.9.1
 menu_order: 10
 post_excerpt: ""
-feature_maturity: preview
 enterprise: 'no'
 ---
 

--- a/frameworks/hdfs/docs/install.md
+++ b/frameworks/hdfs/docs/install.md
@@ -1,7 +1,6 @@
 ---
 post_title: Install and Customize
 menu_order: 20
-feature_maturity: preview
 enterprise: 'no'
 ---
 

--- a/frameworks/hdfs/docs/limitations.md
+++ b/frameworks/hdfs/docs/limitations.md
@@ -1,6 +1,6 @@
 ---
 post_title: Limitations
-menu_order: 50
+menu_order: 100
 enterprise: 'no'
 ---
 

--- a/frameworks/hdfs/docs/managing.md
+++ b/frameworks/hdfs/docs/managing.md
@@ -1,7 +1,6 @@
 ---
 post_title: Managing
 menu_order: 60
-feature_maturity: preview
 enterprise: 'no'
 ---
 

--- a/frameworks/hdfs/docs/quick-start.md
+++ b/frameworks/hdfs/docs/quick-start.md
@@ -1,7 +1,6 @@
 ---
 post_title: Quickstart
 menu_order: 40
-feature_maturity: experimental
 enterprise: 'no'
 ---
 

--- a/frameworks/hdfs/docs/release-notes.md
+++ b/frameworks/hdfs/docs/release-notes.md
@@ -1,6 +1,6 @@
 ---
 post_title: Release Notes
-menu_order: 40
+menu_order: 120
 enterprise: 'no'
 ---
 

--- a/frameworks/hdfs/docs/support.md
+++ b/frameworks/hdfs/docs/support.md
@@ -3,7 +3,6 @@ post_title: Supported Versions
 nav_title: Supported Versions
 menu_order: 110
 post_excerpt: ""
-feature_maturity: preview
 enterprise: 'no'
 ---
 

--- a/frameworks/hdfs/docs/troubleshooting.md
+++ b/frameworks/hdfs/docs/troubleshooting.md
@@ -1,7 +1,6 @@
 ---
 post_title: Troubleshooting
 menu_order: 90
-feature_maturity: preview
 enterprise: 'no'
 ---
 

--- a/frameworks/hdfs/docs/uninstall.md
+++ b/frameworks/hdfs/docs/uninstall.md
@@ -1,7 +1,6 @@
 ---
 post_title: Uninstall
 menu_order: 30
-feature_maturity: preview
 enterprise: 'no'
 ---
 

--- a/frameworks/hdfs/docs/upgrade.md
+++ b/frameworks/hdfs/docs/upgrade.md
@@ -1,7 +1,6 @@
 ---
 post_title: Upgrade
 menu_order: 130
-feature_maturity: preview
 enterprise: 'no'
 ---
 

--- a/frameworks/kafka/docs/api-reference.md
+++ b/frameworks/kafka/docs/api-reference.md
@@ -1,7 +1,6 @@
 ---
 post_title: API Reference
 menu_order: 70
-feature_maturity: preview
 enterprise: 'no'
 ---
 

--- a/frameworks/kafka/docs/connecting-clients.md
+++ b/frameworks/kafka/docs/connecting-clients.md
@@ -1,7 +1,6 @@
 ---
 post_title: Connecting Clients
 menu_order: 50
-feature_maturity: preview
 enterprise: 'no'
 ---
 

--- a/frameworks/kafka/docs/index.md
+++ b/frameworks/kafka/docs/index.md
@@ -1,7 +1,6 @@
 ---
 post_title: Kafka
 menu_order: 10
-feature_maturity: preview
 enterprise: 'no'
 ---
 

--- a/frameworks/kafka/docs/install.md
+++ b/frameworks/kafka/docs/install.md
@@ -1,7 +1,6 @@
 ---
 post_title: Install and Customize
 menu_order: 20
-feature_maturity: preview
 enterprise: 'no'
 ---
 

--- a/frameworks/kafka/docs/limitations.md
+++ b/frameworks/kafka/docs/limitations.md
@@ -1,6 +1,6 @@
 ---
 post_title: Limitations
-menu_order: 80
+menu_order: 100
 enterprise: 'no'
 ---
 

--- a/frameworks/kafka/docs/managing.md
+++ b/frameworks/kafka/docs/managing.md
@@ -1,7 +1,6 @@
 ---
 post_title: Managing
 menu_order: 60
-feature_maturity: preview
 enterprise: 'no'
 ---
 # Updating Configuration

--- a/frameworks/kafka/docs/quick-start.md
+++ b/frameworks/kafka/docs/quick-start.md
@@ -1,7 +1,6 @@
 ---
 post_title: Quick Start
 menu_order: 40
-feature_maturity: preview
 enterprise: 'no'
 ---
 

--- a/frameworks/kafka/docs/release-notes.md
+++ b/frameworks/kafka/docs/release-notes.md
@@ -1,6 +1,6 @@
 ---
 post_title: Release Notes
-menu_order: 40
+menu_order: 120
 enterprise: 'no'
 ---
 

--- a/frameworks/kafka/docs/support.md
+++ b/frameworks/kafka/docs/support.md
@@ -1,7 +1,6 @@
 ---
 post_title: Supported Versions
 menu_order: 110
-feature_maturity: preview
 enterprise: 'no'
 ---
 

--- a/frameworks/kafka/docs/troubleshooting.md
+++ b/frameworks/kafka/docs/troubleshooting.md
@@ -1,7 +1,6 @@
 ---
 post_title: Troubleshooting
 menu_order: 90
-feature_maturity: preview
 enterprise: 'no'
 ---
 

--- a/frameworks/kafka/docs/uninstall.md
+++ b/frameworks/kafka/docs/uninstall.md
@@ -1,7 +1,6 @@
 ---
 post_title: Uninstall
 menu_order: 30
-feature_maturity: preview
 enterprise: 'no'
 ---
 

--- a/frameworks/kafka/docs/upgrade.md
+++ b/frameworks/kafka/docs/upgrade.md
@@ -1,7 +1,6 @@
 ---
 post_title: Upgrade
 menu_order: 130
-feature_maturity: preview
 enterprise: 'no'
 ---
 


### PR DESCRIPTION
* Reapply layout following master->0.30.X backports.
  * Ensure `menu_order` matches new 1.10 layout.
  * Ensure `feature_maturity` field is removed.
  * Ensure no `beta-` present.