### PR TITLE
[INFINITY-1547] Emit scheduler metrics through statsd

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,7 @@ allprojects {
     targetCompatibility = '1.8'
 
     repositories {
+        jcenter()
         mavenLocal()
         mavenCentral()
         maven {

--- a/sdk/scheduler/build.gradle
+++ b/sdk/scheduler/build.gradle
@@ -120,6 +120,7 @@ dependencies {
     compile "io.dropwizard.metrics:metrics-servlets:${dropWizardMetricsVer}"
     compile "io.prometheus:simpleclient_dropwizard:0.0.26"
     compile "io.prometheus:simpleclient_servlet:0.0.26"
+    compile "com.readytalk:metrics3-statsd:4.2.0"
     testCompile "org.hamcrest:hamcrest-all:${hamcrestVer}" // note: must be above junit
     testCompile "junit:junit:${junitVer}"
     testCompile "com.github.stefanbirkner:system-rules:${systemRulesVer}"

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/AbstractScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/AbstractScheduler.java
@@ -3,7 +3,6 @@ package com.mesosphere.sdk.scheduler;
 import com.codahale.metrics.Timer;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.TextFormat;
-import com.mesosphere.sdk.offer.Constants;
 import com.mesosphere.sdk.offer.OfferUtils;
 import com.mesosphere.sdk.queue.OfferQueue;
 import com.mesosphere.sdk.reconciliation.DefaultReconciler;

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerConfig.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerConfig.java
@@ -30,6 +30,7 @@ import java.util.Map;
  */
 public class SchedulerConfig {
 
+
     /**
      * Exception which is thrown when failing to retrieve or parse a given flag value.
      */
@@ -133,6 +134,13 @@ public class SchedulerConfig {
     private static final String PACKAGE_NAME_ENV = "PACKAGE_NAME";
     private static final String PACKAGE_VERSION_ENV = "PACKAGE_VERSION";
     private static final String PACKAGE_BUILD_TIME_EPOCH_MS_ENV = "PACKAGE_BUILD_TIME_EPOCH_MS";
+
+    /**
+     * Environment variables for configuring metrics reporting behavior.
+     */
+    private String STATSD_POLL_INTERVAL_S_ENV = "STATSD_POLL_INTERVAL_S";
+    private String STATSD_UDP_HOST_ENV = "STATSD_UDP_HOST";
+    private String STATSD_UDP_PORT_ENV = "STATSD_UDP_PORT";
 
     /**
      * Returns a new {@link SchedulerConfig} instance which is based off the process environment.
@@ -280,6 +288,27 @@ public class SchedulerConfig {
     }
 
     /**
+     * Returns the interval in seconds between StatsD reports
+     */
+    public long getStatsDPollIntervalS() {
+        return envStore.getOptionalLong(STATSD_POLL_INTERVAL_S_ENV, 10);
+    }
+
+    /**
+     * Returns the StatsD host.
+     */
+    public String getStatsdHost() {
+        return envStore.getRequired(STATSD_UDP_HOST_ENV);
+    }
+
+    /**
+     * Returns the StatsD port.
+     */
+    public int getStatsdPort() {
+        return envStore.getRequiredInt(STATSD_UDP_PORT_ENV);
+    }
+
+    /**
      * Internal utility class for grabbing values from a mapping of flag values (typically the process env).
      */
     private static class EnvStore {
@@ -292,6 +321,10 @@ public class SchedulerConfig {
 
         private int getOptionalInt(String envKey, int defaultValue) {
             return toInt(envKey, getOptional(envKey, String.valueOf(defaultValue)));
+        }
+
+        private long getOptionalLong(String envKey, long defaultValue) {
+            return toLong(envKey, getOptional(envKey, String.valueOf(defaultValue)));
         }
 
         private int getRequiredInt(String envKey) {


### PR DESCRIPTION
It worked:
```
$ curl --header "Authorization: token=eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJleHAiOjE1MDg4NTU4MTIsInVpZCI6ImJvb3RzdHJhcHVzZXIifQ.EnsERVeexRm4z7wLOZaUArQkSi4_DZa09cj1LtZpzpSLYgDsTUoSobhnTvhGqgNPXHCbyWZcRT1f4Cm3pbYQxE4JneUnqr3dnOfYeiMkAvU6bySH85HsuobLaOjp-zpeg_0W3ESZUiHs4h4OtupjIrPKlVRZLzxX7bTqiViix4RupdPm3FjJdUU-8kNWIyyDuj0KRlxtcJU4X_aMhFGpLKlUhAPOzIDeJCnskZP3xlZCDP_xgN_a4OAHFbBRhgPwWawg-copsef9iwY--ssBMfsUSDfYPaKfPkY75-8ZPG5cMfaakYbFHpQli9WVN5B86EPJKy38XZXCz9B0y4o3KQ" -s http://localhost:61001/system/v1/metrics/v0/containers/1a94c064-7c62-4cae-8904-fa0f879e29ba/app | jq .
{
  "datapoints": [
    {
      "name": "offers.process.m15_rate",
      "value": 0.51,
      "unit": "",
      "timestamp": "2017-10-20T00:58:15Z"
    },
    {
      "name": "offers.process.p50",
      "value": 0.37,
      "unit": "",
      "timestamp": "2017-10-20T00:58:15Z"
    },
    {
      "name": "offers.received",
      "value": 18,
      "unit": "",
      "timestamp": "2017-10-20T00:58:15Z"
    },
    {
      "name": "declines.long",
      "value": 15,
      "unit": "",
      "timestamp": "2017-10-20T00:58:15Z"
    },
    {
      "name": "offers.process.mean_rate",
      "value": 0.22,
      "unit": "",
      "timestamp": "2017-10-20T00:58:15Z"
    },
    {
      "name": "revives",
      "value": 3,
      "unit": "",
      "timestamp": "2017-10-20T00:58:15Z"
    },
    {
      "name": "dcos.metrics.module.container_throttled_bytes_per_sec",
      "value": 0,
      "unit": "",
      "timestamp": "2017-10-20T00:57:35Z"
    },
    {
      "name": "operation.create",
      "value": 5,
      "unit": "",
      "timestamp": "2017-10-20T00:58:15Z"
    },
    {
      "name": "offers.process.samples",
      "value": 55,
      "unit": "",
      "timestamp": "2017-10-20T00:58:15Z"
    },
    {
      "name": "offers.process.p99",
      "value": 94.94,
      "unit": "",
      "timestamp": "2017-10-20T00:58:15Z"
    },
    {
      "name": "offers.process.stddev",
      "value": 51.96,
      "unit": "",
      "timestamp": "2017-10-20T00:58:15Z"
    },
    {
      "name": "offers.process.m1_rate",
      "value": 0.21,
      "unit": "",
      "timestamp": "2017-10-20T00:58:15Z"
    },
    {
      "name": "offers.process.min",
      "value": 0.28,
      "unit": "",
      "timestamp": "2017-10-20T00:58:15Z"
    },
    {
      "name": "offers.processed",
      "value": 18,
      "unit": "",
      "timestamp": "2017-10-20T00:58:15Z"
    },
    {
      "name": "offers.process.p75",
      "value": 0.55,
      "unit": "",
      "timestamp": "2017-10-20T00:58:15Z"
    },
    {
      "name": "operation.reserve",
      "value": 20,
      "unit": "",
      "timestamp": "2017-10-20T00:58:15Z"
    },
    {
      "name": "offers.process.p999",
      "value": 1003.83,
      "unit": "",
      "timestamp": "2017-10-20T00:58:15Z"
    },
    {
      "name": "offers.process.p95",
      "value": 88.31,
      "unit": "",
      "timestamp": "2017-10-20T00:58:15Z"
    },
    {
      "name": "dcos.metrics.module.container_received_bytes_per_sec",
      "value": 57.9333,
      "unit": "",
      "timestamp": "2017-10-20T00:57:35Z"
    },
    {
      "name": "offers.process.m5_rate",
      "value": 0.38,
      "unit": "",
      "timestamp": "2017-10-20T00:58:15Z"
    },
    {
      "name": "offers.process.mean",
      "value": 10.77,
      "unit": "",
      "timestamp": "2017-10-20T00:58:15Z"
    },
    {
      "name": "offers.process.max",
      "value": 1003.83,
      "unit": "",
      "timestamp": "2017-10-20T00:58:15Z"
    },
    {
      "name": "task_status.task_running",
      "value": 6,
      "unit": "",
      "timestamp": "2017-10-20T00:58:15Z"
    },
    {
      "name": "offers.process.p98",
      "value": 89.82,
      "unit": "",
      "timestamp": "2017-10-20T00:58:15Z"
    },
    {
      "name": "operation.launch_group",
      "value": 3,
      "unit": "",
      "timestamp": "2017-10-20T00:58:15Z"
    }
  ],
  "dimensions": {
    "mesos_id": "e86c614f-cb5f-4a28-a9f3-74710f3bd40a-S3",
    "cluster_id": "99ef5b47-b7f2-46e6-87e4-1ffd01f0ddaf",
    "container_id": "1a94c064-7c62-4cae-8904-fa0f879e29ba",
    "executor_id": "hello-world.1a0a31c9-b531-11e7-9d2e-460ff947d7aa",
    "framework_id": "e86c614f-cb5f-4a28-a9f3-74710f3bd40a-0001",
    "task_name": "hello-world",
    "task_id": "hello-world.1a0a31c9-b531-11e7-9d2e-460ff947d7aa",
    "hostname": "10.0.2.35"
  }
}
```