### PR TITLE
Refactor the StringMatcher rules

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/AttributeRule.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/AttributeRule.java
@@ -4,8 +4,6 @@ import java.util.Collection;
 import java.util.stream.Collectors;
 
 import com.mesosphere.sdk.specification.PodInstance;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.mesos.Protos.Attribute;
 import org.apache.mesos.Protos.Offer;
 import org.apache.mesos.Protos.TaskInfo;
@@ -21,48 +19,26 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * @see AttributeStringUtils#toString(Attribute)
  */
 public class AttributeRule extends StringMatcherRule {
-    private final StringMatcher matcher;
-
     @JsonCreator
     public AttributeRule(@JsonProperty("matcher") StringMatcher matcher) {
-        this.matcher = matcher;
+        super("AttributeRule", matcher);
     }
 
     @Override
     public EvaluationOutcome filter(Offer offer, PodInstance podInstance, Collection<TaskInfo> tasks) {
-        if (isAcceptable(matcher, offer, podInstance, tasks)) {
+        if (isAcceptable(offer, podInstance, tasks)) {
             return EvaluationOutcome.pass(
                     this,
-                    "Match found for attribute pattern: '%s'", matcher.toString())
+                    "Match found for attribute pattern: '%s'", getMatcher().toString())
                     .build();
         } else {
             return EvaluationOutcome.fail(
                     this,
                     "None of %d attributes matched pattern: '%s'",
                     offer.getAttributesCount(),
-                    matcher.toString())
+                    getMatcher().toString())
                     .build();
         }
-    }
-
-    @JsonProperty("matcher")
-    private StringMatcher getMatcher() {
-        return matcher;
-    }
-
-    @Override
-    public String toString() {
-        return String.format("AttributeRule{matcher=%s}", matcher);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        return EqualsBuilder.reflectionEquals(this, o);
-    }
-
-    @Override
-    public int hashCode() {
-        return HashCodeBuilder.reflectionHashCode(this);
     }
 
     @Override

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/AttributeRule.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/AttributeRule.java
@@ -1,9 +1,6 @@
 package com.mesosphere.sdk.offer.evaluate.placement;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.List;
 import java.util.stream.Collectors;
 
 import com.mesosphere.sdk.specification.PodInstance;
