### PR TITLE
[INFINITY-2540] Add module-level skip for test_resource_refinement in strict

### DIFF
--- a/frameworks/helloworld/tests/test_resource_refinement.py
+++ b/frameworks/helloworld/tests/test_resource_refinement.py
@@ -3,6 +3,10 @@ import sdk_install
 import sdk_utils
 from tests import config
 
+pytestmark = pytest.mark.skipif(sdk_utils.is_strict_mode(),
+                                reason='resource refinement is not yet supported in strict mode')
+
+
 @pytest.fixture(scope='module', autouse=True)
 def configure_package(configure_security):
     try:
@@ -13,9 +17,12 @@ def configure_package(configure_security):
             }
         }
 
-        sdk_install.install(config.PACKAGE_NAME, config.SERVICE_NAME, config.DEFAULT_TASK_COUNT, additional_options=options)
+        sdk_install.install(config.PACKAGE_NAME,
+                            config.SERVICE_NAME,
+                            config.DEFAULT_TASK_COUNT,
+                            additional_options=options)
 
-        yield # let the test session execute
+        yield  # let the test session execute
     finally:
         sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
 


### PR DESCRIPTION
`test_resource_refinement.test_install` cannot currently succeed in *strict* mode.

Disable this so that this failure does not cascade to other tests.

This would also allow the enabling of a strict-mode PR job.

This should also be backported.