### PR TITLE
Generalize constraints for region/zone extension

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/AbstractRoundRobinRule.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/AbstractRoundRobinRule.java
@@ -14,8 +14,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Base implementation of common round-robin logic used by {@link RoundRobinByHostnameRule} and
- * {@link RoundRobinByAttributeRule}.
+ * Base implementation of common round-robin logic.
  */
 abstract class AbstractRoundRobinRule implements PlacementRule {
 
@@ -33,20 +32,20 @@ abstract class AbstractRoundRobinRule implements PlacementRule {
     }
 
     /**
-     * Returns a value to round robin against from the provided {@link Offer}, or {@code null} if
+     * Returns a key to round robin against from the provided {@link Offer}, or {@code null} if
      * none was found.
      */
-    protected abstract String getValue(Offer offer);
+    protected abstract String getKey(Offer offer);
 
     /**
-     * Returns a value to round robin against from the provided {@link TaskInfo}, or {@code null} if
+     * Returns a key to round robin against from the provided {@link TaskInfo}, or {@code null} if
      * none was found.
      */
-    protected abstract String getValue(TaskInfo task);
+    protected abstract String getKey(TaskInfo task);
 
     @Override
     public EvaluationOutcome filter(Offer offer, PodInstance podInstance, Collection<TaskInfo> tasks) {
-        final String offerValue = getValue(offer);
+        final String offerValue = getKey(offer);
         if (offerValue == null) {
             // offer doesn't have the required attribute at all. denied.
             return EvaluationOutcome.fail(this, "Offer lacks required round robin value").build();
@@ -67,7 +66,7 @@ abstract class AbstractRoundRobinRule implements PlacementRule {
                 continue;
             }
 
-            final String taskAttributeValue = getValue(task);
+            final String taskAttributeValue = getKey(task);
             if (taskAttributeValue == null) {
                 // no attribute matching the name was found. ignore.
                 continue;

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/AttributeRule.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/AttributeRule.java
@@ -23,7 +23,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  *
  * @see AttributeStringUtils#toString(Attribute)
  */
-public class AttributeRule implements StringMatcherRule {
+public class AttributeRule extends StringMatcherRule {
 
     /**
      * Requires that a task be placed on the provided attribute matcher.

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/AttributeRule.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/AttributeRule.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import com.mesosphere.sdk.specification.PodInstance;
 import org.apache.commons.lang3.builder.EqualsBuilder;
@@ -22,7 +23,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  *
  * @see AttributeStringUtils#toString(Attribute)
  */
-public class AttributeRule implements PlacementRule {
+public class AttributeRule implements StringMatcherRule {
 
     /**
      * Requires that a task be placed on the provided attribute matcher.
@@ -97,22 +98,19 @@ public class AttributeRule implements PlacementRule {
 
     @Override
     public EvaluationOutcome filter(Offer offer, PodInstance podInstance, Collection<TaskInfo> tasks) {
-        for (Attribute attributeProto : offer.getAttributesList()) {
-            String attributeString = AttributeStringUtils.toString(attributeProto);
-            if (matcher.matches(attributeString)) {
-                return EvaluationOutcome.pass(
-                        this,
-                        "Match found for attribute pattern: '%s'", matcher.toString())
-                        .build();
-            }
+        if (isAcceptable(matcher, offer, podInstance, tasks)) {
+            return EvaluationOutcome.pass(
+                    this,
+                    "Match found for attribute pattern: '%s'", matcher.toString())
+                    .build();
+        } else {
+            return EvaluationOutcome.fail(
+                    this,
+                    "None of %d attributes matched pattern: '%s'",
+                    offer.getAttributesCount(),
+                    matcher.toString())
+                    .build();
         }
-
-        return EvaluationOutcome.fail(
-                this,
-                "None of %d attributes matched pattern: '%s'",
-                offer.getAttributesCount(),
-                matcher.toString())
-                .build();
     }
 
     @JsonProperty("matcher")
@@ -133,5 +131,12 @@ public class AttributeRule implements PlacementRule {
     @Override
     public int hashCode() {
         return HashCodeBuilder.reflectionHashCode(this);
+    }
+
+    @Override
+    public Collection<String> getKeys(Offer offer) {
+        return offer.getAttributesList().stream()
+                .map(attribute -> AttributeStringUtils.toString(attribute))
+                .collect(Collectors.toList());
     }
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/HostnameRule.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/HostnameRule.java
@@ -18,7 +18,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * This rule enforces that a task be placed on the specified hostname, or enforces that the task
  * avoid that hostname.
  */
-public class HostnameRule implements StringMatcherRule {
+public class HostnameRule extends StringMatcherRule {
 
     /**
      * Requires that a task be placed on the provided hostname.

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/HostnameRule.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/HostnameRule.java
@@ -18,7 +18,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * This rule enforces that a task be placed on the specified hostname, or enforces that the task
  * avoid that hostname.
  */
-public class HostnameRule implements PlacementRule {
+public class HostnameRule implements StringMatcherRule {
 
     /**
      * Requires that a task be placed on the provided hostname.
@@ -143,7 +143,7 @@ public class HostnameRule implements PlacementRule {
 
     @Override
     public EvaluationOutcome filter(Offer offer, PodInstance podInstance, Collection<TaskInfo> tasks) {
-        if (matcher.matches(offer.getHostname())) {
+        if (isAcceptable(matcher, offer, podInstance, tasks)) {
             return EvaluationOutcome.pass(this, "Offer hostname matches pattern: '%s'", matcher.toString()).build();
         } else {
             return EvaluationOutcome.fail(this, "Offer hostname didn't match pattern: '%s'", matcher.toString())
@@ -198,5 +198,10 @@ public class HostnameRule implements PlacementRule {
             rules.add(require(matcher));
         }
         return rules;
+    }
+
+    @Override
+    public Collection<String> getKeys(Offer offer) {
+        return Arrays.asList(offer.getHostname());
     }
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/MaxPerAttributeRule.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/MaxPerAttributeRule.java
@@ -5,15 +5,18 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.mesosphere.sdk.offer.evaluate.EvaluationOutcome;
 import com.mesosphere.sdk.offer.taskdata.AttributeStringUtils;
 import com.mesosphere.sdk.offer.taskdata.TaskLabelReader;
-
 import com.mesosphere.sdk.specification.PodInstance;
+import com.mesosphere.sdk.specification.validation.ValidationUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.mesos.Protos.Attribute;
 import org.apache.mesos.Protos.Offer;
 import org.apache.mesos.Protos.TaskInfo;
 
-import java.util.*;
+import javax.validation.Valid;
+import javax.validation.constraints.Min;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.stream.Collectors;
 
 /**
  * Ensures that the given Offer’s attributes each have no more than N instances of tasks of a given task type
@@ -50,8 +53,10 @@ import java.util.*;
  * 'index-.*'. This allows us to only enforce the rule against certain task types or task instances
  * within the service.
  */
-public class MaxPerAttributeRule implements PlacementRule {
+public class MaxPerAttributeRule implements MaxPerRule {
 
+    @Valid
+    @Min(1)
     private final int maxTasksPerSelectedAttribute;
     private final StringMatcher attributeMatcher;
     private final StringMatcher taskFilter;
@@ -94,70 +99,26 @@ public class MaxPerAttributeRule implements PlacementRule {
             taskFilter = AnyMatcher.create();
         }
         this.taskFilter = taskFilter;
+        ValidationUtils.validate(this);
     }
 
     @Override
     public EvaluationOutcome filter(Offer offer, PodInstance podInstance, Collection<TaskInfo> tasks) {
-        // collect all the attribute values present in this offer:
-        Set<String> offerAttributeStrings = new HashSet<>();
-        for (Attribute attributeProto : offer.getAttributesList()) {
-            offerAttributeStrings.add(AttributeStringUtils.toString(attributeProto));
+        if (isAcceptable(offer, podInstance, tasks, maxTasksPerSelectedAttribute)) {
+            return EvaluationOutcome.pass(
+                    this,
+                    "Fits within limit of %d tasks matching filter '%s' on this agent with attribute: %s",
+                    maxTasksPerSelectedAttribute, taskFilter.toString(), attributeMatcher.toString())
+                    .build();
+        } else {
+            return EvaluationOutcome.fail(
+                    this,
+                    "Reached greater than %d tasks matching filter '%s' on this agent with attribute: %s",
+                    maxTasksPerSelectedAttribute,
+                    taskFilter.toString(),
+                    attributeMatcher.toString())
+                    .build();
         }
-        if (offerAttributeStrings.isEmpty()) {
-            // shortcut: offer has no attributes to enforce. offer accepted!
-            return EvaluationOutcome.pass(this, "Offer has no attributes to enforce").build();
-        }
-
-        // map: enforced attribute in offer => # other tasks which were launched against attribute
-        Map<String, Integer> offerAttrTaskCounts = new HashMap<>();
-        for (TaskInfo task : tasks) {
-            // only tally tasks which match the task matcher (eg 'index-.*')
-            if (!taskFilter.matches(task.getName())) {
-                continue;
-            }
-            if (PlacementUtils.areEquivalent(task, podInstance)) {
-                // This is stale data for the same task that we're currently evaluating for
-                // placement. Don't worry about counting its attribute usage. This occurs when we're
-                // redeploying a given task with a new configuration (old data not deleted yet).
-                continue;
-            }
-            for (String taskAttributeString : new TaskLabelReader(task).getOfferAttributeStrings()) {
-                // only tally attribute values that are actually present in the offer
-                if (!offerAttributeStrings.contains(taskAttributeString)) {
-                    continue;
-                }
-                // only tally attribute(s) that match the attribute matcher (eg 'rack:.*'):
-                if (!attributeMatcher.matches(taskAttributeString)) {
-                    continue;
-                }
-                // increment the tally for this exact attribute value (eg 'rack:9'):
-                Integer val = offerAttrTaskCounts.get(taskAttributeString);
-                if (val == null) {
-                    val = 0;
-                }
-                val++;
-                if (val >= maxTasksPerSelectedAttribute) {
-                    // this attribute value's usage meets or exceeds the limit, and it is
-                    // present in this offer per the earlier check. offer denied!
-                    return EvaluationOutcome.fail(
-                            this,
-                            "Reached %d/%d tasks matching filter '%s' on this agent with attribute: %s",
-                            val,
-                            maxTasksPerSelectedAttribute,
-                            taskFilter.toString(),
-                            attributeMatcher.toString())
-                            .build();
-                }
-                offerAttrTaskCounts.put(taskAttributeString, val);
-            }
-        }
-        // after scanning all the tasks for usage of attributes present in this offer, nothing
-        // hit or exceeded the limit. offer accepted!
-        return EvaluationOutcome.pass(
-                this,
-                "Fits within limit of %d tasks matching filter '%s' on this agent with attribute: %s",
-                maxTasksPerSelectedAttribute, taskFilter.toString(), attributeMatcher.toString())
-                .build();
     }
 
     @JsonProperty("max")
@@ -170,8 +131,27 @@ public class MaxPerAttributeRule implements PlacementRule {
         return attributeMatcher;
     }
 
+    @Override
+    public Collection<String> getKeys(TaskInfo taskInfo) {
+        if (!taskFilter.matches(taskInfo.getName())) {
+            return Collections.emptyList();
+        }
+
+        return new TaskLabelReader(taskInfo).getOfferAttributeStrings().stream()
+                .filter(attribute -> attributeMatcher.matches(attribute))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public Collection<String> getKeys(Offer offer) {
+        return offer.getAttributesList().stream()
+                .map(proto -> AttributeStringUtils.toString(proto))
+                .filter(attribute -> attributeMatcher.matches(attribute))
+                .collect(Collectors.toList());
+    }
+
     @JsonProperty("task-filter")
-    private StringMatcher getTaskFilter() {
+    public StringMatcher getTaskFilter() {
         return taskFilter;
     }
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/MaxPerAttributeRule.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/MaxPerAttributeRule.java
@@ -53,7 +53,7 @@ import java.util.stream.Collectors;
  * 'index-.*'. This allows us to only enforce the rule against certain task types or task instances
  * within the service.
  */
-public class MaxPerAttributeRule implements MaxPerRule {
+public class MaxPerAttributeRule extends MaxPerRule {
 
     @Valid
     @Min(1)

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/MaxPerHostnameRule.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/MaxPerHostnameRule.java
@@ -5,8 +5,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.mesosphere.sdk.offer.TaskException;
 import com.mesosphere.sdk.offer.evaluate.EvaluationOutcome;
 import com.mesosphere.sdk.offer.taskdata.TaskLabelReader;
-
 import com.mesosphere.sdk.specification.PodInstance;
+import com.mesosphere.sdk.specification.validation.ValidationUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.mesos.Protos.Offer;
@@ -14,7 +14,11 @@ import org.apache.mesos.Protos.TaskInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.validation.Valid;
+import javax.validation.constraints.Min;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 
 /**
  * Ensures that no more than N instances of a task type are running on a given hostname (or hostname
@@ -37,10 +41,12 @@ import java.util.Collection;
  * on any given host. Among the above three hosts, any offers from host-1 and host-3 will be
  * accepted and offers from host-2 will be denied.
  */
-public class MaxPerHostnameRule implements PlacementRule {
+public class MaxPerHostnameRule implements MaxPerRule {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MaxPerHostnameRule.class);
 
+    @Valid
+    @Min(1)
     private final int maxTasksPerHostname;
     private final StringMatcher taskFilter;
 
@@ -74,51 +80,24 @@ public class MaxPerHostnameRule implements PlacementRule {
             taskFilter = AnyMatcher.create();
         }
         this.taskFilter = taskFilter;
+        ValidationUtils.validate(this);
     }
 
     @Override
     public EvaluationOutcome filter(Offer offer, PodInstance podInstance, Collection<TaskInfo> tasks) {
-        int offerHostnameTaskCounts = 0;
-        for (TaskInfo task : tasks) {
-            // only tally tasks which match the task matcher (eg 'index-.*')
-            if (!taskFilter.matches(task.getName())) {
-                continue;
-            }
-            if (PlacementUtils.areEquivalent(task, podInstance)) {
-                // This is stale data for the same task that we're currently evaluating for
-                // placement. Don't worry about counting its usage. This occurs when we're
-                // redeploying a given task with a new configuration (old data not deleted yet).
-                continue;
-            }
-            final String taskHostname;
-            try {
-                taskHostname = new TaskLabelReader(task).getHostname();
-            } catch (TaskException e) {
-                LOGGER.warn("Unable to extract hostname from task for filtering", e);
-                continue;
-            }
-            if (!taskHostname.equals(offer.getHostname())) {
-                continue;
-            }
-            ++offerHostnameTaskCounts;
-            if (offerHostnameTaskCounts >= maxTasksPerHostname) {
-                // the hostname for this offer meets or exceeds the limit. offer denied!
-                return EvaluationOutcome.fail(
-                        this,
-                        "%d/%d tasks matching filter '%s' are already present on this host",
-                        offerHostnameTaskCounts,
-                        maxTasksPerHostname,
-                        taskFilter.toString())
-                        .build();
-            }
+        if (isAcceptable(offer, podInstance, tasks, maxTasksPerHostname)) {
+            return EvaluationOutcome.pass(
+                    this,
+                    "Fewer than %d tasks matching filter '%s' are present on this host",
+                    maxTasksPerHostname, taskFilter.toString())
+                    .build();
+        } else {
+            return EvaluationOutcome.fail(
+                    this,
+                    "%d tasks matching filter '%s' are already present on this host",
+                    maxTasksPerHostname, taskFilter.toString())
+                    .build();
         }
-        // after scanning all the tasks for usage of attributes present in this offer, nothing
-        // hit or exceeded the limit. offer accepted!
-        return EvaluationOutcome.pass(
-                this,
-                "%d/%d tasks matching filter '%s' are present on this host",
-                offerHostnameTaskCounts, maxTasksPerHostname, taskFilter.toString())
-                .build();
     }
 
     @JsonProperty("max")
@@ -126,8 +105,23 @@ public class MaxPerHostnameRule implements PlacementRule {
         return maxTasksPerHostname;
     }
 
+    @Override
+    public Collection<String> getKeys(TaskInfo taskInfo) {
+        try {
+            return Arrays.asList(new TaskLabelReader(taskInfo).getHostname());
+        } catch (TaskException e) {
+            LOGGER.warn("Unable to extract hostname from task for filtering", e);
+            return Collections.emptyList();
+        }
+    }
+
+    @Override
+    public Collection<String> getKeys(Offer offer) {
+        return Arrays.asList(offer.getHostname());
+    }
+
     @JsonProperty("task-filter")
-    private StringMatcher getTaskFilter() {
+    public StringMatcher getTaskFilter() {
         return taskFilter;
     }
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/MaxPerHostnameRule.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/MaxPerHostnameRule.java
@@ -41,7 +41,7 @@ import java.util.Collections;
  * on any given host. Among the above three hosts, any offers from host-1 and host-3 will be
  * accepted and offers from host-2 will be denied.
  */
-public class MaxPerHostnameRule implements MaxPerRule {
+public class MaxPerHostnameRule extends MaxPerRule {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MaxPerHostnameRule.class);
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/MaxPerRule.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/MaxPerRule.java
@@ -1,0 +1,54 @@
+package com.mesosphere.sdk.offer.evaluate.placement;
+
+import com.mesosphere.sdk.specification.PodInstance;
+import org.apache.mesos.Protos;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * This interface defines the required methods for generic application of a PlacementRule which forces a
+ * maximum per some key (e.g. attribute, hostname, region, zone ...).
+ */
+public interface MaxPerRule extends PlacementRule {
+    Collection<String> getKeys(Protos.TaskInfo taskInfo);
+    Collection<String> getKeys(Protos.Offer offer);
+    StringMatcher getTaskFilter();
+
+    default boolean isAcceptable(
+            Protos.Offer offer,
+            PodInstance podInstance,
+            Collection<Protos.TaskInfo> tasks,
+            Integer max) {
+
+        tasks = tasks.stream()
+                .filter(task -> getTaskFilter().matches(task.getName()))
+                .filter(task -> !PlacementUtils.areEquivalent(task, podInstance))
+                .collect(Collectors.toList());
+
+        Map<String, Integer> counts = new HashMap<>();
+
+        Collection<String> offerKeys = getKeys(offer);
+        updateMap(counts, offerKeys);
+
+        for (Protos.TaskInfo task : tasks) {
+            updateMap(
+                    counts,
+                    getKeys(task).stream()
+                            .filter(key -> offerKeys.contains(key))
+                            .collect(Collectors.toList()));
+        }
+
+        return counts.values().stream().allMatch(value -> value <= max);
+    }
+
+    default void updateMap(Map<String, Integer> map, Collection<String> keys) {
+        for (String key : keys) {
+            Integer count = map.get(key);
+            count = count == null ? 1 : count + 1;
+            map.put(key, count);
+        }
+    }
+}

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/MaxPerRule.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/MaxPerRule.java
@@ -12,12 +12,12 @@ import java.util.stream.Collectors;
  * This interface defines the required methods for generic application of a PlacementRule which forces a
  * maximum per some key (e.g. attribute, hostname, region, zone ...).
  */
-public interface MaxPerRule extends PlacementRule {
-    Collection<String> getKeys(Protos.TaskInfo taskInfo);
-    Collection<String> getKeys(Protos.Offer offer);
-    StringMatcher getTaskFilter();
+public abstract class MaxPerRule implements PlacementRule {
+    public abstract Collection<String> getKeys(Protos.TaskInfo taskInfo);
+    public abstract Collection<String> getKeys(Protos.Offer offer);
+    public abstract StringMatcher getTaskFilter();
 
-    default boolean isAcceptable(
+    public boolean isAcceptable(
             Protos.Offer offer,
             PodInstance podInstance,
             Collection<Protos.TaskInfo> tasks,
@@ -44,7 +44,7 @@ public interface MaxPerRule extends PlacementRule {
         return counts.values().stream().allMatch(value -> value <= max);
     }
 
-    default void updateMap(Map<String, Integer> map, Collection<String> keys) {
+    private void updateMap(Map<String, Integer> map, Collection<String> keys) {
         for (String key : keys) {
             Integer count = map.get(key);
             count = count == null ? 1 : count + 1;

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/RoundRobinByAttributeRule.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/RoundRobinByAttributeRule.java
@@ -58,7 +58,7 @@ public class RoundRobinByAttributeRule extends AbstractRoundRobinRule {
     }
 
     @Override
-    protected String getValue(Offer offer) {
+    protected String getKey(Offer offer) {
         for (Attribute attribute : offer.getAttributesList()) {
             if (attribute.getName().equalsIgnoreCase(attributeName)) {
                 return AttributeStringUtils.valueString(attribute);
@@ -68,7 +68,7 @@ public class RoundRobinByAttributeRule extends AbstractRoundRobinRule {
     }
 
     @Override
-    protected String getValue(TaskInfo task) {
+    protected String getKey(TaskInfo task) {
         for (String taskAttributeString : new TaskLabelReader(task).getOfferAttributeStrings()) {
             AttributeStringUtils.NameValue taskAttributeNameValue =
                     AttributeStringUtils.split(taskAttributeString);

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/RoundRobinByHostnameRule.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/RoundRobinByHostnameRule.java
@@ -59,14 +59,14 @@ public class RoundRobinByHostnameRule extends AbstractRoundRobinRule {
     /**
      * Returns a value to round robin against from the provided {@link Offer}.
      */
-    protected String getValue(Offer offer) {
+    protected String getKey(Offer offer) {
         return offer.getHostname();
     }
 
     /**
      * Returns a value to round robin against from the provided {@link TaskInfo}.
      */
-    protected String getValue(TaskInfo task) {
+    protected String getKey(TaskInfo task) {
         try {
             return new TaskLabelReader(task).getHostname();
         } catch (TaskException e) {

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/StringMatcherRule.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/StringMatcherRule.java
@@ -9,10 +9,10 @@ import java.util.Collection;
  * This interface defines the required methods for generic application of a PlacementRule which depends on the presence
  * of some key (e.g. attribute, hostname, region, zone ...).
  */
-public interface StringMatcherRule extends PlacementRule {
-    public Collection<String> getKeys(Protos.Offer offer);
+public abstract class StringMatcherRule implements PlacementRule {
+    public abstract Collection<String> getKeys(Protos.Offer offer);
 
-    public default boolean isAcceptable(
+    public boolean isAcceptable(
             StringMatcher matcher,
             Protos.Offer offer,
             PodInstance podInstance,

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/StringMatcherRule.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/StringMatcherRule.java
@@ -1,0 +1,28 @@
+package com.mesosphere.sdk.offer.evaluate.placement;
+
+import com.mesosphere.sdk.specification.PodInstance;
+import org.apache.mesos.Protos;
+
+import java.util.Collection;
+
+/**
+ * This interface defines the required methods for generic application of a PlacementRule which depends on the presence
+ * of some key (e.g. attribute, hostname, region, zone ...).
+ */
+public interface StringMatcherRule extends PlacementRule {
+    public Collection<String> getKeys(Protos.Offer offer);
+
+    public default boolean isAcceptable(
+            StringMatcher matcher,
+            Protos.Offer offer,
+            PodInstance podInstance,
+            Collection<Protos.TaskInfo> tasks) {
+        for (String key : getKeys(offer)) {
+            if (matcher.matches(key)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/placement/MaxPerHostnameRuleTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/placement/MaxPerHostnameRuleTest.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import javax.validation.ConstraintViolationException;
 
 import static org.junit.Assert.*;
 
@@ -103,44 +104,9 @@ public class MaxPerHostnameRuleTest {
         return o.build();
     }
 
-    @Test
+    @Test(expected = ConstraintViolationException.class)
     public void testLimitZero() {
-        PlacementRule rule = new MaxPerHostnameRule(0);
-
-        assertTrue(rule.filter(OFFER_NO_HOSTNAME, REQ, TASKS).isPassing());
-        assertFalse(rule.filter(OFFER_HOSTNAME_1, REQ, TASKS).isPassing());
-        assertFalse(rule.filter(OFFER_HOSTNAME_2, REQ, TASKS).isPassing());
-        assertFalse(rule.filter(OFFER_HOSTNAME_3, REQ, TASKS).isPassing());
-
-        assertTrue(rule.filter(OFFER_NO_HOSTNAME, REQ, Collections.emptyList()).isPassing());
-        assertTrue(rule.filter(OFFER_HOSTNAME_1, REQ, Collections.emptyList()).isPassing());
-        assertTrue(rule.filter(OFFER_HOSTNAME_2, REQ, Collections.emptyList()).isPassing());
-        assertTrue(rule.filter(OFFER_HOSTNAME_3, REQ, Collections.emptyList()).isPassing());
-    }
-
-    @Test
-    public void testLimitZeroWithSamePresent() {
-        PlacementRule rule = new MaxPerHostnameRule(0);
-
-        assertTrue(rule.filter(OFFER_NO_HOSTNAME, REQ_WITH_NO_HOSTNAME, TASKS).isPassing());
-        assertFalse(rule.filter(OFFER_HOSTNAME_1, REQ_WITH_NO_HOSTNAME, TASKS).isPassing());
-        assertFalse(rule.filter(OFFER_HOSTNAME_2, REQ_WITH_NO_HOSTNAME, TASKS).isPassing());
-        assertFalse(rule.filter(OFFER_HOSTNAME_3, REQ_WITH_NO_HOSTNAME, TASKS).isPassing());
-
-        assertTrue(rule.filter(OFFER_NO_HOSTNAME, REQ_WITH_HOSTNAME_1, TASKS).isPassing());
-        assertTrue(rule.filter(OFFER_HOSTNAME_1, REQ_WITH_HOSTNAME_1, TASKS).isPassing());
-        assertFalse(rule.filter(OFFER_HOSTNAME_2, REQ_WITH_HOSTNAME_1, TASKS).isPassing());
-        assertFalse(rule.filter(OFFER_HOSTNAME_3, REQ_WITH_HOSTNAME_1, TASKS).isPassing());
-
-        assertTrue(rule.filter(OFFER_NO_HOSTNAME, REQ_WITH_NO_HOSTNAME, Collections.emptyList()).isPassing());
-        assertTrue(rule.filter(OFFER_HOSTNAME_1, REQ_WITH_NO_HOSTNAME, Collections.emptyList()).isPassing());
-        assertTrue(rule.filter(OFFER_HOSTNAME_2, REQ_WITH_NO_HOSTNAME, Collections.emptyList()).isPassing());
-        assertTrue(rule.filter(OFFER_HOSTNAME_3, REQ_WITH_NO_HOSTNAME, Collections.emptyList()).isPassing());
-
-        assertTrue(rule.filter(OFFER_NO_HOSTNAME, REQ_WITH_HOSTNAME_1, Collections.emptyList()).isPassing());
-        assertTrue(rule.filter(OFFER_HOSTNAME_1, REQ_WITH_HOSTNAME_1, Collections.emptyList()).isPassing());
-        assertTrue(rule.filter(OFFER_HOSTNAME_2, REQ_WITH_HOSTNAME_1, Collections.emptyList()).isPassing());
-        assertTrue(rule.filter(OFFER_HOSTNAME_3, REQ_WITH_HOSTNAME_1, Collections.emptyList()).isPassing());
+        new MaxPerHostnameRule(0);
     }
 
     @Test
@@ -358,10 +324,6 @@ public class MaxPerHostnameRuleTest {
     @Test
     public void testSerializeDeserialize() throws IOException {
         PlacementRule rule = new MaxPerHostnameRule(2);
-        assertEquals(rule, SerializationUtils.fromString(
-                SerializationUtils.toJsonString(rule), PlacementRule.class, TestPlacementUtils.OBJECT_MAPPER));
-
-        rule = new MaxPerHostnameRule(0, ExactMatcher.create("hi"));
         assertEquals(rule, SerializationUtils.fromString(
                 SerializationUtils.toJsonString(rule), PlacementRule.class, TestPlacementUtils.OBJECT_MAPPER));
     }

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/testutils/DefaultCapabilitiesTestSuite.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/testutils/DefaultCapabilitiesTestSuite.java
@@ -25,7 +25,7 @@ public abstract class DefaultCapabilitiesTestSuite {
         when(capabilities.supportsFileBasedSecrets()).thenReturn(true);
         when(capabilities.supportsEnvBasedSecretsProtobuf()).thenReturn(true);
         when(capabilities.supportsEnvBasedSecretsDirectiveLabel()).thenReturn(true);
-        context = new ResourceRefinementCapabilityContext(Capabilities.getInstance());
+        context = new ResourceRefinementCapabilityContext(capabilities);
 
     }
 


### PR DESCRIPTION
All tests are mostly unbothered.  This PR generalizes some patterns so that adding region/zone rules is easier.  Will need to generalize testing in the next PR, but this PR proves that at least no harm was done.