### PR TITLE
[ELASTIC-136] Add scripting parameters. Please note that deprecated settings are omitted

### DIFF
--- a/frameworks/elastic/src/main/dist/elasticsearch.yml
+++ b/frameworks/elastic/src/main/dist/elasticsearch.yml
@@ -47,8 +47,12 @@ xpack.security.http.ssl.enabled: true
 xpack.security.http.ssl.client_authentication: none
 {{/ELASTIC_ENABLE_TLS}}
 
+{{#SCRIPT_ALLOWED_CONTEXTS}}
 script.allowed_contexts: {{SCRIPT_ALLOWED_CONTEXTS}}
+{{/SCRIPT_ALLOWED_CONTEXTS}}
+{{#SCRIPT_ALLOWED_TYPES}}
 script.allowed_types: {{SCRIPT_ALLOWED_TYPES}}
+{{/SCRIPT_ALLOWED_TYPES}}
 
 network.tcp.no_delay: {{NETWORK_TCP_NO_DELAY}}
 network.tcp.keep_alive: {{NETWORK_TCP_KEEP_ALIVE}}

--- a/frameworks/elastic/src/main/dist/elasticsearch.yml
+++ b/frameworks/elastic/src/main/dist/elasticsearch.yml
@@ -47,6 +47,9 @@ xpack.security.http.ssl.enabled: true
 xpack.security.http.ssl.client_authentication: none
 {{/ELASTIC_ENABLE_TLS}}
 
+script.allowed_contexts: {{SCRIPT_ALLOWED_CONTEXTS}}
+script.allowed_types: {{SCRIPT_ALLOWED_TYPES}}
+
 network.tcp.no_delay: {{NETWORK_TCP_NO_DELAY}}
 network.tcp.keep_alive: {{NETWORK_TCP_KEEP_ALIVE}}
 network.tcp.reuse_address: {{NETWORK_TCP_REUSE_ADDRESS}}

--- a/frameworks/elastic/universe/config.json
+++ b/frameworks/elastic/universe/config.json
@@ -330,6 +330,16 @@
           "type": "string",
           "default": "5m"
         },
+        "script_allowed_types": {
+          "description": "By default all script types (inline,file,stored) are allowed to be executed. This can be modified using the setting script.allowed_types. Only the types specified as part of the setting will be allowed to be executed. To specify no types are allowed, set script.allowed_types to be none.",
+          "type": "string",
+          "default": "inline,file,stored"
+        },
+        "script_allowed_contexts": {
+          "description": "By default all script contexts (search,update,aggs,plugin) are allowed to be executed. This can be modified using the setting script.allowed_contexts. Only the contexts specified as part of the setting will be allowed to be executed. To specify no contexts are allowed, set script.allowed_contexts to be none.",
+         "type": "string",
+         "default": "search,update,aggs,plugin"
+        }, 
         "network_tcp_no_delay": {
           "description": "Enable or disable the TCP no delay setting. Defaults to true.",
           "type": "boolean",

--- a/frameworks/elastic/universe/config.json
+++ b/frameworks/elastic/universe/config.json
@@ -331,14 +331,14 @@
           "default": "5m"
         },
         "script_allowed_types": {
-          "description": "By default all script types (inline,file,stored) are allowed to be executed. This can be modified using the setting script.allowed_types. Only the types specified as part of the setting will be allowed to be executed. To specify no types are allowed, set script.allowed_types to be none.",
+          "description": "By default all script types (inline,file,stored) are allowed to be executed. This can be modified using the setting script_allowed_types. Only the types specified as part of the setting will be allowed to be executed. To specify no types are allowed, set script.allowed_types to be none. Empty string \"\" means all types (default).",
           "type": "string",
-          "default": "inline,file,stored"
+          "default": ""
         },
         "script_allowed_contexts": {
-          "description": "By default all script contexts (search,update,aggs,plugin) are allowed to be executed. This can be modified using the setting script.allowed_contexts. Only the contexts specified as part of the setting will be allowed to be executed. To specify no contexts are allowed, set script.allowed_contexts to be none.",
+          "description": "By default all script contexts (search,update,aggs,plugin) are allowed to be executed. This can be modified using the setting script_allowed_contexts. Only the contexts specified as part of the setting will be allowed to be executed. To specify no contexts are allowed, set script_allowed_contexts to be none. Empty string \"\" means all contexts (default).",
          "type": "string",
-         "default": "search,update,aggs,plugin"
+         "default": ""
         }, 
         "network_tcp_no_delay": {
           "description": "Enable or disable the TCP no delay setting. Defaults to true.",

--- a/frameworks/elastic/universe/marathon.json.mustache
+++ b/frameworks/elastic/universe/marathon.json.mustache
@@ -96,6 +96,8 @@
     "ELASTICSEARCH_HEALTH_USER_PASSWORD": "{{elasticsearch.health_user_password}}",
     "TASKCFG_ALL_ELASTICSEARCH_PLUGINS": "{{elasticsearch.plugins}}",
     "TASKCFG_ALL_GATEWAY_RECOVER_AFTER_TIME": "{{elasticsearch.gateway_recover_after_time}}",
+    "TASKCFG_ALL_SCRIPT_ALLOWED_CONTEXTS": "{{elasticsearch.script_allowed_contexts}}",
+    "TASKCFG_ALL_SCRIPT_ALLOWED_TYPES": "{{elasticsearch.script_allowed_types}}",
     "TASKCFG_ALL_NETWORK_TCP_NO_DELAY": "{{elasticsearch.network_tcp_no_delay}}",
     "TASKCFG_ALL_NETWORK_TCP_KEEP_ALIVE": "{{elasticsearch.network_tcp_keep_alive}}",
     "TASKCFG_ALL_NETWORK_TCP_REUSE_ADDRESS": "{{elasticsearch.network_tcp_reuse_address}}",

--- a/frameworks/elastic/universe/marathon.json.mustache
+++ b/frameworks/elastic/universe/marathon.json.mustache
@@ -96,8 +96,12 @@
     "ELASTICSEARCH_HEALTH_USER_PASSWORD": "{{elasticsearch.health_user_password}}",
     "TASKCFG_ALL_ELASTICSEARCH_PLUGINS": "{{elasticsearch.plugins}}",
     "TASKCFG_ALL_GATEWAY_RECOVER_AFTER_TIME": "{{elasticsearch.gateway_recover_after_time}}",
+    {{#elasticsearch.script_allowed_contexts}}
     "TASKCFG_ALL_SCRIPT_ALLOWED_CONTEXTS": "{{elasticsearch.script_allowed_contexts}}",
+    {{/elasticsearch.script_allowed_contexts}}
+    {{#elasticsearch.script_allowed_types}}
     "TASKCFG_ALL_SCRIPT_ALLOWED_TYPES": "{{elasticsearch.script_allowed_types}}",
+    {{/elasticsearch.script_allowed_types}}
     "TASKCFG_ALL_NETWORK_TCP_NO_DELAY": "{{elasticsearch.network_tcp_no_delay}}",
     "TASKCFG_ALL_NETWORK_TCP_KEEP_ALIVE": "{{elasticsearch.network_tcp_keep_alive}}",
     "TASKCFG_ALL_NETWORK_TCP_REUSE_ADDRESS": "{{elasticsearch.network_tcp_reuse_address}}",


### PR DESCRIPTION
https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-scripting-security.html#_deprecated_script_settings  