### PR TITLE
Fetch xpack binary only when xpack enabled

### DIFF
--- a/frameworks/elastic/src/main/dist/svc.yml
+++ b/frameworks/elastic/src/main/dist/svc.yml
@@ -15,7 +15,9 @@ pods:
       - {{ELASTICSEARCH_JAVA_URI}}
       - {{SCHEDULER_URI}}
       - {{ELASTICSEARCH_URI}}
+      {{#XPACK_ENABLED}}
       - {{XPACK_URI}}
+      {{/XPACK_ENABLED}}
       - {{DIAGNOSTICS_URI}}
       - {{STATSD_URI}}
     rlimits:
@@ -82,7 +84,9 @@ pods:
       - {{ELASTICSEARCH_JAVA_URI}}
       - {{SCHEDULER_URI}}
       - {{ELASTICSEARCH_URI}}
+      {{#XPACK_ENABLED}}
       - {{XPACK_URI}}
+      {{/XPACK_ENABLED}}
       - {{DIAGNOSTICS_URI}}
       - {{STATSD_URI}}
     rlimits:
@@ -147,7 +151,9 @@ pods:
       - {{ELASTICSEARCH_JAVA_URI}}
       - {{SCHEDULER_URI}}
       - {{ELASTICSEARCH_URI}}
+      {{#XPACK_ENABLED}}
       - {{XPACK_URI}}
+      {{/XPACK_ENABLED}}
       - {{DIAGNOSTICS_URI}}
       - {{STATSD_URI}}
     rlimits:
@@ -212,7 +218,9 @@ pods:
       - {{ELASTICSEARCH_JAVA_URI}}
       - {{SCHEDULER_URI}}
       - {{ELASTICSEARCH_URI}}
+      {{#XPACK_ENABLED}}
       - {{XPACK_URI}}
+      {{/XPACK_ENABLED}}
       - {{DIAGNOSTICS_URI}}
       - {{STATSD_URI}}
     rlimits:

--- a/frameworks/elastic/src/main/dist/svc.yml
+++ b/frameworks/elastic/src/main/dist/svc.yml
@@ -15,9 +15,9 @@ pods:
       - {{ELASTICSEARCH_JAVA_URI}}
       - {{SCHEDULER_URI}}
       - {{ELASTICSEARCH_URI}}
-      {{#XPACK_ENABLED}}
+      {{#TASKCFG_ALL_XPACK_ENABLED}}
       - {{XPACK_URI}}
-      {{/XPACK_ENABLED}}
+      {{/TASKCFG_ALL_XPACK_ENABLED}}
       - {{DIAGNOSTICS_URI}}
       - {{STATSD_URI}}
     rlimits:
@@ -84,9 +84,9 @@ pods:
       - {{ELASTICSEARCH_JAVA_URI}}
       - {{SCHEDULER_URI}}
       - {{ELASTICSEARCH_URI}}
-      {{#XPACK_ENABLED}}
+      {{#TASKCFG_ALL_XPACK_ENABLED}}
       - {{XPACK_URI}}
-      {{/XPACK_ENABLED}}
+      {{/TASKCFG_ALL_XPACK_ENABLED}}
       - {{DIAGNOSTICS_URI}}
       - {{STATSD_URI}}
     rlimits:
@@ -151,9 +151,9 @@ pods:
       - {{ELASTICSEARCH_JAVA_URI}}
       - {{SCHEDULER_URI}}
       - {{ELASTICSEARCH_URI}}
-      {{#XPACK_ENABLED}}
+      {{#TASKCFG_ALL_XPACK_ENABLED}}
       - {{XPACK_URI}}
-      {{/XPACK_ENABLED}}
+      {{/TASKCFG_ALL_XPACK_ENABLED}}
       - {{DIAGNOSTICS_URI}}
       - {{STATSD_URI}}
     rlimits:
@@ -218,9 +218,9 @@ pods:
       - {{ELASTICSEARCH_JAVA_URI}}
       - {{SCHEDULER_URI}}
       - {{ELASTICSEARCH_URI}}
-      {{#XPACK_ENABLED}}
+      {{#TASKCFG_ALL_XPACK_ENABLED}}
       - {{XPACK_URI}}
-      {{/XPACK_ENABLED}}
+      {{/TASKCFG_ALL_XPACK_ENABLED}}
       - {{DIAGNOSTICS_URI}}
       - {{STATSD_URI}}
     rlimits:


### PR DESCRIPTION
Currently Elasic fetches unnecessary xpack archive even when it's disabled.