### PR TITLE
[INFINITY-2462] Rely on Mesos offer accept/decline behavior

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/AbstractScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/AbstractScheduler.java
@@ -131,11 +131,11 @@ public abstract class AbstractScheduler implements Scheduler {
                 // Get the current work
                 Collection<Step> steps = getPlanCoordinator().getCandidates();
 
-                // Revive offers if necessary
-                reviveManager.revive(steps);
-
                 // Match offers with work
                 executePlans(offers, steps);
+
+                // Revive offers if necessary
+                reviveManager.revive(steps);
 
                 synchronized (inProgressLock) {
                     offersInProgress.removeAll(

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/ReviveManager.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/ReviveManager.java
@@ -91,7 +91,7 @@ public class ReviveManager {
      */
     private Set<WorkItem> getCandidates(Collection<Step> steps) {
         return steps.stream()
-                .filter(step -> step.getStatus().equals(Status.PENDING) || step.getStatus().equals(Status.PREPARED))
+                .filter(step -> !step.getStatus().equals(Status.COMPLETE))
                 .map(step -> new WorkItem(step))
                 .collect(Collectors.toSet());
     }
@@ -103,12 +103,10 @@ public class ReviveManager {
     private static class WorkItem {
         private final Optional<PodInstanceRequirement> podInstanceRequirement;
         private final String name;
-        private final Status status;
 
         private WorkItem(Step step) {
             this.podInstanceRequirement = step.getPodInstanceRequirement();
             this.name = step.getName();
-            this.status = step.getStatus();
         }
 
         @Override
@@ -123,9 +121,8 @@ public class ReviveManager {
 
         @Override
         public String toString() {
-            return String.format("%s [%s][%s]",
+            return String.format("%s [%s]",
                     name,
-                    status,
                     podInstanceRequirement.isPresent() ?
                             podInstanceRequirement.get().getRecoveryType() :
                             "N/A");


### PR DESCRIPTION
This is a small PR with a big effect because it relies on Mesos behavior.  The end result of this PR is that any given set of crash looping tasks generate at most `1` revive call.  This means that very scalable recovery is possible without any actions which impact other frameworks (i.e. `revive` calls) and without relying on our revive throttling mechanism.

## Big Change
No revive calls are necessary from a Mesos perspective when a Task crashes.  The task was originally launched by _accepting_ an offer.  So that offer was not declined forever (2 weeks).  When the task crashes those resources will be re-offered to the scheduler.  The re-offer is guaranteed in our case because we reserve resources.  The scheduler should accept them and recover the task.

From an SDK scheduler perspective we now treat work as falling into only 2 categories: `COMPLETE` or not.  When new _incomplete_ work is detected `revive` is called.  Otherwise it isn't.  When work is completed it leaves the set of `current` work, so if it becomes incomplete again it will be processed again.  We accomplish this categorization by leaving status out of the definition of a `WorkItem`.  Complete work is removed from the system, by being filtered out in the `getCandidates` call.

### Testing
I ran 13 scheduler's with one crash-looping task and one good task on each.  No starvation occurred for any scheduler including Marathon.  No `revive` calls were observed on any scheduler while Tasks were continually relaunched at great speed.  I'll be doing further larger scale testing later.

#### Small change
I moved the revive check after plan processing as it made more sense to me.  Shouldn't have any real effect, but basically it makes sense to evaluate the state of the system with regard to needing to revive after execution of plans.


