### PR TITLE
INFINITY-2564 Remove auto-replace on failed initial launch

### DIFF
--- a/sdk/common/src/main/java/com/mesosphere/sdk/offer/taskdata/LabelConstants.java
+++ b/sdk/common/src/main/java/com/mesosphere/sdk/offer/taskdata/LabelConstants.java
@@ -37,8 +37,6 @@ class LabelConstants {
 
     /** Label for tracking in the state store whether a task failed. Not passed to Mesos itself. */
     static final String PERMANENTLY_FAILED_LABEL = "permanently-failed";
-    /** Label for tracking in the state store whether this is the first launch of this task at its current location. */
-    static final String INITIAL_LAUNCH_LABEL = "initial_launch";
 
     // TaskStatus
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/taskdata/AuxLabelAccess.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/taskdata/AuxLabelAccess.java
@@ -59,37 +59,6 @@ public class AuxLabelAccess {
         networkInfoBuilder.setLabels(LabelUtils.toProto(map));
     }
 
-    // Task initial launch
-
-    /**
-     * Ensures that the task is identified as being launched for the first time at its current location in the cluster.
-     * This is intentionally stored in the initial stub STAGING {@link Protos.TaskStatus} as it will be automatically
-     * overwritten/cleared when Mesos first sends a real status for the task to indicate launch success or failure.
-     */
-    public static void setInitialLaunch(Protos.TaskStatus.Builder taskStatusBuilder) {
-        if (taskStatusBuilder.getState() != Protos.TaskState.TASK_STAGING) {
-            throw new IllegalArgumentException(
-                    "initial_launch bit may only be set for stub STAGING status, got: " + taskStatusBuilder);
-        }
-        taskStatusBuilder.setLabels(withLabel(
-                taskStatusBuilder.getLabels(),
-                LabelConstants.INITIAL_LAUNCH_LABEL, LabelConstants.BOOLEAN_LABEL_TRUE_VALUE));
-    }
-
-    /**
-     * Returns whether the task is still in the initial launch phase, where both of the following are true:
-     * <ul>
-     * <li>This is the first time it's been launched on this machine (initial deployment or pod replacement)</li>
-     * <li>The scheduler hasn't yet received a TaskStatus update for this task from Mesos, indicating a successful or
-     * failed launch.</li>
-     * </ul>
-     * When this is the case, the task could be relaunched elsewhere without worrying about losing persistent data.
-     */
-    public static boolean isInitialLaunch(Protos.TaskStatus taskStatus) {
-        String val = LabelUtils.toMap(taskStatus.getLabels()).get(LabelConstants.INITIAL_LAUNCH_LABEL);
-        return LabelConstants.BOOLEAN_LABEL_TRUE_VALUE.equals(val);
-    }
-
     // VIPs
 
     /**

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerConfig.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerConfig.java
@@ -138,9 +138,9 @@ public class SchedulerConfig {
     /**
      * Environment variables for configuring metrics reporting behavior.
      */
-    private String STATSD_POLL_INTERVAL_S_ENV = "STATSD_POLL_INTERVAL_S";
-    private String STATSD_UDP_HOST_ENV = "STATSD_UDP_HOST";
-    private String STATSD_UDP_PORT_ENV = "STATSD_UDP_PORT";
+    private static String STATSD_POLL_INTERVAL_S_ENV = "STATSD_POLL_INTERVAL_S";
+    private static String STATSD_UDP_HOST_ENV = "STATSD_UDP_HOST";
+    private static String STATSD_UDP_PORT_ENV = "STATSD_UDP_PORT";
 
     /**
      * Returns a new {@link SchedulerConfig} instance which is based off the process environment.
@@ -288,7 +288,7 @@ public class SchedulerConfig {
     }
 
     /**
-     * Returns the interval in seconds between StatsD reports
+     * Returns the interval in seconds between StatsD reports.
      */
     public long getStatsDPollIntervalS() {
         return envStore.getOptionalLong(STATSD_POLL_INTERVAL_S_ENV, 10);

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/state/PersistentLaunchRecorder.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/state/PersistentLaunchRecorder.java
@@ -2,10 +2,8 @@ package com.mesosphere.sdk.state;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.mesosphere.sdk.offer.*;
-import com.mesosphere.sdk.offer.taskdata.AuxLabelAccess;
 import com.mesosphere.sdk.offer.taskdata.TaskLabelReader;
 import com.mesosphere.sdk.scheduler.plan.DefaultPodInstance;
-import com.mesosphere.sdk.scheduler.recovery.FailureUtils;
 import com.mesosphere.sdk.specification.*;
 import org.apache.mesos.Protos;
 import org.slf4j.Logger;
@@ -37,21 +35,6 @@ public class PersistentLaunchRecorder implements OperationRecorder {
         Protos.TaskInfo taskInfo = launchOfferRecommendation.getStoreableTaskInfo();
 
         Optional<PodInstance> podInstance = getPodInstance(taskInfo);
-        final boolean isInitialLaunch;
-        if (!podInstance.isPresent()) {
-            // This may happen in one of the following cases:
-            // - The TaskInfo lacked the needed labels to determine what pod it belonged to
-            // - The TaskInfo refers to a pod that can't be found in the ServiceSpec (change in service definition?)
-            // In either case, let's play it safe and assume that this shouldn't be treated as an initial launch.
-            isInitialLaunch = false;
-            logger.warn("No pod found for task {}: treating this as not an initial launch", taskInfo.getName());
-        } else {
-            Collection<Protos.TaskInfo> podTasks =
-                    StateStoreUtils.fetchPodTasks(stateStore, podInstance.get());
-            // If there are no taskinfos, then treat this as an initial launch:
-            isInitialLaunch = podTasks.isEmpty() ||
-                    podTasks.stream().allMatch(podTask -> FailureUtils.isPermanentlyFailed(podTask));
-        }
 
         Optional<Protos.TaskStatus> taskStatus = Optional.empty();
         String taskStatusDescription = "";
@@ -67,16 +50,10 @@ public class PersistentLaunchRecorder implements OperationRecorder {
                 taskStatusBuilder.setExecutorId(taskInfo.getExecutor().getExecutorId());
             }
 
-            if (isInitialLaunch) {
-                // Mark in the TaskStatus that this was the first launch of the task at this location.
-                AuxLabelAccess.setInitialLaunch(taskStatusBuilder);
-            }
-
             taskStatus = Optional.of(taskStatusBuilder.build());
         }
 
-        logger.info("Persisting {} operation{} for {}",
-                isInitialLaunch ? "initial launch" : "relaunch",
+        logger.info("Persisting launch operation{} for {}",
                 taskStatusDescription,
                 taskInfo.getName());
 

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/taskdata/AuxLabelAccessTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/taskdata/AuxLabelAccessTest.java
@@ -1,7 +1,6 @@
 package com.mesosphere.sdk.offer.taskdata;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
@@ -61,26 +60,6 @@ public class AuxLabelAccessTest {
         EndpointUtils.VipInfo vip = vips.iterator().next();
         assertEquals("vip", vip.getVipName());
         assertEquals(5, vip.getVipPort());
-    }
-
-    @Test(expected=IllegalArgumentException.class)
-    public void testSetInitialLaunchFailsNotStaging() {
-        Protos.TaskStatus.Builder statusBuilder = Protos.TaskStatus.newBuilder()
-                .setState(Protos.TaskState.TASK_ERROR);
-        statusBuilder.getTaskIdBuilder().setValue("task");
-
-        AuxLabelAccess.setInitialLaunch(statusBuilder);
-    }
-
-    @Test
-    public void testGetSetInitialLaunch() {
-        Protos.TaskStatus.Builder statusBuilder = Protos.TaskStatus.newBuilder()
-                .setState(Protos.TaskState.TASK_STAGING);
-        statusBuilder.getTaskIdBuilder().setValue("task");
-
-        assertFalse(AuxLabelAccess.isInitialLaunch(statusBuilder.build()));
-        AuxLabelAccess.setInitialLaunch(statusBuilder);
-        assertTrue(AuxLabelAccess.isInitialLaunch(statusBuilder.build()));
     }
 
     @Test


### PR DESCRIPTION
The feature introduces more complexity than it's really worth in practice, and can lead to a race wrt unreserving resources when uninstalling the service.
Revert back to the prior behavior where the task always starts "pinned" regardless of initial launch outcome.