### PR TITLE
Cache config objects in memory in the ConfigStore

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/state/ConfigStore.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/state/ConfigStore.java
@@ -203,10 +203,6 @@ public class ConfigStore<T extends Configuration> implements ConfigTargetStore {
         }
     }
 
-    public void close() {
-        persister.close();
-    }
-
     private static String getConfigPath(UUID id) {
         return PersisterUtils.join(CONFIGURATIONS_PATH_NAME, id.toString());
     }


### PR DESCRIPTION
Used VisualVM profiler to find what was slowing down DefaultSchedulerTests.  ConfigStore was caching the ServiceSpec's serialized format but still parsing it every time some component looked up a configuration.  The parsing was taking a long time.  So I've added some caching post-parsing.  This manifested in the Scheduler logs as an approximately `0.250s` delay on an empty iteration of the scheduling loop.  This delay has disappeared.