### PR TITLE
[INFINITY-2454] Handle a 417 return code on the plan endpoint. (#1664)

### DIFF
--- a/cli/commands/plan_test.go
+++ b/cli/commands/plan_test.go
@@ -516,3 +516,35 @@ func (suite *PlanTestSuite) TestPrintStatusTree() {
 	expectedOutput := suite.loadFile("testdata/output/deploy-tree-twophase.txt")
 	assert.Equal(suite.T(), string(expectedOutput), suite.capturedOutput.String())
 }
+
+// TestPrintStatusWithError tests that the plan command handled plans that
+// return 417 when one of the phases has an error that is not registered.
+func (suite *PlanTestSuite) TestPrintStatusWithError() {
+	suite.responseBody = []byte(`{
+    "phases" : [ {
+      "id" : "b35c149a-1fa2-447a-9c22-d42cc7129de4",
+      "name" : "node-deploy",
+      "steps" : [ {
+      "id" : "1a71141b-392d-4c72-924d-82b3d4cd922a",
+      "status" : "COMPLETE",
+      "name" : "node-0:[server]",
+      "message" : ""
+      } ],
+      "status" : "COMPLETE"
+    } ],
+    "errors" : [ "deploy error" ],
+    "status" : "ERROR"
+    }`)
+	suite.responseStatus = http.StatusExpectationFailed
+
+	printStatus("deploy", false)
+
+	expectedOutput := `deploy (ERROR)
+└─ node-deploy (COMPLETE)
+   └─ node-0:[server] (COMPLETE)
+
+Errors:
+- deploy error
+`
+	assert.Equal(suite.T(), string(expectedOutput), suite.capturedOutput.String())
+}


### PR DESCRIPTION
Backport of #1664:

* INFINITY-2454: Handle a 417 return code on the plan endpoint.

(this replaced #1663)