### PR TITLE
[INFINITY-2611] Enable tests to work correctly in strict mode clusters

### DIFF
--- a/frameworks/hdfs/tests/test_auth.py
+++ b/frameworks/hdfs/tests/test_auth.py
@@ -80,11 +80,15 @@ def kerberos(configure_security):
 
 
 @pytest.fixture(autouse=True)
+@pytest.mark.dcos_min_version('1.10')
+@sdk_utils.dcos_ee_only
 @pytest.mark.smoke
 def test_health_of_kerberized_hdfs():
     config.check_healthy(service_name=config.SERVICE_NAME)
 
 
+@pytest.mark.dcos_min_version('1.10')
+@sdk_utils.dcos_ee_only
 @pytest.mark.auth
 @pytest.mark.sanity
 def test_user_can_write_and_read(kerberos):

--- a/frameworks/hdfs/tests/test_auth.py
+++ b/frameworks/hdfs/tests/test_auth.py
@@ -16,7 +16,7 @@ log = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope='module', autouse=True)
-def kerberos(configure_universe):
+def kerberos(configure_security):
     try:
         primaries = ["hdfs", "HTTP"]
         fqdn = "{service_name}.{host_suffix}".format(
@@ -78,21 +78,13 @@ def kerberos(configure_universe):
         if kerberos_env:
             kerberos_env.cleanup()
 
-# General process for each test
-# 1. Will use a keytab local to the client binary (key will either be a generic one or one made within the test context)
-# 2. Launch marathon app referencing said keytab via secret store
-# 3. container environment will have kerberos CLI and conf file setup
-# 4. task exec to app's container
-# 5. within each test, depending on the keytab that's pulled, one should kinit with appropriate principal
-# 6. use service client binary to interact with client once authed
 
-
+@pytest.fixture(autouse=True)
 @pytest.mark.smoke
 def test_health_of_kerberized_hdfs():
     config.check_healthy(service_name=config.SERVICE_NAME)
 
 
-sdk_utils.is_strict_mode()
 @pytest.mark.auth
 @pytest.mark.sanity
 def test_user_can_write_and_read(kerberos):

--- a/frameworks/hdfs/tools/hdfsclient.json
+++ b/frameworks/hdfs/tools/hdfsclient.json
@@ -1,6 +1,7 @@
 {
     "id": "hdfsclient",
     "mem": 1024,
+    "user": "nobody",
     "container": {
         "type": "MESOS",
         "docker": {
@@ -27,6 +28,8 @@
     "env": {
         "REALM": "LOCAL",
         "KDC_ADDRESS": "kdc.marathon.autoip.dcos.thisdcos.directory:2500",
-        "JAVA_HOME": "/usr/lib/jvm/default-java"
+        "JAVA_HOME": "/usr/lib/jvm/default-java",
+        "KRB5_CONFIG": "/etc/krb5.conf",
+        "HDFS_SERVICE_NAME": "hdfs"
     }
 }

--- a/test.sh
+++ b/test.sh
@@ -145,7 +145,8 @@ if [ -z $interactive ]; then
         echo "Cluster not found. Create and configure one then set \$CLUSTER_URL."
         exit 1
     else
-        if [ x"$security" == x"strict" -a $CLUSTER_URL != https* ]; then
+        if [[ x"$security" == x"strict" ]] && [[ $CLUSTER_URL != https* ]]; then
+            echo $CLUSTER_URL
             echo "CLUSTER_URL must be https in strict mode"
             exit 1
         fi

--- a/tools/kdc.json
+++ b/tools/kdc.json
@@ -3,6 +3,7 @@
   "instances": 1,
   "cpus": 1,
   "mem": 512,
+  "user": "nobody",
   "container": {
     "type": "MESOS",
     "docker": {

--- a/tools/kdc.py
+++ b/tools/kdc.py
@@ -6,6 +6,9 @@ Wrapper script around sdk_auth.py used to ad-hoc setup and tear down a KDC envir
 This assumes there will be only one KDC in the cluster at any time, and thus that only instance
 of the KDC will be aptly named `kdc`.
 
+If invoked from the repo root, PYTHONPATH must also be set. For eg
+`PYTHONPATH=testing ./tools/kdc.py deploy PRINCIPALS_FILE`
+
 This tool expects as its arguments:
     - subcommand for setup or teardown
     - path to file holding principals as newline-separated strings


### PR DESCRIPTION
The main issue with this not working initially was performing operations in the `kdc` (and `hdfsclient` app) as `root` user, hence it working in permissive. When the same set of steps were performed, it obviously failed because the images (and the files/executables being accessed) weren't given the appropriate permissions/ownership for user `nobody`.

Since this now works in both strict and permissive, it's safe to say these pieces of the auth tooling are relatively stable now, so we should probably move the image to the `mesosphere` docker hub  account.