### PR TITLE
Skip the v1 API test in strict mode (#1737)

### DIFF
--- a/frameworks/helloworld/tests/test_sanity.py
+++ b/frameworks/helloworld/tests/test_sanity.py
@@ -51,6 +51,7 @@ def test_install():
 # Note: presently the mesos v1 api does _not_ work in strict mode.
 # As such, we expect this test to fail until it does in fact work in strict mode.
 @pytest.mark.sanity
+@pytest.mark.skipif(sdk_utils.is_strict_mode(), reason='v1 API is not yet supported in strict mode')
 def test_mesos_v1_api():
     # Install Hello World using the v1 api.
     # Then, clean up afterwards.

--- a/testing/sdk_install.py
+++ b/testing/sdk_install.py
@@ -187,7 +187,7 @@ def _uninstall(
 
 def get_package_options(additional_options={}):
     # expected SECURITY values: 'permissive', 'strict', 'disabled'
-    if os.environ.get('SECURITY', '') == 'strict':
+    if sdk_utils.is_strict_mode():
         # strict mode requires correct principal and secret to perform install.
         # see also: tools/setup_permissions.sh and tools/create_service_account.sh
         return merge_dictionaries({

--- a/testing/sdk_utils.py
+++ b/testing/sdk_utils.py
@@ -50,6 +50,11 @@ def is_open_dcos():
     return not (os.environ.get('DCOS_ENTERPRISE', 'true').lower() == 'true')
 
 
+def is_strict_mode():
+    '''Determine if the tests are being run on a strict mode cluster.'''
+    return os.environ.get('SECURITY', '') == 'strict'
+
+
 dcos_ee_only = pytest.mark.skipif(
     'sdk_utils.is_open_dcos()',
     reason="Feature only supported in DC/OS EE.")


### PR DESCRIPTION
* Skip v1 api in strict

* Use mark.skipif

Backport of #1737 