### PR TITLE
INFINITY-2434 Add task envvars: service VIP domain, scheduler API hostname

### DIFF
--- a/docs/pages/reference/yaml-reference.md
+++ b/docs/pages/reference/yaml-reference.md
@@ -152,7 +152,9 @@ This documentation effectively reflects the Java object tree under [RawServiceSp
       <div class="noyaml"><ul>
       <li><code>TASK_NAME</code>: The name of the task, of the form <code>&lt;pod>-&lt;#>-&lt;task></code>. For example: <code>mypod-0-node</code>.</li>
       <li><code>FRAMEWORK_NAME</code>: The name of the service.</li>
-      <li><code>FRAMEWORK_HOST</code>: The host domain of the service. For example, the full hostname for the task would be [TASK_NAME].[FRAMEWORK_HOST].</li>
+      <li><code>FRAMEWORK_HOST</code>: The host domain for pods on the service. For example, the full hostname for a task would be <code>[TASK_NAME].[FRAMEWORK_HOST]</code>.</li>
+      <li><code>FRAMEWORK_VIP_HOST</code>: The host domain for VIPs on the service. For example, the full hostname for a VIP would be <code>[VIP_NAME].[FRAMEWORK_VIP_HOST]</code>.</li>
+      <li><code>SCHEDULER_API_HOSTNAME</code>: The hostname for the Scheduler HTTP API. For example, an endpoint on the scheduler would be <code>http://[SCHEDULER_API_HOSTNAME]/myendpoint</code>.</li>
       <li><code>POD_INSTANCE_INDEX</code>: The index of the pod instance, starting at 0 for the first instance.</li>
       <li><code>&lt;TASK_NAME>=true</code>: The task name as the envvar name, with <code>true</code> as the value.</li>
       </ul></div>

--- a/frameworks/hdfs/src/main/dist/svc.yml
+++ b/frameworks/hdfs/src/main/dist/svc.yml
@@ -40,7 +40,7 @@ pods:
           echo "Creating version directory in the journal-data persistent volume" &&
           mkdir -p journal-data/hdfs/current &&
           echo "Fetching VERSION file" &&
-          curl api.$FRAMEWORK_SCHEDULER_NAME.marathon.l4lb.thisdcos.directory/v1/state/files/VERSION > journal-data/hdfs/current/VERSION &&
+          curl $SCHEDULER_API_HOSTNAME/v1/state/files/VERSION > journal-data/hdfs/current/VERSION &&
           echo "VERSION has the following content:" &&
           cat journal-data/hdfs/current/VERSION
         resource-set: journal-resources
@@ -87,7 +87,7 @@ pods:
               export LAGGING_TX_COUNT=$(grep "CurrentLagTxns" tmpJmx.json | sed s/,//g | awk '{print $3}') &&
               export WRITTEN_TX_COUNT=$(grep "TxnsWritten" tmpJmx.json | sed s/,//g | awk '{print $3}') &&
               if [ -f journal-data/hdfs/current/VERSION ] && [ ! -f journal-data/uploadedVersionFile ]; then
-                curl -X PUT -F 'file=@journal-data/hdfs/current/VERSION' api.$FRAMEWORK_SCHEDULER_NAME.marathon.l4lb.thisdcos.directory/v1/state/files/VERSION &&
+                curl -X PUT -F 'file=@journal-data/hdfs/current/VERSION' $SCHEDULER_API_HOSTNAME/v1/state/files/VERSION &&
                 touch journal-data/uploadedVersionFile
               fi &&
               [[ $LAGGING_TX_COUNT -eq {{JOURNAL_LAGGING_TX_COUNT}} ]] && [[ $WRITTEN_TX_COUNT -gt 0 ]]

--- a/frameworks/helloworld/src/main/dist/examples/overlay.yml
+++ b/frameworks/helloworld/src/main/dist/examples/overlay.yml
@@ -54,7 +54,7 @@ pods:
         cmd: "python3 http_py3responder.py server $PORT_OVERLAY_DYNPORT hello from the overlay network!"
         resource-set: hello-resource
         readiness-check:
-          cmd: "python3 http_py3responder.py GET http://hello-overlay-0-server.hello-world.autoip.dcos.thisdcos.directory:1026"
+          cmd: "python3 http_py3responder.py GET http://hello-overlay-0-server.$FRAMEWORK_HOST:1026"
           interval: 10
           delay: 15
           timeout: 10
@@ -109,10 +109,10 @@ pods:
         memory: {{HELLO_MEM}}
         cmd: |
           sleep 40 &&
-          curl -f -X GET hello-overlay-0-server.hello-world.autoip.dcos.thisdcos.directory:1026 >> output &&
-          curl -f -X GET overlay-vip.hello-world.l4lb.thisdcos.directory:80 >> output &&
-          curl -f -X GET host-vip.hello-world.l4lb.thisdcos.directory:80 >> output &&
-          curl -f -X GET hello-host-0-server.hello-world.autoip.dcos.thisdcos.directory:4044 >> output
+          curl -f -X GET hello-overlay-0-server.$FRAMEWORK_HOST:1026 >> output &&
+          curl -f -X GET overlay-vip.$FRAMEWORK_VIP_HOST:80 >> output &&
+          curl -f -X GET host-vip.$FRAMEWORK_VIP_HOST:80 >> output &&
+          curl -f -X GET hello-host-0-server.$FRAMEWORK_HOST:4044 >> output
 
 plans:
   deploy:

--- a/sdk/common/src/main/java/com/mesosphere/sdk/offer/taskdata/EnvConstants.java
+++ b/sdk/common/src/main/java/com/mesosphere/sdk/offer/taskdata/EnvConstants.java
@@ -12,15 +12,23 @@ public class EnvConstants {
 
     /** Provides the Task/Pod index of the instance, starting at 0. */
     public static final String POD_INSTANCE_INDEX_TASKENV = "POD_INSTANCE_INDEX";
+
     /** Prefix used for port environment variables which advertise reserved ports by their name. */
     public static final String PORT_NAME_TASKENV_PREFIX = "PORT_";
+
     /** Provides the configured name of the framework/service. */
     public static final String FRAMEWORK_NAME_TASKENV = "FRAMEWORK_NAME";
     /** Provides the name of the pod/task within the service. */
     public static final String TASK_NAME_TASKENV = "TASK_NAME";
-    /** Provides the host domain of the service. Pods within the service would be accessed as subdomains under this
-     *  domain. For example, <TASK_NAME>.<FRAMEWORK_HOST> => pod hostname. **/
+
+    /** Provides the host domain for pods within the service. Pods within the service would be accessed as subdomains
+     *  under this domain. For example, <TASK_NAME>.<FRAMEWORK_HOST> => pod hostname. */
     public static final String FRAMEWORK_HOST_TASKENV = "FRAMEWORK_HOST";
-    /** Provides the converted name of the scheduler in case the service has a foldered name. **/
-    public static final String FRAMEWORK_SCHEDULER_NAME_TASKENV = "FRAMEWORK_SCHEDULER_NAME";
+    /** Provides the host domain for VIPs within the service. VIPs within the service would be accessed as subdomains
+     *  under this domain. For example, <VIP_NAME>.<FRAMEWORK_VIP_HOST> => vip hostname. */
+    public static final String FRAMEWORK_VIP_HOST_TASKENV = "FRAMEWORK_VIP_HOST";
+
+    /** Provides the hostname of the Scheduler's own API. Pods within the service may access scheduler-hosted APIs under
+     *  this hostname. For example, <SCHEDULER_API_HOSTNAME>/v1/state/files/notavirus.exe.txt */
+    public static final String SCHEDULER_API_HOSTNAME_TASKENV = "SCHEDULER_API_HOSTNAME";
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/api/EndpointUtils.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/api/EndpointUtils.java
@@ -63,13 +63,17 @@ public class EndpointUtils {
     }
 
     /**
+     * Returns the correct DNS domain for VIPs within the service.
+     */
+    public static String toVipDomain(String serviceName) {
+        return String.format("%s.%s", removeSlashes(serviceName), Constants.VIP_HOST_TLD);
+    }
+
+    /**
      * Returns the correct L4LB VIP hostname for the provided task running within the provided service.
      */
     public static String toVipHostname(String serviceName, VipInfo vipInfo) {
-        return String.format("%s.%s.%s",
-                removeSlashes(vipInfo.getVipName()),
-                removeSlashes(serviceName),
-                Constants.VIP_HOST_TLD);
+        return String.format("%s.%s", removeSlashes(vipInfo.getVipName()), toVipDomain(serviceName));
     }
 
     /**

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/PodInfoBuilder.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/PodInfoBuilder.java
@@ -376,12 +376,15 @@ public class PodInfoBuilder {
 
         // Inject Pod Instance Index
         environmentMap.put(EnvConstants.POD_INSTANCE_INDEX_TASKENV, String.valueOf(podInstance.getIndex()));
-        // Inject Framework Scheduler Name in order to hit the scheduler jetty server from within the YAML
-        environmentMap.put(EnvConstants.FRAMEWORK_SCHEDULER_NAME_TASKENV, EndpointUtils.removeSlashes(serviceName));
         // Inject Framework Name (raw, not safe for use in hostnames)
         environmentMap.put(EnvConstants.FRAMEWORK_NAME_TASKENV, serviceName);
-        // Inject Framework host domain (with hostname-safe framework name)
+        // Inject Framework pod host domain (with hostname-safe framework name)
         environmentMap.put(EnvConstants.FRAMEWORK_HOST_TASKENV, EndpointUtils.toAutoIpDomain(serviceName));
+        // Inject Framework VIP domain (with hostname-safe framework name)
+        environmentMap.put(EnvConstants.FRAMEWORK_VIP_HOST_TASKENV, EndpointUtils.toVipDomain(serviceName));
+        // Inject Scheduler API hostname (with hostname-safe scheduler name)
+        environmentMap.put(EnvConstants.SCHEDULER_API_HOSTNAME_TASKENV,
+                EndpointUtils.toSchedulerApiVipHostname(serviceName));
 
         // Inject TASK_NAME as KEY:VALUE
         environmentMap.put(EnvConstants.TASK_NAME_TASKENV, TaskSpec.getInstanceName(podInstance, taskSpec));


### PR DESCRIPTION
- Adds `FRAMEWORK_VIP_HOST` in parallel to existing `FRAMEWORK_HOST`: a domain for pointing service tasks to VIPs within the service
- Replaces `FRAMEWORK_SCHEDULER_NAME` (originally added for, and currently only used by, HDFS) with `SCHEDULER_API_HOSTNAME`, allowing tasks to avoid hardcoding the rest of the scheduler API VIP in tasks.
- Update docs and examples to reflect the above