### PR TITLE
Implement multi-disk sending support through the framework

### DIFF
--- a/frameworks/helloworld/src/main/java/com/mesosphere/sdk/helloworld/scheduler/Main.java
+++ b/frameworks/helloworld/src/main/java/com/mesosphere/sdk/helloworld/scheduler/Main.java
@@ -42,7 +42,7 @@ public class Main {
                                             .id("hello-resources")
                                             .cpus(CPUS)
                                             .memory(256.0)
-                                            .addVolume("ROOT", 5000.0, "hello-container-path")
+                                            .addVolume("ROOT", 5000.0, "", "hello-container-path")
                                             .build()).build()).build()).build(),
                     schedulerFlags,
                     Collections.emptyList())

--- a/sdk/common/src/main/java/com/mesosphere/sdk/testutils/TestConstants.java
+++ b/sdk/common/src/main/java/com/mesosphere/sdk/testutils/TestConstants.java
@@ -16,6 +16,7 @@ public class TestConstants {
     public static final String HOSTNAME = "test-hostname";
     public static final String OVERLAY_HOSTNAME = "overlay-hostname";
     public static final String MOUNT_ROOT = "test-mount-root";
+    public static final String PATH_ROOT = "test-mount-root";
     public static final Protos.OfferID OFFER_ID = Protos.OfferID.newBuilder().setValue("test-offer-id").build();
     public static final String PERSISTENCE_ID = "test-persistence-id";
     public static final String PRINCIPAL = "test-principal";

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/MesosResource.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/MesosResource.java
@@ -29,6 +29,13 @@ public class MesosResource {
             && resource.getDisk().getSource().getType().equals(Source.Type.MOUNT);
     }
 
+    public boolean isSharedNamed() {
+        return resource.hasDisk()
+                && resource.getDisk().hasSource()
+                && resource.getDisk().getSource().getType().equals(Source.Type.PATH);
+    }
+
+
     public String getName() {
         return resource.getName();
     }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/ResourceUtils.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/ResourceUtils.java
@@ -116,7 +116,11 @@ public class ResourceUtils {
 
     public static Optional<String> getSourceRoot(Resource resource) {
         if (resource.hasDisk() && resource.getDisk().hasSource()) {
-            return Optional.of(resource.getDisk().getSource().getMount().getRoot());
+            if (resource.getDisk().getSource().hasMount()) {
+                return Optional.of(resource.getDisk().getSource().getMount().getRoot());
+            } else {
+                return Optional.of(resource.getDisk().getSource().getPath().getRoot());
+            }
         }
 
         return Optional.empty();

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultResourceSet.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultResourceSet.java
@@ -173,6 +173,7 @@ public class DefaultResourceSet implements ResourceSet {
 
         public Builder addVolume(String volumeType,
                                  Double size,
+                                 String rootPath,
                                  String containerPath) {
             VolumeSpec.Type volumeTypeEnum;
             try {
@@ -183,7 +184,7 @@ public class DefaultResourceSet implements ResourceSet {
                         volumeType, containerPath, Arrays.asList(VolumeSpec.Type.values())));
             }
             DefaultVolumeSpec volume =
-                    new DefaultVolumeSpec(size, volumeTypeEnum, containerPath, role, preReservedRole, principal);
+                    new DefaultVolumeSpec(size, volumeTypeEnum, rootPath, containerPath, role, preReservedRole, principal);
             if (volumes.stream()
                     .anyMatch(volumeSpecification ->
                             Objects.equals(volumeSpecification.getContainerPath(), containerPath))) {

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultVolumeSpec.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultVolumeSpec.java
@@ -30,16 +30,19 @@ public class DefaultVolumeSpec extends DefaultResourceSpec implements VolumeSpec
      */
     @Pattern(regexp = "[a-zA-Z0-9]+([a-zA-Z0-9_-]*)*")
     private final String containerPath;
+    private final String rootPath;
 
     public DefaultVolumeSpec(
             double diskSize,
             Type type,
+            String rootPath,
             String containerPath,
             String role,
             String preReservedRole,
             String principal) {
         this(
                 type,
+                rootPath,
                 containerPath,
                 Constants.DISK_RESOURCE_TYPE,
                 scalarValue(diskSize),
@@ -51,6 +54,7 @@ public class DefaultVolumeSpec extends DefaultResourceSpec implements VolumeSpec
     @JsonCreator
     private DefaultVolumeSpec(
             @JsonProperty("type") Type type,
+            @JsonProperty("root-path") String rootPath,
             @JsonProperty("container-path") String containerPath,
             @JsonProperty("name") String name,
             @JsonProperty("value") Protos.Value value,
@@ -59,6 +63,7 @@ public class DefaultVolumeSpec extends DefaultResourceSpec implements VolumeSpec
             @JsonProperty("principal")  String principal) {
         super(name, value, role, preReservedRole, principal);
         this.type = type;
+        this.rootPath = rootPath;
         this.containerPath = containerPath;
 
         ValidationUtils.validate(this);
@@ -67,6 +72,11 @@ public class DefaultVolumeSpec extends DefaultResourceSpec implements VolumeSpec
     @Override
     public Type getType() {
         return type;
+    }
+
+    @Override
+    public String getRootPath() {
+        return rootPath;
     }
 
     @Override

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/VolumeSpec.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/VolumeSpec.java
@@ -21,6 +21,9 @@ public interface VolumeSpec extends ResourceSpec {
     @JsonProperty("type")
     Type getType();
 
+    @JsonProperty("root-path")
+    String getRootPath();
+
     @JsonProperty("container-path")
     String getContainerPath();
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/RawVolume.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/RawVolume.java
@@ -7,17 +7,24 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  */
 public class RawVolume {
 
+    private final String root;
     private final String path;
     private final String type;
     private final int size;
 
     private RawVolume(
+            @JsonProperty("root") String root,
             @JsonProperty("path") String path,
             @JsonProperty("type") String type,
             @JsonProperty("size") int size) {
+        this.root = root;
         this.path = path;
         this.type = type;
         this.size = size;
+    }
+
+    public String getRoot() {
+        return root;
     }
 
     public String getPath() {

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/YAMLToInternalMappers.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/YAMLToInternalMappers.java
@@ -431,6 +431,7 @@ public class YAMLToInternalMappers {
                 resourceSetBuilder.addVolume(
                         rawVolume.getType(),
                         Double.valueOf(rawVolume.getSize()),
+                        rawVolume.getRoot(),
                         rawVolume.getPath());
             }
         }
@@ -438,6 +439,7 @@ public class YAMLToInternalMappers {
             resourceSetBuilder.addVolume(
                     rawSingleVolume.getType(),
                     Double.valueOf(rawSingleVolume.getSize()),
+                    rawSingleVolume.getRoot(),
                     rawSingleVolume.getPath());
         }
 
@@ -486,7 +488,14 @@ public class YAMLToInternalMappers {
         }
 
         return new DefaultVolumeSpec(
-                rawVolume.getSize(), volumeTypeEnum, rawVolume.getPath(), role, preReservedRole, principal);
+                rawVolume.getSize(),
+                volumeTypeEnum,
+                rawVolume.getRoot(),
+                rawVolume.getPath(),
+                role,
+                preReservedRole,
+                principal
+        );
     }
 
     private static DefaultNetworkSpec convertNetwork(

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/config/validate/TaskVolumesCannotChangeTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/config/validate/TaskVolumesCannotChangeTest.java
@@ -24,6 +24,7 @@ public class TaskVolumesCannotChangeTest {
     private static final VolumeSpec VOLUME1 = new DefaultVolumeSpec(
             DISK_SIZE_MB,
             VolumeSpec.Type.MOUNT,
+            "",
             "some_path",
             "role",
             "*",
@@ -31,6 +32,7 @@ public class TaskVolumesCannotChangeTest {
     private static final VolumeSpec VOLUME2 = new DefaultVolumeSpec(
             DISK_SIZE_MB + 3,
             VolumeSpec.Type.MOUNT,
+            "",
             "some_path",
             "role",
             "*",
@@ -38,6 +40,7 @@ public class TaskVolumesCannotChangeTest {
     private static final VolumeSpec VOLUME3 = new DefaultVolumeSpec(
             DISK_SIZE_MB,
             VolumeSpec.Type.ROOT,
+            "",
             "some_path",
             "role",
             "*",

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/config/validate/VerifyVolumePathTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/config/validate/VerifyVolumePathTest.java
@@ -14,55 +14,55 @@ public class VerifyVolumePathTest {
     @Test(expected = Exception.class)
     public void testVolumePathEmpty() {
         new DefaultVolumeSpec(
-                DISK_SIZE_MB, VolumeSpec.Type.MOUNT, "", "role", "*", "principal");
+                DISK_SIZE_MB, VolumeSpec.Type.MOUNT, "", "", "role", "*", "principal");
     }
 
     @Test(expected = Exception.class)
     public void testVolumePathBlank() {
         new DefaultVolumeSpec(
-                DISK_SIZE_MB, VolumeSpec.Type.MOUNT, " ", "role", "*", "principal");
+                DISK_SIZE_MB, VolumeSpec.Type.MOUNT, "", " ", "role", "*", "principal");
     }
 
     @Test(expected = Exception.class)
     public void testVolumePathSlash() {
         new DefaultVolumeSpec(
-                DISK_SIZE_MB, VolumeSpec.Type.MOUNT, "/path/to/volume0", "role", "*", "principal");
+                DISK_SIZE_MB, VolumeSpec.Type.MOUNT, "", "/path/to/volume0", "role", "*", "principal");
     }
 
     @Test(expected = Exception.class)
     public void testVolumePathChar() {
         new DefaultVolumeSpec(
-                DISK_SIZE_MB, VolumeSpec.Type.MOUNT, "@?test", "role", "*", "principal");
+                DISK_SIZE_MB, VolumeSpec.Type.MOUNT, "", "@?test", "role", "*", "principal");
     }
 
     @Test(expected = Exception.class)
     public void testVolumePathBeg() {
         new DefaultVolumeSpec(
-                DISK_SIZE_MB, VolumeSpec.Type.MOUNT, "-test", "role", "*", "principal");
+                DISK_SIZE_MB, VolumeSpec.Type.MOUNT, "", "-test", "role", "*", "principal");
     }
 
     @Test
     public void testVolumePathNumber() {
         new DefaultVolumeSpec(
-                DISK_SIZE_MB, VolumeSpec.Type.ROOT, "path-0_1-path", "role", "*", "principal");
+                DISK_SIZE_MB, VolumeSpec.Type.ROOT, "", "path-0_1-path", "role", "*", "principal");
     }
 
     @Test
     public void testVolumePathCorrect0() {
         new DefaultVolumeSpec(
-                DISK_SIZE_MB, VolumeSpec.Type.ROOT, "path", "role", "*", "principal");
+                DISK_SIZE_MB, VolumeSpec.Type.ROOT, "", "path", "role", "*", "principal");
     }
 
 
     @Test(expected = Exception.class)
     public void testVolumePathSlash1() {
         new DefaultVolumeSpec(
-                DISK_SIZE_MB, VolumeSpec.Type.ROOT, "path/path", "role", "*", "principal");
+                DISK_SIZE_MB, VolumeSpec.Type.ROOT, "", "path/path", "role", "*", "principal");
     }
 
     @Test(expected = Exception.class)
     public void testVolumePathSlash2() {
         new DefaultVolumeSpec(
-                DISK_SIZE_MB, VolumeSpec.Type.ROOT, "path-0/1-path", "role", "*", "principal");
+                DISK_SIZE_MB, VolumeSpec.Type.ROOT, "", "path-0/1-path", "role", "*", "principal");
     }
 }

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/ResourceBuilderTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/ResourceBuilderTest.java
@@ -166,6 +166,7 @@ public class ResourceBuilderTest extends DefaultCapabilitiesTestSuite {
         VolumeSpec volumeSpec = new DefaultVolumeSpec(
                 10,
                 VolumeSpec.Type.ROOT,
+                "",
                 TestConstants.CONTAINER_PATH,
                 TestConstants.ROLE,
                 Constants.ANY_ROLE,
@@ -224,6 +225,7 @@ public class ResourceBuilderTest extends DefaultCapabilitiesTestSuite {
         VolumeSpec volumeSpec = new DefaultVolumeSpec(
                 10,
                 VolumeSpec.Type.ROOT,
+                "",
                 TestConstants.CONTAINER_PATH,
                 TestConstants.ROLE,
                 Constants.ANY_ROLE,
@@ -263,6 +265,7 @@ public class ResourceBuilderTest extends DefaultCapabilitiesTestSuite {
         VolumeSpec volumeSpec = new DefaultVolumeSpec(
                 10,
                 VolumeSpec.Type.MOUNT,
+                "",
                 TestConstants.CONTAINER_PATH,
                 TestConstants.ROLE,
                 Constants.ANY_ROLE,
@@ -284,6 +287,35 @@ public class ResourceBuilderTest extends DefaultCapabilitiesTestSuite {
         Assert.assertTrue(source.hasMount());
         Assert.assertEquals(TestConstants.MOUNT_SOURCE_ROOT, source.getMount().getRoot());
     }
+
+    @Test
+    public void testNewFromPathVolumeSpec() {
+        VolumeSpec volumeSpec = new DefaultVolumeSpec(
+                10,
+                VolumeSpec.Type.PATH,
+                "/disk1",
+                TestConstants.CONTAINER_PATH,
+                TestConstants.ROLE,
+                Constants.ANY_ROLE,
+                TestConstants.PRINCIPAL);
+        ResourceBuilder resourceBuilder = ResourceBuilder.fromSpec(
+                volumeSpec,
+                Optional.empty(),
+                Optional.empty(),
+                Optional.of("/disk1"));
+
+        Protos.Resource resource = resourceBuilder.build();
+        validateScalarResoure(resource);
+        validateDisk(resource);
+
+        Protos.Resource.DiskInfo diskInfo = resource.getDisk();
+        Assert.assertTrue(diskInfo.hasSource());
+        Protos.Resource.DiskInfo.Source source = diskInfo.getSource();
+        Assert.assertEquals("PATH", source.getType().toString());
+        Assert.assertTrue(source.hasPath());
+        Assert.assertEquals("/disk1", source.getPath().getRoot());
+    }
+
 
     /*
         name: "disk"
@@ -334,6 +366,7 @@ public class ResourceBuilderTest extends DefaultCapabilitiesTestSuite {
         VolumeSpec volumeSpec = new DefaultVolumeSpec(
                 10,
                 VolumeSpec.Type.MOUNT,
+                "",
                 TestConstants.CONTAINER_PATH,
                 TestConstants.ROLE,
                 Constants.ANY_ROLE,
@@ -405,6 +438,7 @@ public class ResourceBuilderTest extends DefaultCapabilitiesTestSuite {
         VolumeSpec volumeSpec = new DefaultVolumeSpec(
                 10,
                 VolumeSpec.Type.ROOT,
+                "",
                 TestConstants.CONTAINER_PATH,
                 TestConstants.ROLE,
                 Constants.ANY_ROLE,
@@ -437,6 +471,7 @@ public class ResourceBuilderTest extends DefaultCapabilitiesTestSuite {
         VolumeSpec volumeSpec = new DefaultVolumeSpec(
                 10,
                 VolumeSpec.Type.MOUNT,
+                "",
                 TestConstants.CONTAINER_PATH,
                 TestConstants.ROLE,
                 Constants.ANY_ROLE,

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/plan/PodInstanceRequirementTestUtils.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/plan/PodInstanceRequirementTestUtils.java
@@ -33,12 +33,20 @@ public class PodInstanceRequirementTestUtils {
         return getMountVolumeRequirement(cpus, diskSize, 0);
     }
 
+    public static PodInstanceRequirement getPathVolumeRequirement(double cpus, double diskSize) {
+        return getPathVolumeRequirement(cpus, diskSize, 0);
+    }
+
     public static PodInstanceRequirement getRootVolumeRequirement(double cpus, double diskSize, int index) {
         return getRequirement(getRootVolumeResourceSet(cpus, diskSize), index);
     }
 
     public static PodInstanceRequirement getMountVolumeRequirement(double cpus, double diskSize, int index) {
         return getRequirement(getMountVolumeResourceSet(cpus, diskSize), index);
+    }
+
+    public static PodInstanceRequirement getPathVolumeRequirement(double cpus, double diskSize, int index) {
+        return getRequirement(getPathVolumeResourceSet(cpus, diskSize), index);
     }
 
     public static PodInstanceRequirement getPortRequirement(int... ports) {
@@ -78,11 +86,15 @@ public class PodInstanceRequirementTestUtils {
         return getVolumeResourceSet(cpus, diskSize, VolumeSpec.Type.MOUNT.name());
     }
 
+    private static ResourceSet getPathVolumeResourceSet(double cpus, double diskSize) {
+        return getVolumeResourceSet(cpus, diskSize, VolumeSpec.Type.PATH.name());
+    }
+
     private static ResourceSet getVolumeResourceSet(double cpus, double diskSize, String diskType) {
         return DefaultResourceSet.newBuilder(TestConstants.ROLE, Constants.ANY_ROLE, TestConstants.PRINCIPAL)
                 .id(TestConstants.RESOURCE_SET_ID)
                 .cpus(cpus)
-                .addVolume(diskType, diskSize, TestConstants.CONTAINER_PATH)
+                .addVolume(diskType, diskSize, "", TestConstants.CONTAINER_PATH)
                 .build();
     }
 

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/specification/DefaultTaskSpecTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/specification/DefaultTaskSpecTest.java
@@ -34,6 +34,7 @@ public class DefaultTaskSpecTest {
                                 new DefaultVolumeSpec(
                                         100,
                                         VolumeSpec.Type.ROOT,
+                                        "",
                                         TestConstants.CONTAINER_PATH,
                                         TestConstants.ROLE,
                                         TestConstants.PRE_RESERVED_ROLE,

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/specification/TestPodFactory.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/specification/TestPodFactory.java
@@ -109,7 +109,7 @@ public class TestPodFactory {
                 .id(id)
                 .cpus(cpu)
                 .memory(mem)
-                .addVolume(VolumeSpec.Type.ROOT.toString(), disk, TestConstants.CONTAINER_PATH)
+                .addVolume(VolumeSpec.Type.ROOT.toString(), disk, "", TestConstants.CONTAINER_PATH)
                 .build();
     }
 

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/testutils/ResourceTestUtils.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/testutils/ResourceTestUtils.java
@@ -77,6 +77,36 @@ public class ResourceTestUtils {
                 principal).build();
     }
 
+    public static Resource getExpectedPathVolume(
+            double diskSize,
+            String resourceId,
+            String role,
+            String principal,
+            String root,
+            String containerPath,
+            String persistenceId) {
+        Value diskValue = Value.newBuilder()
+                .setType(Value.Type.SCALAR)
+                .setScalar(Value.Scalar.newBuilder().setValue(diskSize))
+                .build();
+        DiskInfo pathVolumeDiskInfo = DiskInfo.newBuilder(getUnreservedPathVolumeDiskInfo(root))
+                .setPersistence(Persistence.newBuilder()
+                        .setId(persistenceId)
+                        .setPrincipal(principal)
+                        .build())
+                .setVolume(Volume.newBuilder()
+                        .setContainerPath(containerPath)
+                        .setMode(Volume.Mode.RW)
+                        .build())
+                .build();
+        return addReservation(
+                Resource.newBuilder(getUnreservedResource("disk", diskValue)).setDisk(pathVolumeDiskInfo),
+                resourceId,
+                role,
+                principal).build();
+    }
+
+
     public static Resource getUnreservedRootVolume(double diskSize) {
         Value diskValue = Value.newBuilder()
                 .setType(Value.Type.SCALAR)
@@ -97,6 +127,7 @@ public class ResourceTestUtils {
         VolumeSpec volumeSpec = new DefaultVolumeSpec(
                 diskSize,
                 VolumeSpec.Type.ROOT,
+                "",
                 containerPath,
                 role,
                 Constants.ANY_ROLE,
@@ -172,6 +203,17 @@ public class ResourceTestUtils {
                 .build();
     }
 
+    private static DiskInfo getUnreservedPathVolumeDiskInfo(String root) {
+        return DiskInfo.newBuilder()
+                .setSource(Source.newBuilder()
+                        .setType(Source.Type.PATH)
+                        .setPath(Source.Path.newBuilder()
+                                .setRoot(root)
+                                .build())
+                        .build())
+                .build();
+    }
+
     public static Resource setLabel(Resource resource, String key, String value) {
         Resource.Builder builder = resource.toBuilder();
         builder.getReservationBuilder().getLabelsBuilder().addLabelsBuilder().setKey(key).setValue(value);
@@ -212,8 +254,38 @@ public class ResourceTestUtils {
                 .build();
     }
 
+    public static Resource getUnreservedPathVolume(double diskSize) {
+        Value diskValue = Value.newBuilder()
+                .setType(Value.Type.SCALAR)
+                .setScalar(Value.Scalar.newBuilder().setValue(diskSize))
+                .build();
+        return Resource.newBuilder(getUnreservedResource("disk", diskValue))
+                .setRole("*")
+                .setDisk(getUnreservedPathVolumeDiskInfo(TestConstants.PATH_ROOT))
+                .build();
+    }
+
+    public static Resource getUnreservedPathVolume(double diskSize, String root) {
+        Value diskValue = Value.newBuilder()
+                .setType(Value.Type.SCALAR)
+                .setScalar(Value.Scalar.newBuilder().setValue(diskSize))
+                .build();
+        return Resource.newBuilder(getUnreservedResource("disk", diskValue))
+                .setRole("*")
+                .setDisk(getUnreservedPathVolumeDiskInfo(root))
+                .build();
+    }
+
     public static Resource getExpectedMountVolume(double diskSize) {
         return getExpectedMountVolume(diskSize, TestConstants.RESOURCE_ID, TestConstants.PERSISTENCE_ID);
+    }
+
+    public static Resource getExpectedPathVolume(double diskSize) {
+        return getExpectedPathVolume(diskSize, TestConstants.RESOURCE_ID, TestConstants.PERSISTENCE_ID);
+    }
+
+    public static Resource getExpectedPathVolume(double diskSize, String root) {
+        return getExpectedPathVolume(diskSize, root, TestConstants.RESOURCE_ID, TestConstants.PERSISTENCE_ID);
     }
 
     public static Resource getExpectedMountVolume(double diskSize, String resourceId, String persistenceId) {
@@ -223,6 +295,28 @@ public class ResourceTestUtils {
                 TestConstants.ROLE,
                 TestConstants.PRINCIPAL,
                 TestConstants.MOUNT_ROOT,
+                TestConstants.CONTAINER_PATH,
+                persistenceId);
+    }
+
+    public static Resource getExpectedPathVolume(double diskSize, String resourceId, String persistenceId) {
+        return getExpectedPathVolume(
+                diskSize,
+                resourceId,
+                TestConstants.ROLE,
+                TestConstants.PRINCIPAL,
+                TestConstants.PATH_ROOT,
+                TestConstants.CONTAINER_PATH,
+                persistenceId);
+    }
+
+    public static Resource getExpectedPathVolume(double diskSize, String root, String resourceId, String persistenceId) {
+        return getExpectedPathVolume(
+                diskSize,
+                resourceId,
+                TestConstants.ROLE,
+                TestConstants.PRINCIPAL,
+                root,
                 TestConstants.CONTAINER_PATH,
                 persistenceId);
     }


### PR DESCRIPTION
Ping @triclambert, @gabrielhartmann 

Details on what this does are here: https://jira.mesosphere.com/projects/DCOS_HDFS/issues/DCOS_HDFS-4

Basically, what this work does is start implementation on supporting PATH volumes. The path volumes are not atomic in the sense that offers can be shared between frameworks. So, I added code that can handle this splitting of PATH volumes between frameworks, as well as some tests. 

The ugliest part is actually sending the needed resources through to the framework, since we only have environment variables, and actually using this array of objects inside the Mustache template. . Another way would be to encode a json or something in an environment variable value. 

This isn't by any means final, but let me know if this is a direction that would be acceptable, or any other hints on how to proceed. 

This patch has been tested with both the HDFS and Kafka frameworks (some more changes in the service yaml files needed, I can to a PR for those as well. Please see https://github.com/adragomir/dcos-commons