### PR TITLE
INFINITY-2512 Resource builder cleanup

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/MesosResource.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/MesosResource.java
@@ -71,13 +71,13 @@ public class MesosResource {
 
     private String getRefinedPreviousRole() {
         if (resource.getReservationsCount() <= 1) {
-            return resource.getRole();
+            return ResourceUtils.getRootRole(resource);
         } else {
             return resource.getReservations(resource.getReservationsCount() - 2).getRole();
         }
     }
 
-    private String getLegacyPreviousRole() {
+    private static String getLegacyPreviousRole() {
         return Constants.ANY_ROLE;
     }
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/ResourceBuilder.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/ResourceBuilder.java
@@ -2,15 +2,11 @@ package com.mesosphere.sdk.offer;
 
 import com.mesosphere.sdk.dcos.Capabilities;
 import com.mesosphere.sdk.offer.taskdata.AuxLabelAccess;
-import com.mesosphere.sdk.specification.DefaultResourceSpec;
-import com.mesosphere.sdk.specification.DefaultVolumeSpec;
 import com.mesosphere.sdk.specification.ResourceSpec;
 import com.mesosphere.sdk.specification.VolumeSpec;
+
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.mesos.Protos;
-import org.apache.mesos.Protos.Resource;
-import org.apache.mesos.Protos.Resource.DiskInfo;
-import org.apache.mesos.Protos.Value;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -21,86 +17,98 @@ import java.util.UUID;
 public class ResourceBuilder {
     private final String resourceName;
     private Optional<String> principal;
-    private Value value;
+    private Protos.Value value;
     private Optional<String> role;
     private final String preReservedRole;
     private Optional<String> resourceId;
     private Optional<String> diskContainerPath;
     private Optional<String> diskPersistenceId;
-    private Optional<DiskInfo.Source> diskMountInfo;
+    private Optional<Protos.Resource.DiskInfo.Source> diskMountInfo;
     private MesosResource mesosResource;
 
+    /**
+     * Creates a new builder using basic resource information in the provided {@link ResourceSpec}.
+     *
+     * @throws IllegalArgumentException if the provided {@code spec} is a {@link VolumeSpec}
+     */
     public static ResourceBuilder fromSpec(ResourceSpec spec, Optional<String> resourceId) {
+        if (spec instanceof VolumeSpec) {
+            throw new IllegalArgumentException(
+                    "Provided VolumeSpec must be passed to one of the VolumeSpec-specific functions: " +
+                    spec.toString());
+        }
+        return fromSpecInternal(spec, resourceId);
+    }
+
+    /**
+     * Creates a new builder using root volume-specific information in the provided {@link ResourceSpec}.
+     *
+     * @throws IllegalArgumentException if the provided {@code spec} is for a mount volume
+     */
+    public static ResourceBuilder fromRootVolumeSpec(
+            VolumeSpec spec, Optional<String> resourceId, Optional<String> persistenceId) {
+        if (spec.getType() != VolumeSpec.Type.ROOT) {
+            throw new IllegalArgumentException("Provided VolumeSpec must be of type ROOT: " + spec.toString());
+        }
+        return fromSpecInternal(spec, resourceId).setRootVolume(spec.getContainerPath(), persistenceId);
+    }
+
+    /**
+     * Creates a new builder using mount volume-specific information in the provided {@link ResourceSpec}.
+     *
+     * @throws IllegalArgumentException if the provided {@code spec} is for a root volume
+     */
+    public static ResourceBuilder fromMountVolumeSpec(
+            VolumeSpec spec, Optional<String> resourceId, Optional<String> persistenceId, String mountRoot) {
+        if (spec.getType() != VolumeSpec.Type.MOUNT) {
+            throw new IllegalArgumentException("Provided VolumeSpec must be of type MOUNT: " + spec.toString());
+        }
+        return fromSpecInternal(spec, resourceId).setMountVolume(spec.getContainerPath(), persistenceId, mountRoot);
+    }
+
+    private static ResourceBuilder fromSpecInternal(ResourceSpec spec, Optional<String> resourceId) {
         return new ResourceBuilder(spec.getName(), spec.getValue(), spec.getPreReservedRole())
                 .setRole(Optional.of(spec.getRole()))
                 .setPrincipal(Optional.of(spec.getPrincipal()))
                 .setResourceId(resourceId);
     }
 
-    public static ResourceBuilder fromSpec(
-            VolumeSpec spec,
-            Optional<String> resourceId,
-            Optional<String> persistenceId,
-            Optional<String> sourceRoot) {
-
-        ResourceBuilder resourceBuilder = fromSpec(spec, resourceId);
-        switch (spec.getType()) {
-            case ROOT:
-                return resourceBuilder.setRootVolume(spec.getContainerPath(), persistenceId);
-            case MOUNT:
-                if (!sourceRoot.isPresent()) {
-                    throw new IllegalStateException("Source path must be set on MOUNT volumes.");
-                }
-                return resourceBuilder.setMountVolume(spec.getContainerPath(), persistenceId, sourceRoot);
-            default:
-                throw new IllegalStateException(String.format("Unexpected disk type: %s", spec.getType()));
-        }
-    }
-
-    public static ResourceBuilder fromExistingResource(Resource resource) {
+    /**
+     * Pre-populates a new {@link ResourceBuilder} instance using the details in the provided Mesos
+     * {@link Protos.Resource} which must have been reserved by the SDK.
+     */
+    public static ResourceBuilder fromExistingResource(Protos.Resource resource) {
         Optional<String> resourceId = ResourceUtils.getResourceId(resource);
-
-        if (!resource.hasDisk()) {
-            ResourceSpec resourceSpec = getResourceSpec(resource);
-            return fromSpec(resourceSpec, resourceId);
-        } else {
-            VolumeSpec volumeSpec = getVolumeSpec(resource);
-            Optional<String> persistenceId = ResourceUtils.getPersistenceId(resource);
-            Optional<String> sourceRoot = ResourceUtils.getSourceRoot(resource);
-            return fromSpec(volumeSpec, resourceId, persistenceId, sourceRoot);
-        }
-    }
-
-    public static ResourceBuilder fromUnreservedValue(String resourceName, Value value) {
-        return new ResourceBuilder(resourceName, value, Constants.ANY_ROLE);
-    }
-
-    private static ResourceSpec getResourceSpec(Resource resource) {
-        if (!ResourceUtils.hasResourceId(resource)) {
+        if (!resourceId.isPresent()) {
             throw new IllegalStateException(
                     "Cannot generate resource spec from resource which has not been reserved by the SDK.");
         }
 
-        return new DefaultResourceSpec(
-                resource.getName(),
-                ValueUtils.getValue(resource),
-                ResourceUtils.getRole(resource),
-                resource.getRole(),
-                ResourceUtils.getPrincipal(resource).get());
+        ResourceBuilder builder = new ResourceBuilder(
+                resource.getName(), ValueUtils.getValue(resource), ResourceUtils.getRootRole(resource))
+                .setRole(Optional.of(ResourceUtils.getRole(resource)))
+                .setPrincipal(ResourceUtils.getPrincipal(resource))
+                .setResourceId(resourceId);
+        if (resource.hasDisk()) {
+            if (resource.getDisk().hasSource()) {
+                builder.setMountVolume(
+                        resource.getDisk().getVolume().getContainerPath(),
+                        ResourceUtils.getPersistenceId(resource),
+                        ResourceUtils.getSourceRoot(resource).get());
+            } else {
+                builder.setRootVolume(
+                        resource.getDisk().getVolume().getContainerPath(),
+                        ResourceUtils.getPersistenceId(resource));
+            }
+        }
+        return builder;
     }
 
-    private static VolumeSpec getVolumeSpec(Resource resource) {
-        VolumeSpec.Type type = resource.getDisk().hasSource() ? VolumeSpec.Type.MOUNT : VolumeSpec.Type.ROOT;
-        return new DefaultVolumeSpec(
-                resource.getScalar().getValue(),
-                type,
-                resource.getDisk().getVolume().getContainerPath(),
-                ResourceUtils.getRole(resource),
-                resource.getRole(),
-                resource.getDisk().getPersistence().getPrincipal());
+    public static ResourceBuilder fromUnreservedValue(String resourceName, Protos.Value value) {
+        return new ResourceBuilder(resourceName, value, Constants.ANY_ROLE);
     }
 
-    private ResourceBuilder(String resourceName, Value value, String preReservedRole) {
+    private ResourceBuilder(String resourceName, Protos.Value value, String preReservedRole) {
         this.resourceName = resourceName;
         this.value = value;
         this.preReservedRole = preReservedRole;
@@ -115,7 +123,7 @@ public class ResourceBuilder {
     /**
      * Sets the value for this resource. Supported types are {@code SCALAR}, {@code RANGES}, and {@code SET}.
      */
-    public ResourceBuilder setValue(Value value) {
+    public ResourceBuilder setValue(Protos.Value value) {
         this.value = value;
         return this;
     }
@@ -130,29 +138,12 @@ public class ResourceBuilder {
     }
 
     /**
-     * Clears a previously set resource ID, or does nothing if the resource ID is already unset. This may be used to
-     * disassociate a task with a given reserved resource, e.g. with task replacement.
-     */
-    public ResourceBuilder clearResourceId() {
-        this.resourceId = Optional.empty();
-        return this;
-    }
-
-    /**
-     * Clears a previously set disk persistence ID, or does nothing if the disk persistence ID is already unset.
-     */
-    public ResourceBuilder clearPersistenceId() {
-        this.diskPersistenceId = Optional.empty();
-        return this;
-    }
-
-    /**
      * Assigns information relating to {@code ROOT} disk volumes for this resource.
      *
      * @param existingPersistenceId the persistence ID of a previously reserved disk resource to be associated with
      * @throws IllegalStateException if the resource does not have type {@code disk}
      */
-    public ResourceBuilder setRootVolume(String containerPath, Optional<String> existingPersistenceId) {
+    private ResourceBuilder setRootVolume(String containerPath, Optional<String> existingPersistenceId) {
         if (!this.resourceName.equals(Constants.DISK_RESOURCE_TYPE)) {
             throw new IllegalStateException(
                     "Refusing to set disk information against resource of type: " + resourceName);
@@ -168,15 +159,14 @@ public class ResourceBuilder {
      * @param existingPersistenceId the persistence ID of a previously reserved disk resource to be associated with
      * @throws IllegalStateException if the resource does not have type {@code disk}
      */
-    public ResourceBuilder setMountVolume(
-            String containerPath, Optional<String> existingPersistenceId, Optional<String> existingMountRoot) {
+    private ResourceBuilder setMountVolume(
+            String containerPath, Optional<String> existingPersistenceId, String mountRoot) {
         // common information across ROOT + MOUNT volumes:
         setRootVolume(containerPath, existingPersistenceId);
         // additional information specific to MOUNT volumes:
-        DiskInfo.Source.Builder sourceBuilder = DiskInfo.Source.newBuilder().setType(DiskInfo.Source.Type.MOUNT);
-        if (existingMountRoot.isPresent()) {
-            sourceBuilder.getMountBuilder().setRoot(existingMountRoot.get());
-        }
+        Protos.Resource.DiskInfo.Source.Builder sourceBuilder = Protos.Resource.DiskInfo.Source.newBuilder()
+                .setType(Protos.Resource.DiskInfo.Source.Type.MOUNT);
+        sourceBuilder.getMountBuilder().setRoot(mountRoot);
         this.diskMountInfo = Optional.of(sourceBuilder.build());
         return this;
     }
@@ -186,20 +176,46 @@ public class ResourceBuilder {
         return this;
     }
 
-    public Resource build() {
+    public ResourceBuilder setRole(Optional<String> role) {
+        this.role = role;
+        return this;
+    }
+
+    public ResourceBuilder setPrincipal(Optional<String> principal) {
+        this.principal = principal;
+        return this;
+    }
+
+    public Protos.Resource build() {
         // Note:
         // In the pre-resource-refinment world (< 1.9), Mesos will expect
         // reserved Resources to have role and reservation set.
         //
         // In the post-resource-refinement world (1.10+), Mesos will expect
         // reserved Resources to have reservations (and ONLY reservations) set.
-        Resource.Builder builder =
-                mesosResource == null ? Resource.newBuilder() : mesosResource.getResource().toBuilder();
+        Protos.Resource.Builder builder =
+                mesosResource == null ? Protos.Resource.newBuilder() : mesosResource.getResource().toBuilder();
         builder.setName(resourceName)
-                .setRole(Constants.ANY_ROLE)
                 .setType(value.getType());
 
         boolean preReservedSupported = Capabilities.getInstance().supportsPreReservedResources();
+        final Optional<String> rootRoleToUse;
+        if (preReservedSupported) {
+            // 1.10+ uses prereservation as a list of hierarchical roles, clear root role of "*"
+            if (builder.getReservationsCount() > 0) {
+                rootRoleToUse = Optional.empty();
+            } else {
+                rootRoleToUse = Optional.of(Constants.ANY_ROLE);
+            }
+        } else {
+            // <=1.9 doesn't support prereservation, use root role of "*" or specified role if any
+            if (role.isPresent()) {
+                rootRoleToUse = role;
+            } else {
+                rootRoleToUse = Optional.of(Constants.ANY_ROLE);
+            }
+        }
+        builder = ResourceUtils.setRootRole(builder, rootRoleToUse);
 
         // Set the reservation (<1.9) or reservations (1.10+) for Resources that do not
         // already have a resource id.
@@ -207,14 +223,13 @@ public class ResourceBuilder {
         // is the reservation setting destructive / non-repeatable?
         if (role.isPresent() && !ResourceUtils.hasResourceId(builder.build())) {
             String resId = resourceId.isPresent() ? resourceId.get() : UUID.randomUUID().toString();
-            Resource.ReservationInfo reservationInfo = getReservationInfo(role.get(), resId);
+            Protos.Resource.ReservationInfo reservationInfo = getReservationInfo(role.get(), resId);
 
             if (preReservedSupported) {
                 if (!preReservedRole.equals(Constants.ANY_ROLE) && mesosResource == null) {
-                    builder.addReservations(
-                            Resource.ReservationInfo.newBuilder()
+                    builder.addReservationsBuilder()
                             .setRole(preReservedRole)
-                            .setType(Resource.ReservationInfo.Type.STATIC));
+                            .setType(Protos.Resource.ReservationInfo.Type.STATIC);
                 }
                 builder.addReservations(reservationInfo);
             } else {
@@ -222,15 +237,8 @@ public class ResourceBuilder {
             }
         }
 
-        // Set the role (<1.9) or clear it (1.10+) for reserved resources.
-        if (role.isPresent() && !preReservedSupported) {
-            builder.setRole(role.get());
-        } else if (preReservedSupported && builder.getReservationsCount() > 0) {
-            builder.clearRole();
-        }
-
         if (diskContainerPath.isPresent()) {
-            DiskInfo.Builder diskBuilder = builder.getDiskBuilder();
+            Protos.Resource.DiskInfo.Builder diskBuilder = builder.getDiskBuilder();
             diskBuilder.getVolumeBuilder()
                     .setContainerPath(diskContainerPath.get())
                     .setMode(Protos.Volume.Mode.RW);
@@ -245,7 +253,12 @@ public class ResourceBuilder {
         return setValue(builder, value).build();
     }
 
-    private Resource.ReservationInfo getReservationInfo(String role, String resId) {
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
+    }
+
+    private Protos.Resource.ReservationInfo getReservationInfo(String role, String resId) {
         if (Capabilities.getInstance().supportsPreReservedResources()) {
             return getRefinedReservationInfo(role, resId);
         } else {
@@ -253,23 +266,23 @@ public class ResourceBuilder {
         }
     }
 
-    private Resource.ReservationInfo getRefinedReservationInfo(String role, String resId) {
-        Resource.ReservationInfo.Builder reservationBuilder = Resource.ReservationInfo.newBuilder()
+    private Protos.Resource.ReservationInfo getRefinedReservationInfo(String role, String resId) {
+        Protos.Resource.ReservationInfo.Builder reservationBuilder = Protos.Resource.ReservationInfo.newBuilder()
                 .setRole(role)
-                .setType(Resource.ReservationInfo.Type.DYNAMIC)
+                .setType(Protos.Resource.ReservationInfo.Type.DYNAMIC)
                 .setPrincipal(principal.get());
         AuxLabelAccess.setResourceId(reservationBuilder, resId);
         return reservationBuilder.build();
     }
 
-    private Resource.ReservationInfo getLegacyReservationInfo(String resId) {
-        Resource.ReservationInfo.Builder reservationBuilder = Resource.ReservationInfo.newBuilder()
+    private Protos.Resource.ReservationInfo getLegacyReservationInfo(String resId) {
+        Protos.Resource.ReservationInfo.Builder reservationBuilder = Protos.Resource.ReservationInfo.newBuilder()
                 .setPrincipal(principal.get());
         AuxLabelAccess.setResourceId(reservationBuilder, resId);
         return reservationBuilder.build();
     }
 
-    private static Resource.Builder setValue(Resource.Builder builder, Value value) {
+    private static Protos.Resource.Builder setValue(Protos.Resource.Builder builder, Protos.Value value) {
         builder.setType(value.getType());
         switch (value.getType()) {
         case SCALAR:
@@ -284,20 +297,5 @@ public class ResourceBuilder {
         default:
             throw new IllegalArgumentException(String.format("Unsupported spec value type: %s", value.getType()));
         }
-    }
-
-    @Override
-    public String toString() {
-        return ToStringBuilder.reflectionToString(this);
-    }
-
-    public ResourceBuilder setRole(Optional<String> role) {
-        this.role = role;
-        return this;
-    }
-
-    public ResourceBuilder setPrincipal(Optional<String> principal) {
-        this.principal = principal;
-        return this;
     }
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/ResourceUtils.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/ResourceUtils.java
@@ -60,6 +60,23 @@ public class ResourceUtils {
         return new MesosResource(resource).getRole();
     }
 
+    @SuppressWarnings("deprecation") // For access to the deprecated 'role' field, used by older Mesos
+    public static String getRootRole(Protos.Resource resource) {
+        return resource.getRole();
+    }
+
+    /**
+     * Assigns or clears the role in the provided builder, and returns the builder.
+     */
+    @SuppressWarnings("deprecation") // For access to the deprecated 'role' field, used by older Mesos
+    public static Protos.Resource.Builder setRootRole(Protos.Resource.Builder builder, Optional<String> role) {
+        if (role.isPresent()) {
+            return builder.setRole(role.get());
+        } else {
+            return builder.clearRole();
+        }
+    }
+
     public static Optional<String> getPrincipal(Resource resource) {
         Optional<Resource.ReservationInfo> reservationInfo = getReservation(resource);
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/TaskUtils.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/TaskUtils.java
@@ -10,7 +10,6 @@ import com.mesosphere.sdk.state.ConfigStoreException;
 import com.mesosphere.sdk.state.StateStore;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.mesos.Protos.Resource;
 import org.apache.mesos.Protos.TaskInfo;
 import org.apache.mesos.Protos.TaskState;
 import org.apache.mesos.Protos.TaskStatus;
@@ -405,20 +404,15 @@ public class TaskUtils {
      */
     public static boolean isRecoveryNeeded(TaskStatus taskStatus) {
         switch (taskStatus.getState()) {
-            case TASK_FINISHED:
-            case TASK_FAILED:
-            case TASK_KILLED:
-            case TASK_ERROR:
-            case TASK_LOST:
-                return true;
-            case TASK_KILLING:
-            case TASK_RUNNING:
-            case TASK_STAGING:
-            case TASK_STARTING:
-                break;
+        case TASK_FINISHED:
+        case TASK_FAILED:
+        case TASK_KILLED:
+        case TASK_ERROR:
+        case TASK_LOST:
+            return true;
+        default:
+            return false;
         }
-
-        return false;
     }
 
     /**
@@ -433,20 +427,14 @@ public class TaskUtils {
      */
     public static boolean isTerminal(TaskState taskState) {
         switch (taskState) {
-            case TASK_FINISHED:
-            case TASK_FAILED:
-            case TASK_KILLED:
-            case TASK_ERROR:
-                return true;
-            case TASK_LOST:
-            case TASK_KILLING:
-            case TASK_RUNNING:
-            case TASK_STAGING:
-            case TASK_STARTING:
-                break;
+        case TASK_FINISHED:
+        case TASK_FAILED:
+        case TASK_KILLED:
+        case TASK_ERROR:
+            return true;
+        default:
+            return false;
         }
-
-        return false;
     }
 
     /**
@@ -477,39 +465,5 @@ public class TaskUtils {
      */
     public static String getStepName(PodInstance podInstance, Collection<String> tasksToLaunch) {
         return podInstance.getName() + ":" + tasksToLaunch;
-    }
-
-    /**
-     * Returns TaskInfos will all reservations and persistence IDs removed from their Resources.
-     */
-    public static Collection<TaskInfo> clearReservations(Collection<TaskInfo> taskInfos) {
-        return taskInfos.stream()
-                .map(TaskUtils::clearReservationIds)
-                .collect(Collectors.toList());
-    }
-
-    private static TaskInfo clearReservationIds(TaskInfo taskInfo) {
-        TaskInfo.Builder taskInfoBuilder = TaskInfo.newBuilder(taskInfo)
-                .clearResources()
-                .addAllResources(clearReservationIds(taskInfo.getResourcesList()));
-
-        if (taskInfo.hasExecutor()) {
-            taskInfoBuilder.getExecutorBuilder()
-                    .clearResources()
-                    .addAllResources(clearReservationIds(taskInfoBuilder.getExecutor().getResourcesList()));
-        }
-
-        return taskInfoBuilder.build();
-    }
-
-    private static List<Resource> clearReservationIds(List<Resource> resources) {
-        List<Resource> clearedResources = new ArrayList<>();
-        for (Resource resource : resources) {
-            clearedResources.add(ResourceBuilder.fromExistingResource(resource)
-                    .clearResourceId()
-                    .clearPersistenceId()
-                    .build());
-        }
-        return clearedResources;
     }
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/DestroyEvaluationStage.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/DestroyEvaluationStage.java
@@ -2,7 +2,6 @@ package com.mesosphere.sdk.offer.evaluate;
 
 import com.google.protobuf.TextFormat;
 import com.mesosphere.sdk.offer.DestroyOfferRecommendation;
-import com.mesosphere.sdk.offer.MesosResource;
 import com.mesosphere.sdk.offer.MesosResourcePool;
 import org.apache.mesos.Protos;
 
@@ -16,18 +15,16 @@ import static com.mesosphere.sdk.offer.evaluate.EvaluationOutcome.pass;
 public class DestroyEvaluationStage implements OfferEvaluationStage {
     private final Protos.Resource resource;
 
-    public DestroyEvaluationStage (Protos.Resource resource) {
+    public DestroyEvaluationStage(Protos.Resource resource) {
         this.resource = resource;
     }
 
     @Override
     public EvaluationOutcome evaluate(MesosResourcePool mesosResourcePool, PodInfoBuilder podInfoBuilder) {
-        return pass(
-                this,
+        return pass(this,
                 Arrays.asList(new DestroyOfferRecommendation(mesosResourcePool.getOffer(), resource)),
                 "Unreserving orphaned resource: %s",
                 TextFormat.shortDebugString(resource))
-                .mesosResource(new MesosResource(resource))
                 .build();
     }
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/EvaluationOutcome.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/EvaluationOutcome.java
@@ -1,6 +1,5 @@
 package com.mesosphere.sdk.offer.evaluate;
 
-import com.mesosphere.sdk.offer.MesosResource;
 import com.mesosphere.sdk.offer.OfferRecommendation;
 
 import java.util.*;
@@ -22,7 +21,6 @@ public class EvaluationOutcome {
 
     private final Type type;
     private final String source;
-    private final MesosResource mesosResource;
     private final Collection<OfferRecommendation> offerRecommendations;
     private final Collection<EvaluationOutcome> children;
     private final String reason;
@@ -84,13 +82,11 @@ public class EvaluationOutcome {
     private EvaluationOutcome(
             Type type,
             Object source,
-            MesosResource mesosResource,
             Collection<OfferRecommendation> offerRecommendations,
             Collection<EvaluationOutcome> children,
             String reason) {
         this.type = type;
         this.source = source.getClass().getSimpleName();
-        this.mesosResource = mesosResource;
         this.offerRecommendations = offerRecommendations;
         this.children = children;
         this.reason = reason;
@@ -124,10 +120,6 @@ public class EvaluationOutcome {
         return children;
     }
 
-    public Optional<MesosResource> getMesosResource() {
-        return Optional.ofNullable(mesosResource);
-    }
-
     public List<OfferRecommendation> getOfferRecommendations() {
         List<OfferRecommendation> recommendations = new ArrayList<>();
         recommendations.addAll(offerRecommendations);
@@ -151,7 +143,6 @@ public class EvaluationOutcome {
         private final Collection<OfferRecommendation> offerRecommendations;
         private final Collection<EvaluationOutcome> children;
         private final String reason;
-        private MesosResource mesosResource;
 
         public Builder(
                 Type type,
@@ -166,11 +157,6 @@ public class EvaluationOutcome {
             this.reason = String.format(reasonFormat, reasonArgs);
         }
 
-        public Builder mesosResource(MesosResource mesosResource) {
-            this.mesosResource = mesosResource;
-            return this;
-        }
-
         public Builder addChild(EvaluationOutcome child) {
             children.add(child);
             return this;
@@ -182,7 +168,7 @@ public class EvaluationOutcome {
         }
 
         public EvaluationOutcome build() {
-            return new EvaluationOutcome(type, source, mesosResource, offerRecommendations, children, reason);
+            return new EvaluationOutcome(type, source, offerRecommendations, children, reason);
         }
     }
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/PodInfoBuilder.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/PodInfoBuilder.java
@@ -163,40 +163,15 @@ public class PodInfoBuilder {
         }
     }
 
-    public static Protos.Resource getExistingExecutorVolume(
-            VolumeSpec volumeSpec, String resourceId, String persistenceId) {
-        Protos.Resource.Builder resourceBuilder = Protos.Resource.newBuilder()
-                .setName("disk")
-                .setType(Protos.Value.Type.SCALAR)
-                .setScalar(volumeSpec.getValue().getScalar());
-
-        Protos.Resource.DiskInfo.Builder diskInfoBuilder = resourceBuilder.getDiskBuilder();
-        diskInfoBuilder.getPersistenceBuilder()
-                .setId(persistenceId)
-                .setPrincipal(volumeSpec.getPrincipal());
-        diskInfoBuilder.getVolumeBuilder()
-                .setContainerPath(volumeSpec.getContainerPath())
-                .setMode(Protos.Volume.Mode.RW);
-
-        Protos.Resource.ReservationInfo.Builder reservationBuilder = resourceBuilder.addReservationsBuilder();
-        reservationBuilder
-                .setPrincipal(volumeSpec.getPrincipal())
-                .setRole(volumeSpec.getRole());
-        AuxLabelAccess.setResourceId(reservationBuilder, resourceId);
-
-        return resourceBuilder.build();
-    }
-
     private static Protos.Volume getVolume(VolumeSpec volumeSpec) {
-        Protos.Volume.Builder builder = Protos.Volume.newBuilder();
-        builder.setMode(Protos.Volume.Mode.RW)
-                .setContainerPath(volumeSpec.getContainerPath())
-                .setSource(Protos.Volume.Source.newBuilder()
-                        .setType(Protos.Volume.Source.Type.SANDBOX_PATH)
-                        .setSandboxPath(Protos.Volume.Source.SandboxPath.newBuilder()
-                                .setType(Protos.Volume.Source.SandboxPath.Type.PARENT)
-                                .setPath(volumeSpec.getContainerPath())));
-
+        Protos.Volume.Builder builder = Protos.Volume.newBuilder()
+                .setMode(Protos.Volume.Mode.RW)
+                .setContainerPath(volumeSpec.getContainerPath());
+        builder.getSourceBuilder()
+                .setType(Protos.Volume.Source.Type.SANDBOX_PATH)
+                .getSandboxPathBuilder()
+                        .setType(Protos.Volume.Source.SandboxPath.Type.PARENT)
+                        .setPath(volumeSpec.getContainerPath());
         return builder.build();
     }
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/PortEvaluationStage.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/PortEvaluationStage.java
@@ -87,8 +87,7 @@ public class PortEvaluationStage implements OfferEvaluationStage {
                 return evaluationOutcome;
             }
 
-            Optional<String> resourceIdResult = reserveEvaluationOutcome.getResourceId();
-            setProtos(podInfoBuilder, ResourceBuilder.fromSpec(updatedPortSpec, resourceIdResult).build());
+            setProtos(podInfoBuilder, reserveEvaluationOutcome.getTaskResource().get());
             return EvaluationOutcome.pass(
                     this,
                     evaluationOutcome.getOfferRecommendations(),
@@ -96,7 +95,6 @@ public class PortEvaluationStage implements OfferEvaluationStage {
                     resourceId.isPresent() ? "previously reserved " : "",
                     assignedPort,
                     resourceId)
-                    .mesosResource(evaluationOutcome.getMesosResource().get())
                     .build();
         } else {
             setProtos(podInfoBuilder, ResourceBuilder.fromSpec(updatedPortSpec, resourceId).build());

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/ResourceEvaluationStage.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/ResourceEvaluationStage.java
@@ -39,10 +39,10 @@ public class ResourceEvaluationStage implements OfferEvaluationStage {
             return evaluationOutcome;
         }
 
-        // Use the reservation outcome's resourceId, which is a newly generated UUID if requiredResourceId was empty.
+        // Use the reservation outcome's resource, which has a newly generated UUID if requiredResourceId was empty.
         OfferEvaluationUtils.setProtos(
                 podInfoBuilder,
-                ResourceBuilder.fromSpec(resourceSpec, reserveEvaluationOutcome.getResourceId()).build(),
+                reserveEvaluationOutcome.getTaskResource().get(),
                 Optional.ofNullable(taskName));
 
         return evaluationOutcome;

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/config/validate/TaskVolumesCannotChangeTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/config/validate/TaskVolumesCannotChangeTest.java
@@ -1,5 +1,6 @@
 package com.mesosphere.sdk.config.validate;
 
+import com.mesosphere.sdk.offer.Constants;
 import com.mesosphere.sdk.offer.InvalidRequirementException;
 import com.mesosphere.sdk.specification.*;
 import com.mesosphere.sdk.testutils.TestConstants;
@@ -26,21 +27,21 @@ public class TaskVolumesCannotChangeTest {
             VolumeSpec.Type.MOUNT,
             "some_path",
             "role",
-            "*",
+            Constants.ANY_ROLE,
             "principal");
     private static final VolumeSpec VOLUME2 = new DefaultVolumeSpec(
             DISK_SIZE_MB + 3,
             VolumeSpec.Type.MOUNT,
             "some_path",
             "role",
-            "*",
+            Constants.ANY_ROLE,
             "principal");
     private static final VolumeSpec VOLUME3 = new DefaultVolumeSpec(
             DISK_SIZE_MB,
             VolumeSpec.Type.ROOT,
             "some_path",
             "role",
-            "*",
+            Constants.ANY_ROLE,
             "principal");
 
     @Mock private PodSpec mockPodSpec1;

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/config/validate/VerifyVolumePathTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/config/validate/VerifyVolumePathTest.java
@@ -1,4 +1,5 @@
 package com.mesosphere.sdk.config.validate;
+import com.mesosphere.sdk.offer.Constants;
 import com.mesosphere.sdk.specification.*;
 import org.junit.Test;
 
@@ -14,55 +15,55 @@ public class VerifyVolumePathTest {
     @Test(expected = Exception.class)
     public void testVolumePathEmpty() {
         new DefaultVolumeSpec(
-                DISK_SIZE_MB, VolumeSpec.Type.MOUNT, "", "role", "*", "principal");
+                DISK_SIZE_MB, VolumeSpec.Type.MOUNT, "", "role", Constants.ANY_ROLE, "principal");
     }
 
     @Test(expected = Exception.class)
     public void testVolumePathBlank() {
         new DefaultVolumeSpec(
-                DISK_SIZE_MB, VolumeSpec.Type.MOUNT, " ", "role", "*", "principal");
+                DISK_SIZE_MB, VolumeSpec.Type.MOUNT, " ", "role", Constants.ANY_ROLE, "principal");
     }
 
     @Test(expected = Exception.class)
     public void testVolumePathSlash() {
         new DefaultVolumeSpec(
-                DISK_SIZE_MB, VolumeSpec.Type.MOUNT, "/path/to/volume0", "role", "*", "principal");
+                DISK_SIZE_MB, VolumeSpec.Type.MOUNT, "/path/to/volume0", "role", Constants.ANY_ROLE, "principal");
     }
 
     @Test(expected = Exception.class)
     public void testVolumePathChar() {
         new DefaultVolumeSpec(
-                DISK_SIZE_MB, VolumeSpec.Type.MOUNT, "@?test", "role", "*", "principal");
+                DISK_SIZE_MB, VolumeSpec.Type.MOUNT, "@?test", "role", Constants.ANY_ROLE, "principal");
     }
 
     @Test(expected = Exception.class)
     public void testVolumePathBeg() {
         new DefaultVolumeSpec(
-                DISK_SIZE_MB, VolumeSpec.Type.MOUNT, "-test", "role", "*", "principal");
+                DISK_SIZE_MB, VolumeSpec.Type.MOUNT, "-test", "role", Constants.ANY_ROLE, "principal");
     }
 
     @Test
     public void testVolumePathNumber() {
         new DefaultVolumeSpec(
-                DISK_SIZE_MB, VolumeSpec.Type.ROOT, "path-0_1-path", "role", "*", "principal");
+                DISK_SIZE_MB, VolumeSpec.Type.ROOT, "path-0_1-path", "role", Constants.ANY_ROLE, "principal");
     }
 
     @Test
     public void testVolumePathCorrect0() {
         new DefaultVolumeSpec(
-                DISK_SIZE_MB, VolumeSpec.Type.ROOT, "path", "role", "*", "principal");
+                DISK_SIZE_MB, VolumeSpec.Type.ROOT, "path", "role", Constants.ANY_ROLE, "principal");
     }
 
 
     @Test(expected = Exception.class)
     public void testVolumePathSlash1() {
         new DefaultVolumeSpec(
-                DISK_SIZE_MB, VolumeSpec.Type.ROOT, "path/path", "role", "*", "principal");
+                DISK_SIZE_MB, VolumeSpec.Type.ROOT, "path/path", "role", Constants.ANY_ROLE, "principal");
     }
 
     @Test(expected = Exception.class)
     public void testVolumePathSlash2() {
         new DefaultVolumeSpec(
-                DISK_SIZE_MB, VolumeSpec.Type.ROOT, "path-0/1-path", "role", "*", "principal");
+                DISK_SIZE_MB, VolumeSpec.Type.ROOT, "path-0/1-path", "role", Constants.ANY_ROLE, "principal");
     }
 }

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/testutils/OfferTestUtils.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/testutils/OfferTestUtils.java
@@ -5,9 +5,12 @@ import org.apache.mesos.Protos.Offer;
 import org.apache.mesos.Protos.Resource;
 import org.apache.mesos.Protos.Value;
 
+import com.mesosphere.sdk.offer.ResourceUtils;
+
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * This class provides utilities for tests concerned with Offers.
@@ -90,7 +93,7 @@ public class OfferTestUtils {
     public static void addResource(Offer.Builder o, String name, String role) {
         Resource.Builder b = o.addResourcesBuilder().setType(Value.Type.RANGES).setName(name);
         if (role != null) {
-            b.setRole(role);
+            ResourceUtils.setRootRole(b, Optional.of(role));
         }
     }
 

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/testutils/ResourceTestUtils.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/testutils/ResourceTestUtils.java
@@ -58,11 +58,8 @@ public class ResourceTestUtils {
                 TestConstants.ROLE,
                 Constants.ANY_ROLE,
                 TestConstants.PRINCIPAL);
-        return ResourceBuilder.fromSpec(
-                volumeSpec,
-                Optional.of(resourceId),
-                Optional.of(persistenceId),
-                Optional.empty())
+        return ResourceBuilder
+                .fromRootVolumeSpec(volumeSpec, Optional.of(resourceId), Optional.of(persistenceId))
                 .build();
     }
 
@@ -111,7 +108,6 @@ public class ResourceTestUtils {
         return getUnreservedResource("ports", builder.build());
     }
 
-    @SuppressWarnings("deprecation") // for Resource.setRole()
     private static Protos.Resource.Builder addReservation(
             Protos.Resource.Builder builder, String resourceId) {
         if (Capabilities.getInstance().supportsPreReservedResources()) {
@@ -120,7 +116,7 @@ public class ResourceTestUtils {
                     .setPrincipal(TestConstants.PRINCIPAL);
             AuxLabelAccess.setResourceId(reservationBuilder, resourceId);
         } else {
-            builder.setRole(TestConstants.ROLE);
+            ResourceUtils.setRootRole(builder, Optional.of(TestConstants.ROLE));
             Protos.Resource.ReservationInfo.Builder reservationBuilder = builder.getReservationBuilder()
                     .setPrincipal(TestConstants.PRINCIPAL);
             AuxLabelAccess.setResourceId(reservationBuilder, resourceId);
@@ -128,10 +124,9 @@ public class ResourceTestUtils {
         return builder;
     }
 
-    @SuppressWarnings("deprecation") // for Resource.setRole()
     private static Protos.Resource getUnreservedResource(String name, Protos.Value value) {
-        Protos.Resource.Builder resBuilder = Protos.Resource.newBuilder()
-                .setRole("*")
+        Protos.Resource.Builder resBuilder =
+                ResourceUtils.setRootRole(Protos.Resource.newBuilder(), Optional.of(Constants.ANY_ROLE))
                 .setName(name)
                 .setType(value.getType());
         switch (value.getType()) {


### PR DESCRIPTION
- Be more stringent/explicit in ResourceBuilder construction: reduce the risk of mixing up basic resource vs root volume vs mount volume.
- Remove unread MesosResource field from EvaluationOutcome.
- Avoid building the Resource object twice when evaluating resources (once in `OfferEvaluationUtils`, then again upstream).
- Silence Mesos deprecation warnings by wrapping access to the `role` field. We still need it for compatibility with 1.9 and earlier.