### PR TITLE
[KAF-374] Fix test_availability env variable consistency

### DIFF
--- a/frameworks/kafka/tests/test_availability.py
+++ b/frameworks/kafka/tests/test_availability.py
@@ -22,7 +22,7 @@ STARTUP_POLL_DELAY_SECONDS = os.environ.get('STARTUP_LOG_POLL_DELAY', 2)
 def setup_module(module):
     options = {
         "brokers": {
-            "kill_grace_period": BROKERS_KILL_GRACE_PERIOD
+            "kill_grace_period": BROKER_KILL_GRACE_PERIOD
         }
     }
 
@@ -40,7 +40,6 @@ def teardown_module(module):
     sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
 
 
-@pytest.mark.paegun
 @pytest.mark.availability
 @pytest.mark.soak_availability
 @sdk_utils.dcos_1_9_or_higher

--- a/frameworks/kafka/tests/test_availability.py
+++ b/frameworks/kafka/tests/test_availability.py
@@ -58,11 +58,12 @@ def test_service_startup_rapid():
     stdout = ''
     retries = 15
     while retries > 0:
+        retries -= 1
         stdout = sdk_cmd.svc_cli(config.PACKAGE_NAME, config.SERVICE_NAME, 'topic producer_test test 100')
         if 'records sent' in stdout:
             break
 
-    jsonobj = sdk_cmd.svc_cli(config.PACKAGE_NAME, config.SERVICE_NAME, 'pods restart {}'.format(task_short_name), json=True)
+    jsonobj = sdk_cmd.svc_cli(config.PACKAGE_NAME, config.SERVICE_NAME, 'pod restart {}'.format(task_short_name), json=True)
     assert len(jsonobj) == 2
     assert jsonobj['pod'] == task_short_name
     assert jsonobj['tasks'] == [ '{}-broker'.format(task_short_name) ]


### PR DESCRIPTION
* Make env variable name consistent BROKER_KILL_GRACE_PERIOD.
* Remove errant personal pytest mark.

backport PR #1611 