### PR TITLE
[INFINITY-2408] Fix HDFS test_sanity - tasks updated detection

### DIFF
--- a/frameworks/hdfs/tests/test_sanity.py
+++ b/frameworks/hdfs/tests/test_sanity.py
@@ -284,6 +284,7 @@ def test_modify_app_config():
     app_config_field = 'TASKCFG_ALL_CLIENT_READ_SHORTCIRCUIT_STREAMS_CACHE_SIZE_EXPIRY_MS'
     journal_ids = sdk_tasks.get_task_ids(foldered_name, 'journal')
     name_ids = sdk_tasks.get_task_ids(foldered_name, 'name')
+    data_ids = sdk_tasks.get_task_ids(foldered_name, 'data')
 
     marathon_config = sdk_marathon.get_config(foldered_name)
     log.info('marathon config: ')
@@ -296,7 +297,7 @@ def test_modify_app_config():
     config.check_healthy(service_name=foldered_name)
     sdk_tasks.check_tasks_updated(foldered_name, 'journal', journal_ids)
     sdk_tasks.check_tasks_updated(foldered_name, 'name', name_ids)
-    sdk_tasks.check_tasks_updated(foldered_name, 'data', journal_ids)
+    sdk_tasks.check_tasks_updated(foldered_name, 'data', data_ids)
 
     sdk_plan.wait_for_completed_recovery(foldered_name)
     new_recovery_plan = sdk_plan.get_plan(foldered_name, "recovery")

--- a/frameworks/kafka/cli/dcos-kafka/.gitignore
+++ b/frameworks/kafka/cli/dcos-kafka/.gitignore
@@ -1,4 +1,4 @@
-dcos-kafka*
+dcos-*
 *.whl
 native-*
 .native-*

--- a/testing/sdk_tasks.py
+++ b/testing/sdk_tasks.py
@@ -47,6 +47,9 @@ def get_task_ids(service_name, task_prefix):
 
 
 def check_tasks_updated(service_name, prefix, old_task_ids, timeout_seconds=DEFAULT_TIMEOUT_SECONDS):
+    # TODO: strongly consider merging the use of checking that tasks have been replaced (this method)
+    # and checking that the deploy/upgrade/repair plan has completed. Each serves a part in the bigger
+    # atomic test, that the plan completed properly where properly includes that no old tasks remain.
     def fn():
         try:
             task_ids = get_task_ids(service_name, prefix)
@@ -66,7 +69,7 @@ def check_tasks_updated(service_name, prefix, old_task_ids, timeout_seconds=DEFA
         # deploy/recovery/whatever plan, not task cardinality, but some uses of this method are not
         # using the plan, so not the definitive source, so will fail when the finished state of a
         # plan yields more or less tasks per pod.
-        all_updated = len(newly_launched_set) == len(new_set) and len(old_remaining_set) == 0 and len(old_set) == len(new_set)
+        all_updated = len(newly_launched_set) == len(new_set) and len(old_remaining_set) == 0 and len(new_set) >= len(old_set)
         if all_updated:
             log.info('All of the tasks{} have updated\n- Old tasks: {}\n- New tasks: {}'.format(
                 prefix_clause,

--- a/testing/sdk_tasks.py
+++ b/testing/sdk_tasks.py
@@ -62,8 +62,16 @@ def check_tasks_updated(service_name, prefix, old_task_ids, timeout_seconds=DEFA
         new_set = set(task_ids)
         newly_launched_set = new_set.difference(old_set)
         old_remaining_set = old_set.intersection(new_set)
-        all_updated = len(newly_launched_set) == len(new_set) and len(old_remaining_set) == 0
+        # the constrainst of old and new task cardinality match should be covered by completion of
+        # deploy/recovery/whatever plan, not task cardinality, but some uses of this method are not
+        # using the plan, so not the definitive source, so will fail when the finished state of a
+        # plan yields more or less tasks per pod.
+        all_updated = len(newly_launched_set) == len(new_set) and len(old_remaining_set) == 0 and len(old_set) == len(new_set)
         if all_updated:
+            log.info('All of the tasks{} have updated\n- Old tasks: {}\n- New tasks: {}'.format(
+                prefix_clause,
+                old_set,
+                new_set))
             return all_updated
 
         # forgive the language a bit, but len('remained') == len('launched'),

--- a/testing/sdk_tasks.py
+++ b/testing/sdk_tasks.py
@@ -60,8 +60,9 @@ def check_tasks_updated(service_name, prefix, old_task_ids, timeout_seconds=DEFA
 
         old_set = set(old_task_ids)
         new_set = set(task_ids)
-        newly_launched_set = (new_set - old_set)
-        all_updated = len(newly_launched_set) == len(new_set)
+        newly_launched_set = new_set.difference(old_set)
+        old_remaining_set = old_set.intersection(new_set)
+        all_updated = len(newly_launched_set) == len(new_set) and len(old_remaining_set) == 0
         if all_updated:
             return all_updated
 
@@ -70,7 +71,7 @@ def check_tasks_updated(service_name, prefix, old_task_ids, timeout_seconds=DEFA
         # so makes for easier reading
         log.info('Waiting for tasks{} to have updated ids:\n- Old tasks (remained): {}\n- New tasks (launched): {}'.format(
             prefix_clause,
-            old_set & new_set,
+            old_remaining_set,
             newly_launched_set))
 
     shakedown.wait_for(lambda: fn(), noisy=True, timeout_seconds=timeout_seconds)


### PR DESCRIPTION
* Fix HDFS test_sanity.test_modify_app_config, send proper task
  prefixes.
* Improve tasks updated detection, not yet reconciled log line to
  use set methods to report the intersection and difference instead
  of iteration.

Unrelated, but discovered:
* Fix .gitignore for Kafka to match pattern used in other services.