### PR TITLE
Use argparse for kdc.py. Minor changes to sdk_cmd and sdk_marathon.

### DIFF
--- a/testing/kdc.py
+++ b/testing/kdc.py
@@ -8,26 +8,20 @@ This tool expects as its arguments:
     - subcommand for setup or teardown
     - path to file holding principals as newline-separated strings
 """
+import argparse
+import logging
 import os
-import sys
-from subprocess import run
 
 import sdk_auth
+import sdk_cmd
 
-usage_msg = """Usage:
-    python kdc -h, --help
-    python kdc setup <path-to-principals-file>
-    python kdc teardown
-"""
 
-verbose_usage_msg = """Usage:
-    python kdc -h, --help
-    python kdc setup <path-to-principals-file>
-    python kdc teardown
-    
-    - <Path to principals file> is a path to a file listing the principals
-    as newline-separated strings.
-"""
+logging.basicConfig(
+    format='[%(asctime)s|%(name)s|%(levelname)s]: %(message)s',
+    level=logging.INFO)
+
+log = logging.getLogger(__name__)
+
 
 def parse_principals(principals_file: str) -> list:
     """
@@ -39,11 +33,8 @@ def parse_principals(principals_file: str) -> list:
         print(principals_file)
         raise RuntimeError("The provided principal file path is invalid")
 
-    principals = []
     with open(principals_file) as f:
-        lines = f.readlines()
-        for line in lines:
-            principals.append(line)
+        principals = f.readlines()
 
     print("Successfully parsed principals")
     for principal in principals:
@@ -52,46 +43,48 @@ def parse_principals(principals_file: str) -> list:
     return principals
 
 
-def main(args):
-    if args[0] in ["-h", "--help"]:
-        print(verbose_usage_msg)
-        return 1
+def deploy(args: dict):
+    log.info("Deploying KDC")
 
-    if args[0] not in ["deploy", "teardown"]:
-        print(usage_msg)
-        return 1
+    principals = parse_principals(args.principals_file)
 
-    if args[0] == "deploy":
-        try:
-            principals = parse_principals(args[1])
-        except Exception as e:
-            print(repr(e))
-            return 1
+    kerberos = sdk_auth.KerberosEnvironment()
+    kerberos.add_principals(principals)
+    kerberos.finalize_environment()
 
-        try:
-            kerberos = sdk_auth.KerberosEnvironment()
-            kerberos.add_principals(principals)
-            kerberos.finalize_environment()
-        except Exception as e:
-            print(repr(e))
-            return 1
+    log.info("KDC cluster successfully deployed")
 
-        print("\nSuccessfully deployed the KDC instance")
 
-    elif args[0] == "teardown":
-        print("Removing the KDC marathon app and keytab secret")
-        try:
-            run(["dcos", "marathon", "app", "remove", "kdc"])
-            run(["dcos", "package", "install", "--yes", "--cli", "dcos-enterprise-cli"])
-            run(["dcos", "security", "secrets", "delete", "__dcos_base64___keytab"])
-        except Exception as e:
-            print(repr(e))
-            return 1
-    
-        print("\nSuccessfully teared down the KDC instance")
+def teardown(args: dict):
+    log.info("Tearing down KDC")
 
-    return 0
+    sdk_cmd.run_cli(["marathon", "app", "remove", "kdc"])
+    sdk_cmd.run_cli(["package", "install", "--yes", "--cli", "dcos-enterprise-cli"])
+    sdk_cmd.run_cli(["security", "secrets", "delete", "__dcos_base64___keytab"])
+
+    log.info("KDC cluster successfully torn down")
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description='Manage a KDC instance')
+
+    subparsers = parser.add_subparsers(help='deploy help')
+
+    deploy_parser = subparsers.add_parser('deploy', help='deploy help')
+    deploy_parser.add_argument('principals_file', type=str,
+                               help='Path to a file listing the principals as newline-separated strings')
+    deploy_parser.set_defaults(func=deploy)
+
+    teardown_parser = subparsers.add_parser('teardown', help='deploy help')
+    teardown_parser.set_defaults(func=teardown)
+
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    args.func(args)
 
 
 if __name__ == "__main__":
-    sys.exit(main(sys.argv[1:]))
+    main()

--- a/testing/sdk_cmd.py
+++ b/testing/sdk_cmd.py
@@ -49,11 +49,17 @@ def run_raw_cli(cmd, print_output):
     eg. `cmd`= "package install <package-name>" results in:
     $ dcos package install <package-name>
     """
-    stdout, stderr, ret = shakedown.run_dcos_command(cmd, print_output=print_output)
+
+    if isinstance(cmd, list):
+        cmd_str = " ".join(cmd)
+    else:
+        cmd_str = cmd
+
+    stdout, stderr, ret = shakedown.run_dcos_command(cmd_str, print_output=print_output)
     if ret:
         err = 'Got error code {} when running command "dcos {}":\n'\
               'stdout: "{}"\n'\
-              'stderr: "{}"'.format(ret, cmd, stdout, stderr)
+              'stderr: "{}"'.format(ret, cmd_str, stdout, stderr)
         log.error(err)
         raise dcos.errors.DCOSException(err)
 


### PR DESCRIPTION
@NimaVaziri here is a quick PR that adds `argparse` support to `kdc.py`. I ran through the `deploy` and `teardown` until I also got the same SSL error that @benclarkwood observed in the CI. This is secondary though. We could remove these additional files, and get the test tooling in first.