### PR TITLE
[INFINITY-2630] Reduce excessive style warning output

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -102,6 +102,10 @@ allprojects {
         }
     }
 
+    tasks.withType(Javadoc) {
+        options.addStringOption('Xdoclint:none', '-quiet')
+    }
+
     // Print results on the fly
     test {
         testLogging {

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/MesosResource.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/MesosResource.java
@@ -69,6 +69,7 @@ public class MesosResource {
         }
     }
 
+    @SuppressWarnings("deprecation")
     private String getRefinedPreviousRole() {
         if (resource.getReservationsCount() <= 1) {
             return resource.getRole();

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/MesosResourcePool.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/MesosResourcePool.java
@@ -234,6 +234,7 @@ public class MesosResourcePool {
         reservableMergedPoolByRole.put(previousRole, pool);
     }
 
+    @SuppressWarnings("deprecation")
     private void freeAtomicResource(MesosResource mesosResource) {
         Resource.Builder resBuilder = Resource.newBuilder(mesosResource.getResource());
         resBuilder.clearReservation();

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/ResourceBuilder.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/ResourceBuilder.java
@@ -75,6 +75,7 @@ public class ResourceBuilder {
         return new ResourceBuilder(resourceName, value, Constants.ANY_ROLE);
     }
 
+    @SuppressWarnings("deprecation")
     private static ResourceSpec getResourceSpec(Resource resource) {
         if (!ResourceUtils.hasResourceId(resource)) {
             throw new IllegalStateException(
@@ -89,6 +90,7 @@ public class ResourceBuilder {
                 ResourceUtils.getPrincipal(resource).get());
     }
 
+    @SuppressWarnings("deprecation")
     private static VolumeSpec getVolumeSpec(Resource resource) {
         VolumeSpec.Type type = resource.getDisk().hasSource() ? VolumeSpec.Type.MOUNT : VolumeSpec.Type.ROOT;
         return new DefaultVolumeSpec(
@@ -186,6 +188,7 @@ public class ResourceBuilder {
         return this;
     }
 
+    @SuppressWarnings("deprecation")
     public Resource build() {
         // Note:
         // In the pre-resource-refinment world (< 1.9), Mesos will expect

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/ResourceBuilderTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/ResourceBuilderTest.java
@@ -19,6 +19,7 @@ import java.util.UUID;
 /**
  * Test construction of Resource protobufs.
  */
+@SuppressWarnings("deprecation")
 public class ResourceBuilderTest extends DefaultCapabilitiesTestSuite {
     /*
         name: "cpus"

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluatorTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluatorTest.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+@SuppressWarnings("deprecation")
 public class OfferEvaluatorTest extends OfferEvaluatorTestBase {
     @Mock ServiceSpec serviceSpec;
 

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/testutils/OfferTestUtils.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/testutils/OfferTestUtils.java
@@ -12,6 +12,7 @@ import java.util.List;
 /**
  * This class provides utilities for tests concerned with Offers.
  */
+@SuppressWarnings("deprecation")
 public class OfferTestUtils {
 
     private OfferTestUtils() {

--- a/sdk/testing/src/main/java/com/mesosphere/sdk/testing/ClusterState.java
+++ b/sdk/testing/src/main/java/com/mesosphere/sdk/testing/ClusterState.java
@@ -123,7 +123,7 @@ public class ClusterState {
     }
 
     /**
-     * Returns the last task launched with the specified name
+     * Returns the last task launched with the specified name.
      *
      * @param taskName the task name to be found
      * @return the task's info
@@ -154,7 +154,7 @@ public class ClusterState {
     }
 
     /**
-     * Returns the last task id for a task of the specified name
+     * Returns the last task id for a task of the specified name.
      *
      * @param taskName the task name to be found
      * @return the task id


### PR DESCRIPTION
1. Stop warning on javadoc style errors
2. Suppress deprecated API use warnings
3. Fix some style complaints about ending with a `.`