@@ -24,75 +21,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * @see AttributeStringUtils#toString(Attribute)
  */
 public class AttributeRule extends StringMatcherRule {
-
-    /**
-     * Requires that a task be placed on the provided attribute matcher.
-     *
-     * @param matcher matcher for attribute to require
-     */
-    public static PlacementRule require(StringMatcher matcher) {
-        return new AttributeRule(matcher);
-    }
-
-    /**
-     * Requires that a task be placed on one of the provided attribute matchers.
-     *
-     * @param matchers matchers for attributes to require
-     */
-    public static PlacementRule require(Collection<StringMatcher> matchers) {
-        if (matchers.size() == 1) {
-            return require(matchers.iterator().next());
-        }
-        List<PlacementRule> rules = new ArrayList<>();
-        for (StringMatcher matcher : matchers) {
-            rules.add(require(matcher));
-        }
-        return new OrRule(rules);
-    }
-
-    /**
-     * Requires that a task be placed on one of the provided attribute matchers.
-     *
-     * @param matchers matchers for attributes to require
-     */
-    public static PlacementRule require(StringMatcher... matchers) {
-        return require(Arrays.asList(matchers));
-    }
-
-    /**
-     * Requires that a task NOT be placed on the provided attribute matcher.
-     *
-     * @param matcher matcher for attribute to avoid
-     */
-    public static PlacementRule avoid(StringMatcher matcher) {
-        return new NotRule(require(matcher));
-    }
-
-    /**
-     * Requires that a task NOT be placed on any of the provided attribute matchers.
-     *
-     * @param matchers matchers for attributes to avoid
-     */
-    public static PlacementRule avoid(Collection<StringMatcher> matchers) {
-        if (matchers.size() == 1) {
-            return avoid(matchers.iterator().next());
-        }
-        return new NotRule(require(matchers));
-    }
-
-    /**
-     * Requires that a task NOT be placed on any of the provided attribute matchers.
-     *
-     * @param matchers matchers for attributes to avoid
-     */
-    public static PlacementRule avoid(StringMatcher... matchers) {
-        return avoid(Arrays.asList(matchers));
-    }
-
     private final StringMatcher matcher;
 
     @JsonCreator
-    private AttributeRule(@JsonProperty("matcher") StringMatcher matcher) {
+    public AttributeRule(@JsonProperty("matcher") StringMatcher matcher) {
         this.matcher = matcher;
     }
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/AttributeRuleFactory.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/AttributeRuleFactory.java
@@ -1,0 +1,22 @@
+package com.mesosphere.sdk.offer.evaluate.placement;
+
+
+/**
+ * Created by gabriel on 11/8/17.
+ */
+public class AttributeRuleFactory implements RuleFactory {
+    private static final AttributeRuleFactory factory = new AttributeRuleFactory();
+
+    public static AttributeRuleFactory getInstance() {
+        return factory;
+    }
+
+    private AttributeRuleFactory() {
+        // Do not instantiate this class
+    }
+
+    @Override
+    public PlacementRule require(StringMatcher matcher) {
+        return new AttributeRule(matcher);
+    }
+}

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/AttributeRuleFactory.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/AttributeRuleFactory.java
@@ -2,7 +2,7 @@ package com.mesosphere.sdk.offer.evaluate.placement;
 
 
 /**
- * Created by gabriel on 11/8/17.
+ * This class generates {@link AttributeRule}s.
  */
 public class AttributeRuleFactory implements RuleFactory {
     private static final AttributeRuleFactory factory = new AttributeRuleFactory();

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/HostnameRule.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/HostnameRule.java
@@ -1,9 +1,7 @@
 package com.mesosphere.sdk.offer.evaluate.placement;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.List;
 
 import com.mesosphere.sdk.specification.PodInstance;
 import org.apache.commons.lang3.builder.EqualsBuilder;
@@ -20,124 +18,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  */
 public class HostnameRule extends StringMatcherRule {
 
-    /**
-     * Requires that a task be placed on the provided hostname.
-     *
-     * @param hostname hostname of the mesos agent to require
-     */
-    public static PlacementRule requireExact(String hostname) {
-        return require(toExactMatchers(hostname));
-    }
-
-    /**
-     * Requires that a task be placed on one of the provided hostnames.
-     *
-     * @param hostnames hostnames of the mesos agents to require
-     */
-    public static PlacementRule requireExact(Collection<String> hostnames) {
-        return require(toExactMatchers(hostnames));
-    }
-
-    /**
-     * Requires that a task be placed on one of the provided hostnames.
-     *
-     * @param hostnames for hostnames of the mesos agents to require
-     */
-    public static PlacementRule requireExact(String... hostnames) {
-        return require(toExactMatchers(hostnames));
-    }
-
-    /**
-     * Requires that a task be placed on the provided hostname.
-     *
-     * @param matcher matcher for hostname of the mesos agent to require
-     */
-    public static PlacementRule require(StringMatcher matcher) {
-        return new HostnameRule(matcher);
-    }
-
-    /**
-     * Requires that a task be placed on one of the provided hostnames.
-     *
-     * @param matchers matchers for hostnames of the mesos agents to require
-     */
-    public static PlacementRule require(Collection<StringMatcher> matchers) {
-        if (matchers.size() == 1) {
-            return require(matchers.iterator().next());
-        }
-        return new OrRule(toHostnameRules(matchers));
-    }
-
-    /**
-     * Requires that a task be placed on one of the provided hostnames.
-     *
-     * @param matchers matchers for hostnames of the mesos agents to require
-     */
-    public static PlacementRule require(StringMatcher... matchers) {
-        return require(Arrays.asList(matchers));
-    }
-
-    /**
-     * Requires that a task NOT be placed on the provided hostname.
-     *
-     * @param hostname hostname of the mesos agent to avoid
-     */
-    public static PlacementRule avoidExact(String hostname) {
-        return avoid(toExactMatchers(hostname));
-    }
-
-    /**
-     * Requires that a task NOT be placed on any of the provided hostnames.
-     *
-     * @param hostnames hostnames of the mesos agents to avoid
-     */
-    public static PlacementRule avoidExact(Collection<String> hostnames) {
-        return avoid(toExactMatchers(hostnames));
-    }
-
-    /**
-     * Requires that a task NOT be placed on any of the provided hostnames.
-     *
-     * @param hostnames hostnames of the mesos agents to avoid
-     */
-    public static PlacementRule avoidExact(String... hostnames) {
-        return avoid(toExactMatchers(hostnames));
-    }
-
-    /**
-     * Requires that a task NOT be placed on the provided hostname.
-     *
-     * @param matcher matcher for hostname of the mesos agent to avoid
-     */
-    public static PlacementRule avoid(StringMatcher matcher) {
-        return new NotRule(require(matcher));
-    }
-
-    /**
-     * Requires that a task NOT be placed on any of the provided hostnames.
-     *
-     * @param matchers matchers for hostnames of the mesos agents to avoid
-     */
-    public static PlacementRule avoid(Collection<StringMatcher> matchers) {
-        if (matchers.size() == 1) {
-            return avoid(matchers.iterator().next());
-        }
-        return new NotRule(require(matchers));
-    }
-
-    /**
-     * Requires that a task NOT be placed on any of the provided hostnames.
-     *
-     * @param matchers matchers for hostnames of the mesos agents to avoid
-     */
-    public static PlacementRule avoid(StringMatcher... matchers) {
-        return avoid(Arrays.asList(matchers));
-    }
-
     private final StringMatcher matcher;
 
     @JsonCreator
-    private HostnameRule(@JsonProperty("matcher") StringMatcher matcher) {
+    public HostnameRule(@JsonProperty("matcher") StringMatcher matcher) {
         this.matcher = matcher;
     }
 
@@ -169,35 +53,6 @@ public class HostnameRule extends StringMatcherRule {
     @Override
     public int hashCode() {
         return HashCodeBuilder.reflectionHashCode(this);
-    }
-
-    /**
-     * Converts the provided hostnames into {@link ExactMatcher}s.
-     */
-    private static Collection<StringMatcher> toExactMatchers(Collection<String> hostnames) {
-        List<StringMatcher> matchers = new ArrayList<>();
-        for (String hostname : hostnames) {
-            matchers.add(ExactMatcher.create(hostname));
-        }
-        return matchers;
-    }
-
-    /**
-     * Converts the provided hostnames into {@link ExactMatcher}s.
-     */
-    private static Collection<StringMatcher> toExactMatchers(String... hostnames) {
-        return toExactMatchers(Arrays.asList(hostnames));
-    }
-
-    /**
-     * Converts the provided matchers into {@link HostnameRule}s.
-     */
-    private static Collection<PlacementRule> toHostnameRules(Collection<StringMatcher> matchers) {
-        List<PlacementRule> rules = new ArrayList<>();
-        for (StringMatcher matcher : matchers) {
-            rules.add(require(matcher));
-        }
-        return rules;
     }
 
     @Override

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/HostnameRule.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/HostnameRule.java
@@ -4,8 +4,6 @@ import java.util.Arrays;
 import java.util.Collection;
 
 import com.mesosphere.sdk.specification.PodInstance;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.mesos.Protos.Offer;
 import org.apache.mesos.Protos.TaskInfo;
 import com.mesosphere.sdk.offer.evaluate.EvaluationOutcome;
@@ -18,41 +16,23 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  */
 public class HostnameRule extends StringMatcherRule {
 
-    private final StringMatcher matcher;
-
     @JsonCreator
     public HostnameRule(@JsonProperty("matcher") StringMatcher matcher) {
-        this.matcher = matcher;
+        super("HostnameRule", matcher);
     }
 
     @Override
     public EvaluationOutcome filter(Offer offer, PodInstance podInstance, Collection<TaskInfo> tasks) {
-        if (isAcceptable(matcher, offer, podInstance, tasks)) {
-            return EvaluationOutcome.pass(this, "Offer hostname matches pattern: '%s'", matcher.toString()).build();
+        if (isAcceptable(offer, podInstance, tasks)) {
+            return EvaluationOutcome.pass(
+                    this,
+                    "Offer hostname matches pattern: '%s'",
+                    getMatcher().toString())
+                    .build();
         } else {
-            return EvaluationOutcome.fail(this, "Offer hostname didn't match pattern: '%s'", matcher.toString())
+            return EvaluationOutcome.fail(this, "Offer hostname didn't match pattern: '%s'", getMatcher().toString())
                     .build();
         }
-    }
-
-    @JsonProperty("matcher")
-    private StringMatcher getMatcher() {
-        return matcher;
-    }
-
-    @Override
-    public String toString() {
-        return String.format("HostnameRule{matcher=%s}", matcher);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        return EqualsBuilder.reflectionEquals(this, o);
-    }
-
-    @Override
-    public int hashCode() {
-        return HashCodeBuilder.reflectionHashCode(this);
     }
 
     @Override

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/HostnameRuleFactory.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/HostnameRuleFactory.java
@@ -1,0 +1,21 @@
+package com.mesosphere.sdk.offer.evaluate.placement;
+
+/**
+ * Created by gabriel on 11/8/17.
+ */
+public class HostnameRuleFactory implements RuleFactory {
+    private static final HostnameRuleFactory factory = new HostnameRuleFactory();
+
+    public static HostnameRuleFactory getInstance() {
+        return factory;
+    }
+
+    private HostnameRuleFactory() {
+        // Do not instantiate this class
+    }
+
+    @Override
+    public PlacementRule require(StringMatcher matcher) {
+        return new HostnameRule(matcher);
+    }
+}

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/HostnameRuleFactory.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/HostnameRuleFactory.java
@@ -1,7 +1,7 @@
 package com.mesosphere.sdk.offer.evaluate.placement;
 
 /**
- * Created by gabriel on 11/8/17.
+ * This class generates {@link HostnameRule}s.
  */
 public class HostnameRuleFactory implements RuleFactory {
     private static final HostnameRuleFactory factory = new HostnameRuleFactory();

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/MarathonConstraintParser.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/MarathonConstraintParser.java
@@ -229,7 +229,8 @@ public class MarathonConstraintParser {
                 // - Task doesn't exceed one instance on those nodes (MaxPerAttributeRule)
                 StringMatcher matcher = RegexMatcher.createAttribute(fieldName, ".*");
                 return new AndRule(
-                        AttributeRule.require(matcher), new MaxPerAttributeRule(1, matcher, taskFilter));
+                        AttributeRuleFactory.getInstance()
+                                .require(matcher), new MaxPerAttributeRule(1, matcher, taskFilter));
             }
         }
     }
@@ -247,9 +248,9 @@ public class MarathonConstraintParser {
                                  Optional<String> requiredParameter) throws IOException {
             String parameter = validateRequiredParameter(operatorName, requiredParameter);
             if (isHostname(fieldName)) {
-                return HostnameRule.require(ExactMatcher.create(parameter));
+                return HostnameRuleFactory.getInstance().require(ExactMatcher.create(parameter));
             } else {
-                return AttributeRule.require(ExactMatcher.createAttribute(fieldName, parameter));
+                return AttributeRuleFactory.getInstance().require(ExactMatcher.createAttribute(fieldName, parameter));
             }
         }
     }
@@ -304,9 +305,9 @@ public class MarathonConstraintParser {
                                  Optional<String> requiredParameter) throws IOException {
             String parameter = validateRequiredParameter(operatorName, requiredParameter);
             if (isHostname(fieldName)) {
-                return HostnameRule.require(RegexMatcher.create(parameter));
+                return HostnameRuleFactory.getInstance().require(RegexMatcher.create(parameter));
             } else {
-                return AttributeRule.require(RegexMatcher.createAttribute(fieldName, parameter));
+                return AttributeRuleFactory.getInstance().require(RegexMatcher.createAttribute(fieldName, parameter));
             }
         }
     }
@@ -322,9 +323,9 @@ public class MarathonConstraintParser {
                                  Optional<String> requiredParameter) throws IOException {
             String parameter = validateRequiredParameter(operatorName, requiredParameter);
             if (isHostname(fieldName)) {
-                return HostnameRule.avoid(RegexMatcher.create(parameter));
+                return HostnameRuleFactory.getInstance().avoid(RegexMatcher.create(parameter));
             } else {
-                return AttributeRule.avoid(RegexMatcher.createAttribute(fieldName, parameter));
+                return AttributeRuleFactory.getInstance().avoid(RegexMatcher.createAttribute(fieldName, parameter));
             }
         }
     }
@@ -355,7 +356,8 @@ public class MarathonConstraintParser {
                 // - Task doesn't exceed one instance on those nodes (MaxPerAttributeRule)
                 StringMatcher matcher = RegexMatcher.createAttribute(fieldName, ".*");
                 return new AndRule(
-                        AttributeRule.require(matcher), new MaxPerAttributeRule(max, matcher, taskFilter));
+                        AttributeRuleFactory.getInstance()
+                                .require(matcher), new MaxPerAttributeRule(max, matcher, taskFilter));
             }
         }
     }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/PlacementUtils.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/PlacementUtils.java
