### PR TITLE
Update KDC app's networking type

### DIFF
--- a/testing/sdk_auth.py
+++ b/testing/sdk_auth.py
@@ -246,7 +246,7 @@ class KerberosEnvironment:
         kdc_app_def["id"] = KERBEROS_APP_ID
         _launch_marathon_app(kdc_app_def)
         _check_kdc_marathon_task_is_running()
-        self.kdc_port = 88
+        self.kdc_port = int(kdc_app_def["portDefinitions"][0]["port"])
         self.kdc_fqdn = "{app_id}.marathon.{host_suffix}".format(
             app_id=KERBEROS_APP_ID, host_suffix=sdk_hosts.VIP_HOST_SUFFIX)
         self.kdc_host_id = _get_host_id()

--- a/tools/kdc.json
+++ b/tools/kdc.json
@@ -6,30 +6,24 @@
   "container": {
     "type": "MESOS",
     "docker": {
-      "image": "mesosphere/kdc:latest",
+      "image": "nvaziri/kdc:dev",
       "forcePullImage": true
-    },
-    "portMappings": [
-      {
-        "containerPort": 88,
-        "protocol": "tcp",
-        "labels": {"VIP_0": "kdc:88"}
-      },
-      {
-        "containerPort": 88,
-        "protocol": "udp",
-        "labels": {"VIP_0": "kdc:88"}
-      },
-      {
-        "containerPort": 8000,
-        "protocol": "tcp",
-        "labels": {"VIP_0": "kdc:8000"}
-      }
-    ]
+    }
   },
   "networks": [
     {
-      "mode": "container/bridge"
+      "mode": "host"
     }
-  ]
+  ],
+  "portDefinitions": [
+    {
+      "port": 2500,
+      "protocol": "tcp",
+      "name": "tcp",
+      "labels": {"VIP_0": "kdc:2500"}
+    }
+  ],
+  "env": {
+    "LOG_LEVEL": "LOG_DEBUG"
+  }
 }


### PR DESCRIPTION
This changes 3 things:  
- the KDC container's networking type to `host` mode
- forces KDC to handle all traffic through TCP
- allows configuration of the TCP port it listens on