### PR TITLE
[INFINITY-2455] correctly handle errors in options json

### DIFF
--- a/cli/client/cosmos.go
+++ b/cli/client/cosmos.go
@@ -40,8 +40,8 @@ type cosmosErrorInstance struct {
 type cosmosError struct {
 	Keyword  string
 	Message  string
-	Found    string
-	Expected []string
+	Found    interface{}
+	Expected []interface{}
 	Instance cosmosErrorInstance
 	// deliberately omitting:
 	// level
@@ -100,7 +100,7 @@ func parseCosmosHTTPErrorResponse(response *http.Response, body []byte) error {
 	var errorResponse cosmosErrorResponse
 	err := json.Unmarshal(body, &errorResponse)
 	if err != nil {
-		printMessage(err.Error())
+		printMessage("Error unmarshalling cosmosErrorResponse: %v", err.Error())
 		return createResponseError(response)
 	}
 	if errorResponse.ErrorType != "" {


### PR DESCRIPTION
This is a backport of the changes from #1698 to properly handle validation errors in service update.