@@ -1,15 +1,13 @@
 package com.mesosphere.sdk.offer.evaluate.placement;
 
-import java.util.List;
-import java.util.Optional;
-
-import com.mesosphere.sdk.offer.*;
-
+import com.mesosphere.sdk.offer.TaskException;
+import com.mesosphere.sdk.offer.TaskUtils;
 import com.mesosphere.sdk.specification.PodInstance;
+import org.apache.mesos.Protos.TaskInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.apache.mesos.Protos.TaskInfo;
+import java.util.*;
 
 /**
  * This class provides Utilities for commonly needed Placement rule scenarios.
@@ -66,5 +64,40 @@ public class PlacementUtils {
             LOGGER.warn("Unable to extract pod type or index from TaskInfo", e);
             return false;
         }
+    }
+
+    /**
+     * Requires that a task be placed on one of the provided string matchers.
+     *
+     * @param matchers matchers for keys to require
+     */
+    public static PlacementRule require(RuleFactory ruleFactory, Collection<StringMatcher> matchers) {
+        if (matchers.size() == 1) {
+            return ruleFactory.require(matchers.iterator().next());
+        }
+        List<PlacementRule> rules = new ArrayList<>();
+        for (StringMatcher matcher : matchers) {
+            rules.add(ruleFactory.require(matcher));
+        }
+        return new OrRule(rules);
+    }
+
+    /**
+     * Converts the provided keys into {@link ExactMatcher}s.
+     */
+    public static Collection<StringMatcher> toExactMatchers(String... hostnames) {
+        return toExactMatchers(Arrays.asList(hostnames));
+    }
+
+
+    /**
+     * Converts the provided keys into {@link ExactMatcher}s.
+     */
+    public static Collection<StringMatcher> toExactMatchers(Collection<String> hostnames) {
+        List<StringMatcher> matchers = new ArrayList<>();
+        for (String hostname : hostnames) {
+            matchers.add(ExactMatcher.create(hostname));
+        }
+        return matchers;
     }
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/RuleFactory.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/RuleFactory.java
@@ -4,7 +4,7 @@ import java.util.Arrays;
 import java.util.Collection;
 
 /**
- * Created by gabriel on 11/8/17.
+ * This interface defines the requirements for a factory which generates {@link PlacementRule}s.
  */
 public interface RuleFactory {
     /**

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/RuleFactory.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/RuleFactory.java
@@ -1,0 +1,64 @@
+package com.mesosphere.sdk.offer.evaluate.placement;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+/**
+ * Created by gabriel on 11/8/17.
+ */
+public interface RuleFactory {
+    /**
+     * Requires that a task be placed on the provided string matcher.
+     *
+     * @param matcher matcher for key to require
+     */
+    PlacementRule require(StringMatcher matcher);
+
+    /**
+     * Requires that a task be placed on one of the provided string matchers.
+     *
+     * @param matchers matchers for key to require
+     */
+    default PlacementRule require(Collection<StringMatcher> matchers) {
+        return PlacementUtils.require(this, matchers);
+    }
+
+    /**
+     * Requires that a task be placed on one of the provided string matchers.
+     *
+     * @param matchers matchers for keys to require
+     */
+    default PlacementRule require(StringMatcher... matchers) {
+        return PlacementUtils.require(this, Arrays.asList(matchers));
+    }
+
+    /**
+     * Requires that a task NOT be placed on the provided string matchers.
+     *
+     * @param matcher matcher for key to avoid
+     */
+    default PlacementRule avoid(StringMatcher matcher) {
+        return new NotRule(require(matcher));
+    }
+
+    /**
+     * Requires that a task NOT be placed on any of the provided string matchers.
+     *
+     * @param matchers matchers for keys to avoid
+     */
+    default PlacementRule avoid(Collection<StringMatcher> matchers) {
+        if (matchers.size() == 1) {
+            return avoid(matchers.iterator().next());
+        }
+        return new NotRule(require(matchers));
+    }
+
+    /**
+     * Requires that a task NOT be placed on any of the provided string matchers.
+     *
+     * @param matchers matchers for keys to avoid
+     */
+    default PlacementRule avoid(StringMatcher... matchers) {
+        return avoid(Arrays.asList(matchers));
+    }
+}

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/StringMatcherRule.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/StringMatcherRule.java
@@ -1,6 +1,9 @@
 package com.mesosphere.sdk.offer.evaluate.placement;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.mesosphere.sdk.specification.PodInstance;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.mesos.Protos;
 
 import java.util.Collection;
@@ -10,15 +13,39 @@ import java.util.Collection;
  * of some key (e.g. attribute, hostname, region, zone ...).
  */
 public abstract class StringMatcherRule implements PlacementRule {
+    private final StringMatcher matcher;
+    private final String name;
+
+    protected StringMatcherRule(String name, StringMatcher matcher) {
+        this.name = name;
+        this.matcher = matcher;
+    }
+
+    @JsonProperty("matcher")
+    protected StringMatcher getMatcher() {
+        return matcher;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return EqualsBuilder.reflectionEquals(this, o);
+    }
+
+    @Override
+    public int hashCode() {
+        return HashCodeBuilder.reflectionHashCode(this);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%s{matcher=%s}", name, matcher);
+    }
+
     public abstract Collection<String> getKeys(Protos.Offer offer);
 
-    public boolean isAcceptable(
-            StringMatcher matcher,
-            Protos.Offer offer,
-            PodInstance podInstance,
-            Collection<Protos.TaskInfo> tasks) {
+    protected boolean isAcceptable(Protos.Offer offer, PodInstance podInstance, Collection<Protos.TaskInfo> tasks) {
         for (String key : getKeys(offer)) {
-            if (matcher.matches(key)) {
+            if (getMatcher().matches(key)) {
                 return true;
             }
         }

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/placement/AttributeRuleTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/placement/AttributeRuleTest.java
@@ -65,22 +65,22 @@ public class AttributeRuleTest {
     public void testExactMatchesString() {
         Offer.Builder o = getOfferWithResources()
                 .addAttributes(ATTR_TEXT);
-        assertTrue(AttributeRule.require(ExactMatcher.create(AttributeStringUtils.toString(ATTR_TEXT)))
+        assertTrue(AttributeRuleFactory.getInstance().require(ExactMatcher.create(AttributeStringUtils.toString(ATTR_TEXT)))
                 .filter(o.build(), POD_INSTANCE, Collections.emptyList()).isPassing());
 
         o = getOfferWithResources()
                 .addAttributes(ATTR_SCALAR);
-        assertTrue(AttributeRule.require(ExactMatcher.create(AttributeStringUtils.toString(ATTR_SCALAR)))
+        assertTrue(AttributeRuleFactory.getInstance().require(ExactMatcher.create(AttributeStringUtils.toString(ATTR_SCALAR)))
                 .filter(o.build(), POD_INSTANCE, Collections.emptyList()).isPassing());
 
         o = getOfferWithResources()
                 .addAttributes(ATTR_RANGES);
-        assertTrue(AttributeRule.require(ExactMatcher.create(AttributeStringUtils.toString(ATTR_RANGES)))
+        assertTrue(AttributeRuleFactory.getInstance().require(ExactMatcher.create(AttributeStringUtils.toString(ATTR_RANGES)))
                 .filter(o.build(), POD_INSTANCE, Collections.emptyList()).isPassing());
 
         o = getOfferWithResources()
                 .addAttributes(ATTR_SET);
-        assertTrue(AttributeRule.require(ExactMatcher.create(AttributeStringUtils.toString(ATTR_SET)))
+        assertTrue(AttributeRuleFactory.getInstance().require(ExactMatcher.create(AttributeStringUtils.toString(ATTR_SET)))
                 .filter(o.build(), POD_INSTANCE, Collections.emptyList()).isPassing());
     }
 
@@ -92,13 +92,13 @@ public class AttributeRuleTest {
                 .addAttributes(ATTR_RANGES)
                 .addAttributes(ATTR_SET)
                 .build();
-        assertTrue(AttributeRule.require(ExactMatcher.create(AttributeStringUtils.toString(ATTR_TEXT)))
+        assertTrue(AttributeRuleFactory.getInstance().require(ExactMatcher.create(AttributeStringUtils.toString(ATTR_TEXT)))
                 .filter(o, POD_INSTANCE, Collections.emptyList()).isPassing());
-        assertTrue(AttributeRule.require(ExactMatcher.create(AttributeStringUtils.toString(ATTR_SCALAR)))
+        assertTrue(AttributeRuleFactory.getInstance().require(ExactMatcher.create(AttributeStringUtils.toString(ATTR_SCALAR)))
                 .filter(o, POD_INSTANCE, Collections.emptyList()).isPassing());
-        assertTrue(AttributeRule.require(ExactMatcher.create(AttributeStringUtils.toString(ATTR_RANGES)))
+        assertTrue(AttributeRuleFactory.getInstance().require(ExactMatcher.create(AttributeStringUtils.toString(ATTR_RANGES)))
                 .filter(o, POD_INSTANCE, Collections.emptyList()).isPassing());
-        assertTrue(AttributeRule.require(ExactMatcher.create(AttributeStringUtils.toString(ATTR_SET)))
+        assertTrue(AttributeRuleFactory.getInstance().require(ExactMatcher.create(AttributeStringUtils.toString(ATTR_SET)))
                 .filter(o, POD_INSTANCE, Collections.emptyList()).isPassing());
     }
 
@@ -108,26 +108,26 @@ public class AttributeRuleTest {
                 .addAttributes(ATTR_SCALAR)
                 .addAttributes(ATTR_SET)
                 .build();
-        assertFalse(AttributeRule.require(ExactMatcher.create(AttributeStringUtils.toString(ATTR_TEXT)))
+        assertFalse(AttributeRuleFactory.getInstance().require(ExactMatcher.create(AttributeStringUtils.toString(ATTR_TEXT)))
                 .filter(o, POD_INSTANCE, Collections.emptyList()).isPassing());
-        assertTrue(AttributeRule.require(ExactMatcher.create(AttributeStringUtils.toString(ATTR_SCALAR)))
+        assertTrue(AttributeRuleFactory.getInstance().require(ExactMatcher.create(AttributeStringUtils.toString(ATTR_SCALAR)))
                 .filter(o, POD_INSTANCE, Collections.emptyList()).isPassing());
-        assertFalse(AttributeRule.require(ExactMatcher.create(AttributeStringUtils.toString(ATTR_RANGES)))
+        assertFalse(AttributeRuleFactory.getInstance().require(ExactMatcher.create(AttributeStringUtils.toString(ATTR_RANGES)))
                 .filter(o, POD_INSTANCE, Collections.emptyList()).isPassing());
-        assertTrue(AttributeRule.require(ExactMatcher.create(AttributeStringUtils.toString(ATTR_SET)))
+        assertTrue(AttributeRuleFactory.getInstance().require(ExactMatcher.create(AttributeStringUtils.toString(ATTR_SET)))
                 .filter(o, POD_INSTANCE, Collections.emptyList()).isPassing());
 
         o = getOfferWithResources()
                 .addAttributes(ATTR_RANGES)
                 .addAttributes(ATTR_TEXT)
                 .build();
-        assertTrue(AttributeRule.require(ExactMatcher.create(AttributeStringUtils.toString(ATTR_TEXT)))
+        assertTrue(AttributeRuleFactory.getInstance().require(ExactMatcher.create(AttributeStringUtils.toString(ATTR_TEXT)))
                 .filter(o, POD_INSTANCE, Collections.emptyList()).isPassing());
-        assertFalse(AttributeRule.require(ExactMatcher.create(AttributeStringUtils.toString(ATTR_SCALAR)))
+        assertFalse(AttributeRuleFactory.getInstance().require(ExactMatcher.create(AttributeStringUtils.toString(ATTR_SCALAR)))
                 .filter(o, POD_INSTANCE, Collections.emptyList()).isPassing());
-        assertTrue(AttributeRule.require(ExactMatcher.create(AttributeStringUtils.toString(ATTR_RANGES)))
+        assertTrue(AttributeRuleFactory.getInstance().require(ExactMatcher.create(AttributeStringUtils.toString(ATTR_RANGES)))
                 .filter(o, POD_INSTANCE, Collections.emptyList()).isPassing());
-        assertFalse(AttributeRule.require(ExactMatcher.create(AttributeStringUtils.toString(ATTR_SET)))
+        assertFalse(AttributeRuleFactory.getInstance().require(ExactMatcher.create(AttributeStringUtils.toString(ATTR_SET)))
                 .filter(o, POD_INSTANCE, Collections.emptyList()).isPassing());
     }
 
@@ -135,22 +135,22 @@ public class AttributeRuleTest {
     public void testExactMatchesRegex() {
         Offer.Builder o = getOfferWithResources()
                 .addAttributes(ATTR_TEXT);
-        assertTrue(AttributeRule.require(RegexMatcher.create(ATTR_TEXT_REGEX))
+        assertTrue(AttributeRuleFactory.getInstance().require(RegexMatcher.create(ATTR_TEXT_REGEX))
                 .filter(o.build(), POD_INSTANCE, Collections.emptyList()).isPassing());
 
         o = getOfferWithResources()
                 .addAttributes(ATTR_SCALAR);
-        assertTrue(AttributeRule.require(RegexMatcher.create(ATTR_SCALAR_REGEX))
+        assertTrue(AttributeRuleFactory.getInstance().require(RegexMatcher.create(ATTR_SCALAR_REGEX))
                 .filter(o.build(), POD_INSTANCE, Collections.emptyList()).isPassing());
 
         o = getOfferWithResources()
                 .addAttributes(ATTR_RANGES);
-        assertTrue(AttributeRule.require(RegexMatcher.create(ATTR_RANGES_REGEX))
+        assertTrue(AttributeRuleFactory.getInstance().require(RegexMatcher.create(ATTR_RANGES_REGEX))
                 .filter(o.build(), POD_INSTANCE, Collections.emptyList()).isPassing());
 
         o = getOfferWithResources()
                 .addAttributes(ATTR_SET);
-        assertTrue(AttributeRule.require(RegexMatcher.create(ATTR_SET_REGEX))
+        assertTrue(AttributeRuleFactory.getInstance().require(RegexMatcher.create(ATTR_SET_REGEX))
                 .filter(o.build(), POD_INSTANCE, Collections.emptyList()).isPassing());
     }
 
@@ -162,13 +162,13 @@ public class AttributeRuleTest {
                 .addAttributes(ATTR_RANGES)
                 .addAttributes(ATTR_SET)
                 .build();
-        assertTrue(AttributeRule.require(RegexMatcher.create(ATTR_TEXT_REGEX))
+        assertTrue(AttributeRuleFactory.getInstance().require(RegexMatcher.create(ATTR_TEXT_REGEX))
                 .filter(o, POD_INSTANCE, Collections.emptyList()).isPassing());
-        assertTrue(AttributeRule.require(RegexMatcher.create(ATTR_SCALAR_REGEX))
+        assertTrue(AttributeRuleFactory.getInstance().require(RegexMatcher.create(ATTR_SCALAR_REGEX))
                 .filter(o, POD_INSTANCE, Collections.emptyList()).isPassing());
-        assertTrue(AttributeRule.require(RegexMatcher.create(ATTR_RANGES_REGEX))
+        assertTrue(AttributeRuleFactory.getInstance().require(RegexMatcher.create(ATTR_RANGES_REGEX))
                 .filter(o, POD_INSTANCE, Collections.emptyList()).isPassing());
-        assertTrue(AttributeRule.require(RegexMatcher.create(ATTR_SET_REGEX))
+        assertTrue(AttributeRuleFactory.getInstance().require(RegexMatcher.create(ATTR_SET_REGEX))
                 .filter(o, POD_INSTANCE, Collections.emptyList()).isPassing());
     }
 
@@ -178,37 +178,37 @@ public class AttributeRuleTest {
                 .addAttributes(ATTR_SCALAR)
                 .addAttributes(ATTR_SET)
                 .build();
-        assertFalse(AttributeRule.require(RegexMatcher.create(ATTR_TEXT_REGEX))
+        assertFalse(AttributeRuleFactory.getInstance().require(RegexMatcher.create(ATTR_TEXT_REGEX))
                 .filter(o, POD_INSTANCE, Collections.emptyList()).isPassing());
-        assertTrue(AttributeRule.require(RegexMatcher.create(ATTR_SCALAR_REGEX))
+        assertTrue(AttributeRuleFactory.getInstance().require(RegexMatcher.create(ATTR_SCALAR_REGEX))
                 .filter(o, POD_INSTANCE, Collections.emptyList()).isPassing());
-        assertFalse(AttributeRule.require(RegexMatcher.create(ATTR_RANGES_REGEX))
+        assertFalse(AttributeRuleFactory.getInstance().require(RegexMatcher.create(ATTR_RANGES_REGEX))
                 .filter(o, POD_INSTANCE, Collections.emptyList()).isPassing());
-        assertTrue(AttributeRule.require(RegexMatcher.create(ATTR_SET_REGEX))
+        assertTrue(AttributeRuleFactory.getInstance().require(RegexMatcher.create(ATTR_SET_REGEX))
                 .filter(o, POD_INSTANCE, Collections.emptyList()).isPassing());
 
         o = getOfferWithResources()
                 .addAttributes(ATTR_RANGES)
                 .addAttributes(ATTR_TEXT)
                 .build();
-        assertTrue(AttributeRule.require(RegexMatcher.create(ATTR_TEXT_REGEX))
+        assertTrue(AttributeRuleFactory.getInstance().require(RegexMatcher.create(ATTR_TEXT_REGEX))
                 .filter(o, POD_INSTANCE, Collections.emptyList()).isPassing());
-        assertFalse(AttributeRule.require(RegexMatcher.create(ATTR_SCALAR_REGEX))
+        assertFalse(AttributeRuleFactory.getInstance().require(RegexMatcher.create(ATTR_SCALAR_REGEX))
                 .filter(o, POD_INSTANCE, Collections.emptyList()).isPassing());
-        assertTrue(AttributeRule.require(RegexMatcher.create(ATTR_RANGES_REGEX))
+        assertTrue(AttributeRuleFactory.getInstance().require(RegexMatcher.create(ATTR_RANGES_REGEX))
                 .filter(o, POD_INSTANCE, Collections.emptyList()).isPassing());
-        assertFalse(AttributeRule.require(RegexMatcher.create(ATTR_SET_REGEX))
+        assertFalse(AttributeRuleFactory.getInstance().require(RegexMatcher.create(ATTR_SET_REGEX))
                 .filter(o, POD_INSTANCE, Collections.emptyList()).isPassing());
     }
 
     @Test
     public void testSerializeDeserialize() throws IOException {
-        PlacementRule rule = AttributeRule.require(
+        PlacementRule rule = AttributeRuleFactory.getInstance().require(
                 ExactMatcher.create(AttributeStringUtils.toString(ATTR_SCALAR)));
         assertEquals(rule, SerializationUtils.fromString(
                 SerializationUtils.toJsonString(rule), PlacementRule.class, TestPlacementUtils.OBJECT_MAPPER));
 
-        rule = AttributeRule.require(
+        rule = AttributeRuleFactory.getInstance().require(
                 RegexMatcher.create(ATTR_RANGES_REGEX));
         assertEquals(rule, SerializationUtils.fromString(
                 SerializationUtils.toJsonString(rule), PlacementRule.class, TestPlacementUtils.OBJECT_MAPPER));

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/placement/HostnameRuleTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/placement/HostnameRuleTest.java
@@ -36,12 +36,12 @@ public class HostnameRuleTest {
 
     @Test
     public void testRequireHostname() {
-        PlacementRule rule = HostnameRule.require(HOST_MATCHER_1);
+        PlacementRule rule = HostnameRuleFactory.getInstance().require(HOST_MATCHER_1);
         assertTrue(rule.filter(offerWithHost(HOST_1), POD_INSTANCE, Collections.emptyList()).isPassing());
         assertFalse(rule.filter(offerWithHost(HOST_2), POD_INSTANCE, Collections.emptyList()).isPassing());
         assertFalse(rule.filter(offerWithHost(HOST_3), POD_INSTANCE, Collections.emptyList()).isPassing());
 
-        rule = HostnameRule.require(HOST_MATCHER_2);
+        rule = HostnameRuleFactory.getInstance().require(HOST_MATCHER_2);
         assertFalse(rule.filter(offerWithHost(HOST_1), POD_INSTANCE, Collections.emptyList()).isPassing());
         assertTrue(rule.filter(offerWithHost(HOST_2), POD_INSTANCE, Collections.emptyList()).isPassing());
         assertFalse(rule.filter(offerWithHost(HOST_3), POD_INSTANCE, Collections.emptyList()).isPassing());
@@ -49,12 +49,12 @@ public class HostnameRuleTest {
 
     @Test
     public void testAvoidHostname() {
-        PlacementRule rule = HostnameRule.avoid(HOST_MATCHER_1);
+        PlacementRule rule = HostnameRuleFactory.getInstance().avoid(HOST_MATCHER_1);
         assertFalse(rule.filter(offerWithHost(HOST_1), POD_INSTANCE, Collections.emptyList()).isPassing());
         assertTrue(rule.filter(offerWithHost(HOST_2), POD_INSTANCE, Collections.emptyList()).isPassing());
         assertTrue(rule.filter(offerWithHost(HOST_3), POD_INSTANCE, Collections.emptyList()).isPassing());
 
-        rule = HostnameRule.avoid(HOST_MATCHER_2);
+        rule = HostnameRuleFactory.getInstance().avoid(HOST_MATCHER_2);
         assertTrue(rule.filter(offerWithHost(HOST_1), POD_INSTANCE, Collections.emptyList()).isPassing());
         assertFalse(rule.filter(offerWithHost(HOST_2), POD_INSTANCE, Collections.emptyList()).isPassing());
         assertTrue(rule.filter(offerWithHost(HOST_3), POD_INSTANCE, Collections.emptyList()).isPassing());
@@ -62,12 +62,12 @@ public class HostnameRuleTest {
 
     @Test
     public void testRequireHostnames() {
-        PlacementRule rule = HostnameRule.require(HOST_MATCHER_1, HOST_MATCHER_3);
+        PlacementRule rule = HostnameRuleFactory.getInstance().require(HOST_MATCHER_1, HOST_MATCHER_3);
         assertTrue(rule.filter(offerWithHost(HOST_1), POD_INSTANCE, Collections.emptyList()).isPassing());
         assertFalse(rule.filter(offerWithHost(HOST_2), POD_INSTANCE, Collections.emptyList()).isPassing());
         assertTrue(rule.filter(offerWithHost(HOST_3), POD_INSTANCE, Collections.emptyList()).isPassing());
 
-        rule = HostnameRule.require(HOST_MATCHER_2, HOST_MATCHER_3);
+        rule = HostnameRuleFactory.getInstance().require(HOST_MATCHER_2, HOST_MATCHER_3);
         assertFalse(rule.filter(offerWithHost(HOST_1), POD_INSTANCE, Collections.emptyList()).isPassing());
         assertTrue(rule.filter(offerWithHost(HOST_2), POD_INSTANCE, Collections.emptyList()).isPassing());
         assertTrue(rule.filter(offerWithHost(HOST_3), POD_INSTANCE, Collections.emptyList()).isPassing());
@@ -75,12 +75,12 @@ public class HostnameRuleTest {
 
     @Test
     public void testAvoidHostnames() {
-        PlacementRule rule = HostnameRule.avoid(HOST_MATCHER_1, HOST_MATCHER_3);
+        PlacementRule rule = HostnameRuleFactory.getInstance().avoid(HOST_MATCHER_1, HOST_MATCHER_3);
         assertFalse(rule.filter(offerWithHost(HOST_1), POD_INSTANCE, Collections.emptyList()).isPassing());
         assertTrue(rule.filter(offerWithHost(HOST_2), POD_INSTANCE, Collections.emptyList()).isPassing());
         assertFalse(rule.filter(offerWithHost(HOST_3), POD_INSTANCE, Collections.emptyList()).isPassing());
 
-        rule = HostnameRule.avoid(HOST_MATCHER_2, HOST_MATCHER_3);
+        rule = HostnameRuleFactory.getInstance().avoid(HOST_MATCHER_2, HOST_MATCHER_3);
         assertTrue(rule.filter(offerWithHost(HOST_1), POD_INSTANCE, Collections.emptyList()).isPassing());
         assertFalse(rule.filter(offerWithHost(HOST_2), POD_INSTANCE, Collections.emptyList()).isPassing());
         assertFalse(rule.filter(offerWithHost(HOST_3), POD_INSTANCE, Collections.emptyList()).isPassing());
@@ -88,19 +88,19 @@ public class HostnameRuleTest {
 
     @Test
     public void testSerializeDeserialize() throws IOException {
-        PlacementRule rule = HostnameRule.avoid(HOST_MATCHER_1, HOST_MATCHER_3);
+        PlacementRule rule = HostnameRuleFactory.getInstance().avoid(HOST_MATCHER_1, HOST_MATCHER_3);
         assertEquals(rule, SerializationUtils.fromString(
                 SerializationUtils.toJsonString(rule), PlacementRule.class, TestPlacementUtils.OBJECT_MAPPER));
 
-        rule = HostnameRule.require(HOST_MATCHER_1, HOST_MATCHER_3);
+        rule = HostnameRuleFactory.getInstance().require(HOST_MATCHER_1, HOST_MATCHER_3);
         assertEquals(rule, SerializationUtils.fromString(
                 SerializationUtils.toJsonString(rule), PlacementRule.class, TestPlacementUtils.OBJECT_MAPPER));
 
-        rule = HostnameRule.avoid(HOST_MATCHER_1);
+        rule = HostnameRuleFactory.getInstance().avoid(HOST_MATCHER_1);
         assertEquals(rule, SerializationUtils.fromString(
                 SerializationUtils.toJsonString(rule), PlacementRule.class, TestPlacementUtils.OBJECT_MAPPER));
 
-        rule = HostnameRule.require(HOST_MATCHER_3);
+        rule = HostnameRuleFactory.getInstance().require(HOST_MATCHER_3);
         assertEquals(rule, SerializationUtils.fromString(
                 SerializationUtils.toJsonString(rule), PlacementRule.class, TestPlacementUtils.OBJECT_MAPPER));
     }

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/placement/NotRuleTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/placement/NotRuleTest.java
@@ -47,7 +47,7 @@ public class NotRuleTest {
         assertEquals(rule, SerializationUtils.fromString(
                 SerializationUtils.toJsonString(rule), PlacementRule.class, TestPlacementUtils.OBJECT_MAPPER));
 
-        rule = new NotRule(HostnameRule.requireExact("foo", "bar"));
+        rule = new NotRule(HostnameRuleFactory.getInstance().require(PlacementUtils.toExactMatchers("foo", "bar")));
         assertEquals(rule, SerializationUtils.fromString(
                 SerializationUtils.toJsonString(rule), PlacementRule.class, TestPlacementUtils.OBJECT_MAPPER));
     }


### PR DESCRIPTION
This PR reduces substantially the amount of boilerplate needed to write a StringMatcher based Rule.  It also now enforces interface requirements instead of relying on convention.

I'm going to need this to add Zone/Region rules.