### PR TITLE
[INFINITY-2422] Squelch common lib test coverage

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -40,8 +40,13 @@ if [ x$PULLREQUEST = "xtrue" ]; then
     git pull origin $MERGE_FROM --no-commit --ff
 fi
 
-# Verify SDK CLI, run unit tests
-go test ./...
+# Verify golang-based projects: SDK CLI (exercised via helloworld, our model service)
+# and SDK bootstrap, run unit tests
+for golang_sub_project in frameworks/helloworld/cli/dcos-hello-world sdk/bootstrap; do
+    pushd $golang_sub_project
+    go test .
+    popd
+done
 
 # Build steps for SDK libraries:
 ./gradlew clean jar check

--- a/sdk/common/build.gradle
+++ b/sdk/common/build.gradle
@@ -96,12 +96,13 @@ dependencies {
     testCompile "org.awaitility:awaitility:${awaitilityVer}"
 }
 
-check.finalizedBy jacocoTestReport
-
-jacocoTestReport {
+// squelch code coverage report for this project
+// check.finalizedBy jacocoTestReport
+/*jacocoTestReport {
     reports {
         xml.enabled false
         csv.enabled false
         html.destination "${buildDir}/jacocoHtml"
     }
 }
+*/

--- a/tools/build_go_exe.sh
+++ b/tools/build_go_exe.sh
@@ -74,6 +74,13 @@ if [ ! -h "$SYMLINK_LOCATION" -o "$(readlink $SYMLINK_LOCATION)" != "$REPO_ROOT_
     ln -s "$REPO_ROOT_DIR" $REPO_NAME
 fi
 
+# Add symlink from GOPATH for the vendor deps that aren't under our repo org
+for external_vendor in github.com/containernetworking github.com/dcos github.com/vishvanada; do
+    if [ ! -e $GOPATH/src/$external_vendor ]; then
+        ln -s $(pwd)/govendor/$external_vendor/ $GOPATH/src/$external_vendor
+    fi
+done
+
 # Run 'go test'/'go build' from within GOPATH:
 cd $GOPATH_EXE_DIR
 

--- a/tools/build_go_exe.sh
+++ b/tools/build_go_exe.sh
@@ -76,8 +76,8 @@ fi
 
 # Add symlink from GOPATH for the vendor deps that aren't under our repo org
 for external_vendor in github.com/containernetworking github.com/dcos github.com/vishvanada; do
-    if [ ! -e $GOPATH/src/$external_vendor ]; then
-        ln -s $(pwd)/govendor/$external_vendor/ $GOPATH/src/$external_vendor
+    if [ ! -h $GOPATH/src/$external_vendor ]; then
+        ln -s $REPO_ROOT_DIR/govendor/$external_vendor/ $GOPATH/src/$external_vendor
     fi
 done
 


### PR DESCRIPTION
* Squelch common lib test coverage.
  * Benefit of common lib test coverage is low, coverage is including
    lines that cannot cause issue such as setting a const used as a key.
* Fix unrelated golang sub-project setup, closing out the great
  re-vendoring.