### PR TITLE
backport "replace dcos version markers" (#1552)

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,6 @@
+import sys
+import os.path
+
+# Add /testing/ to PYTHONPATH:
+this_file_dir = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(os.path.normpath(os.path.join(this_file_dir, 'testing')))

--- a/conftest.py
+++ b/conftest.py
@@ -9,6 +9,7 @@ import os
 import subprocess
 
 import pytest
+import sdk_utils
 
 log_level = os.getenv('TEST_LOG_LEVEL', 'INFO').upper()
 
@@ -62,6 +63,17 @@ def pytest_runtest_makereport(item, call):
     # be "setup", "call", "teardown"
 
     setattr(item, "rep_" + rep.when, rep)
+
+
+def pytest_runtest_setup(item):
+    min_version_mark = item.get_marker('dcos_min_version')
+    if min_version_mark:
+        min_version = min_version_mark.args[0]
+        message = 'Feature only supported in DC/OS {} and up'.format(min_version)
+        if 'reason' in min_version_mark.kwargs:
+            message += ': {}'.format(min_version_mark.kwargs['reason'])
+        if sdk_utils.dcos_version_less_than(min_version):
+            pytest.skip(message)
 
 
 @pytest.fixture(autouse=True)

--- a/frameworks/cassandra/tests/__init__.py
+++ b/frameworks/cassandra/tests/__init__.py
@@ -1,8 +1,0 @@
-#!/usr/bin/python
-
-import sys
-import os.path
-
-# Add /testing/ to PYTHONPATH:
-this_file_dir = os.path.dirname(os.path.abspath(__file__))
-sys.path.append(os.path.normpath(os.path.join(this_file_dir, '..', '..', '..', 'testing')))

--- a/frameworks/cassandra/tests/test_overlay.py
+++ b/frameworks/cassandra/tests/test_overlay.py
@@ -5,7 +5,6 @@ import sdk_install
 import sdk_jobs
 import sdk_networks
 import sdk_plan
-import sdk_utils
 import shakedown
 from tests import config
 
@@ -36,7 +35,7 @@ def configure_package(configure_security):
 @pytest.mark.sanity
 @pytest.mark.smoke
 @pytest.mark.overlay
-@sdk_utils.dcos_1_9_or_higher
+@pytest.mark.dcos_min_version('1.9')
 def test_service_overlay_health():
     shakedown.service_healthy(config.PACKAGE_NAME)
     node_tasks = (
@@ -51,7 +50,7 @@ def test_service_overlay_health():
 @pytest.mark.sanity
 @pytest.mark.smoke
 @pytest.mark.overlay
-@sdk_utils.dcos_1_9_or_higher
+@pytest.mark.dcos_min_version('1.9')
 def test_functionality():
     parameters = {'CASSANDRA_KEYSPACE': 'testspace1'}
 
@@ -75,7 +74,7 @@ def test_functionality():
 
 @pytest.mark.sanity
 @pytest.mark.overlay
-@sdk_utils.dcos_1_9_or_higher
+@pytest.mark.dcos_min_version('1.9')
 def test_endpoints():
     endpoints = sdk_networks.get_and_test_endpoints("", config.PACKAGE_NAME, 1)  # tests that the correct number of endpoints are found, should just be "node"
     assert "node" in endpoints, "Cassandra endpoints should contain only 'node', got {}".format(endpoints)

--- a/frameworks/cassandra/tests/test_recovery.py
+++ b/frameworks/cassandra/tests/test_recovery.py
@@ -8,7 +8,6 @@ import sdk_install
 import sdk_marathon
 import sdk_plan
 import sdk_tasks
-import sdk_utils
 import shakedown
 from tests import config
 
@@ -30,7 +29,7 @@ def configure_package(configure_security):
 
 
 @pytest.mark.sanity
-@sdk_utils.dcos_1_9_or_higher  # dcos task exec not supported < 1.9
+@pytest.mark.dcos_min_version('1.9', reason='dcos task exec not supported < 1.9')
 def test_node_replace_replaces_seed_node():
     pod_to_replace = 'node-0'
 
@@ -42,7 +41,7 @@ def test_node_replace_replaces_seed_node():
 
 @pytest.mark.sanity
 @pytest.mark.local
-@sdk_utils.dcos_1_9_or_higher  # dcos task exec not supported < 1.9
+@pytest.mark.dcos_min_version('1.9', reason='dcos task exec not supported < 1.9')
 def test_node_replace_replaces_node():
     pod_to_replace = 'node-2'
     pod_host = get_pod_host(pod_to_replace)

--- a/frameworks/cassandra/tests/test_sanity.py
+++ b/frameworks/cassandra/tests/test_sanity.py
@@ -9,7 +9,6 @@ import sdk_jobs
 import sdk_metrics
 import sdk_plan
 import sdk_upgrade
-import sdk_utils
 import shakedown
 from tests import config
 
@@ -78,7 +77,7 @@ def test_repair_cleanup_plans_complete():
 
 @pytest.mark.sanity
 @pytest.mark.metrics
-@sdk_utils.dcos_1_9_or_higher
+@pytest.mark.dcos_min_version('1.9')
 def test_metrics():
     sdk_metrics.wait_for_any_metrics(
         config.get_foldered_service_name(), "node-0-server", config.DEFAULT_CASSANDRA_TIMEOUT)

--- a/frameworks/elastic/tests/__init__.py
+++ b/frameworks/elastic/tests/__init__.py
@@ -1,8 +1,0 @@
-#!/usr/bin/python
-
-import sys
-import os.path
-
-# Add /testing/ to PYTHONPATH:
-this_file_dir = os.path.dirname(os.path.abspath(__file__))
-sys.path.append(os.path.normpath(os.path.join(this_file_dir, '..', '..', '..', 'testing')))

--- a/frameworks/elastic/tests/test_overlay.py
+++ b/frameworks/elastic/tests/test_overlay.py
@@ -2,7 +2,6 @@ import pytest
 import sdk_install
 import sdk_networks
 import sdk_tasks
-import sdk_utils
 import shakedown
 from tests import config
 
@@ -38,14 +37,14 @@ def default_populated_index():
 @pytest.mark.sanity
 @pytest.mark.smoke
 @pytest.mark.overlay
-@sdk_utils.dcos_1_9_or_higher
+@pytest.mark.dcos_min_version('1.9')
 def test_service_health():
     assert shakedown.service_healthy(config.PACKAGE_NAME)
 
 
 @pytest.mark.sanity
 @pytest.mark.overlay
-@sdk_utils.dcos_1_9_or_higher
+@pytest.mark.dcos_min_version('1.9')
 def test_indexing(default_populated_index):
     def fun():
         indices_stats = config.get_elasticsearch_indices_stats(config.DEFAULT_INDEX_NAME)
@@ -60,7 +59,7 @@ def test_indexing(default_populated_index):
 
 @pytest.mark.sanity
 @pytest.mark.overlay
-@sdk_utils.dcos_1_9_or_higher
+@pytest.mark.dcos_min_version('1.9')
 def test_tasks_on_overlay():
     elastic_tasks = shakedown.get_service_task_ids(config.PACKAGE_NAME)
     assert len(elastic_tasks) == config.NO_INGEST_TASK_COUNT, \
@@ -71,7 +70,7 @@ def test_tasks_on_overlay():
 
 @pytest.mark.sanity
 @pytest.mark.overlay
-@sdk_utils.dcos_1_9_or_higher
+@pytest.mark.dcos_min_version('1.9')
 def test_endpoints_on_overlay():
     endpoint_types_without_ingest = (
         'coordinator-http', 'coordinator-transport',

--- a/frameworks/elastic/tests/test_sanity.py
+++ b/frameworks/elastic/tests/test_sanity.py
@@ -79,7 +79,7 @@ def test_indexing(default_populated_index):
 
 @pytest.mark.sanity
 @pytest.mark.metrics
-@sdk_utils.dcos_1_9_or_higher
+@pytest.mark.dcos_min_version('1.9')
 def test_metrics():
     sdk_metrics.wait_for_any_metrics(FOLDERED_SERVICE_NAME, "data-0-node", config.DEFAULT_ELASTIC_TIMEOUT)
 

--- a/frameworks/hdfs/tests/__init__.py
+++ b/frameworks/hdfs/tests/__init__.py
@@ -1,6 +1,0 @@
-import sys
-import os.path
-
-# Add /testing/ to PYTHONPATH:
-this_file_dir = os.path.dirname(os.path.abspath(__file__))
-sys.path.append(os.path.normpath(os.path.join(this_file_dir, '..', '..', '..', 'testing')))

--- a/frameworks/hdfs/tests/test_overlay.py
+++ b/frameworks/hdfs/tests/test_overlay.py
@@ -6,7 +6,6 @@ import sdk_install
 import sdk_networks
 import sdk_plan
 import sdk_tasks
-import sdk_utils
 import shakedown
 from tests import config
 
@@ -33,7 +32,7 @@ def pre_test_setup():
 
 @pytest.mark.sanity
 @pytest.mark.overlay
-@sdk_utils.dcos_1_9_or_higher
+@pytest.mark.dcos_min_version('1.9')
 def test_tasks_on_overlay():
     hdfs_tasks = shakedown.shakedown.get_service_task_ids(config.PACKAGE_NAME)
     assert len(hdfs_tasks) == config.DEFAULT_TASK_COUNT, "Not enough tasks got launched,"\
@@ -44,7 +43,7 @@ def test_tasks_on_overlay():
 
 @pytest.mark.overlay
 @pytest.mark.sanity
-@sdk_utils.dcos_1_9_or_higher
+@pytest.mark.dcos_min_version('1.9')
 def test_endpoints_on_overlay():
     observed_endpoints = sdk_networks.get_and_test_endpoints("", config.PACKAGE_NAME, 2)
     expected_endpoints = ("hdfs-site.xml", "core-site.xml")
@@ -58,7 +57,7 @@ def test_endpoints_on_overlay():
 @pytest.mark.overlay
 @pytest.mark.sanity
 @pytest.mark.data_integrity
-@sdk_utils.dcos_1_9_or_higher
+@pytest.mark.dcos_min_version('1.9')
 def test_write_and_read_data_on_overlay():
     config.write_data_to_hdfs(config.PACKAGE_NAME, config.TEST_FILE_1_NAME)
     config.read_data_from_hdfs(config.PACKAGE_NAME, config.TEST_FILE_1_NAME)

--- a/frameworks/hdfs/tests/test_sanity.py
+++ b/frameworks/hdfs/tests/test_sanity.py
@@ -22,7 +22,7 @@ def configure_package(configure_security):
     try:
         sdk_install.uninstall(config.FOLDERED_SERVICE_NAME, package_name=config.PACKAGE_NAME)
 
-        if shakedown.dcos_version_less_than("1.9"):
+        if sdk_utils.dcos_version_less_than("1.9"):
             # HDFS upgrade in 1.8 is not supported.
             sdk_install.install(
                 config.PACKAGE_NAME,
@@ -328,7 +328,7 @@ def test_modify_app_config_rollback():
 
 @pytest.mark.sanity
 @pytest.mark.metrics
-@sdk_utils.dcos_1_9_or_higher
+@pytest.mark.dcos_min_version('1.9')
 def test_metrics():
     sdk_metrics.wait_for_any_metrics(config.FOLDERED_SERVICE_NAME, "journal-0-node", config.DEFAULT_HDFS_TIMEOUT)
 

--- a/frameworks/helloworld/tests/__init__.py
+++ b/frameworks/helloworld/tests/__init__.py
@@ -1,8 +1,0 @@
-#!/usr/bin/python
-
-import sys
-import os.path
-
-# Add /testing/ to PYTHONPATH:
-this_file_dir = os.path.dirname(os.path.abspath(__file__))
-sys.path.append(os.path.normpath(os.path.join(this_file_dir, '..', '..', '..', 'testing')))

--- a/frameworks/helloworld/tests/test_canary_strategy.py
+++ b/frameworks/helloworld/tests/test_canary_strategy.py
@@ -7,7 +7,6 @@ import sdk_install
 import sdk_marathon
 import sdk_plan
 import sdk_tasks
-import sdk_utils
 import shakedown
 from tests import config
 
@@ -15,7 +14,7 @@ log = logging.getLogger(__name__)
 
 
 # global pytest variable applicable to whole module
-pytestmark = sdk_utils.dcos_1_9_or_higher
+pytestmark = pytest.mark.dcos_min_version('1.9')
 
 @pytest.fixture(scope='module', autouse=True)
 def configure_package(configure_security):

--- a/frameworks/helloworld/tests/test_overlay.py
+++ b/frameworks/helloworld/tests/test_overlay.py
@@ -7,7 +7,6 @@ import sdk_hosts
 import sdk_install
 import sdk_networks
 import sdk_plan
-import sdk_utils
 import shakedown
 from dcos.http import DCOSHTTPException
 from shakedown.dcos.spinner import TimeoutExpired
@@ -47,7 +46,7 @@ EXPECTED_NETWORK_LABELS = {
 @pytest.mark.sanity
 @pytest.mark.overlay
 @pytest.mark.smoke
-@sdk_utils.dcos_1_9_or_higher
+@pytest.mark.dcos_min_version('1.9')
 def test_overlay_network():
     """Verify that the current deploy plan matches the expected plan from the spec."""
 
@@ -131,7 +130,7 @@ def test_overlay_network():
 
 @pytest.mark.sanity
 @pytest.mark.overlay
-@sdk_utils.dcos_1_9_or_higher
+@pytest.mark.dcos_min_version('1.9')
 def test_cni_labels():
     def check_labels(labels, idx):
         k = labels[idx]["key"]
@@ -156,7 +155,7 @@ def test_cni_labels():
 
 @pytest.mark.sanity
 @pytest.mark.overlay
-@sdk_utils.dcos_1_9_or_higher
+@pytest.mark.dcos_min_version('1.9')
 def test_port_names():
     def check_task_ports(task_name, expected_port_count, expected_port_names):
         endpoint = "/v1/tasks/info/{}".format(task_name)
@@ -175,7 +174,7 @@ def test_port_names():
 
 @pytest.mark.sanity
 @pytest.mark.overlay
-@sdk_utils.dcos_1_9_or_higher
+@pytest.mark.dcos_min_version('1.9')
 def test_srv_records():
     def check_port_record(task_records, task_name, record_name):
         record_name_prefix = "_{}.".format(record_name)

--- a/frameworks/helloworld/tests/test_placement.py
+++ b/frameworks/helloworld/tests/test_placement.py
@@ -7,7 +7,6 @@ import sdk_install
 import sdk_marathon
 import sdk_plan
 import sdk_tasks
-import sdk_utils
 import shakedown
 from tests import config
 
@@ -26,7 +25,7 @@ def configure_package(configure_security):
         sdk_install.uninstall(config.PACKAGE_NAME)
 
 
-@sdk_utils.dcos_1_9_or_higher
+@pytest.mark.dcos_min_version('1.9')
 @pytest.mark.smoke
 @pytest.mark.sanity
 def test_rack_not_found():

--- a/frameworks/helloworld/tests/test_recovery.py
+++ b/frameworks/helloworld/tests/test_recovery.py
@@ -7,7 +7,6 @@ import sdk_cmd
 import sdk_install
 import sdk_marathon
 import sdk_tasks
-import sdk_utils
 import shakedown
 from tests import config
 
@@ -60,7 +59,7 @@ def test_pod_restart():
 
 @pytest.mark.sanity
 @pytest.mark.recovery
-@sdk_utils.dcos_1_9_or_higher
+@pytest.mark.dcos_min_version('1.9')
 def test_pods_restart_graceful_shutdown():
     options = {
         "world": {

--- a/frameworks/helloworld/tests/test_resource_refinement.py
+++ b/frameworks/helloworld/tests/test_resource_refinement.py
@@ -1,7 +1,5 @@
 import pytest
 import sdk_install
-import sdk_utils
-import shakedown  # required by @sdk_utils.dcos_X_Y_or_higher
 from tests import config
 
 
@@ -24,6 +22,6 @@ def configure_package(configure_security):
 
 @pytest.mark.sanity
 @pytest.mark.smoke
-@sdk_utils.dcos_1_10_or_higher
+@pytest.mark.dcos_min_version('1.10')
 def test_install():
     config.check_running(config.PACKAGE_NAME)

--- a/frameworks/helloworld/tests/test_secrets.py
+++ b/frameworks/helloworld/tests/test_secrets.py
@@ -73,7 +73,7 @@ def configure_package(configure_security):
 @pytest.mark.sanity
 @pytest.mark.smoke
 @pytest.mark.secrets
-@sdk_utils.dcos_1_10_or_higher
+@pytest.mark.dcos_min_version('1.10')
 @sdk_utils.dcos_ee_only
 def test_secrets_basic():
     # 1) create Secrets
@@ -110,7 +110,7 @@ def test_secrets_basic():
 @pytest.mark.sanity
 @pytest.mark.smoke
 @pytest.mark.secrets
-@sdk_utils.dcos_1_10_or_higher
+@pytest.mark.dcos_min_version('1.10')
 @sdk_utils.dcos_ee_only
 def test_secrets_verify():
     # 1) create Secrets
@@ -163,7 +163,7 @@ def test_secrets_verify():
 @pytest.mark.sanity
 @pytest.mark.smoke
 @pytest.mark.secrets
-@sdk_utils.dcos_1_10_or_higher
+@pytest.mark.dcos_min_version('1.10')
 @sdk_utils.dcos_ee_only
 def test_secrets_update():
     # 1) create Secrets
@@ -224,7 +224,7 @@ def test_secrets_update():
 @pytest.mark.sanity
 @pytest.mark.secrets
 @pytest.mark.smoke
-@sdk_utils.dcos_1_10_or_higher
+@pytest.mark.dcos_min_version('1.10')
 @sdk_utils.dcos_ee_only
 def test_secrets_config_update():
     # 1) install examples/secrets.yml
@@ -299,7 +299,7 @@ def test_secrets_config_update():
 @pytest.mark.sanity
 @pytest.mark.smoke
 @pytest.mark.secrets
-@sdk_utils.dcos_1_10_or_higher
+@pytest.mark.dcos_min_version('1.10')
 @sdk_utils.dcos_ee_only
 def test_secrets_dcos_space():
     # 1) create secrets in hello-world/somePath, i.e. hello-world/somePath/secret1 ...

--- a/frameworks/helloworld/tests/test_soak.py
+++ b/frameworks/helloworld/tests/test_soak.py
@@ -2,13 +2,11 @@ import logging
 import os
 
 import pytest
-import shakedown
 
 import sdk_cmd
 import sdk_plan
 import sdk_tasks
 import sdk_upgrade
-import sdk_utils
 from tests import config
 
 log = logging.getLogger(__name__)
@@ -32,7 +30,7 @@ def test_soak_upgrade_downgrade():
 
 
 @pytest.mark.soak_secrets_update
-@sdk_utils.dcos_1_10_or_higher
+@pytest.mark.dcos_min_version('1.10')
 def test_soak_secrets_update():
 
     secret_content_alternative = "hello-world-secret-data-alternative"
@@ -67,7 +65,7 @@ def test_soak_secrets_update():
 
 
 @pytest.mark.soak_secrets_alive
-@sdk_utils.dcos_1_10_or_higher
+@pytest.mark.dcos_min_version('1.10')
 def test_soak_secrets_framework_alive():
 
     sdk_plan.wait_for_completed_deployment(FRAMEWORK_NAME)

--- a/frameworks/helloworld/tests/test_tls.py
+++ b/frameworks/helloworld/tests/test_tls.py
@@ -99,7 +99,7 @@ def hello_world_service(service_account):
 
 @pytest.mark.tls
 @pytest.mark.sanity
-@sdk_utils.dcos_1_10_or_higher
+@pytest.mark.dcos_min_version('1.10')
 @sdk_utils.dcos_ee_only
 def test_java_truststore(hello_world_service):
     """
@@ -128,7 +128,7 @@ def test_java_truststore(hello_world_service):
 
 @pytest.mark.tls
 @pytest.mark.sanity
-@sdk_utils.dcos_1_10_or_higher
+@pytest.mark.dcos_min_version('1.10')
 @sdk_utils.dcos_ee_only
 def test_tls_basic_artifacts(hello_world_service):
     task_id = sdk_tasks.get_task_ids(config.PACKAGE_NAME, 'artifacts')[0]
@@ -162,7 +162,7 @@ def test_tls_basic_artifacts(hello_world_service):
 
 @pytest.mark.tls
 @pytest.mark.sanity
-@sdk_utils.dcos_1_10_or_higher
+@pytest.mark.dcos_min_version('1.10')
 @sdk_utils.dcos_ee_only
 def test_java_keystore(hello_world_service):
     """
@@ -196,7 +196,7 @@ def test_java_keystore(hello_world_service):
 
 @pytest.mark.tls
 @pytest.mark.sanity
-@sdk_utils.dcos_1_10_or_higher
+@pytest.mark.dcos_min_version('1.10')
 @sdk_utils.dcos_ee_only
 def test_tls_nginx(hello_world_service):
     """
@@ -225,7 +225,7 @@ def test_tls_nginx(hello_world_service):
 
 @pytest.mark.tls
 @pytest.mark.sanity
-@sdk_utils.dcos_1_10_or_higher
+@pytest.mark.dcos_min_version('1.10')
 @sdk_utils.dcos_ee_only
 def test_changing_discovery_replaces_certificate_sans(hello_world_service):
     """

--- a/frameworks/kafka/tests/__init__.py
+++ b/frameworks/kafka/tests/__init__.py
@@ -1,6 +1,0 @@
-import sys
-import os.path
-
-# Add /testing/ to PYTHONPATH:
-this_file_dir = os.path.dirname(os.path.abspath(__file__))
-sys.path.append(os.path.normpath(os.path.join(this_file_dir, '..', '..', '..', 'testing')))

--- a/frameworks/kafka/tests/test_availability.py
+++ b/frameworks/kafka/tests/test_availability.py
@@ -11,7 +11,6 @@ import sdk_cmd
 import sdk_install
 import sdk_plan
 import sdk_tasks
-import sdk_utils
 
 from tests.test_utils import *
 
@@ -43,7 +42,7 @@ def teardown_module(module):
 
 @pytest.mark.availability
 @pytest.mark.soak_availability
-@sdk_utils.dcos_1_9_or_higher
+@pytest.mark.dcos_min_version('1.9')
 def test_service_startup_rapid():
     max_restart_seconds = EXPECTED_KAFKA_STARTUP_SECONDS
     startup_padding_seconds = EXPECTED_DCOS_STARTUP_SECONDS

--- a/frameworks/kafka/tests/test_overlay.py
+++ b/frameworks/kafka/tests/test_overlay.py
@@ -2,7 +2,6 @@ import pytest
 import sdk_install as install
 import sdk_networks
 import sdk_tasks
-import sdk_utils
 import shakedown
 from tests import config, test_utils
 
@@ -25,7 +24,7 @@ def configure_package(configure_security):
 @pytest.mark.overlay
 @pytest.mark.smoke
 @pytest.mark.sanity
-@sdk_utils.dcos_1_9_or_higher
+@pytest.mark.dcos_min_version('1.9')
 def test_service_overlay_health():
     """Installs SDK based Kafka on with virtual networks set to True. Tests that the deployment completes
     and the service is healthy, then checks that all of the service tasks (brokers) are on the overlay network
@@ -43,7 +42,7 @@ def test_service_overlay_health():
 @pytest.mark.smoke
 @pytest.mark.sanity
 @pytest.mark.overlay
-@sdk_utils.dcos_1_9_or_higher
+@pytest.mark.dcos_min_version('1.9')
 def test_overlay_network_deployment_and_endpoints():
     # double check
     sdk_tasks.check_running(config.SERVICE_NAME, config.DEFAULT_BROKER_COUNT)
@@ -59,7 +58,7 @@ def test_overlay_network_deployment_and_endpoints():
 
 @pytest.mark.sanity
 @pytest.mark.overlay
-@sdk_utils.dcos_1_9_or_higher
+@pytest.mark.dcos_min_version('1.9')
 def test_pod_restart_on_overlay():
     test_utils.restart_broker_pods()
     test_overlay_network_deployment_and_endpoints()
@@ -67,7 +66,7 @@ def test_pod_restart_on_overlay():
 
 @pytest.mark.sanity
 @pytest.mark.overlay
-@sdk_utils.dcos_1_9_or_higher
+@pytest.mark.dcos_min_version('1.9')
 def test_pod_replace_on_overlay():
     test_utils.replace_broker_pod()
     test_overlay_network_deployment_and_endpoints()
@@ -75,13 +74,13 @@ def test_pod_replace_on_overlay():
 
 @pytest.mark.sanity
 @pytest.mark.overlay
-@sdk_utils.dcos_1_9_or_higher
+@pytest.mark.dcos_min_version('1.9')
 def test_topic_create_overlay():
     test_utils.create_topic()
 
 
 @pytest.mark.sanity
 @pytest.mark.overlay
-@sdk_utils.dcos_1_9_or_higher
+@pytest.mark.dcos_min_version('1.9')
 def test_topic_delete_overlay():
     test_utils.delete_topic()

--- a/frameworks/kafka/tests/test_sanity.py
+++ b/frameworks/kafka/tests/test_sanity.py
@@ -26,7 +26,7 @@ def configure_package(configure_security):
     try:
         install.uninstall(FOLDERED_SERVICE_NAME, package_name=config.PACKAGE_NAME)
 
-        if shakedown.dcos_version_less_than("1.9"):
+        if sdk_utils.dcos_version_less_than("1.9"):
             # Last beta-kafka release (1.1.25-0.10.1.0-beta) excludes 1.8. Skip upgrade tests with 1.8 and just install
             install.install(
                 config.PACKAGE_NAME,
@@ -287,7 +287,7 @@ def test_pod_cli():
 
 @pytest.mark.sanity
 @pytest.mark.metrics
-@sdk_utils.dcos_1_9_or_higher
+@pytest.mark.dcos_min_version('1.9')
 def test_metrics():
     sdk_metrics.wait_for_any_metrics(FOLDERED_SERVICE_NAME, "kafka-0-broker", config.DEFAULT_KAFKA_TIMEOUT)
 

--- a/frameworks/kafka/tests/test_tls.py
+++ b/frameworks/kafka/tests/test_tls.py
@@ -67,7 +67,7 @@ def kafka_service_tls(service_account):
 @pytest.mark.tls
 @pytest.mark.smoke
 @pytest.mark.sanity
-@sdk_utils.dcos_1_10_or_higher
+@pytest.mark.dcos_min_version('1.10')
 @pytest.mark.skip(reason="TLS not supported in stable.")
 @sdk_utils.dcos_ee_only
 def test_tls_endpoints(kafka_service_tls):
@@ -84,7 +84,7 @@ def test_tls_endpoints(kafka_service_tls):
 @pytest.mark.tls
 @pytest.mark.smoke
 @pytest.mark.sanity
-@sdk_utils.dcos_1_10_or_higher
+@pytest.mark.dcos_min_version('1.10')
 @pytest.mark.skip(reason="TLS not supported in stable.")
 @sdk_utils.dcos_ee_only
 def test_producer_over_tls(kafka_service_tls):

--- a/frameworks/template/tests/__init__.py
+++ b/frameworks/template/tests/__init__.py
@@ -1,6 +1,0 @@
-import sys
-import os.path
-
-# Add /testing/ to PYTHONPATH:
-this_file_dir = os.path.dirname(os.path.abspath(__file__))
-sys.path.append(os.path.normpath(os.path.join(this_file_dir, '..', '..', '..', 'testing')))

--- a/frameworks/template/tests/test_overlay.py
+++ b/frameworks/template/tests/test_overlay.py
@@ -3,8 +3,6 @@ import os
 import pytest
 import sdk_install
 import sdk_networks
-import sdk_utils
-import shakedown  # required by @sdk_utils.dcos_X_Y_or_higher
 from tests import config
 
 overlay_nostrict = pytest.mark.skipif(os.environ.get("SECURITY") == "strict",
@@ -28,6 +26,6 @@ def configure_package(configure_security):
 @pytest.mark.smoke
 @pytest.mark.overlay
 @overlay_nostrict
-@sdk_utils.dcos_1_9_or_higher
+@pytest.mark.dcos_min_version('1.9')
 def test_install():
     sdk_networks.check_task_network("template-0-node")

--- a/testing/sdk_install.py
+++ b/testing/sdk_install.py
@@ -72,7 +72,7 @@ def install(
         sdk_plan.wait_for_completed_deployment(service_name, timeout_seconds)
 
         # given the above wait for plan completion, here we just wait up to 5 minutes
-        if shakedown.dcos_version_less_than("1.9"):
+        if sdk_utils.dcos_version_less_than("1.9"):
             log.info("Skipping `is_suppressed` check for %s/%s as this is only suppored starting in version 1.9",
                      package_name, service_name)
         else:
@@ -110,7 +110,7 @@ def _uninstall(
     if package_name is None:
         package_name = service_name
 
-    if shakedown.dcos_version_less_than("1.10"):
+    if sdk_utils.dcos_version_less_than("1.10"):
         log.info('Uninstalling/janitoring {}'.format(service_name))
         try:
             shakedown.uninstall_package_and_wait(

--- a/testing/sdk_upgrade.py
+++ b/testing/sdk_upgrade.py
@@ -8,6 +8,7 @@ import sdk_cmd as cmd
 import sdk_install as install
 import sdk_marathon as marathon
 import sdk_tasks as tasks
+import sdk_utils
 
 log = logging.getLogger(__name__)
 
@@ -231,7 +232,7 @@ def _upgrade_or_downgrade(
         additional_options,
         timeout_seconds):
     task_ids = tasks.get_task_ids(service_name, '')
-    if shakedown.dcos_version_less_than("1.10") or shakedown.ee_version() is None or from_package_name != to_package_name:
+    if sdk_utils.dcos_version_less_than("1.10") or shakedown.ee_version() is None or from_package_name != to_package_name:
         log.info('Using marathon upgrade flow to upgrade {} => {} {}'.format(from_package_name, to_package_name, to_package_version))
         marathon.destroy_app(service_name)
         install.install(

--- a/testing/sdk_utils.py
+++ b/testing/sdk_utils.py
@@ -51,14 +51,5 @@ def is_open_dcos():
 
 
 dcos_ee_only = pytest.mark.skipif(
-    'sdk_utils.is_open_dcos()',
+    is_open_dcos(),
     reason="Feature only supported in DC/OS EE.")
-
-
-# WARNING: Any file that uses these must also "import shakedown" in the same file.
-dcos_1_9_or_higher = pytest.mark.skipif(
-    'sdk_utils.dcos_version_less_than("1.9")',
-    reason="Feature only supported in DC/OS 1.9 and up")
-dcos_1_10_or_higher = pytest.mark.skipif(
-    'sdk_utils.dcos_version_less_than("1.10")',
-    reason="Feature only supported in DC/OS 1.10 and up")


### PR DESCRIPTION
cherry-picking gave odd results, so this backport is manual