### PR TITLE
INFINITY-2573 Add opt-in bit to pod specs allowing truncation of pods

### DIFF
--- a/docs/pages/reference/yaml-reference.md
+++ b/docs/pages/reference/yaml-reference.md
@@ -32,6 +32,10 @@ This documentation effectively reflects the Java object tree under [RawServiceSp
 
     Custom zookeeper URL for storing scheduler state. Defaults to `master.mesos:2181`.
 
+  * `user`
+
+    The system user to run the service's scheduler and pods as. Availability of usernames depends on the cluster. If DC/OS Security is enabled, this may need to be set to `nobody`, or the administrator may be required to configure custom permissions allowing the service to run as a different user.
+
 * `pods`
 
   This section contains a listing of all pod types managed by the service.
@@ -50,7 +54,11 @@ This documentation effectively reflects the Java object tree under [RawServiceSp
 
   * `count`
 
-    The number of pods of this type to be deployed. This may either be hardcoded or exposed to end users via mustache templating.
+    The number of pods of this type to be deployed. This may either be hardcoded or exposed to end users via mustache templating. This value may be always increased after the service has been deployed, but it can only be decreased if `allow-decomission` is `true`.
+
+  * `allow-decommission`
+
+    Whether to allow the `count` to be decreased by an operator in a configuration update. For safety reasons this defaults to `false`, but the service developer may set this field to `true` to explicitly allow scale-down on a per-pod basis.
 
   * `container`
 
@@ -125,6 +133,14 @@ This documentation effectively reflects the Java object tree under [RawServiceSp
   * `volume`/`volumes`
 
     One or more persistent volumes to be mounted into the pod environment. These behave the same as volumes on a task or resource set, but are guaranteed to be shared between tasks in a pod. Although volumes defined on a task currently behave the same way, individual tasks will not be able to access volumes defined by another task in the future.
+
+  * `pre-reserved-role`
+
+    TODO(nickbp): Explain Mesos pre-reserved roles.
+
+  * `share-pid-namespace`
+
+    Whether the tasks within this pod should share the same process id namespace (`true`), or whether pid namespaces should be distinct for every task in the pod (`false`).
 
   * `tasks`
 
@@ -374,10 +390,6 @@ This documentation effectively reflects the Java object tree under [RawServiceSp
         This can be set either to `TLS` for PEM encoded private key file, certificate and CA bundle or `KEYSTORE` for certificate and private key to be delivered in a separate keystore file and CA bundle in other truststore file.
 
       For detailed information see the [SDK Developer Guide](developer-guide.html#tls).
-
-  * `user`
-
-    The system user to run this pod as. The available users depend on the administrator's cluster. If clusters are using DC/OS Security enabled, this may need to be set to `nobody`.
 
 * `plans`
 

--- a/docs/pages/reference/yaml-reference.md
+++ b/docs/pages/reference/yaml-reference.md
@@ -58,7 +58,7 @@ This documentation effectively reflects the Java object tree under [RawServiceSp
 
   * `allow-decommission`
 
-    Whether to allow the `count` to be decreased by an operator in a configuration update. For safety reasons this defaults to `false`, but the service developer may set this field to `true` to explicitly allow scale-down on a per-pod basis.
+    Whether to allow this pod's `count` to be decreased by an operator in a configuration update. For safety reasons this defaults to `false`, but the service developer may set this field to `true` to explicitly allow scale-down on a per-pod basis.
 
   * `container`
 
@@ -136,7 +136,7 @@ This documentation effectively reflects the Java object tree under [RawServiceSp
 
   * `pre-reserved-role`
 
-    TODO(nickbp): Explain Mesos pre-reserved roles.
+    Ensures that this pod only consumes resources against a role which has already been statically assigned within the cluster. This is mainly useful for placing pods within a predefined quota, or otherwise assigning them a specific set of resources. For example, DC/OS clusters have a convention of using the `slave_public` role for machines which are not firewalled. Pods which have their `pre-reserved-role` set to `slave_public` will be placed on those machines so that they are visible outside the cluster.
 
   * `share-pid-namespace`
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/config/validate/PodSpecsCannotShrink.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/config/validate/PodSpecsCannotShrink.java
@@ -32,16 +32,23 @@ public class PodSpecsCannotShrink implements ConfigValidator<ServiceSpec> {
         Collection<ConfigValidationError> errors = new ArrayList<>();
         for (PodSpec oldPod : oldConfig.get().getPods()) {
             PodSpec newPod = newPods.get(oldPod.getType());
-            if (newPod == null && !oldPod.getAllowDecommission()) {
-                // Old pod is now missing. Allow the removal only if the old pod's allow-decommission bit was set.
-                // This could be used as an admittedly convoluted path for migrating away from an old service layout.
-                errors.add(ConfigValidationError.transitionError(
-                        String.format("PodSpec[name:%s]", oldPod.getType()),
-                        String.valueOf(oldPod.getCount()),
-                        "null",
-                        String.format("New config is missing PodSpec named '%s' (expected present with >= %d tasks)",
-                                oldPod.getType(), oldPod.getCount())));
-            } else if (newPod != null && newPod.getCount() < oldPod.getCount() && !newPod.getAllowDecommission()) {
+            if (newPod == null) {
+                // Prior pod of this name is now missing. Allow the removal only if the old pod's allow-decommission bit
+                // was set. This could be used as an (admittedly convoluted) path for migrating away from an old service
+                // layout, with an interim release marking a pod with allow-decommission before it's removed entirely.
+                if (!oldPod.getAllowDecommission()) {
+                    errors.add(ConfigValidationError.transitionError(
+                            String.format("PodSpec[name:%s]", oldPod.getType()),
+                            String.valueOf(oldPod.getCount()),
+                            "null",
+                            String.format(
+                                    "New config is missing PodSpec named '%s' (expected present with >= %d tasks)",
+                                    oldPod.getType(), oldPod.getCount())));
+                }
+                continue;
+            }
+
+            if (newPod.getCount() < oldPod.getCount() && !newPod.getAllowDecommission()) {
                 // New pod is present and is smaller than old pod.
                 // Only allow the new pod to be shrunk if its allow-decommission bit is set. We intentionally check
                 // allow-decommission against the new pod instead of the old pod with the following reasoning:

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/config/validate/PodSpecsCannotShrink.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/config/validate/PodSpecsCannotShrink.java
@@ -32,16 +32,24 @@ public class PodSpecsCannotShrink implements ConfigValidator<ServiceSpec> {
         Collection<ConfigValidationError> errors = new ArrayList<>();
         for (PodSpec oldPod : oldConfig.get().getPods()) {
             PodSpec newPod = newPods.get(oldPod.getType());
-            if (newPod == null) {
+            if (newPod == null && !oldPod.getAllowDecommission()) {
+                // Old pod is now missing. Allow the removal only if the old pod's allow-decommission bit was set.
+                // This could be used as an admittedly convoluted path for migrating away from an old service layout.
                 errors.add(ConfigValidationError.transitionError(
                         String.format("PodSpec[name:%s]", oldPod.getType()),
                         String.valueOf(oldPod.getCount()),
                         "null",
                         String.format("New config is missing PodSpec named '%s' (expected present with >= %d tasks)",
                                 oldPod.getType(), oldPod.getCount())));
-            } else if (newPod.getCount() < oldPod.getCount()) {
+            } else if (newPod != null && newPod.getCount() < oldPod.getCount() && !newPod.getAllowDecommission()) {
+                // New pod is present and is smaller than old pod.
+                // Only allow the new pod to be shrunk if its allow-decommission bit is set. We intentionally check
+                // allow-decommission against the new pod instead of the old pod with the following reasoning:
+                // - Older version disallows, newer version allows: Allow count to decrease now that it's supported
+                // - Older version allows, newer version disallows: Disallow count from decreasing now that it's no
+                //   longer supported
                 errors.add(ConfigValidationError.transitionError(
-                        String.format("PodSpec[setname:%s]", newPod.getType()),
+                        String.format("PodSpec[name:%s]", newPod.getType()),
                         String.valueOf(oldPod.getCount()),
                         String.valueOf(newPod.getCount()),
                         String.format("New config's PodSpec named '%s' has %d tasks, expected >=%d tasks",

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultPodSpec.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultPodSpec.java
@@ -28,6 +28,8 @@ public class DefaultPodSpec implements PodSpec {
     @NotNull
     @Min(0)
     private final Integer count;
+    @NotNull
+    private Boolean allowDecommission;
     @Size(min = 1)
     private String image;
     @Valid
@@ -65,7 +67,8 @@ public class DefaultPodSpec implements PodSpec {
             @JsonProperty("volumes") Collection<VolumeSpec> volumes,
             @JsonProperty("pre-reserved-role") String preReservedRole,
             @JsonProperty("secrets") Collection<SecretSpec> secrets,
-            @JsonProperty("share-pid-namespace") Boolean sharePidNamespace) {
+            @JsonProperty("share-pid-namespace") Boolean sharePidNamespace,
+            @JsonProperty("allow-decommission") Boolean allowDecommission) {
         this(
                 new Builder(Optional.empty()) // Assume that Executor URI is already present
                         .type(type)
@@ -80,11 +83,13 @@ public class DefaultPodSpec implements PodSpec {
                         .volumes(volumes)
                         .preReservedRole(preReservedRole)
                         .secrets(secrets)
-                        .sharePidNamespace(sharePidNamespace));
+                        .sharePidNamespace(sharePidNamespace)
+                        .allowDecommission(allowDecommission));
     }
 
     private DefaultPodSpec(Builder builder) {
         this.count = builder.count;
+        this.allowDecommission = builder.allowDecommission;
         this.image = builder.image;
         this.networks = builder.networks;
         this.placementRule = builder.placementRule;
@@ -107,6 +112,7 @@ public class DefaultPodSpec implements PodSpec {
     public static Builder newBuilder(PodSpec copy) {
         Builder builder = new Builder(Optional.empty()); // Assume that Executor URI is already present
         builder.count = copy.getCount();
+        builder.allowDecommission = copy.getAllowDecommission();
         builder.image = copy.getImage().isPresent() ? copy.getImage().get() : null;
         builder.networks = copy.getNetworks();
         builder.placementRule = copy.getPlacementRule().isPresent() ? copy.getPlacementRule().get() : null;
@@ -135,6 +141,11 @@ public class DefaultPodSpec implements PodSpec {
     @Override
     public Integer getCount() {
         return count;
+    }
+
+    @Override
+    public Boolean getAllowDecommission() {
+        return allowDecommission;
     }
 
     @Override
@@ -211,6 +222,7 @@ public class DefaultPodSpec implements PodSpec {
         private String type;
         private String user;
         private Integer count;
+        private Boolean allowDecommission = false;
         private String image;
         private PlacementRule placementRule;
         public String preReservedRole = Constants.ANY_ROLE;
@@ -256,6 +268,17 @@ public class DefaultPodSpec implements PodSpec {
          */
         public Builder count(Integer count) {
             this.count = count;
+            return this;
+        }
+
+        /**
+         * Sets whether the {@link #count(Integer)} for this pod can ever be decreased in a config update.
+         *
+         * @param allowDecommission whether the count can be decreased in a config update
+         * @return a reference to this Builder
+         */
+        public Builder allowDecommission(Boolean allowDecommission) {
+            this.allowDecommission = allowDecommission != null && allowDecommission;
             return this;
         }
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/PodSpec.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/PodSpec.java
@@ -21,6 +21,9 @@ public interface PodSpec {
     @JsonProperty("count")
     Integer getCount();
 
+    @JsonProperty("allow-decommission")
+    Boolean getAllowDecommission();
+
     @JsonProperty("image")
     Optional<String> getImage();
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/RawPod.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/RawPod.java
@@ -29,6 +29,7 @@ public class RawPod implements RawContainerInfoProvider {
     private final String preReservedRole;
     private final WriteOnceLinkedHashMap<String, RawSecret> secrets;
     private final Boolean sharePidNamespace;
+    private final Boolean allowDecommission;
 
     private RawPod(
             @JsonProperty("resource-sets") WriteOnceLinkedHashMap<String, RawResourceSet> resourceSets,
@@ -44,7 +45,8 @@ public class RawPod implements RawContainerInfoProvider {
             @JsonProperty("volumes") WriteOnceLinkedHashMap<String, RawVolume> volumes,
             @JsonProperty("pre-reserved-role") String preReservedRole,
             @JsonProperty("secrets") WriteOnceLinkedHashMap<String, RawSecret> secrets,
-            @JsonProperty("share-pid-namespace") Boolean sharePidNamespace) {
+            @JsonProperty("share-pid-namespace") Boolean sharePidNamespace,
+            @JsonProperty("allow-decommission") Boolean allowDecommission) {
         this.placement = placement;
         this.count = count;
         this.container = container;
@@ -59,6 +61,7 @@ public class RawPod implements RawContainerInfoProvider {
         this.preReservedRole = preReservedRole == null ? Constants.ANY_ROLE : preReservedRole;
         this.secrets = secrets == null ? new WriteOnceLinkedHashMap<>() : secrets;
         this.sharePidNamespace = sharePidNamespace != null && sharePidNamespace;
+        this.allowDecommission = allowDecommission != null && allowDecommission;
     }
 
     public String getPlacement() {
@@ -115,5 +118,9 @@ public class RawPod implements RawContainerInfoProvider {
 
     public Boolean getSharePidNamespace() {
         return sharePidNamespace;
+    }
+
+    public Boolean getAllowDecommission() {
+        return allowDecommission;
     }
 }


### PR DESCRIPTION
Just updates the spec and config validation to implement the new bit. The actual shrink flow will be implemented separately. The YAML reference has also been updated a bit to reflect current reality following some recent prior changes. Going to leave this unmentioned in the ops guide until it's actually usable (and until the actual decommission behavior is more quantifiable).