### PR TITLE
[INFINITY-2553] Skip Elastic TLS tests in Open DC/OS

### DIFF
--- a/frameworks/elastic/tests/test_tls.py
+++ b/frameworks/elastic/tests/test_tls.py
@@ -8,7 +8,7 @@ import sdk_security
 import sdk_utils
 from tests import config
 
-pytestmark = pytest.mark.skipif(sdk_utils.is_open_dcos,
+pytestmark = pytest.mark.skipif(sdk_utils.is_open_dcos(),
                                 reason='Feature only supported in DC/OS EE')
 
 

--- a/frameworks/elastic/tests/test_tls.py
+++ b/frameworks/elastic/tests/test_tls.py
@@ -7,11 +7,9 @@ import sdk_plan
 import sdk_security
 import sdk_utils
 from tests import config
-from tests.config import (
-    PACKAGE_NAME,
-    DEFAULT_TASK_COUNT,
-    SERVICE_NAME,
-)
+
+pytestmark = pytest.mark.skipif(sdk_utils.is_open_dcos,
+                                reason='Feature only supported in DC/OS EE')
 
 
 @pytest.fixture(scope='module')
@@ -19,7 +17,7 @@ def service_account():
     """
     Creates service account with `elastic` name and yields the name.
     """
-    name = SERVICE_NAME
+    name = config.SERVICE_NAME
     sdk_security.create_service_account(
         service_account_name=name, service_account_secret=name)
     # TODO(mh): Fine grained permissions needs to be addressed in DCOS-16475
@@ -33,9 +31,9 @@ def service_account():
 @pytest.fixture(scope='module')
 def elastic_service_tls(service_account):
     sdk_install.install(
-        PACKAGE_NAME,
-        service_name=SERVICE_NAME,
-        expected_running_tasks=DEFAULT_TASK_COUNT,
+        config.PACKAGE_NAME,
+        service_name=config.SERVICE_NAME,
+        expected_running_tasks=config.DEFAULT_TASK_COUNT,
         additional_options={
             "service": {
                 "service_account_secret": service_account,
@@ -48,21 +46,21 @@ def elastic_service_tls(service_account):
         }
     )
 
-    sdk_plan.wait_for_completed_deployment(SERVICE_NAME)
+    sdk_plan.wait_for_completed_deployment(config.SERVICE_NAME)
 
     # Wait for service health check to pass
-    shakedown.service_healthy(SERVICE_NAME)
+    shakedown.service_healthy(config.SERVICE_NAME)
 
     yield
 
-    sdk_install.uninstall(PACKAGE_NAME, SERVICE_NAME)
+    sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
 
 
 @pytest.mark.tls
 @pytest.mark.smoke
 @pytest.mark.dcos_min_version('1.10')
 def test_healthy(elastic_service_tls):
-    assert shakedown.service_healthy(SERVICE_NAME)
+    assert shakedown.service_healthy(config.SERVICE_NAME)
 
 
 @pytest.mark.tls
@@ -72,14 +70,14 @@ def test_crud_over_tls(elastic_service_tls):
     config.create_index(
         config.DEFAULT_INDEX_NAME,
         config.DEFAULT_SETTINGS_MAPPINGS,
-        service_name=SERVICE_NAME,
+        service_name=config.SERVICE_NAME,
         https=True)
     config.create_document(
         config.DEFAULT_INDEX_NAME,
         config.DEFAULT_INDEX_TYPE,
         1,
         {"name": "Loren", "role": "developer"},
-        service_name=SERVICE_NAME,
+        service_name=config.SERVICE_NAME,
         https=True)
     document = config.get_document(
         config.DEFAULT_INDEX_NAME,


### PR DESCRIPTION
The TLS tests were still enabled for Elastic on Open DC/OS and were failing:

https://teamcity.mesosphere.io/viewLog.html?buildId=820071&tab=buildResultsDiv&buildTypeId=DcosIo_DcosCommons_Elastic_Open_DcOs110Open#testNameId3594191691547943286

This should be backported.