### PR TITLE
[INFINITY-2408] Fix HDFS test_sanity - tasks updated detection

### DIFF
--- a/frameworks/hdfs/tests/test_sanity.py
+++ b/frameworks/hdfs/tests/test_sanity.py
@@ -270,6 +270,7 @@ def test_modify_app_config():
     app_config_field = 'TASKCFG_ALL_CLIENT_READ_SHORTCIRCUIT_STREAMS_CACHE_SIZE_EXPIRY_MS'
     journal_ids = sdk_tasks.get_task_ids(config.FOLDERED_SERVICE_NAME, 'journal')
     name_ids = sdk_tasks.get_task_ids(config.FOLDERED_SERVICE_NAME, 'name')
+    data_ids = sdk_tasks.get_task_ids(config.FOLDERED_SERVICE_NAME, 'data')
 
     marathon_config = sdk_marathon.get_config(config.FOLDERED_SERVICE_NAME)
     log.info('marathon config: ')
@@ -282,7 +283,7 @@ def test_modify_app_config():
     config.check_healthy(service_name=config.FOLDERED_SERVICE_NAME)
     sdk_tasks.check_tasks_updated(config.FOLDERED_SERVICE_NAME, 'journal', journal_ids)
     sdk_tasks.check_tasks_updated(config.FOLDERED_SERVICE_NAME, 'name', name_ids)
-    sdk_tasks.check_tasks_updated(config.FOLDERED_SERVICE_NAME, 'data', journal_ids)
+    sdk_tasks.check_tasks_updated(config.FOLDERED_SERVICE_NAME, 'data', data_ids)
 
     sdk_plan.wait_for_completed_recovery(config.FOLDERED_SERVICE_NAME)
     new_recovery_plan = sdk_plan.get_plan(config.FOLDERED_SERVICE_NAME, "recovery")

--- a/frameworks/kafka/cli/dcos-kafka/.gitignore
+++ b/frameworks/kafka/cli/dcos-kafka/.gitignore
@@ -1,3 +1,3 @@
-dcos-kafka*
+dcos-*
 *.whl
 native-*

--- a/testing/sdk_tasks.py
+++ b/testing/sdk_tasks.py
@@ -79,8 +79,6 @@ def check_tasks_updated(service_name, prefix, old_task_ids, timeout_seconds=DEFA
             old_remaining_set,
             newly_launched_set))
 
-        log.info('Waiting for tasks{} to have updated ids:\n- Old tasks (remained): {}\n- New tasks (launched): {}'.format(
-
 
 def check_tasks_not_updated(service_name, prefix, old_task_ids):
     sdk_plan.wait_for_completed_deployment(service_name)

--- a/testing/sdk_tasks.py
+++ b/testing/sdk_tasks.py
@@ -41,6 +41,9 @@ def get_task_ids(service_name, task_prefix):
 
 
 def check_tasks_updated(service_name, prefix, old_task_ids, timeout_seconds=DEFAULT_TIMEOUT_SECONDS):
+    # TODO: strongly consider merging the use of checking that tasks have been replaced (this method)
+    # and checking that the deploy/upgrade/repair plan has completed. Each serves a part in the higher
+    # atomic test, that the plan completed properly where properly includes that no old tasks remain.
     def fn():
         try:
             task_ids = get_task_ids(service_name, prefix)
@@ -48,17 +51,35 @@ def check_tasks_updated(service_name, prefix, old_task_ids, timeout_seconds=DEFA
             log.info('Failed to get task ids for service {}'.format(service_name))
             task_ids = []
 
-        log.info('Waiting for tasks starting with "{}" to be updated:\n- Old tasks: {}\n- Current tasks: {}'.format(
-            prefix, sorted(old_task_ids), sorted(task_ids)))
-        all_updated = True
-        for id in task_ids:
-            if id in old_task_ids:
-                all_updated = False
-        if len(task_ids) < len(old_task_ids):
-            all_updated = False
-        return all_updated
+        prefix_clause = ''
+        if prefix:
+            prefix_clause = ' starting with "{}"'.format(prefix)
 
-    shakedown.wait_for(lambda: fn(), noisy=True, timeout_seconds=timeout_seconds)
+        old_set = set(old_task_ids)
+        new_set = set(task_ids)
+        newly_launched_set = new_set.difference(old_set)
+        old_remaining_set = old_set.intersection(new_set)
+        # the constrainst of old and new task cardinality match should be covered by completion of
+        # deploy/recovery/whatever plan, not task cardinality, but some uses of this method are not
+        # using the plan, so not the definitive source, so will fail when the finished state of a
+        # plan yields more or less tasks per pod.9
+        all_updated = len(newly_launched_set) == len(new_set) and len(old_remaining_set) == 0 and len(new_set) >= len(old_set)
+        if all_updated:
+            log.info('All of the tasks{} have updated\n- Old tasks: {}\n- New tasks: {}'.format(
+                prefix_clause,
+                old_set,
+                new_set))
+            return all_updated
+
+        # forgive the language a bit, but len('remained') == len('launched'),
+        # and similar for the rest of the label for task ids in the log line,
+        # so makes for easier reading
+        log.info('Waiting for tasks{} to have updated ids:\n- Old tasks (remained): {}\n- New tasks (launched): {}'.format(
+            prefix_clause,
+            old_remaining_set,
+            newly_launched_set))
+
+        log.info('Waiting for tasks{} to have updated ids:\n- Old tasks (remained): {}\n- New tasks (launched): {}'.format(
 
 
 def check_tasks_not_updated(service_name, prefix, old_task_ids):

--- a/testing/sdk_tasks.py
+++ b/testing/sdk_tasks.py
@@ -79,6 +79,7 @@ def check_tasks_updated(service_name, prefix, old_task_ids, timeout_seconds=DEFA
             old_remaining_set,
             newly_launched_set))
 
+    shakedown.wait_for(lambda: fn(), noisy=True, timeout_seconds=timeout_seconds)
 
 def check_tasks_not_updated(service_name, prefix, old_task_ids):
     sdk_plan.wait_for_completed_deployment(service_name)


### PR DESCRIPTION
* Backport of #1619.

* Fix HDFS test_sanity.test_modify_app_config, send proper task
  prefixes.
* Improve tasks updated detection, not yet reconciled log line to
  use set methods to report the intersection and difference instead
  of iteration.

Unrelated, but discovered:

* Fix .gitignore for Kafka to match pattern used in other services.