### PR TITLE
Remove root shim from hello world upgrade.

### DIFF
--- a/frameworks/helloworld/tests/test_sanity.py
+++ b/frameworks/helloworld/tests/test_sanity.py
@@ -25,7 +25,7 @@ def configure_package(configure_security):
             config.PACKAGE_NAME,
             foldered_name,
             config.DEFAULT_TASK_COUNT,
-            additional_options={"service": {"name": foldered_name, "user": "root"}})
+            additional_options={"service": {"name": foldered_name}})
 
         yield  # let the test session execute
     finally:


### PR DESCRIPTION
We stopped giving root special permissions but we were secretly using them in Hello World.

Strict run: https://teamcity.mesosphere.io/viewLog.html?buildId=837339&tab=buildResultsDiv&buildTypeId=DcosIo_DcosCommons_Sdk_Stri_DcOs110Strict