### PR TITLE
backport log handling on failure from master

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -9,6 +9,8 @@ import os
 import subprocess
 
 import pytest
+import requests
+import sdk_security
 import sdk_utils
 
 log_level = os.getenv('TEST_LOG_LEVEL', 'INFO').upper()
@@ -39,14 +41,17 @@ def get_task_ids(user: str=None):
 
 
 def get_task_logs_for_id(task_id: str,  task_file: str='stdout', lines: int=1000000):
-    try:
-        task_logs = subprocess.check_output([
-            'dcos', 'task', 'log', task_id, '--lines', str(lines), task_file
-        ]).decode()
-        return task_logs
-    except subprocess.CalledProcessError as e:
-        log.exception('Failed to get {} task log for task_id={}'.format(task_file, task_id))
+    result = subprocess.run(
+        ['dcos', 'task', 'log', task_id, '--lines', str(lines), task_file],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if result.returncode:
+        errmessage = result.stderr.decode()
+        if not errmessage.startswith('No files exist. Exiting.'):
+            log.error('Failed to get {} task log for task_id={}: {}'.format(task_file, task_id, errmessage))
         return None
+    return result.stdout.decode()
 
 
 @pytest.hookimpl(tryfirst=True, hookwrapper=True)
@@ -55,14 +60,26 @@ def pytest_runtest_makereport(item, call):
     See: https://docs.pytest.org/en/latest/example/simple.html\
     #making-test-result-information-available-in-fixtures
     """
-    # execute all other hooks to obtain the report object
+    # execute all other hooks to obtain the report object, then a report
+    # attribute for each phase of a call, which can be "setup", "call", "teardown"
+    # Subsequent fixtures can get the reports off of the request object like:
+    # `request.rep_setup.failed`.
     outcome = yield
     rep = outcome.get_result()
-
-    # set a report attribute for each phase of a call, which can
-    # be "setup", "call", "teardown"
-
     setattr(item, "rep_" + rep.when, rep)
+
+    # Handle failures. Must be done here and not in a fixture in order to
+    # properly handle post-yield fixture teardown failures.
+    if rep.failed:
+        log.error('Test {} failed in {} phase, dumping state'.format(item.name, rep.when))
+        try:
+            get_task_logs_on_failure(item.name)
+        except Exception:
+            log.exception('Task log collection failed!')
+        try:
+            get_mesos_state_on_failure(item.name)
+        except Exception:
+            log.exception('Mesos state collection failed!')
 
 
 def pytest_runtest_setup(item):
@@ -76,20 +93,36 @@ def pytest_runtest_setup(item):
             pytest.skip(message)
 
 
-@pytest.fixture(autouse=True)
-def get_task_logs_on_failure(request):
-    """ Scheduler should be the only task running as root
-    """
-    yield
-    for report in ('rep_setup', 'rep_call', 'rep_teardown'):
-        if not hasattr(request.node, report):
-            continue
-        if not getattr(request.node, report).failed:
-            continue
-        for task_id in get_task_ids():
-            for task_file in ('stderr', 'stdout'):
-                log_name = '{}_{}_{}.log'.format(request.node.name, task_id, task_file)
-                task_logs = get_task_logs_for_id(task_id, task_file=task_file)
-                if task_logs:
-                    with open(log_name, 'w') as f:
-                        f.write(task_logs)
+def get_rotating_task_log_lines(task_id: str, task_file: str):
+    rotated_filenames = [task_file,]
+    rotated_filenames.extend(['{}.{}'.format(task_file, i) for i in range(1, 10)])
+    for filename in rotated_filenames:
+        lines = get_task_logs_for_id(task_id, filename)
+        if not lines:
+            return
+        yield filename, lines
+
+
+def get_task_logs_on_failure(test_name: str):
+    for task_id in get_task_ids():
+        for task_file in ('stderr', 'stdout'):
+            for log_filename, log_lines in get_rotating_task_log_lines(task_id, task_file):
+                log_name = '{}_{}_{}.log'.format(test_name, task_id, log_filename)
+                with open(log_name, 'w') as f:
+                    f.write(log_lines)
+
+
+def get_mesos_state_on_failure(test_name: str):
+    dcosurl, headers = sdk_security.get_dcos_credentials()
+    state_json_endpoint = '{}/mesos/state.json'.format(dcosurl)
+    r = requests.get(state_json_endpoint, headers=headers, verify=False)
+    if r.status_code == 200:
+        log_name = '{}_state.json'.format(test_name)
+        with open(log_name, 'w') as f:
+            f.write(r.text)
+    slaves_endpoint = '{}/mesos/slaves'.format(dcosurl)
+    r = requests.get(slaves_endpoint, headers=headers, verify=False)
+    if r.status_code == 200:
+        log_name = '{}_slaves.json'.format(test_name)
+        with open(log_name, 'w') as f:
+            f.write(r.text)

--- a/frameworks/cassandra/tests/conftest.py
+++ b/frameworks/cassandra/tests/conftest.py
@@ -1,6 +1,13 @@
+import json
+import logging
+
 import pytest
 import sdk_repository
 import sdk_security
+import sdk_utils
+import shakedown
+
+log = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope='session')
@@ -10,3 +17,21 @@ def configure_universe():
 @pytest.fixture(scope='session')
 def configure_security(configure_universe):
     yield from sdk_security.security_session('cassandra')
+
+@pytest.fixture(autouse=True)
+def get_cassandra_plans_on_failure(request):
+    yield
+    if sdk_utils.is_test_failure(request):
+        plans, err, rc = shakedown.run_dcos_command('cassandra plan list')
+        if rc:
+            log.error('Unable to fetch cassandra plan list: {}'.format(err))
+            return
+        planlist = json.loads(plans)
+        for plan_name in planlist:
+            plan, err, rc = shakedown.run_dcos_command('cassandra plan show {}'.format(plan_name))
+            if rc:
+                log.error('Unable to fetch cassandra plan for {}: {}'.format(plan_name, err))
+                continue
+            plan_filename = '{}_{}_plan.log'.format(request.node.name, plan_name)
+            with open(plan_filename, 'w') as f:
+                f.write(plan)

--- a/testing/sdk_utils.py
+++ b/testing/sdk_utils.py
@@ -44,6 +44,20 @@ def dcos_version_less_than(version):
     return shakedown.dcos_version_less_than(version)
 
 
+def is_test_failure(pytest_request):
+    '''Determine if the test run failed using the request object from pytest.
+    The reports being evaluated are set in conftest.py:pytest_runtest_makereport()
+    https://docs.pytest.org/en/latest/builtin.html#_pytest.fixtures.FixtureRequest
+    '''
+    for report in ('rep_setup', 'rep_call', 'rep_teardown'):
+        if not hasattr(pytest_request.node, report):
+            continue
+        if not getattr(pytest_request.node, report).failed:
+            continue
+        return True
+    return False
+
+
 def is_open_dcos():
     '''Determine if the tests are being run against open DC/OS. This is presently done by
     checking the envvar DCOS_ENTERPRISE.'''


### PR DESCRIPTION
This is a copy/paste backport of the log handling on failure work from `master`. (Cherry picking was catching some unrelated changes.)

`infinity/helloworld` tests are failing consistently with the `0.30.X` branch.