### PR TITLE
[INFINITY-2552] Add basic logging to get_framework_srv_records

### DIFF
--- a/frameworks/helloworld/tests/test_overlay.py
+++ b/frameworks/helloworld/tests/test_overlay.py
@@ -180,6 +180,7 @@ def test_srv_records():
             "Missing SRV record for {} (prefix={}) in task {}:\nmatching={}\nall={}".format(
                 record_name, record_name_prefix, task_name, matching_records, task_records)
 
+    log.info("Getting framework srv records for %s", config.SERVICE_NAME)
     fmk_srvs = sdk_networks.get_framework_srv_records(config.SERVICE_NAME)
     for task in TASKS_WITH_PORTS:
         task_records = sdk_networks.get_task_record(task, fmk_srvs)

--- a/testing/sdk_networks.py
+++ b/testing/sdk_networks.py
@@ -5,10 +5,11 @@ SHOULD ALSO BE APPLIED TO sdk_networks IN ANY OTHER PARTNER REPOS
 ************************************************************************
 '''
 import json
-
+import logging
 import shakedown
 import sdk_cmd
 
+log = logging.getLogger(__name__)
 
 ENABLE_VIRTUAL_NETWORKS_OPTIONS = {'service': {'virtual_network_enabled': True}}
 
@@ -71,9 +72,16 @@ def check_endpoints_on_overlay(endpoints):
 
 def get_framework_srv_records(package_name):
     cmd = "curl localhost:8123/v1/enumerate"
+    log.info("Running '%s' on master", cmd)
     ok, out = shakedown.run_command_on_master(cmd)
+    log.info("Running command returned: ok=%s\n\tout=%s", ok, out)
     assert ok, "Failed to get srv records. command was {}".format(cmd)
-    srvs = json.loads(out)
+    try:
+        srvs = json.loads(out)
+    except Exception as e:
+        log.error("Error converting out=%s to json", out)
+        raise e
+
     framework_srvs = [f for f in srvs["frameworks"] if f["name"] == package_name]
     assert len(framework_srvs) == 1, "Got too many srv records matching package {}, got {}"\
         .format(package_name, framework_srvs)


### PR DESCRIPTION
The test `test_overlay.test_srv_records()` fails on 1.9. This PR adds some basic logging to make it simpler to debug this failure.