### PR TITLE
Use custom test options for a smaller Elastic footprint during testing.

### DIFF
--- a/frameworks/elastic/tests/config.py
+++ b/frameworks/elastic/tests/config.py
@@ -47,6 +47,38 @@ DEFAULT_SETTINGS_MAPPINGS = {
                 "role": {"type": "keyword"}}}}}
 
 
+def install(
+        package_name,
+        expected_running_tasks,
+        service_name,
+        additional_options,
+        package_version,
+        timeout_seconds,
+        wait_for_deployment):
+    test_options={
+        "master_nodes": {
+            "cpus": 0.25
+        },
+        "date_nodes": {
+            "cpus": 0.25
+        },
+        "ingest_nodes": {
+            "cpus": 0.25
+        },
+        "coordinator_nodes": {
+            "cpus": 0.25
+        }
+    }
+
+    sdk_install.install(package_name=package_name,
+                        expected_running_tasks=expected_running_tasks,
+                        service_name=service_name,
+                        additional_options=sdk_install.merge_dictionaries(test_options, additional_options),
+                        package_version=package_version,
+                        timeout_seconds=timeout_seconds,
+                        wait_for_deployment=wait_for_deployment)
+
+
 def as_json(fn):
     @wraps(fn)
     def wrapper(*args, **kwargs):

--- a/frameworks/elastic/tests/config.py
+++ b/frameworks/elastic/tests/config.py
@@ -9,6 +9,7 @@ import sdk_hosts
 import sdk_marathon
 import sdk_plan
 import sdk_tasks
+import sdk_install
 
 log = logging.getLogger(__name__)
 

--- a/frameworks/elastic/tests/config.py
+++ b/frameworks/elastic/tests/config.py
@@ -49,12 +49,12 @@ DEFAULT_SETTINGS_MAPPINGS = {
 
 def install(
         package_name,
-        expected_running_tasks,
         service_name,
-        additional_options,
-        package_version,
-        timeout_seconds,
-        wait_for_deployment):
+        expected_running_tasks,
+        additional_options={},
+        package_version=None,
+        timeout_seconds=5*60,
+        wait_for_deployment=True):
     test_options={
         "master_nodes": {
             "cpus": 0.25

--- a/frameworks/elastic/tests/test_ingest.py
+++ b/frameworks/elastic/tests/test_ingest.py
@@ -21,7 +21,7 @@ from tests import config
 def configure_package(configure_security):
     try:
         sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
-        sdk_install.install(config.PACKAGE_NAME, config.SERVICE_NAME, config.NO_INGEST_TASK_COUNT)
+        config.install(config.PACKAGE_NAME, config.SERVICE_NAME, config.NO_INGEST_TASK_COUNT)
 
         yield  # let the test session execute
     finally:

--- a/frameworks/elastic/tests/test_overlay.py
+++ b/frameworks/elastic/tests/test_overlay.py
@@ -11,7 +11,7 @@ from tests import config
 def configure_package(configure_security):
     try:
         sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
-        sdk_install.install(
+        config.install(
             config.PACKAGE_NAME,
             config.SERVICE_NAME,
             config.NO_INGEST_TASK_COUNT,

--- a/frameworks/elastic/tests/test_sanity.py
+++ b/frameworks/elastic/tests/test_sanity.py
@@ -30,8 +30,21 @@ def configure_package(configure_security):
             foldered_name,
             current_expected_task_count,
             additional_options={
-                "service": {"name": foldered_name},
-                "ingest_nodes": {"count": 1} })
+                "master_nodes": {
+                    "cpus": 0.25
+                },
+                "date_nodes": {
+                    "cpus": 0.25
+                },
+                "ingest_nodes": {
+                    "cpus": 0.25,
+                    "count": 1
+                },
+                "coordinator_nodes": {
+                    "cpus": 0.25
+                },
+                "service": {"name": foldered_name}
+            })
 
         yield  # let the test session execute
     finally:

--- a/frameworks/elastic/tests/test_tls.py
+++ b/frameworks/elastic/tests/test_tls.py
@@ -11,6 +11,7 @@ from tests.config import (
     PACKAGE_NAME,
     NO_INGEST_TASK_COUNT,
     SERVICE_NAME,
+    install
 )
 
 
@@ -32,7 +33,7 @@ def service_account():
 
 @pytest.fixture(scope='module')
 def elastic_service_tls(service_account):
-    sdk_install.install(
+    install(
         PACKAGE_NAME,
         service_name=SERVICE_NAME,
         expected_running_tasks=NO_INGEST_TASK_COUNT,

--- a/testing/sdk_install.py
+++ b/testing/sdk_install.py
@@ -181,7 +181,7 @@ def get_package_options(additional_options={}):
     if os.environ.get('SECURITY', '') == 'strict':
         # strict mode requires correct principal and secret to perform install.
         # see also: tools/setup_permissions.sh and tools/create_service_account.sh
-        return _merge_dictionaries({
+        return merge_dictionaries({
             'service': {
                 'service_account': 'service-acct',
                 'principal': 'service-acct',
@@ -194,7 +194,7 @@ def get_package_options(additional_options={}):
         return additional_options
 
 
-def _merge_dictionaries(dict1, dict2):
+def merge_dictionaries(dict1, dict2):
     if (not isinstance(dict2, dict)):
         return dict1
     ret = {}
@@ -203,7 +203,7 @@ def _merge_dictionaries(dict1, dict2):
     for k, v in dict2.items():
         if (k in dict1 and isinstance(dict1[k], dict)
                 and isinstance(dict2[k], collections.Mapping)):
-            ret[k] = _merge_dictionaries(dict1[k], dict2[k])
+            ret[k] = merge_dictionaries(dict1[k], dict2[k])
         else:
             ret[k] = dict2[k]
     return ret


### PR DESCRIPTION
Elastic's defaults are too large to fit on a m4.large. Set smaller defaults during tests.