### PR TITLE
[INFINITY-2446] Update docs for changed option for service account.

### DIFF
--- a/docs/pages/developer-guide.md
+++ b/docs/pages/developer-guide.md
@@ -134,7 +134,7 @@ This simple YAML definition of a DC/OS service that prints "hello world" to stdo
 ```yaml
 name: "hello-world"
 scheduler:
-  principal: "hello-world-principal"
+  service_account: "hello-world-principal"
   api-port: {{PORT_API}}
   user: {{SERVICE_USER}}
 pods:
@@ -152,7 +152,7 @@ pods:
 
 * **scheduler**: The Scheduler manages the service and keeps it running. This section contains settings which apply to the Scheduler. The `scheduler` section may be omitted to use reasonable defaults for all of these settings.
 
-    * **principal**: This is the Mesos principal used when registering the framework. In secure Enterprise clusters, this principal must have the necessary permission to perform the actions of a scheduler. This setting may be omitted in which case it defaults to `<svcname>-principal`.
+    * **service_account**: This is the DC/OS service account used when registering the framework. In secure Enterprise clusters, this account must have the necessary permission to perform the actions of a scheduler. This setting may be omitted in which case it defaults to `<svcname>-principal`.
 
     * **api-port**: By default, a DC/OS service written with the SDK provides a number of REST API endpoints that may be used to examine the state of a service as well as alter its operation. In order to expose the endpoints, you must define on which port the HTTP server providing those endpoints should listen. You can also add custom service-specific endpoints.  Learn more in the [Defining a Target Configuration](#defining-a-target-configuration) section. This setting may be omitted in which case it defaults to the `PORT_API` envvar provided by Marathon.
 

--- a/docs/pages/operations-guide.md
+++ b/docs/pages/operations-guide.md
@@ -717,7 +717,7 @@ INFO  2017-04-25 20:26:08,343 [main] com.mesosphere.sdk.config.DefaultConfigurat
 +++ ServiceSpec.new
 @@ -3,5 +3,5 @@
    "role" : "dse-role",
-   "principal" : "dse-principal",
+   "service_account" : "dse-principal",
 -  "api-port" : 18446,
 +  "api-port" : 15063,
    "web-url" : null,

--- a/docs/pages/reference/yaml-reference.md
+++ b/docs/pages/reference/yaml-reference.md
@@ -24,7 +24,7 @@ This documentation effectively reflects the Java object tree under [RawServiceSp
 
   This section contains settings related to the scheduler and its interaction with the cluster. All of these settings are optional, reasonable defaults are used if they are not manually provided.
 
-  * `principal`
+  * `service_account`
 
     The Mesos Principal to register as. Default is `<name>-principal`.
 

--- a/docs/pages/tutorials/kafka-tutorial.md
+++ b/docs/pages/tutorials/kafka-tutorial.md
@@ -52,7 +52,7 @@ configs:
 ```
 name: {{FRAMEWORK_NAME}}
 scheduler:
-  principal: {{FRAMEWORK_PRINCIPAL}}
+  service_account: {{FRAMEWORK_PRINCIPAL}}
   user: {{FRAMEWORK_USER}}
 pods:
   kafka:

--- a/docs/pages/tutorials/secrets-tutorial.md
+++ b/docs/pages/tutorials/secrets-tutorial.md
@@ -70,7 +70,7 @@ The `hello-world` package includes a sample YAML file for secrets. The `examples
 ```
 name: {{FRAMEWORK_NAME}}
 scheduler:
-  principal: {{SERVICE_PRINCIPAL}}
+  service_account: {{SERVICE_PRINCIPAL}}
   user: {{SERVICE_USER}}
 pods:
   hello:

--- a/frameworks/hdfs/docs/api-reference.md
+++ b/frameworks/hdfs/docs/api-reference.md
@@ -770,7 +770,7 @@ $ curl -H "Authorization:token=$auth_token" <dcos_url>/service/hdfs/v1/configura
 {
 	name: "hdfs",
 	role: "hdfs-role",
-	principal: "hdfs-principal",
+	service_account: "hdfs-principal",
 	api - port: 10002,
 	web - url: null,
 	zookeeper: "master.mesos:2181",

--- a/frameworks/hdfs/docs/install.md
+++ b/frameworks/hdfs/docs/install.md
@@ -722,7 +722,7 @@ The service configuration object contains properties that MUST be specified duri
 {
     "service": {
         "name": "hdfs",
-        "principal": "hdfs-principal",
+        "service_account": "hdfs-principal",
     }
 }
 ```
@@ -741,9 +741,9 @@ The service configuration object contains properties that MUST be specified duri
   </tr>
 
   <tr>
-    <td>principal</td>
+    <td>service_account</td>
     <td>string</td>
-    <td>The authentication principal for the HDFS cluster.</td>
+    <td>The DC/OS service account for the HDFS cluster.</td>
   </tr>
 
 </table>

--- a/frameworks/hdfs/docs/managing.md
+++ b/frameworks/hdfs/docs/managing.md
@@ -445,7 +445,7 @@ The service configuration object contains properties that MUST be specified duri
 {
     "service": {
         "name": "hdfs",
-        "principal": "hdfs-principal",
+        "service_account": "hdfs-principal",
     }
 }
 ```
@@ -464,9 +464,9 @@ The service configuration object contains properties that MUST be specified duri
   </tr>
 
   <tr>
-    <td>principal</td>
+    <td>service_account</td>
     <td>string</td>
-    <td>The authentication principal for the HDFS cluster.</td>
+    <td>The service account for the HDFS cluster.</td>
   </tr>
 
 </table>

--- a/frameworks/kafka/docs/api-reference.md
+++ b/frameworks/kafka/docs/api-reference.md
@@ -587,7 +587,7 @@ The following is an example of the configuration resource:
 {
   "name": "kafka",
   "role": "kafka-role",
-  "principal": "kafka-principal",
+  "service_account": "kafka-principal",
   "api-port": 16962,
   "web-url": null,
   "zookeeper": "master.mesos:2181",


### PR DESCRIPTION
We changed the option name.  Docs should follow.

I'm assuming the "principal" that appears in resource sets, reservations, and log messages about offers are all unchanged.
