### PR TITLE
[WIP][IINFINITY-2604] Update libmessos bundle for v1 in strict mode

### DIFF
--- a/frameworks/helloworld/tests/test_sanity.py
+++ b/frameworks/helloworld/tests/test_sanity.py
@@ -37,32 +37,31 @@ def test_install():
     config.check_running(sdk_utils.get_foldered_name(config.SERVICE_NAME))
 
 
-# Note: presently the mesos v1 api does _not_ work in strict mode.
-# As such, we expect this test to fail until it does in fact work in strict mode.
 @pytest.mark.sanity
 @pytest.mark.smoke
 @pytest.mark.mesos_v1
-@pytest.mark.skipif(sdk_utils.is_strict_mode(), reason='v1 API is not yet supported in strict mode')
 def test_mesos_v1_api():
-    foldered_name = sdk_utils.get_foldered_name(config.SERVICE_NAME)
-    # Install Hello World using the v1 api.
-    # Then, clean up afterwards.
-    sdk_install.uninstall(config.PACKAGE_NAME, foldered_name)
-    sdk_install.install(
-        config.PACKAGE_NAME,
-        foldered_name,
-        config.DEFAULT_TASK_COUNT,
-        additional_options={"service": {"name": foldered_name, "mesos_api_version": "V1"}}
-    )
-    config.check_running(foldered_name)
-    sdk_install.uninstall(config.PACKAGE_NAME, foldered_name)
+    try:
+        foldered_name = sdk_utils.get_foldered_name(config.SERVICE_NAME)
+        # Install Hello World using the v1 api.
+        # Then, clean up afterwards.
+        sdk_install.uninstall(config.PACKAGE_NAME, foldered_name)
+        sdk_install.install(
+            config.PACKAGE_NAME,
+            foldered_name,
+            config.DEFAULT_TASK_COUNT,
+            additional_options={"service": {"name": foldered_name, "mesos_api_version": "V1"}}
+        )
+        config.check_running(foldered_name)
+    finally:
+        sdk_install.uninstall(config.PACKAGE_NAME, foldered_name)
 
-    # reinstall the v0 version for the following tests
-    sdk_install.install(
-        config.PACKAGE_NAME,
-        foldered_name,
-        config.DEFAULT_TASK_COUNT,
-        additional_options={"service": {"name": foldered_name}})
+        # reinstall the v0 version for the following tests
+        sdk_install.install(
+            config.PACKAGE_NAME,
+            foldered_name,
+            config.DEFAULT_TASK_COUNT,
+            additional_options={"service": {"name": foldered_name}})
 
 
 @pytest.mark.sanity

