### PR TITLE
[INFINITY-2616] Don't set user=root when running in strict

### DIFF
--- a/frameworks/cassandra/tests/test_backup_and_restore.py
+++ b/frameworks/cassandra/tests/test_backup_and_restore.py
@@ -22,11 +22,17 @@ def configure_package(configure_security):
 
         sdk_install.uninstall(config.PACKAGE_NAME, config.get_foldered_service_name())
         # user=root because Azure CLI needs to run in root...
+        # We don't run the Azure tests in strict however, so don't set it then.
+        if os.environ.get("SECURITY") == "strict":
+            additional_options={"service": { "name": config.get_foldered_service_name()} }
+        else:
+            additional_options={"service": { "name": config.get_foldered_service_name(), "user": "root" } }
+
         sdk_install.install(
             config.PACKAGE_NAME,
             config.get_foldered_service_name(),
             config.DEFAULT_TASK_COUNT,
-            additional_options={"service": { "name": config.get_foldered_service_name(), "user": "root" } })
+            additional_options=additional_options)
 
         tmp_dir = tempfile.mkdtemp(prefix='cassandra-test')
         for job in test_jobs:


### PR DESCRIPTION
Root is needed for azure CLI, but we don't run the azure test in strict.