### PR TITLE
[INFINITY-2498] Drop sticky dynamic ports on replacement (#1702)

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/PodInfoBuilder.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/PodInfoBuilder.java
@@ -4,10 +4,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.mesosphere.sdk.api.ArtifactResource;
 import com.mesosphere.sdk.api.EndpointUtils;
 import com.mesosphere.sdk.dcos.DcosConstants;
-import com.mesosphere.sdk.offer.CommonIdUtils;
-import com.mesosphere.sdk.offer.Constants;
-import com.mesosphere.sdk.offer.InvalidRequirementException;
-import com.mesosphere.sdk.offer.TaskException;
+import com.mesosphere.sdk.offer.*;
 import com.mesosphere.sdk.offer.taskdata.AuxLabelAccess;
 import com.mesosphere.sdk.offer.taskdata.EnvConstants;
 import com.mesosphere.sdk.offer.taskdata.EnvUtils;
@@ -15,6 +12,7 @@ import com.mesosphere.sdk.offer.taskdata.TaskLabelReader;
 import com.mesosphere.sdk.offer.taskdata.TaskLabelWriter;
 import com.mesosphere.sdk.scheduler.SchedulerFlags;
 import com.mesosphere.sdk.scheduler.plan.PodInstanceRequirement;
+import com.mesosphere.sdk.scheduler.recovery.FailureUtils;
 import com.mesosphere.sdk.specification.*;
 import com.mesosphere.sdk.specification.util.RLimit;
 import org.apache.commons.lang3.StringUtils;
@@ -87,7 +85,12 @@ public class PodInfoBuilder {
             // Just store against the full TaskInfo name ala 'broker-0-node'. The task spec name will be mapped to the
             // TaskInfo name in the getter function below. This is easier than extracting the task spec name from the
             // TaskInfo name.
-            portsByTask.put(currentTask.getName(), new TaskPortLookup(currentTask));
+
+            // If the pod was replaced, discard any previously used ports. We want dynamic ports
+            // to re-roll.
+            if (!FailureUtils.isPermanentlyFailed(currentTask)) {
+                portsByTask.put(currentTask.getName(), new TaskPortLookup(currentTask));
+            }
         }
 
         for (Protos.TaskInfo.Builder taskBuilder : taskBuilders.values()) {

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/PortEvaluationStageTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/PortEvaluationStageTest.java
@@ -3,6 +3,7 @@ package com.mesosphere.sdk.offer.evaluate;
 import com.mesosphere.sdk.offer.*;
 import com.mesosphere.sdk.dcos.DcosConstants;
 import com.mesosphere.sdk.scheduler.SchedulerFlags;
+import com.mesosphere.sdk.offer.taskdata.TaskLabelWriter;
 import com.mesosphere.sdk.scheduler.plan.DefaultPodInstance;
 import com.mesosphere.sdk.scheduler.plan.PodInstanceRequirement;
 import com.mesosphere.sdk.specification.*;
@@ -424,5 +425,79 @@ public class PortEvaluationStageTest extends DefaultCapabilitiesTestSuite {
             }
         }
         Assert.assertTrue(portInTaskEnv);
+    }
+
+    @Test
+    public void testDynamicPortNotStickyAfterReplacement() throws Exception {
+        // The initial dynamic port should be the min of the available range.
+        Protos.Resource offeredPorts = ResourceTestUtils.getUnreservedPorts(10000, 10050);
+        Protos.Offer offer = OfferTestUtils.getOffer(offeredPorts);
+
+        PortSpec portSpec = new PortSpec(
+                getPort(0),
+                TestConstants.ROLE,
+                Constants.ANY_ROLE,
+                TestConstants.PRINCIPAL,
+                "PORT_TEST",
+                "TEST",
+                TestConstants.PORT_VISIBILITY,
+                Collections.emptyList());
+
+        PodInstanceRequirement podInstanceRequirement = getPodInstanceRequirement(portSpec);
+        PodInfoBuilder podInfoBuilder = new PodInfoBuilder(
+                podInstanceRequirement,
+                TestConstants.SERVICE_NAME,
+                UUID.randomUUID(),
+                OfferRequirementTestUtils.getTestSchedulerFlags(),
+                Collections.emptyList(),
+                TestConstants.FRAMEWORK_ID,
+                true);
+
+        PortEvaluationStage portEvaluationStage = new PortEvaluationStage(portSpec,
+                TestConstants.TASK_NAME,
+                Optional.empty());
+
+        MesosResourcePool mesosResourcePool = new MesosResourcePool(offer, Optional.of(Constants.ANY_ROLE));
+        EvaluationOutcome outcome = portEvaluationStage.evaluate(mesosResourcePool, podInfoBuilder);
+        Assert.assertEquals(true, outcome.isPassing());
+
+        Protos.TaskInfo.Builder taskBuilder = podInfoBuilder.getTaskBuilder(TestConstants.TASK_NAME);
+        checkDiscoveryInfo(taskBuilder.getDiscovery(), "TEST", 10000);
+
+        // In a restart, we want port stickiness. It should fail if the original dynamic port is not
+        // available in the offer.
+        Protos.TaskInfo.Builder currentTaskBuilder = podInfoBuilder.getTaskBuilders().stream().findFirst().get();
+
+        podInfoBuilder = new PodInfoBuilder(
+                podInstanceRequirement,
+                TestConstants.SERVICE_NAME,
+                UUID.randomUUID(),
+                OfferRequirementTestUtils.getTestSchedulerFlags(),
+                Collections.singleton(currentTaskBuilder.build()),
+                TestConstants.FRAMEWORK_ID,
+                true);
+
+        // Omit 10,000 the expected port.
+        offer = OfferTestUtils.getOffer(ResourceTestUtils.getUnreservedPorts(10001, 10050));
+        mesosResourcePool = new MesosResourcePool(offer, Optional.of(Constants.ANY_ROLE));
+        outcome = portEvaluationStage.evaluate(mesosResourcePool, podInfoBuilder);
+        Assert.assertEquals(false, outcome.isPassing());
+
+        // In permanent replacement, the previous dynamic port should be discarded, so an offer
+        // without that port should be valid.
+        currentTaskBuilder.setLabels(new TaskLabelWriter(currentTaskBuilder).setPermanentlyFailed().toProto());
+
+        podInfoBuilder = new PodInfoBuilder(
+                podInstanceRequirement,
+                TestConstants.SERVICE_NAME,
+                UUID.randomUUID(),
+                OfferRequirementTestUtils.getTestSchedulerFlags(),
+                Collections.singleton(currentTaskBuilder.build()),
+                TestConstants.FRAMEWORK_ID,
+                true);
+
+        mesosResourcePool = new MesosResourcePool(offer, Optional.of(Constants.ANY_ROLE));
+        outcome = portEvaluationStage.evaluate(mesosResourcePool, podInfoBuilder);
+        Assert.assertEquals(true, outcome.isPassing());
     }
 }


### PR DESCRIPTION
* If a task is being replaced, drop its previous dynamic ports from consideration.

Add test for this behavior.

* Fix merge issue