--- a/frameworks/helloworld/universe/marathon.json.mustache
+++ b/frameworks/helloworld/universe/marathon.json.mustache
@@ -22,6 +22,7 @@
   },
   {{/service.service_account_secret}}
   "env": {
+    "GLOG_v": "2",
     "PACKAGE_NAME": "{{package-name}}",
     "PACKAGE_VERSION": "{{package-version}}",
     "PACKAGE_BUILD_TIME_EPOCH_MS": "{{package-build-time-epoch-ms}}",

--- a/frameworks/helloworld/universe/marathon.json.mustache
+++ b/frameworks/helloworld/universe/marathon.json.mustache
@@ -55,8 +55,9 @@
     "LIBMESOS_URI": "{{resource.assets.uris.libmesos-bundle-tar-gz}}",
     {{#service.service_account_secret}}
     "DCOS_SERVICE_ACCOUNT_CREDENTIAL": { "secret": "serviceCredential" },
-    "MESOS_MODULES": "{\"libraries\": [{\"file\": \"libdcos_security.so\", \"modules\": [{\"name\": \"com_mesosphere_dcos_ClassicRPCAuthenticatee\"}]}]}",
+    "MESOS_MODULES": "{\"libraries\":[{\"file\":\"libmesos-bundle\/lib\/mesos\/libdcos_security.so\",\"modules\":[{\"name\":\"com_mesosphere_dcos_http_Authenticatee\",\"parameters\":[{\"key\":\"jwt_exp_timeout\",\"value\":\"5mins\"},{\"key\":\"preemptive_refresh_duration\",\"value\":\"30mins\"}]}]}]}",
     "MESOS_AUTHENTICATEE": "com_mesosphere_dcos_ClassicRPCAuthenticatee",
+    "MESOS_HTTP_AUTHENTICATEE": "com_mesosphere_dcos_http_Authenticatee",
     {{/service.service_account_secret}}
     {{#hello.secret1}}
     "HELLO_SECRET1" : "{{hello.secret1}}",

--- a/frameworks/helloworld/universe/marathon.json.mustache
+++ b/frameworks/helloworld/universe/marathon.json.mustache
@@ -56,7 +56,7 @@
     "LIBMESOS_URI": "{{resource.assets.uris.libmesos-bundle-tar-gz}}",
     {{#service.service_account_secret}}
     "DCOS_SERVICE_ACCOUNT_CREDENTIAL": { "secret": "serviceCredential" },
-    "MESOS_MODULES": "{\"libraries\":[{\"file\":\"libmesos-bundle\/lib\/mesos\/libdcos_security.so\",\"modules\":[{\"name\":\"com_mesosphere_dcos_http_Authenticatee\",\"parameters\":[{\"key\":\"jwt_exp_timeout\",\"value\":\"5mins\"},{\"key\":\"preemptive_refresh_duration\",\"value\":\"30mins\"}]}]}]}",
+    "MESOS_MODULES": "{\"libraries\":[{\"file\":\"libmesos-bundle\/lib\/mesos\/libdcos_security.so\",\"modules\":[{\"name\": \"com_mesosphere_dcos_ClassicRPCAuthenticatee\"},{\"name\":\"com_mesosphere_dcos_http_Authenticatee\",\"parameters\":[{\"key\":\"jwt_exp_timeout\",\"value\":\"5mins\"},{\"key\":\"preemptive_refresh_duration\",\"value\":\"30mins\"}]}]}]}",
     "MESOS_AUTHENTICATEE": "com_mesosphere_dcos_ClassicRPCAuthenticatee",
     "MESOS_HTTP_AUTHENTICATEE": "com_mesosphere_dcos_http_Authenticatee",
     {{/service.service_account_secret}}

--- a/frameworks/helloworld/universe/marathon.json.mustache
+++ b/frameworks/helloworld/universe/marathon.json.mustache
@@ -22,7 +22,6 @@
   },
   {{/service.service_account_secret}}
   "env": {
-    "GLOG_v": "2",
     "PACKAGE_NAME": "{{package-name}}",
     "PACKAGE_VERSION": "{{package-version}}",
     "PACKAGE_BUILD_TIME_EPOCH_MS": "{{package-build-time-epoch-ms}}",

--- a/tools/universe/package_builder.py
+++ b/tools/universe/package_builder.py
@@ -17,7 +17,7 @@ logging.basicConfig(level=logging.DEBUG, format="%(message)s")
 
 _jre_url = 'https://downloads.mesosphere.com/java/jre-8u144-linux-x64.tar.gz'
 _jre_jce_unlimited_url = 'https://downloads.mesosphere.com/java/jre-8u131-linux-x64-jce-unlimited.tar.gz'
-_libmesos_bundle_url = 'https://downloads.mesosphere.io/libmesos-bundle/libmesos-bundle-1.10-1.4-63e0814.tar.gz'
+_libmesos_bundle_url = 'https://downloads.mesosphere.io/libmesos-bundle/libmesos-bundle-master-28f8827.tar.gz'
 
 _docs_root = "https://docs.mesosphere.com"
 


### PR DESCRIPTION
This PR enables the v1 tests in strict mode after updating the libmesos bundle.

Open questions/notes to myself:
- [x] Does the Strict Mode PR job pass? (https://teamcity.mesosphere.io/viewLog.html?buildId=858611&tab=buildResultsDiv&buildTypeId=DcosIo_DcosCommons_PrJobs_HelloWorldStrictPr)
- [x] Is the `MESOS_MODULES` specification change required?

TODO:
- add these changes be made to *ALL* frameworks?
- add v1 API tests be added to *ALL* frameworks?