### PR TITLE
Improve revive calculation

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/AbstractScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/AbstractScheduler.java
@@ -406,6 +406,12 @@ public abstract class AbstractScheduler {
             // Get the current work
             Collection<Step> steps = planCoordinator.getCandidates();
 
+            // Revive previously suspended offers, if necessary
+            Collection<Step> activeWorkSet = new HashSet<>(steps);
+            Collection<Step> inProgressSteps = getInProgressSteps(planCoordinator);
+            activeWorkSet.addAll(inProgressSteps);
+            reviveManager.revive(activeWorkSet);
+
             LOGGER.info("Processing {} offer{} against {} step{}:",
                     offers.size(), offers.size() == 1 ? "" : "s",
                     steps.size(), steps.size() == 1 ? "" : "s");
@@ -422,8 +428,6 @@ public abstract class AbstractScheduler {
             }
             Metrics.incrementProcessedOffers(offers.size());
 
-            // Revive previously suspended offers, if necessary
-            reviveManager.revive(steps);
 
             synchronized (inProgressLock) {
                 offersInProgress.removeAll(
@@ -437,6 +441,16 @@ public abstract class AbstractScheduler {
                         offersInProgress.size() == 1 ? "offer remains" : "offers remain",
                         offersInProgress.stream().map(Protos.OfferID::getValue).collect(Collectors.toList()));
             }
+        }
+
+        private Set<Step> getInProgressSteps(PlanCoordinator planCoordinator) {
+            return planCoordinator.getPlanManagers().stream()
+                    .map(planManager -> planManager.getPlan())
+                    .flatMap(plan -> plan.getChildren().stream())
+                    .flatMap(phase -> phase.getChildren().stream())
+                    .filter(step -> !step.isPending())
+                    .filter(step -> !step.isComplete())
+                    .collect(Collectors.toSet());
         }
 
         /**

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/AbstractScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/AbstractScheduler.java
@@ -409,6 +409,11 @@ public abstract class AbstractScheduler {
             // Revive previously suspended offers, if necessary
             Collection<Step> activeWorkSet = new HashSet<>(steps);
             Collection<Step> inProgressSteps = getInProgressSteps(planCoordinator);
+            LOGGER.info(
+                    "InProgress Steps: {}",
+                    inProgressSteps.stream()
+                            .map(step -> step.getMessage())
+                            .collect(Collectors.toList()));
             activeWorkSet.addAll(inProgressSteps);
             reviveManager.revive(activeWorkSet);
 
@@ -448,8 +453,7 @@ public abstract class AbstractScheduler {
                     .map(planManager -> planManager.getPlan())
                     .flatMap(plan -> plan.getChildren().stream())
                     .flatMap(phase -> phase.getChildren().stream())
-                    .filter(step -> !step.isPending())
-                    .filter(step -> !step.isComplete())
+                    .filter(step -> step.isRunning())
                     .collect(Collectors.toSet());
         }
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/ReviveManager.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/ReviveManager.java
@@ -64,17 +64,20 @@ public class ReviveManager {
      *     kafka-0-broker fails    @ 11:00, it's new work!
      *     ...
      */
-    public void revive(Collection<Step> steps) {
-        Set<WorkItem> currCandidates = getCandidates(steps);
+    public void revive(Collection<Step> activeWorkSet) {
+        Set<WorkItem> currCandidates = getCandidates(activeWorkSet);
         Set<WorkItem> newCandidates = new HashSet<>(currCandidates);
-        newCandidates.removeAll(candidates);
+        newCandidates.removeAll(this.candidates);
 
-        logger.info("Candidates, old: {}, current: {}, new:{}", candidates, currCandidates, newCandidates);
+        logger.info("Candidates, old: {}, current: {}, new:{}", this.candidates, currCandidates, newCandidates);
 
         if (!newCandidates.isEmpty()) {
             if (tokenBucket.tryAcquire()) {
-                logger.info("Reviving offers.");
-                driver.reviveOffers();
+                logger.info(
+                        "Reviving offers with candidates, old: {}, current: {}, new:{}",
+                        this.candidates,
+                        currCandidates,
+                        newCandidates); driver.reviveOffers();
                 Metrics.incrementRevives();
             } else {
                 logger.warn("Revive attempt has been throttled.");
@@ -83,15 +86,15 @@ public class ReviveManager {
             }
         }
 
-        candidates = currCandidates;
+        this.candidates = currCandidates;
     }
+
 
     /**
      * Returns candidates which potentially need new offers.
      */
     private Set<WorkItem> getCandidates(Collection<Step> steps) {
         return steps.stream()
-                .filter(step -> !step.isComplete())
                 .map(step -> new WorkItem(step))
                 .collect(Collectors.toSet());
     }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/ReviveManager.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/ReviveManager.java
@@ -77,7 +77,8 @@ public class ReviveManager {
                         "Reviving offers with candidates, old: {}, current: {}, new:{}",
                         this.candidates,
                         currCandidates,
-                        newCandidates); driver.reviveOffers();
+                        newCandidates);
+                driver.reviveOffers();
                 Metrics.incrementRevives();
             } else {
                 logger.warn("Revive attempt has been throttled.");

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/Element.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/Element.java
@@ -79,6 +79,13 @@ public interface Element {
     }
 
     /**
+     * Indicates whether the Element is starting.
+     */
+    default boolean isStarted() {
+        return getStatus().equals(Status.STARTED);
+    }
+
+    /**
      * Indicates whether this Element is complete.
      */
     default boolean isComplete() {

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/Status.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/Status.java
@@ -78,6 +78,7 @@ public enum Status {
         switch (this) {
         case PREPARED:
         case STARTING:
+        case STARTED:
         case IN_PROGRESS:
             return true;
         default:


### PR DESCRIPTION
When doing scale tests I noticed occasional revives where I expected none.  The fact that we were getting the work candidates, then processing offers then deciding whether we needed to revive was causing a situation where the Steps changed status.  So...
* Move revive calculation right next to candidate selection

There was also the fact that things move in and out of the candidate set, but shouldn't have revives called on them.  Once something moves into the active workset it should only leave upon completion.  So...
* We merge the steps which are in progress (not complete and not pending) into the active work set

N.B. All tasks will be detected as PENDING and in need of revive as part of the getCandidates call.

<img width="1260" alt="screen shot 2017-11-01 at 4 04 10 pm" src="https://user-images.githubusercontent.com/567111/32302646-01834de6-bf21-11e7-8136-40ffd0c637ac.png">

Scale testing confirms no unexpected revives.  20 schedulers with 80 tasks each crash looping have only a single revive (when they start and go from no work to some work).