### PR TITLE
[INFINITY-2514] Fix automatic login regression

### DIFF
--- a/tools/dcos_login.py
+++ b/tools/dcos_login.py
@@ -69,9 +69,18 @@ def login_session() -> None:
     cluster_url = os.environ.get('CLUSTER_URL')
     if not cluster_url:
         raise Exception('Must have CLUSTER_URL set in environment!')
-    dcos_login_username = os.environ.get('DCOS_LOGIN_USERNAME', __CLI_LOGIN_EE_USERNAME)
-    dcos_login_password = os.environ.get('DCOS_LOGIN_PASSWORD', __CLI_LOGIN_EE_PASSWORD)
-    dcos_enterprise = os.environ.get('DCOS_ENTERPRISE', 'true').lower() == 'true'
+
+    def ignore_empty(envvar, default):
+        # Ignore the user passing in empty ENVVARs.
+        value = os.environ.get(envvar, "").strip()
+        if not value:
+            return default
+
+        return value
+
+    dcos_login_username = ignore_empty('DCOS_LOGIN_USERNAME', __CLI_LOGIN_EE_USERNAME)
+    dcos_login_password = ignore_empty('DCOS_LOGIN_PASSWORD', __CLI_LOGIN_EE_PASSWORD)
+    dcos_enterprise = ignore_empty('DCOS_ENTERPRISE', 'true').lower() == 'true'
     dcos_acs_token = os.environ.get('DCOS_ACS_TOKEN')
     if not dcos_acs_token:
         log.info('No ACS token provided, logging in...')


### PR DESCRIPTION
Docker passes in the envvars added in https://github.com/mesosphere/dcos-commons/commit/15fb4dcd6a402c48184fb40581fb47ae1c32f961 as `" "` in the case that the user does not have them set.

I've patched this in the Python, rather than trying figure out how to get Docker to NOT do this. And also because this was the fastest way I thought of to fix it.