### PR TITLE
Return strategy names from plan info endpoint and display in CLI

### DIFF
--- a/cli/commands/plan.go
+++ b/cli/commands/plan.go
@@ -319,7 +319,11 @@ func toPlanStatusTree(planName string, planJSONBytes []byte) string {
 	if !ok {
 		planStatus = "<UNKNOWN>"
 	}
-	buf.WriteString(fmt.Sprintf("%s (%s)\n", planName, planStatus))
+	planStrategy, ok := planJSON["strategy"]
+	if !ok {
+		planStatus = "UNKNOWN"
+	}
+	buf.WriteString(fmt.Sprintf("%s (%s strategy) (%s)\n", planName, planStrategy, planStatus))
 
 	rawPhases, ok := planJSON["phases"].([]interface{})
 	if ok {
@@ -355,7 +359,7 @@ func appendPhase(buf *bytes.Buffer, rawPhase interface{}, lastPhase bool) {
 		return
 	}
 
-	buf.WriteString(fmt.Sprintf("%s%s\n", phasePrefix, elementString(phase)))
+	buf.WriteString(fmt.Sprintf("%s%s\n", phasePrefix, phaseString(phase)))
 
 	rawSteps, ok := phase["steps"].([]interface{})
 	if !ok {
@@ -377,17 +381,33 @@ func appendStep(buf *bytes.Buffer, rawStep interface{}, prefix string, lastStep 
 	} else {
 		prefix += "├─ "
 	}
-	buf.WriteString(fmt.Sprintf("%s%s\n", prefix, elementString(step)))
+	buf.WriteString(fmt.Sprintf("%s%s\n", prefix, stepString(step)))
 }
 
-func elementString(element map[string]interface{}) string {
-	elementName, ok := element["name"]
+func phaseString(phase map[string]interface{}) string {
+	phaseName, ok := phase["name"]
 	if !ok {
-		elementName = "<UNKNOWN>"
+		phaseName = "<UNKNOWN>"
 	}
-	elementStatus, ok := element["status"]
+	phaseStrategy, ok := phase["strategy"]
 	if !ok {
-		elementStatus = "<UNKNOWN>"
+		phaseStrategy = "UNKNOWN"
 	}
-	return fmt.Sprintf("%s (%s)", elementName, elementStatus)
+	phaseStatus, ok := phase["status"]
+	if !ok {
+		phaseStatus = "<UNKNOWN>"
+	}
+	return fmt.Sprintf("%s (%s strategy) (%s)", phaseName, phaseStrategy, phaseStatus)
+}
+
+func stepString(step map[string]interface{}) string {
+	stepName, ok := step["name"]
+	if !ok {
+		stepName = "<UNKNOWN>"
+	}
+	stepStatus, ok := step["status"]
+	if !ok {
+		stepStatus = "<UNKNOWN>"
+	}
+	return fmt.Sprintf("%s (%s)", stepName, stepStatus)
 }

--- a/cli/commands/plan.go
+++ b/cli/commands/plan.go
@@ -15,6 +15,8 @@ import (
 	"gopkg.in/alecthomas/kingpin.v3-unstable"
 )
 
+const UNKNOWN_VALUE = "<UNKNOWN>"
+
 var errPlanStatus417 = errors.New("plan endpoint returned HTTP status code 417")
 
 type planHandler struct {
@@ -317,11 +319,11 @@ func toPlanStatusTree(planName string, planJSONBytes []byte) string {
 
 	planStatus, ok := planJSON["status"]
 	if !ok {
-		planStatus = "<UNKNOWN>"
+		planStatus = UNKNOWN_VALUE
 	}
 	planStrategy, ok := planJSON["strategy"]
 	if !ok {
-		planStatus = "UNKNOWN"
+		planStatus = UNKNOWN_VALUE
 	}
 	buf.WriteString(fmt.Sprintf("%s (%s strategy) (%s)\n", planName, planStrategy, planStatus))
 
@@ -387,15 +389,15 @@ func appendStep(buf *bytes.Buffer, rawStep interface{}, prefix string, lastStep 
 func phaseString(phase map[string]interface{}) string {
 	phaseName, ok := phase["name"]
 	if !ok {
-		phaseName = "<UNKNOWN>"
+		phaseName = UNKNOWN_VALUE
 	}
 	phaseStrategy, ok := phase["strategy"]
 	if !ok {
-		phaseStrategy = "UNKNOWN"
+		phaseStrategy = UNKNOWN_VALUE
 	}
 	phaseStatus, ok := phase["status"]
 	if !ok {
-		phaseStatus = "<UNKNOWN>"
+		phaseStatus = UNKNOWN_VALUE
 	}
 	return fmt.Sprintf("%s (%s strategy) (%s)", phaseName, phaseStrategy, phaseStatus)
 }
@@ -403,11 +405,11 @@ func phaseString(phase map[string]interface{}) string {
 func stepString(step map[string]interface{}) string {
 	stepName, ok := step["name"]
 	if !ok {
-		stepName = "<UNKNOWN>"
+		stepName = UNKNOWN_VALUE
 	}
 	stepStatus, ok := step["status"]
 	if !ok {
-		stepStatus = "<UNKNOWN>"
+		stepStatus = UNKNOWN_VALUE
 	}
 	return fmt.Sprintf("%s (%s)", stepName, stepStatus)
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/api/types/PhaseInfo.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/api/types/PhaseInfo.java
@@ -30,7 +30,7 @@ class PhaseInfo {
                 phase.getId().toString(),
                 phase.getName(),
                 stepInfos,
-                phase.getStrategy().toString(),
+                phase.getStrategy().getName(),
                 phase.getStatus());
     }
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/api/types/PhaseInfo.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/api/types/PhaseInfo.java
@@ -18,6 +18,7 @@ class PhaseInfo {
     private final String id;
     private final String name;
     private final List<StepInfo> steps;
+    private final String strategyName;
     private final Status status;
 
     public static PhaseInfo forPhase(final Phase phase) {
@@ -29,13 +30,20 @@ class PhaseInfo {
                 phase.getId().toString(),
                 phase.getName(),
                 stepInfos,
+                phase.getStrategy().toString(),
                 phase.getStatus());
     }
 
-    private PhaseInfo(final String id, final String name, final List<StepInfo> steps, final Status status) {
+    private PhaseInfo(
+            final String id,
+            final String name,
+            final List<StepInfo> steps,
+            final String strategyName,
+            final Status status) {
         this.id = id;
         this.name = name;
         this.steps = steps;
+        this.strategyName = strategyName;
         this.status = status;
     }
 
@@ -54,6 +62,11 @@ class PhaseInfo {
         return name;
     }
 
+    @JsonProperty("strategy")
+    public String getStrategyName() {
+        return strategyName;
+    }
+
     @JsonProperty("status")
     public Status getStatus() {
         return status;
@@ -66,7 +79,7 @@ class PhaseInfo {
 
     @Override
     public int hashCode() {
-        return Objects.hash(getId(), getName(), getSteps(), getStatus());
+        return Objects.hash(getId(), getName(), getSteps(), getStrategyName(), getStatus());
     }
 
     @Override

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/api/types/PhaseInfo.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/api/types/PhaseInfo.java
@@ -2,6 +2,7 @@ package com.mesosphere.sdk.api.types;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import com.mesosphere.sdk.scheduler.plan.Step;
 import com.mesosphere.sdk.scheduler.plan.Phase;
@@ -79,7 +80,7 @@ class PhaseInfo {
 
     @Override
     public int hashCode() {
-        return Objects.hash(getId(), getName(), getSteps(), getStrategyName(), getStatus());
+        return HashCodeBuilder.reflectionHashCode(this);
     }
 
     @Override

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/api/types/PhaseInfo.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/api/types/PhaseInfo.java
@@ -9,7 +9,6 @@ import com.mesosphere.sdk.scheduler.plan.Phase;
 import com.mesosphere.sdk.scheduler.plan.Status;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 /**

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/api/types/PlanInfo.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/api/types/PlanInfo.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.mesosphere.sdk.scheduler.plan.Phase;
 import com.mesosphere.sdk.scheduler.plan.Plan;
 import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import com.mesosphere.sdk.scheduler.plan.Status;
 
@@ -65,7 +66,7 @@ public class PlanInfo {
 
     @Override
     public int hashCode() {
-        return Objects.hash(getPhases(), getStrategyName(), getErrors(), getStatus());
+        return HashCodeBuilder.reflectionHashCode(this);
     }
 
     @Override

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/api/types/PlanInfo.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/api/types/PlanInfo.java
@@ -18,6 +18,7 @@ import java.util.stream.Collectors;
 public class PlanInfo {
 
     private final List<PhaseInfo> phases;
+    private final String strategyName;
     private final List<String> errors;
     private final Status status;
 
@@ -26,11 +27,13 @@ public class PlanInfo {
                 .map(phase -> PhaseInfo.forPhase(phase))
                 .collect(Collectors.toList());
 
-        return new PlanInfo(phaseInfos, plan.getErrors(), plan.getStatus());
+        return new PlanInfo(phaseInfos, plan.getStrategy().toString(), plan.getErrors(), plan.getStatus());
     }
 
-    private PlanInfo(final List<PhaseInfo> phases, final List<String> errors, final Status status) {
+    private PlanInfo(
+            final List<PhaseInfo> phases, String strategyName, final List<String> errors, final Status status) {
         this.phases = phases;
+        this.strategyName = strategyName;
         this.errors = errors;
         this.status = status;
     }
@@ -38,6 +41,11 @@ public class PlanInfo {
     @JsonProperty("phases")
     public List<PhaseInfo> getPhases() {
         return phases;
+    }
+
+    @JsonProperty("strategy")
+    public String getStrategyName() {
+        return strategyName;
     }
 
     @JsonProperty("errors")
@@ -57,7 +65,7 @@ public class PlanInfo {
 
     @Override
     public int hashCode() {
-        return Objects.hash(getPhases(), getErrors(), getStatus());
+        return Objects.hash(getPhases(), getStrategyName(), getErrors(), getStatus());
     }
 
     @Override

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/api/types/PlanInfo.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/api/types/PlanInfo.java
@@ -27,7 +27,7 @@ public class PlanInfo {
                 .map(phase -> PhaseInfo.forPhase(phase))
                 .collect(Collectors.toList());
 
-        return new PlanInfo(phaseInfos, plan.getStrategy().toString(), plan.getErrors(), plan.getStatus());
+        return new PlanInfo(phaseInfos, plan.getStrategy().getName(), plan.getErrors(), plan.getStatus());
     }
 
     private PlanInfo(

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/api/types/PlanInfo.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/api/types/PlanInfo.java
@@ -10,7 +10,6 @@ import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import com.mesosphere.sdk.scheduler.plan.Status;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 /**

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/strategy/CanaryStrategy.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/strategy/CanaryStrategy.java
@@ -130,6 +130,11 @@ public class CanaryStrategy implements Strategy<Step> {
         return null;
     }
 
+    @Override
+    public String toString() {
+        return strategy.toString() + "-canary";
+    }
+
     /**
      * This class generates Strategy objects of the appropriate type.
      *

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/strategy/CanaryStrategy.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/strategy/CanaryStrategy.java
@@ -85,6 +85,11 @@ public class CanaryStrategy implements Strategy<Step> {
     }
 
     @Override
+    public String getName() {
+        return strategy.toString() + "-canary";
+    }
+
+    @Override
     public void interrupt() {
         Step canaryStep = getNextCanaryStep();
         if (canaryStep != null) {
@@ -128,11 +133,6 @@ public class CanaryStrategy implements Strategy<Step> {
             }
         }
         return null;
-    }
-
-    @Override
-    public String toString() {
-        return strategy.toString() + "-canary";
     }
 
     /**

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/strategy/DependencyStrategy.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/strategy/DependencyStrategy.java
@@ -23,4 +23,9 @@ public class DependencyStrategy<C extends Element> extends InterruptibleStrategy
         // Fixed prerequites as defined in the provided helper:
         return helper.getCandidates(isInterrupted(), dirtyAssets);
     }
+
+    @Override
+    public String getName() {
+        return "dependency";
+    }
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/strategy/ParallelStrategy.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/strategy/ParallelStrategy.java
@@ -18,13 +18,13 @@ public class ParallelStrategy<C extends Element> extends InterruptibleStrategy<C
         return new DependencyStrategyHelper<C>(elements).getCandidates(isInterrupted(), dirtyAssets);
     }
 
-    public StrategyGenerator<C> getGenerator() {
-        return new Generator<>();
+    @Override
+    public String getName() {
+        return "parallel";
     }
 
-    @Override
-    public String toString() {
-        return "parallel";
+    public StrategyGenerator<C> getGenerator() {
+        return new Generator<>();
     }
 
     /**

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/strategy/ParallelStrategy.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/strategy/ParallelStrategy.java
@@ -22,6 +22,11 @@ public class ParallelStrategy<C extends Element> extends InterruptibleStrategy<C
         return new Generator<>();
     }
 
+    @Override
+    public String toString() {
+        return "parallel";
+    }
+
     /**
      * This class generates Strategy objects of the appropriate type.
      *

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/strategy/RandomStrategy.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/strategy/RandomStrategy.java
@@ -24,6 +24,11 @@ public class RandomStrategy<C extends Element> extends InterruptibleStrategy<C> 
         return candidateOptional.isPresent() ? Arrays.asList(candidateOptional.get()) : Collections.emptyList();
     }
 
+    @Override
+    public String getName() {
+        return "random";
+    }
+
     public StrategyGenerator<C> getGenerator() {
         return new Generator<>();
     }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/strategy/SerialStrategy.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/strategy/SerialStrategy.java
@@ -44,6 +44,11 @@ public class SerialStrategy<C extends Element> extends InterruptibleStrategy<C> 
         return dependencyStrategyHelper;
     }
 
+    @Override
+    public String toString() {
+        return "serial";
+    }
+
     /**
      * This class generates Strategy objects of the appropriate type.
      *

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/strategy/SerialStrategy.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/strategy/SerialStrategy.java
@@ -22,6 +22,11 @@ public class SerialStrategy<C extends Element> extends InterruptibleStrategy<C> 
         return getDependencyStrategyHelper(elements).getCandidates(isInterrupted(), dirtyAssets);
     }
 
+    @Override
+    public String getName() {
+        return "serial";
+    }
+
     public StrategyGenerator<C> getGenerator() {
         return new Generator<>();
     }
@@ -42,11 +47,6 @@ public class SerialStrategy<C extends Element> extends InterruptibleStrategy<C> 
         }
 
         return dependencyStrategyHelper;
-    }
-
-    @Override
-    public String toString() {
-        return "serial";
     }
 
     /**

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/strategy/Strategy.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/strategy/Strategy.java
@@ -23,4 +23,6 @@ public interface Strategy<C extends Element> extends Interruptible {
      * @return zero or more candidates for work to be performed
      */
     Collection<C> getCandidates(Collection<C> elements, Collection<PodInstanceRequirement> dirtyAssets);
+
+    String getName();
 }

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/api/types/PlanInfoTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/api/types/PlanInfoTest.java
@@ -1,6 +1,7 @@
 package com.mesosphere.sdk.api.types;
 
 import com.mesosphere.sdk.scheduler.plan.*;
+import com.mesosphere.sdk.scheduler.plan.strategy.SerialStrategy;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -58,6 +59,7 @@ public class PlanInfoTest {
         when(mockPhase0.getName()).thenReturn(phase0Name);
         Status phase0Status = Status.PENDING;
         when(mockPhase0.getStatus()).thenReturn(phase0Status);
+        when(mockPhase0.getStrategy()).thenReturn(new SerialStrategy<>());
         // must use thenAnswer instead of thenReturn to work around java typing of "? extends Step"
         when(mockPhase0.getChildren()).thenReturn(Arrays.asList(mockStep0, mockStep1));
 
@@ -67,6 +69,7 @@ public class PlanInfoTest {
         when(mockPhase1.getName()).thenReturn(phase1Name);
         Status phase1Status = Status.COMPLETE;
         when(mockPhase1.getStatus()).thenReturn(phase1Status);
+        when(mockPhase1.getStrategy()).thenReturn(new SerialStrategy<>());
         when(mockPhase1.getChildren()).thenReturn(new ArrayList<>());
 
         when(mockPlan.getChildren()).thenReturn(Arrays.asList(mockPhase0, mockPhase1));
@@ -75,6 +78,7 @@ public class PlanInfoTest {
         when(mockPlan.getErrors()).thenReturn(stageErrors);
 
         when(mockPlan.getStatus()).thenReturn(Status.WAITING);
+        when(mockPlan.getStrategy()).thenReturn(new SerialStrategy<>());
 
         PlanInfo planInfo = PlanInfo.forPlan(mockPlan);
 


### PR DESCRIPTION
An example from hello-world:
```
deploy (serial strategy) (COMPLETE)
├─ hello (serial strategy) (COMPLETE)
│  └─ hello-0:[server] (COMPLETE)
└─ world (serial strategy) (COMPLETE)
   ├─ world-0:[server] (COMPLETE)
   └─ world-1:[server] (COMPLETE)
```

I imagine we'll have some back and forth about how to format this, but I think we're all on the same page that element strategy should be represented textually rather than through some graphical or formatting arrangement.