### PR TITLE
Standardize dirty asset computation

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/AbstractScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/AbstractScheduler.java
@@ -154,7 +154,9 @@ public abstract class AbstractScheduler implements Scheduler {
             LOGGER.info("Enqueuing {} offer{}. Updated offers in progress: {}",
                     offers.size(),
                     offers.size() == 1 ? "" : "s",
-                    offersInProgress.stream().collect(Collectors.toList()));
+                    offersInProgress.stream()
+                            .map(offerID -> offerID.getValue())
+                            .collect(Collectors.toList()));
         }
 
         for (Protos.Offer offer : offers) {

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/DefaultPlanManager.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/DefaultPlanManager.java
@@ -36,19 +36,6 @@ public class DefaultPlanManager implements PlanManager {
 
     @Override
     public Set<PodInstanceRequirement> getDirtyAssets() {
-        Set<PodInstanceRequirement> dirtyAssets = new HashSet<>();
-        final List<? extends Phase> phases = plan.getChildren();
-        for (Phase phase : phases) {
-            final List<? extends Step> steps = phase.getChildren();
-            for (Step step : steps) {
-                if (step.isAssetDirty()) {
-                    Optional<PodInstanceRequirement> dirtyAsset = step.getAsset();
-                    if (dirtyAsset.isPresent()) {
-                        dirtyAssets.add(dirtyAsset.get());
-                    }
-                }
-            }
-        }
-        return dirtyAssets;
+        return PlanUtils.getDirtyAsseets(plan);
     }
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/PlanUtils.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/PlanUtils.java
@@ -4,9 +4,7 @@ import com.mesosphere.sdk.offer.TaskUtils;
 import org.apache.mesos.Protos.Offer;
 import org.apache.mesos.Protos.OfferID;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 /**
@@ -68,6 +66,19 @@ public class PlanUtils {
                         TaskUtils.getTaskNames(
                                 podInstanceRequirement.getPodInstance(),
                                 podInstanceRequirement.getTasksToLaunch()).stream())
+                .collect(Collectors.toSet());
+    }
+
+    public static Set<PodInstanceRequirement> getDirtyAsseets(Plan plan) {
+        if (plan == null) {
+            return Collections.emptySet();
+        }
+
+        return plan.getChildren().stream()
+                .flatMap(phase -> phase.getChildren().stream())
+                .filter(Step::isAssetDirty)
+                .filter(step -> step.getAsset().isPresent())
+                .map(step -> step.getAsset().get())
                 .collect(Collectors.toSet());
     }
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/recovery/DefaultRecoveryPlanManager.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/recovery/DefaultRecoveryPlanManager.java
@@ -286,17 +286,7 @@ public class DefaultRecoveryPlanManager implements PlanManager {
 
     @Override
     public Set<PodInstanceRequirement> getDirtyAssets() {
-        Set<PodInstanceRequirement> dirtyAssets = new HashSet<>();
-        if (plan != null) {
-            dirtyAssets.addAll(plan.getChildren().stream()
-                    .flatMap(phase -> phase.getChildren().stream())
-                    .filter(step -> step.isPrepared())
-                    .map(step -> step.getPodInstanceRequirement())
-                    .filter(podInstanceRequirement -> podInstanceRequirement.isPresent())
-                    .map(podInstanceRequirement -> podInstanceRequirement.get())
-                    .collect(Collectors.toSet()));
-        }
-        return dirtyAssets;
+        return PlanUtils.getDirtyAsseets(plan);
     }
 
     private List<String> getTaskNames(Collection<Protos.TaskInfo> taskInfos) {


### PR DESCRIPTION
Recovery and Default plan managers were calculating dirty assets in
different ways and the RecoveryPlanManager was doing it wrong.