### PR TITLE
Remove env variable from frameworks/template's svc file

### DIFF
--- a/frameworks/template/src/main/dist/svc.yml
+++ b/frameworks/template/src/main/dist/svc.yml
@@ -21,5 +21,3 @@ pods:
           path: "template-container-path"
           type: {{NODE_DISK_TYPE}}
           size: {{NODE_DISK}}
-        env:
-          SLEEP_DURATION: {{SLEEP_DURATION}}


### PR DESCRIPTION
When creating a new framework in the following way:
`./new-framework frameworks/newframework`
tests fail because `env` is empty (see issue: https://github.com/mesosphere/dcos-commons/issues/1714)

One way to solve it is removing the attribute altogether.