### PR TITLE
Remove quote and period from error string

### DIFF
--- a/cli/client/response.go
+++ b/cli/client/response.go
@@ -50,7 +50,7 @@ func defaultResponseCheck(response *http.Response) error {
 	switch {
 	case response.StatusCode == http.StatusUnauthorized:
 		errorString := `Got 401 Unauthorized response from %s
-"- Bad auth token? Run 'dcos auth login' to log in.`
+- Bad auth token? Run 'dcos auth login' to log in`
 		return fmt.Errorf(errorString, response.Request.URL)
 	case response.StatusCode == http.StatusInternalServerError || response.StatusCode == http.StatusBadGateway || response.StatusCode == http.StatusNotFound:
 		return createServiceNameError()


### PR DESCRIPTION
Certain error conditions in the CLI can result in an error that looks like this:

```
dcos-edgelb: error: Get http://172.17.0.2/service/edgelb/v1/ping: Got 401 Unauthorized response from http://172.17.0.2/service/edgelb/v1/ping
"- Bad auth token? Run 'dcos auth login' to log in., try --help
```

It's preferable to see this:

```
dcos-edgelb: error: Get http://172.17.0.2/service/edgelb/v1/ping: Got 401 Unauthorized response from http://172.17.0.2/service/edgelb/v1/ping
- Bad auth token? Run 'dcos auth login' to log in, try --help
```