### PR TITLE
[INFINITY-2454] Properly handle deploy plans with errors

### DIFF
--- a/cli/client/print.go
+++ b/cli/client/print.go
@@ -18,13 +18,21 @@ var PrintMessage = printMessage
 // PrintMessage() before exiting to allow assertions against captured output.
 var PrintMessageAndExit = printMessageAndExit
 
+// Exit is a placeholder function that wraps a call to os.Exit to allow
+// assertions against exit with an exit code.
+var Exit = exit
+
+func exit(code int) {
+	os.Exit(code)
+}
+
 func printMessage(format string, a ...interface{}) (int, error) {
 	return fmt.Println(fmt.Sprintf(format, a...))
 }
 
 func printMessageAndExit(format string, a ...interface{}) (int, error) {
 	PrintMessage(format, a...)
-	os.Exit(1)
+	Exit(1)
 	return 0, nil
 }
 


### PR DESCRIPTION
In #1365 the plan endpoint was changed to return a 417 instead of 202
when the plan contained errors. This was not properly handled by the
cli.

This PR:
- Adds an explicit handler (and tests) for the case where the plan endpoint
returns 417.
- Terminates the CLI with a non-zero exit code (1) if such an error occurs.

I will make these changes to master too.
