### PR TITLE
[INFINITY-2443] Made the driver port dynamic

### DIFF
--- a/frameworks/sdkspark/src/main/dist/svc.yml
+++ b/frameworks/sdkspark/src/main/dist/svc.yml
@@ -17,13 +17,18 @@ pods:
     tasks:
       driver:
         goal: FINISHED
+        ports:
+          driver:
+            port: {{DRIVER_PORT}}
+            env-key: SPARK_DRIVER_PORT
+            advertise: false
         cmd: >
           ./bin/spark-submit --master mesos://zk://master.mesos:2181/mesos
           --driver-cores {{COORDINATOR_CORES}}
           --driver-memory {{COORDINATOR_MEM}}M
           --class {{SPARK_MAIN_CLASS}}
           --executor-memory {{EXECUTOR_MEM}}M
-          --conf spark.driver.port=9000
+          --conf spark.driver.port=$SPARK_DRIVER_PORT
           --conf spark.ssl.noCertVerification=true
           --conf spark.mesos.backend=sdk
         cpus: {{COORDINATOR_CORES}}
@@ -53,10 +58,15 @@ pods:
     tasks:
       worker:
         goal: FINISHED
+        ports:
+          driver:
+            port: {{DRIVER_PORT}}
+            env-key: SPARK_DRIVER_PORT
+            advertise: false
         cmd: >
           $BOOTSTRAP -resolve-hosts coordinator-0-driver.sdkspark.mesos &&
           /opt/spark/dist/./bin/spark-class org.apache.spark.executor.CoarseGrainedExecutorBackend
-          --driver-url spark://CoarseGrainedScheduler@coordinator-0-driver.sdkspark.mesos:9000
+          --driver-url spark://CoarseGrainedScheduler@coordinator-0-driver.sdkspark.mesos:$SPARK_DRIVER_PORT
           --executor-id $POD_INSTANCE_INDEX
           --hostname $(hostname -i)
           --cores {{EXECUTOR_CORES}}

--- a/frameworks/sdkspark/src/test/java/com/mesosphere/sdk/sdkspark/scheduler/ServiceSpecTest.java
+++ b/frameworks/sdkspark/src/test/java/com/mesosphere/sdk/sdkspark/scheduler/ServiceSpecTest.java
@@ -28,6 +28,7 @@ public class ServiceSpecTest extends BaseServiceSpecTest {
                 "COORDINATOR_MEM", "512",
                 "COORDINATOR_DISK", "5000",
                 "COORDINATOR_DISK_TYPE", "ROOT",
+                "DRIVER_PORT", "0",
                 "SPARK_APP_URL", "http://someplace/mysparkapp.jar",
                 "SLEEP_DURATION", "1000");
     }

--- a/frameworks/sdkspark/universe/config.json
+++ b/frameworks/sdkspark/universe/config.json
@@ -169,6 +169,12 @@
               "MOUNT"
             ],
             "default": "ROOT"
+          },
+          "port": {
+            "title": "Port",
+            "description": "Port for coordinator to listen on",
+            "type": "integer",
+            "default": 0
           }
         },
         "required":[

--- a/frameworks/sdkspark/universe/marathon.json.mustache
+++ b/frameworks/sdkspark/universe/marathon.json.mustache
@@ -48,6 +48,7 @@
     "COORDINATOR_MEM": "{{coordinator.mem}}",
     "COORDINATOR_DISK": "{{coordinator.disk}}",
     "COORDINATOR_DISK_TYPE": "{{coordinator.disk_type}}",
+    "DRIVER_PORT": "{{coordinator.port}}",
 
     "JAVA_URI": "{{resource.assets.uris.jre-tar-gz}}",
     "EXECUTOR_URI": "{{resource.assets.uris.executor-zip}}",


### PR DESCRIPTION
- Made the driver port configurable in config.json, with default of 0
- The coordinator driver task reserves this port and uses it as the spark.driver.port
- The executor tasks uses this port in the `driver-url`