### PR TITLE
[INFINITY-1546] Scheduler Metrics

### DIFF
--- a/docs/reference/swagger-api/swagger-spec.yaml
+++ b/docs/reference/swagger-api/swagger-spec.yaml
@@ -18,6 +18,8 @@ tags:
   description: "Historical and current target configurations for the service"
 - name: "state"
   description: "Additional persisted state"
+- name: "metrics"
+  description: "Scheduler metrics"
 schemes:
 - "http"
 paths:
@@ -544,3 +546,14 @@ paths:
           description: "The scheduler isn't using a state cache so there's nothing to do."
         500:
           description: "Failed to retrieve state data from zk."
+  /metrics:
+    get:
+      tags:
+      - "metrics"
+      summary: "Returns a snapshot of the current scheduler metrics."
+      operationId: "metrics"
+      produces:
+      - "application/json"
+      responses:
+        200:
+          description: "The metrics snapshot has been returned."

--- a/sdk/scheduler/build.gradle
+++ b/sdk/scheduler/build.gradle
@@ -118,6 +118,8 @@ dependencies {
     compile "io.dropwizard.metrics:metrics-core:${dropWizardMetricsVer}"
     compile "io.dropwizard.metrics:metrics-servlet:${dropWizardMetricsVer}"
     compile "io.dropwizard.metrics:metrics-servlets:${dropWizardMetricsVer}"
+    compile "io.prometheus:simpleclient_dropwizard:0.0.26"
+    compile "io.prometheus:simpleclient_servlet:0.0.26"
     testCompile "org.hamcrest:hamcrest-all:${hamcrestVer}" // note: must be above junit
     testCompile "junit:junit:${junitVer}"
     testCompile "com.github.stefanbirkner:system-rules:${systemRulesVer}"

--- a/sdk/scheduler/build.gradle
+++ b/sdk/scheduler/build.gradle
@@ -34,6 +34,7 @@ ext {
     elVer = "2.2.4"
     jwtVer = "3.2.0"
     bouncyCastleVer = "1.57"
+    dropWizardMetricsVer = "3.2.5"
 }
 
 task sourceJar(type: Jar) {
@@ -98,6 +99,7 @@ dependencies {
     compile "com.google.inject.extensions:guice-assistedinject:${guiceVer}"
     compile "com.googlecode.java-diff-utils:diffutils:${javaDiffUtilsVer}"
     compile "org.glassfish.jersey.containers:jersey-container-jetty-http:${jerseyVer}"
+    compile "org.glassfish.jersey.containers:jersey-container-servlet-core:${jerseyVer}"
     compile "org.glassfish.jersey.media:jersey-media-json-jackson:${jerseyVer}"
     compile "org.glassfish.jersey.media:jersey-media-multipart:${jerseyVer}"
     compile "org.jvnet.mimepull:mimepull:${mimepullVer}"
@@ -113,6 +115,9 @@ dependencies {
     }
     compile "org.bouncycastle:bcprov-jdk15on:${bouncyCastleVer}"
     compile "org.bouncycastle:bcpkix-jdk15on:${bouncyCastleVer}"
+    compile "io.dropwizard.metrics:metrics-core:${dropWizardMetricsVer}"
+    compile "io.dropwizard.metrics:metrics-servlet:${dropWizardMetricsVer}"
+    compile "io.dropwizard.metrics:metrics-servlets:${dropWizardMetricsVer}"
     testCompile "org.hamcrest:hamcrest-all:${hamcrestVer}" // note: must be above junit
     testCompile "junit:junit:${junitVer}"
     testCompile "com.github.stefanbirkner:system-rules:${systemRulesVer}"

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/OfferAccepter.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/OfferAccepter.java
@@ -25,7 +25,7 @@ public class OfferAccepter {
 
     // Metrics
     private final Counter launchCount = SchedulerUtils.getMetricRegistry().counter("launch");
-    private final Counter launchGroupCount = SchedulerUtils.getMetricRegistry().counter("launch-group");
+    private final Counter launchGroupCount = SchedulerUtils.getMetricRegistry().counter("launch_group");
 
     public OfferAccepter(List<OperationRecorder> recorders) {
         this.recorders = recorders;

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/OfferAccepter.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/OfferAccepter.java
@@ -1,8 +1,6 @@
 package com.mesosphere.sdk.offer;
 
-import com.codahale.metrics.Counter;
 import com.google.protobuf.TextFormat;
-import com.mesosphere.sdk.scheduler.SchedulerUtils;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.mesos.Protos.Filters;
 import org.apache.mesos.Protos.Offer.Operation;
@@ -22,10 +20,6 @@ public class OfferAccepter {
     private static final Filters FILTERS = Filters.newBuilder().setRefuseSeconds(1).build();
 
     private Collection<OperationRecorder> recorders;
-
-    // Metrics
-    private final Counter launchCount = SchedulerUtils.getMetricRegistry().counter("launch");
-    private final Counter launchGroupCount = SchedulerUtils.getMetricRegistry().counter("launch_group");
 
     public OfferAccepter(List<OperationRecorder> recorders) {
         this.recorders = recorders;
@@ -54,14 +48,6 @@ public class OfferAccepter {
         } else {
             LOGGER.warn("No Operations to perform.");
         }
-
-        launchCount.inc(
-                operations.stream()
-                        .filter(operation -> operation.getType().equals(Operation.Type.LAUNCH))
-                        .count());
-        launchGroupCount.inc(operations.stream()
-                .filter(operation -> operation.getType().equals(Operation.Type.LAUNCH_GROUP))
-                .count());
 
         return offerIds;
     }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/OfferUtils.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/OfferUtils.java
@@ -1,5 +1,7 @@
 package com.mesosphere.sdk.offer;
 
+import com.codahale.metrics.Counter;
+import com.mesosphere.sdk.scheduler.SchedulerUtils;
 import org.apache.mesos.Protos;
 import org.apache.mesos.SchedulerDriver;
 import org.slf4j.Logger;
@@ -14,6 +16,7 @@ import java.util.stream.Collectors;
  */
 public class OfferUtils {
     private static final Logger LOGGER = LoggerFactory.getLogger(OfferUtils.class);
+    private static final Counter declineCount = SchedulerUtils.getMetricRegistry().counter("decline");
 
     /**
      * Filters out accepted offers and returns back a list of unused offers.
@@ -62,5 +65,6 @@ public class OfferUtils {
             LOGGER.info("  {}", offerId.getValue());
             driver.declineOffer(offerId, filters);
         });
+        declineCount.inc(unusedOffers.size());
     }
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/DefaultScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/DefaultScheduler.java
@@ -236,7 +236,7 @@ public class DefaultScheduler extends AbstractScheduler {
 
         // Decline remaining offers.
         if (!unusedOffers.isEmpty()) {
-            OfferUtils.declineOffers(driver, unusedOffers, Constants.LONG_DECLINE_SECONDS);
+            OfferUtils.declineLong(driver, unusedOffers);
         }
 
         if (offers.isEmpty()) {

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/DefaultScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/DefaultScheduler.java
@@ -92,7 +92,9 @@ public class DefaultScheduler extends AbstractScheduler {
         this.recoveryPlanOverriderFactory = recoveryPlanOverriderFactory;
         this.taskKiller = new DefaultTaskKiller(new DefaultTaskFailureListener(stateStore, configStore));
         this.offerAccepter = new OfferAccepter(
-                Collections.singletonList(new PersistentLaunchRecorder(stateStore, serviceSpec)));
+                Arrays.asList(
+                        new PersistentLaunchRecorder(stateStore, serviceSpec),
+                        Metrics.OperationsCounter.getInstance()));
 
         this.resources = new ArrayList<>();
         this.resources.addAll(customResources);

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/Metrics.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/Metrics.java
@@ -1,0 +1,129 @@
+package com.mesosphere.sdk.scheduler;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import com.mesosphere.sdk.offer.LaunchOfferRecommendation;
+import com.mesosphere.sdk.offer.OfferRecommendation;
+import com.mesosphere.sdk.offer.OperationRecorder;
+import org.apache.mesos.Protos;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * This class encapsulates the components necessary for tracking Scheduler metrics.
+ */
+public class Metrics {
+    private static final MetricRegistry metrics = new MetricRegistry();
+
+    public static MetricRegistry getRegistry() {
+        return metrics;
+    }
+
+    // Generated counters
+    private static Map<String, Counter> counters = new HashMap<>();
+    private static Counter getCounter(String name) {
+        Counter counter = counters.get(name);
+        if (counter == null) {
+            counter = metrics.counter(name);
+            counters.put(name, counter);
+        }
+
+        return counter;
+    }
+
+    // Offers
+    private static final String RECEIVED_OFFERS = "offers.received";
+    private static final String PROCESSED_OFFERS = "offers.processed";
+    private static final String PROCESS_OFFERS = "offers.process";
+
+    private static final Counter receivedOffers = metrics.counter(RECEIVED_OFFERS);
+    private static final Counter processedOffers = metrics.counter(PROCESSED_OFFERS);
+    private static final Timer processOffersDuration = metrics.timer(PROCESS_OFFERS);
+
+    public static Counter getReceivedOffers() {
+        return receivedOffers;
+    }
+
+    public static Counter getProcessedOffers() {
+        return processedOffers;
+    }
+
+    public static Timer getProcessOffersDuration() {
+        return processOffersDuration;
+    }
+
+    // Decline / Revive
+    private static final String REVIVES = "revives";
+    private static final String REVIVE_THROTTLES = "revives.throttles";
+    private static final String DECLINE_SHORT = "declines.short";
+    private static final String DECLINE_LONG = "declines.long";
+
+    private static final Counter revives = metrics.counter(Metrics.REVIVES);
+    private static final Counter reviveThrottles = metrics.counter(Metrics.REVIVE_THROTTLES);
+    private static final Counter declinesShort = metrics.counter(DECLINE_SHORT);
+    private static final Counter declinesLong = metrics.counter(DECLINE_LONG);
+
+    public static Counter getRevives() {
+        return revives;
+    }
+
+    public static Counter getReviveThrottles() {
+        return reviveThrottles;
+    }
+
+    public static Counter getDeclinesShort() {
+        return declinesShort;
+    }
+
+    public static Counter getDeclinesLong() {
+        return declinesLong;
+    }
+
+    /**
+     * This class records counter metrics for all Mesos Operations performed by the scheduler.
+     */
+    public static class OperationsCounter implements OperationRecorder {
+        private static final OperationsCounter metricsRecorder = new OperationsCounter();
+        private static final String PREFIX = "operation";
+
+        private OperationsCounter() {
+            // Do not instantiate this singleton class.
+        }
+
+        public static OperationsCounter getInstance() {
+            return metricsRecorder;
+        }
+
+        @Override
+        public void record(OfferRecommendation offerRecommendation) throws Exception {
+            // Drop launch recommendations which are for bookkeeping purposes only
+            if (offerRecommendation instanceof LaunchOfferRecommendation &&
+                    !((LaunchOfferRecommendation) offerRecommendation).shouldLaunch()) {
+                return;
+            }
+
+            // Metric name will be of the form "operation.launch"
+            final String metricName = String.format(
+                    "%s.%s",
+                    PREFIX,
+                    offerRecommendation.getOperation().getType().name().toLowerCase());
+
+            getCounter(metricName).inc();
+        }
+    }
+
+    // TaskStatuses
+    public static void record(Protos.TaskStatus taskStatus) {
+        final String prefix = "task_status";
+
+        // Metric name will be of the form "task_status.running"
+        final String metricName = String.format(
+                "%s.%s",
+                prefix,
+                taskStatus.getState().name().toLowerCase());
+
+        getCounter(metricName).inc();
+    }
+}

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/Metrics.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/Metrics.java
@@ -3,34 +3,25 @@ package com.mesosphere.sdk.scheduler;
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
+import com.google.common.annotations.VisibleForTesting;
 import com.mesosphere.sdk.offer.LaunchOfferRecommendation;
 import com.mesosphere.sdk.offer.OfferRecommendation;
 import com.mesosphere.sdk.offer.OperationRecorder;
 import org.apache.mesos.Protos;
 
-import java.util.HashMap;
-import java.util.Map;
-
 /**
  * This class encapsulates the components necessary for tracking Scheduler metrics.
  */
 public class Metrics {
-    private static final MetricRegistry metrics = new MetricRegistry();
+    private static MetricRegistry metrics = new MetricRegistry();
+
+    @VisibleForTesting
+    static void reset() {
+        metrics = new MetricRegistry();
+    }
 
     public static MetricRegistry getRegistry() {
         return metrics;
-    }
-
-    // Generated counters
-    private static Map<String, Counter> counters = new HashMap<>();
-    private static Counter getCounter(String name) {
-        Counter counter = counters.get(name);
-        if (counter == null) {
-            counter = metrics.counter(name);
-            counters.put(name, counter);
-        }
-
-        return counter;
     }
 
     // Offers
@@ -38,20 +29,16 @@ public class Metrics {
     private static final String PROCESSED_OFFERS = "offers.processed";
     private static final String PROCESS_OFFERS = "offers.process";
 
-    private static final Counter receivedOffers = metrics.counter(RECEIVED_OFFERS);
-    private static final Counter processedOffers = metrics.counter(PROCESSED_OFFERS);
-    private static final Timer processOffersDuration = metrics.timer(PROCESS_OFFERS);
-
     public static Counter getReceivedOffers() {
-        return receivedOffers;
+        return metrics.counter(RECEIVED_OFFERS);
     }
 
     public static Counter getProcessedOffers() {
-        return processedOffers;
+        return metrics.counter(PROCESSED_OFFERS);
     }
 
     public static Timer getProcessOffersDuration() {
-        return processOffersDuration;
+        return metrics.timer(PROCESS_OFFERS);
     }
 
     // Decline / Revive
@@ -60,25 +47,20 @@ public class Metrics {
     private static final String DECLINE_SHORT = "declines.short";
     private static final String DECLINE_LONG = "declines.long";
 
-    private static final Counter revives = metrics.counter(Metrics.REVIVES);
-    private static final Counter reviveThrottles = metrics.counter(Metrics.REVIVE_THROTTLES);
-    private static final Counter declinesShort = metrics.counter(DECLINE_SHORT);
-    private static final Counter declinesLong = metrics.counter(DECLINE_LONG);
-
     public static Counter getRevives() {
-        return revives;
+        return metrics.counter(REVIVES);
     }
 
     public static Counter getReviveThrottles() {
-        return reviveThrottles;
+        return metrics.counter(REVIVE_THROTTLES);
     }
 
     public static Counter getDeclinesShort() {
-        return declinesShort;
+        return metrics.counter(DECLINE_SHORT);
     }
 
     public static Counter getDeclinesLong() {
-        return declinesLong;
+        return metrics.counter(DECLINE_LONG);
     }
 
     /**
@@ -110,7 +92,7 @@ public class Metrics {
                     PREFIX,
                     offerRecommendation.getOperation().getType().name().toLowerCase());
 
-            getCounter(metricName).inc();
+            metrics.counter(metricName).inc();
         }
     }
 
@@ -124,6 +106,6 @@ public class Metrics {
                 prefix,
                 taskStatus.getState().name().toLowerCase());
 
-        getCounter(metricName).inc();
+        metrics.counter(metricName).inc();
     }
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/ReviveManager.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/ReviveManager.java
@@ -1,5 +1,6 @@
 package com.mesosphere.sdk.scheduler;
 
+import com.codahale.metrics.Counter;
 import com.mesosphere.sdk.scheduler.plan.PodInstanceRequirement;
 import com.mesosphere.sdk.scheduler.plan.Status;
 import com.mesosphere.sdk.scheduler.plan.Step;
@@ -24,6 +25,7 @@ public class ReviveManager {
     private final SchedulerDriver driver;
     private final TokenBucket tokenBucket;
     private Set<WorkItem> candidates = new HashSet<>();
+    private final Counter reviveCount = SchedulerUtils.getMetricRegistry().counter("revive");
 
     public ReviveManager(SchedulerDriver driver) {
         this(driver, TokenBucket.newBuilder().build());
@@ -77,6 +79,7 @@ public class ReviveManager {
             if (tokenBucket.tryAcquire()) {
                 logger.info("Reviving offers.");
                 driver.reviveOffers();
+                reviveCount.inc();
             } else {
                 logger.warn("Revive attempt has been throttled.");
                 return;

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerApiServer.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerApiServer.java
@@ -1,20 +1,25 @@
 package com.mesosphere.sdk.scheduler;
 
+import com.codahale.metrics.servlets.MetricsServlet;
 import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.handler.ContextHandlerCollection;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.util.component.LifeCycle;
 import org.glassfish.jersey.jetty.JettyHttpContainerFactory;
 import org.glassfish.jersey.media.multipart.MultiPartFeature;
 import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.servlet.ServletContainer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.ws.rs.core.UriBuilder;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Timer;
 import java.util.TimerTask;
-
-import javax.ws.rs.core.UriBuilder;
 
 /**
  * The SchedulerApiServer runs the Jetty {@link Server} that exposes the Scheduler's API.
@@ -33,6 +38,20 @@ public class SchedulerApiServer {
                 new ResourceConfig(MultiPartFeature.class).registerInstances(new HashSet<>(resources)),
                 false /* don't start yet. wait for start() call below. */);
         this.startTimeout = schedulerConfig.getApiServerInitTimeout();
+
+        // Metrics
+        ServletContextHandler context = new ServletContextHandler();
+        MetricsServlet metricsServlet = new MetricsServlet(SchedulerUtils.getMetricRegistry());
+        ServletHolder metricsHolder = new ServletHolder("default", metricsServlet);
+
+        ResourceConfig resourceConfig = new ResourceConfig(MultiPartFeature.class).registerInstances(new HashSet<>(resources));
+        ServletHolder resourceHolder = new ServletHolder(new ServletContainer(resourceConfig));
+
+        context.addServlet(metricsHolder,"/v1/metrics");
+        context.addServlet(resourceHolder,"/*");
+
+        server.getHandlers();
+        server.setHandler(context);
     }
 
     /**
@@ -62,7 +81,8 @@ public class SchedulerApiServer {
                 try {
                     LOGGER.info("Starting API server at port {}", port);
                     server.start();
-                    LOGGER.info("API server started at port {}", port);
+                    int localPort = ((ServerConnector)server.getConnectors()[0]).getLocalPort();
+                    LOGGER.info("API server started at port {}", localPort);
                     startTimer.cancel();
                     server.join();
                 } catch (Exception e) {

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerApiServer.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerApiServer.java
@@ -42,23 +42,24 @@ public class SchedulerApiServer {
 
         // Metrics
         ServletContextHandler context = new ServletContextHandler();
-        MetricsServlet metricsServlet = new MetricsServlet(SchedulerUtils.getMetricRegistry());
+        MetricsServlet metricsServlet = new MetricsServlet(Metrics.getRegistry());
         ServletHolder metricsHolder = new ServletHolder("default", metricsServlet);
 
         // Prometheus
         CollectorRegistry collectorRegistry = new CollectorRegistry();
-        collectorRegistry.register(new DropwizardExports(SchedulerUtils.getMetricRegistry()));
+        collectorRegistry.register(new DropwizardExports(Metrics.getRegistry()));
         io.prometheus.client.exporter.MetricsServlet prometheusServlet =
                 new io.prometheus.client.exporter.MetricsServlet(collectorRegistry);
         ServletHolder prometheusHolder = new ServletHolder("prometheus", prometheusServlet);
 
         // Resources
-        ResourceConfig resourceConfig = new ResourceConfig(MultiPartFeature.class).registerInstances(new HashSet<>(resources));
+        ResourceConfig resourceConfig = new ResourceConfig(MultiPartFeature.class)
+                .registerInstances(new HashSet<>(resources));
         ServletHolder resourceHolder = new ServletHolder(new ServletContainer(resourceConfig));
 
-        context.addServlet(metricsHolder,"/v1/metrics");
-        context.addServlet(prometheusHolder,"/v1/metrics/prometheus");
-        context.addServlet(resourceHolder,"/*");
+        context.addServlet(metricsHolder, "/v1/metrics");
+        context.addServlet(prometheusHolder, "/v1/metrics/prometheus");
+        context.addServlet(resourceHolder, "/*");
 
         server.getHandlers();
         server.setHandler(context);
@@ -91,7 +92,7 @@ public class SchedulerApiServer {
                 try {
                     LOGGER.info("Starting API server at port {}", port);
                     server.start();
-                    int localPort = ((ServerConnector)server.getConnectors()[0]).getLocalPort();
+                    int localPort = ((ServerConnector) server.getConnectors()[0]).getLocalPort();
                     LOGGER.info("API server started at port {}", localPort);
                     startTimer.cancel();
                     server.join();

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerRunner.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerRunner.java
@@ -59,7 +59,7 @@ public class SchedulerRunner implements Runnable {
      *
      * @param serviceSpec the service specification converted to be used by the config store
      * @param schedulerConfig the scheduler configuration to use (usually based on process environment)
-     * @param configTemplateDir a list of one or more custom plans to be used by the service
+     * @param plans a list of one or more custom plans to be used by the service
      * @return a new {@link SchedulerRunner} instance, which may be launched with {@link #run()}
      */
     public static SchedulerRunner fromServiceSpec(

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerUtils.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerUtils.java
@@ -1,17 +1,16 @@
 package com.mesosphere.sdk.scheduler;
 
+import com.codahale.metrics.MetricRegistry;
 import com.mesosphere.sdk.dcos.DcosConstants;
 import com.mesosphere.sdk.scheduler.plan.Plan;
+import com.mesosphere.sdk.specification.yaml.RawServiceSpec;
+import com.mesosphere.sdk.storage.PersisterUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
-
-import org.apache.commons.lang3.StringUtils;
-
-import com.mesosphere.sdk.specification.yaml.RawServiceSpec;
-import com.mesosphere.sdk.storage.PersisterUtils;
 
 /**
  * This class provides utilities common to the construction and operation of Mesos Schedulers.
@@ -28,6 +27,8 @@ public class SchedulerUtils {
      * confuse ZK with those.
      */
     private static final String FRAMEWORK_NAME_SLASH_ESCAPE = "__";
+
+    private static final MetricRegistry metrics = new MetricRegistry();
 
     /**
      * Returns the configured service name (aka framework name) to use for running the service.
@@ -132,6 +133,10 @@ public class SchedulerUtils {
         System.err.println(message);
         System.out.println(message);
         System.exit(errorCode.getValue());
+    }
+
+    public static MetricRegistry getMetricRegistry() {
+        return metrics;
     }
 
     static Optional<Plan> getDeployPlan(Collection<Plan> plans) {

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerUtils.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerUtils.java
@@ -1,6 +1,5 @@
 package com.mesosphere.sdk.scheduler;
 
-import com.codahale.metrics.MetricRegistry;
 import com.mesosphere.sdk.dcos.DcosConstants;
 import com.mesosphere.sdk.scheduler.plan.Plan;
 import com.mesosphere.sdk.specification.yaml.RawServiceSpec;
@@ -27,8 +26,6 @@ public class SchedulerUtils {
      * confuse ZK with those.
      */
     private static final String FRAMEWORK_NAME_SLASH_ESCAPE = "__";
-
-    private static final MetricRegistry metrics = new MetricRegistry();
 
     /**
      * Returns the configured service name (aka framework name) to use for running the service.
@@ -133,10 +130,6 @@ public class SchedulerUtils {
         System.err.println(message);
         System.out.println(message);
         System.exit(errorCode.getValue());
-    }
-
-    public static MetricRegistry getMetricRegistry() {
-        return metrics;
     }
 
     static Optional<Plan> getDeployPlan(Collection<Plan> plans) {

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/uninstall/UninstallScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/uninstall/UninstallScheduler.java
@@ -129,7 +129,7 @@ public class UninstallScheduler extends AbstractScheduler {
             LOGGER.info("No offers to be declined.");
         } else {
             LOGGER.info("Declining {} unused offers", unusedOffers.size());
-            OfferUtils.declineOffers(driver, unusedOffers, Constants.LONG_DECLINE_SECONDS);
+            OfferUtils.declineLong(driver, unusedOffers);
         }
     }
 

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/OfferUtilsTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/OfferUtilsTest.java
@@ -75,7 +75,7 @@ public class OfferUtilsTest {
     public void testDeclineOffers() {
         final List<Protos.Offer> offers = getOffers(SUFFICIENT_CPUS, SUFFICIENT_MEM, SUFFICIENT_DISK);
         final List<Protos.OfferID> offerIds = offers.stream().map(Protos.Offer::getId).collect(Collectors.toList());
-        OfferUtils.declineOffers(mockSchedulerDriver, offers, Constants.LONG_DECLINE_SECONDS);
+        OfferUtils.declineLong(mockSchedulerDriver, offers);
         verify(mockSchedulerDriver).declineOffer(eq(offerIds.get(0)), any());
         verify(mockSchedulerDriver).declineOffer(eq(offerIds.get(1)), any());
     }

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/MetricsTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/MetricsTest.java
@@ -1,0 +1,158 @@
+package com.mesosphere.sdk.scheduler;
+
+import com.codahale.metrics.Counter;
+import com.mesosphere.sdk.offer.LaunchOfferRecommendation;
+import com.mesosphere.sdk.offer.OfferRecommendation;
+import com.mesosphere.sdk.testutils.OfferTestUtils;
+import com.mesosphere.sdk.testutils.TestConstants;
+import org.apache.mesos.Protos;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * This class tests the {@link Metrics} class.
+ */
+public class MetricsTest {
+    @Before
+    public void beforeEach() {
+        Metrics.reset();
+    }
+
+    @Test
+    public void emptyReceivedOffers() {
+        Assert.assertEquals(0, Metrics.getReceivedOffers().getCount());
+    }
+
+    @Test
+    public void incrementReceivedOffers() {
+       Metrics.getReceivedOffers().inc();
+       Assert.assertEquals(1, Metrics.getReceivedOffers().getCount());
+    }
+
+    @Test
+    public void emptyProcessedOffers() {
+        Assert.assertEquals(0, Metrics.getProcessedOffers().getCount());
+    }
+
+    @Test
+    public void incrementProcessedOffers() {
+        Metrics.getProcessedOffers().inc();
+        Assert.assertEquals(1, Metrics.getProcessedOffers().getCount());
+    }
+
+    @Test
+    public void emptyProcessOffers() {
+        Assert.assertEquals(0, Metrics.getProcessOffersDuration().getCount());
+    }
+
+    @Test
+    public void timeProcessOffers() {
+        Metrics.getProcessOffersDuration().time().stop();
+        Assert.assertEquals(1, Metrics.getProcessOffersDuration().getCount());
+    }
+
+    @Test
+    public void emptyRevives() {
+        Assert.assertEquals(0, Metrics.getRevives().getCount());
+    }
+
+    @Test
+    public void incrementRevives() {
+        Metrics.getRevives().inc();
+        Assert.assertEquals(1, Metrics.getRevives().getCount());
+    }
+
+    @Test
+    public void emptyReviveThrottles() {
+        Assert.assertEquals(0, Metrics.getReviveThrottles().getCount());
+    }
+
+    @Test
+    public void incrementReviveThrottles() {
+        Metrics.getReviveThrottles().inc();
+        Assert.assertEquals(1, Metrics.getReviveThrottles().getCount());
+    }
+
+    @Test
+    public void emptyDeclinesShort() {
+        Assert.assertEquals(0, Metrics.getDeclinesShort().getCount());
+    }
+
+    @Test
+    public void incrementDeclinesShort() {
+        Metrics.getDeclinesShort().inc();
+        Assert.assertEquals(1, Metrics.getDeclinesShort().getCount());
+    }
+
+    @Test
+    public void emptyDeclinesLong() {
+        Assert.assertEquals(0, Metrics.getDeclinesLong().getCount());
+    }
+
+    @Test
+    public void incrementDeclinesLong() {
+        Metrics.getDeclinesLong().inc();
+        Assert.assertEquals(1, Metrics.getDeclinesLong().getCount());
+    }
+
+    @Test
+    public void taskRunning() {
+        Protos.TaskStatus taskStatus = Protos.TaskStatus.newBuilder()
+                .setState(Protos.TaskState.TASK_RUNNING)
+                .setTaskId(TestConstants.TASK_ID)
+                .build();
+
+        Assert.assertEquals(0, Metrics.getRegistry().getCounters().size());
+        Metrics.record(taskStatus);
+        Assert.assertEquals(1, Metrics.getRegistry().getCounters().size());
+
+        String metricName = Metrics.getRegistry().getCounters().firstKey();
+        Counter counter = Metrics.getRegistry().counter(metricName);
+        Assert.assertEquals(1, counter.getCount());
+    }
+
+    @Test
+    public void realTaskLaunch() throws Exception {
+        OfferRecommendation recommendation = getRealRecommendation();
+
+        Assert.assertEquals(0, Metrics.getRegistry().getCounters().size());
+        Metrics.OperationsCounter.getInstance().record(recommendation);
+        Assert.assertEquals(1, Metrics.getRegistry().getCounters().size());
+
+        String metricName = Metrics.getRegistry().getCounters().firstKey();
+        Counter counter = Metrics.getRegistry().counter(metricName);
+        Assert.assertEquals(1, counter.getCount());
+    }
+
+    @Test
+    public void suppressedTaskLaunch() throws Exception {
+        OfferRecommendation recommendation = getSuppressedRecommendation();
+
+        Assert.assertEquals(0, Metrics.getRegistry().getCounters().size());
+        Metrics.OperationsCounter.getInstance().record(recommendation);
+        Assert.assertEquals(0, Metrics.getRegistry().getCounters().size());
+    }
+
+    private OfferRecommendation getRealRecommendation() {
+        return getRecommendation(true);
+    }
+
+    private OfferRecommendation getSuppressedRecommendation() {
+        return getRecommendation(false);
+    }
+
+    private OfferRecommendation getRecommendation(boolean shouldLaunch) {
+        return new LaunchOfferRecommendation(
+                OfferTestUtils.getEmptyOfferBuilder().build(),
+                Protos.TaskInfo.newBuilder()
+                        .setTaskId(TestConstants.TASK_ID)
+                        .setName(TestConstants.TASK_NAME)
+                        .setSlaveId(TestConstants.AGENT_ID)
+                        .build(),
+                Protos.ExecutorInfo.newBuilder().setExecutorId(
+                        Protos.ExecutorID.newBuilder().setValue("executor")).build(),
+                shouldLaunch,
+                true);
+    }
+}

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/SchedulerApiServerTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/SchedulerApiServerTest.java
@@ -14,7 +14,7 @@ import static org.mockito.Mockito.when;
 
 public class SchedulerApiServerTest {
     private static final int SHORT_TIMEOUT_MILLIS = 100;
-    private static final int LONG_TIMEOUT_MILLIS = 30000;
+    private static final int LONG_TIMEOUT_MILLIS = 300000000;
 
     @Test
     public void testApiServerReady() throws Exception {
@@ -22,7 +22,7 @@ public class SchedulerApiServerTest {
                 getSchedulerConfig(0, Duration.ofMillis(LONG_TIMEOUT_MILLIS)), Collections.emptyList());
         Listener listener = new Listener();
         schedulerApiServer.start(listener);
-        waitForTrue(listener.apiServerStarted);
+        waitForTrue(new AtomicBoolean(false));
     }
 
     private SchedulerConfig getSchedulerConfig(int port, Duration timeout) {

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/SchedulerApiServerTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/SchedulerApiServerTest.java
@@ -14,7 +14,7 @@ import static org.mockito.Mockito.when;
 
 public class SchedulerApiServerTest {
     private static final int SHORT_TIMEOUT_MILLIS = 100;
-    private static final int LONG_TIMEOUT_MILLIS = 300000000;
+    private static final int LONG_TIMEOUT_MILLIS = 30000;
 
     @Test
     public void testApiServerReady() throws Exception {
@@ -22,7 +22,7 @@ public class SchedulerApiServerTest {
                 getSchedulerConfig(0, Duration.ofMillis(LONG_TIMEOUT_MILLIS)), Collections.emptyList());
         Listener listener = new Listener();
         schedulerApiServer.start(listener);
-        waitForTrue(new AtomicBoolean(false));
+        waitForTrue(listener.apiServerStarted);
     }
 
     private SchedulerConfig getSchedulerConfig(int port, Duration timeout) {


### PR DESCRIPTION
We now expose some metrics.
1. LAUNCH count
1. LAUNCH_GROUP count
1. revive count
1. decline_long (2 weeks) count
1. decline_short (5 seconds) count
1. received_offers count
1. processed_offers count 
1. process_offers performance histogram (how long does it take to process a set of Offers)

They're exposed in standard json format at `v1/metrics` and in prometheus format at `v1/metrics/prometheus`

This was needed as part of scale testing.  It's been very handy and may turn out to be handy elsewhere.

*EDIT*: After comments addressed:
```
{
	version: "3.1.3",
	gauges: {},
	counters: {
		declines.long: {
			count: 15
		},
		offers.processed: {
			count: 18
		},
		offers.received: {
			count: 18
		},
		operation.create: {
			count: 5
		},
		operation.launch_group: {
			count: 3
		},
		operation.reserve: {
			count: 20
		},
		revives: {
			count: 3
		},
		task_status.task_running: {
			count: 6
		}
	},
	histograms: {},
	meters: {},
	timers: {
		offers.process: {
			count: 16,
			max: 1.2737304340000002,
			mean: 0.08546521439489685,
			min: 0.000540903,
			p50: 0.00080639,
			p75: 0.002886426,
			p95: 0.299465637,
			p98: 1.2737304340000002,
			p99: 1.2737304340000002,
			p999: 1.2737304340000002,
			stddev: 0.26514312711412447,
			m15_rate: 0.3923298855924552,
			m1_rate: 0.3059933114120981,
			m5_rate: 0.3776284947452369,
			mean_rate: 0.2770034341591988,
			duration_units: "seconds",
			rate_units: "calls/second"
		}
	}
}
```