### PR TITLE
[INFINITY-2552] Add basic logging to get_framework_srv_records (#1747)

### DIFF
--- a/frameworks/helloworld/tests/test_overlay.py
+++ b/frameworks/helloworld/tests/test_overlay.py
@@ -22,9 +22,9 @@ def configure_package(configure_security):
         sdk_install.install(
             config.PACKAGE_NAME,
             1,
-            additional_options={ "service": { "spec_file": "examples/overlay.yml" } })
+            additional_options={"service": {"spec_file": "examples/overlay.yml"}})
 
-        yield # let the test session execute
+        yield  # let the test session execute
     finally:
         sdk_install.uninstall(config.PACKAGE_NAME)
 
@@ -42,6 +42,7 @@ EXPECTED_NETWORK_LABELS = {
     "key0": "val0",
     "key1": "val1"
 }
+
 
 @pytest.mark.sanity
 @pytest.mark.overlay
@@ -183,6 +184,7 @@ def test_srv_records():
             "Missing SRV record for {} (prefix={}) in task {}:\nmatching={}\nall={}".format(
                 record_name, record_name_prefix, task_name, matching_records, task_records)
 
+    log.info("Getting framework srv records for %s", config.PACKAGE_NAME)
     fmk_srvs = sdk_networks.get_framework_srv_records(config.PACKAGE_NAME)
     for task in TASKS_WITH_PORTS:
         task_records = sdk_networks.get_task_record(task, fmk_srvs)

--- a/testing/sdk_cmd.py
+++ b/testing/sdk_cmd.py
@@ -25,16 +25,37 @@ def request(method, url, retry=True, log_args=True, **kwargs):
         return fn()
 
 
-def run_cli(cmd, print_output=True, return_stderr_in_stdout=False):
-    (stdout, stderr, ret) = shakedown.run_dcos_command(cmd, print_output=print_output)
-    if ret != 0:
-        err = 'Got error code {} when running command "dcos {}":\nstdout: "{}"\nstderr: "{}"'.format(
-            ret, cmd, stdout, stderr)
+def svc_cli(package_name, service_name, service_cmd, json=False, print_output=True, return_stderr_in_stdout=False):
+    full_cmd = '{} --name={} {}'.format(package_name, service_name, service_cmd)
+
+    if not json:
+        return run_cli(full_cmd, print_output=print_output, return_stderr_in_stdout=return_stderr_in_stdout)
+    else:
+        # TODO(elezar): We shouldn't use json=True and return_stderr_in_stdout=True together
+        # assert not return_stderr_in_stdout, json=True and return_stderr_in_stdout=True together should not be used together
+        return get_json_output(full_cmd, print_output=print_output)
+
+
+def run_raw_cli(cmd, print_output):
+    stdout, stderr, ret = shakedown.run_dcos_command(cmd, print_output=print_output)
+    if ret:
+        err = 'Got error code {} when running command "dcos {}":\n'\
+              'stdout: "{}"\n'\
+              'stderr: "{}"'.format(ret, cmd, stdout, stderr)
         log.error(err)
         raise dcos.errors.DCOSException(err)
+
+    return stdout, stderr
+
+
+def run_cli(cmd, print_output=True, return_stderr_in_stdout=False):
+
+    stdout, stderr = run_raw_cli(cmd, print_output)
+
     if return_stderr_in_stdout:
-        stdout = stdout + "\n" + stderr
-    return stdout
+        return stdout + "\n" + stderr
+    else:
+        return stdout
 
 
 def convert_string_list_to_list(output):
@@ -44,3 +65,19 @@ def convert_string_list_to_list(output):
     In spite of being a one-liner it standardizes the conversion.
     """
     return [element.strip() for element in ast.literal_eval(output)]
+
+
+def get_json_output(cmd, print_output=True):
+    stdout, stderr = run_raw_cli(cmd, print_output)
+
+    if stderr:
+        log.warn("stderr for command '%s' is non-empty: %s", cmd, stderr)
+
+    try:
+        json_stdout = jsonlib.loads(stdout)
+    except Exception as e:
+        log.error("Error converting stdout=%s to json", stdout)
+        log.error(e)
+        raise e
+
+    return json_stdout

--- a/testing/sdk_networks.py
+++ b/testing/sdk_networks.py
@@ -1,7 +1,9 @@
 import json
-
+import logging
+import retrying
 import shakedown
 
+log = logging.getLogger(__name__)
 
 ENABLE_VIRTUAL_NETWORKS_OPTIONS = {'service': {'virtual_network_enabled': True}}
 
@@ -66,10 +68,25 @@ def check_endpoints_on_overlay(endpoints):
 
 
 def get_framework_srv_records(package_name):
-    cmd = "curl localhost:8123/v1/enumerate"
-    ok, out = shakedown.run_command_on_master(cmd)
-    assert ok, "Failed to get srv records. command was {}".format(cmd)
-    srvs = json.loads(out)
+
+    @retrying.retry(wait_exponential_multiplier=1000,
+                    wait_exponential_max=120 * 1000)
+    def call_shakedown():
+        cmd = "curl localhost:8123/v1/enumerate"
+        log.info("Running '%s' on master", cmd)
+        is_ok, out = shakedown.run_command_on_master(cmd)
+        log.info("Running command returned: is_ok=%s\n\tout=%s", is_ok, out)
+        assert is_ok, "Failed to get srv records. command was {}".format(cmd)
+        try:
+            srvs = json.loads(out)
+        except Exception as e:
+            log.error("Error converting out=%s to json", out)
+            log.error(e)
+            raise e
+
+        return srvs
+
+    srvs = call_shakedown()
     framework_srvs = [f for f in srvs["frameworks"] if f["name"] == package_name]
     assert len(framework_srvs) == 1, "Got too many srv records matching package {}, got {}"\
         .format(package_name, framework_srvs)


### PR DESCRIPTION
Backport of #1747

* Adds a retry to `get_framework_srv_records`
* Cleans up the handling of json output from CLI commands.