### PR TITLE
[INFINITY-2455] Properly parse ints in update errors

### DIFF
--- a/cli/client/cosmos.go
+++ b/cli/client/cosmos.go
@@ -40,8 +40,8 @@ type cosmosErrorInstance struct {
 type cosmosError struct {
 	Keyword  string
 	Message  string
-	Found    string
-	Expected []string
+	Found    interface{}
+	Expected []interface{}
 	Instance cosmosErrorInstance
 	// deliberately omitting:
 	// level
@@ -100,7 +100,7 @@ func parseCosmosHTTPErrorResponse(response *http.Response, body []byte) error {
 	var errorResponse cosmosErrorResponse
 	err := json.Unmarshal(body, &errorResponse)
 	if err != nil {
-		printMessage(err.Error())
+		printMessage("Error unmarshalling cosmosErrorResponse: %v", err.Error())
 		return createResponseError(response)
 	}
 	if errorResponse.ErrorType != "" {


### PR DESCRIPTION
This PR properly handles integers (or non-string data type) in update specification errors.

The main problem was the the `Found` field in `cosmosError` was specified as a `string`, meaning that `int` data (e.g. the number of nodes) could not be properly unmarshalled.

I changed the field type (and that of `Expected`) to `interface{}` allowing all data types to be handed.

I also added two simple unit tests for two cases.

