### PR TITLE
[INFINITY-2435] Config to enable running with history server

### DIFF
--- a/frameworks/sdkspark/src/main/dist/svc.yml
+++ b/frameworks/sdkspark/src/main/dist/svc.yml
@@ -14,6 +14,10 @@ pods:
     {{/ENABLE_VIRTUAL_NETWORK}}
     uris:
       - {{SPARK_APP_URL}}
+      {{#HDFS_CONFIG_URL}}
+      - {{HDFS_CONFIG_URL}}/hdfs-site.xml
+      - {{HDFS_CONFIG_URL}}/core-site.xml
+      {{/HDFS_CONFIG_URL}}
     tasks:
       driver:
         goal: FINISHED
@@ -26,6 +30,10 @@ pods:
           --conf spark.driver.port=9000
           --conf spark.ssl.noCertVerification=true
           --conf spark.mesos.backend=sdk
+          {{#EVENTLOG_ENABLED}}
+          --conf spark.eventLog.enabled={{EVENTLOG_ENABLED}}
+          --conf spark.eventLog.dir={{EVENTLOG_DIR}}
+          {{/EVENTLOG_ENABLED}}
         cpus: {{COORDINATOR_CORES}}
         env:
           COORDINATOR_CORES: {{COORDINATOR_CORES}}

--- a/frameworks/sdkspark/universe/config.json
+++ b/frameworks/sdkspark/universe/config.json
@@ -71,6 +71,16 @@
             "description": "Free form string of arguments",
             "type": "string",
             "default": "100"
+          },
+          "eventlog_enabled": {
+            "description": "Enable event logging",
+            "type": "boolean",
+            "default": false
+          },
+          "eventlog_dir": {
+            "description": "Event logging directory",
+            "type": "string",
+            "default": "hdfs://hdfs/history"
           }
         },
         "required":[
@@ -177,6 +187,16 @@
           "disk",
           "disk_type"
         ]
+      },
+      "hdfs": {
+        "description": "Spark-HDFS configuration properties",
+        "type": "object",
+        "properties": {
+          "config-url": {
+            "type": "string",
+            "description": "Base URL that serves HDFS config files (hdfs-site.xml, core-site.xml)."
+          }
+        }
       }
     }
 }

--- a/frameworks/sdkspark/universe/marathon.json.mustache
+++ b/frameworks/sdkspark/universe/marathon.json.mustache
@@ -57,7 +57,13 @@
     "MESOS_AUTHENTICATEE": "com_mesosphere_dcos_ClassicRPCAuthenticatee",
     {{/service.service_account_secret}}
     "LIBMESOS_URI": "{{resource.assets.uris.libmesos-bundle-tar-gz}}",
-    "SPARK_DOCKER_IMAGE": "{{resource.assets.container.docker.spark}}"
+    "SPARK_DOCKER_IMAGE": "{{resource.assets.container.docker.spark}}",
+
+    {{#service.eventlog_enabled}}
+    "EVENTLOG_ENABLED": "true",
+    "EVENTLOG_DIR": "{{service.eventlog_dir}}",
+    {{/service.eventlog_enabled}}
+    "HDFS_CONFIG_URL": "{{hdfs.config-url}}"
 },
   "uris": [
     "{{resource.assets.uris.jre-tar-gz}}",


### PR DESCRIPTION
To run with the history server, set the follow config values in config.json or via DC/OS UI:
- service.eventlog_enabled (=true)
- service.eventlog_dir (example: hdfs://hdfs/history)
- hdfs.config-url (example: "http://api.hdfs.marathon.l4lb.thisdcos.directory/v1/endpoints")
