### PR TITLE
Reduce HW scheduler CPU to match other frameworks.

### DIFF
--- a/frameworks/helloworld/universe/marathon.json.mustache
+++ b/frameworks/helloworld/universe/marathon.json.mustache
@@ -1,6 +1,6 @@
 {
   "id": "{{service.name}}",
-  "cpus": 1.0,
+  "cpus": 0.5,
   "mem": 1024,
   "instances": 1,
   "user": "{{service.user}}",


### PR DESCRIPTION
HW scheduler was using 1.0 CPUs. Reduced to 0.5 CPUs to match other frameworks.