### PR TITLE
Use V1 Mesos HTTP API by default across services

### DIFF
--- a/frameworks/cassandra/tests/test_sanity.py
+++ b/frameworks/cassandra/tests/test_sanity.py
@@ -56,7 +56,7 @@ def test_service_health():
 def test_mesos_v0_api():
     try:
         foldered_name = config.get_foldered_service_name()
-        # Install Cassandra using the v1 api.
+        # Install Cassandra using the v0 api.
         # Then, clean up afterwards.
         sdk_install.uninstall(config.PACKAGE_NAME, foldered_name)
         sdk_install.install(
@@ -71,7 +71,7 @@ def test_mesos_v0_api():
     finally:
         sdk_install.uninstall(config.PACKAGE_NAME, foldered_name)
 
-        # reinstall the v0 version for the following tests
+        # reinstall the v1 version for the following tests
         sdk_install.install(
             config.PACKAGE_NAME,
             foldered_name,

--- a/frameworks/cassandra/tests/test_sanity.py
+++ b/frameworks/cassandra/tests/test_sanity.py
@@ -50,6 +50,35 @@ def test_service_health():
 
 
 @pytest.mark.sanity
+@pytest.mark.smoke
+@pytest.mark.mesos_v0
+def test_mesos_v0_api():
+    try:
+        foldered_name = config.get_foldered_service_name()
+        # Install Cassandra using the v1 api.
+        # Then, clean up afterwards.
+        sdk_install.uninstall(config.PACKAGE_NAME, foldered_name)
+        sdk_install.install(
+            config.PACKAGE_NAME,
+            config.get_foldered_service_name(),
+            config.DEFAULT_TASK_COUNT,
+            additional_options={
+                "service": {"name": foldered_name, "mesos_api_version": "V0"}
+            }
+        )
+        config.check_running(foldered_name)
+    finally:
+        sdk_install.uninstall(config.PACKAGE_NAME, foldered_name)
+
+        # reinstall the v0 version for the following tests
+        sdk_install.install(
+            config.PACKAGE_NAME,
+            foldered_name,
+            config.DEFAULT_TASK_COUNT,
+            additional_options={"service": {"name": foldered_name}})
+
+
+@pytest.mark.sanity
 def test_endpoints():
     # check that we can reach the scheduler via admin router, and that returned endpoints are sanitized:
     endpoints = cmd.svc_cli(

--- a/frameworks/cassandra/tests/test_sanity.py
+++ b/frameworks/cassandra/tests/test_sanity.py
@@ -7,6 +7,7 @@ import sdk_install
 import sdk_jobs
 import sdk_metrics
 import sdk_plan
+import sdk_tasks
 import sdk_upgrade
 import sdk_utils
 import shakedown
@@ -66,7 +67,7 @@ def test_mesos_v0_api():
                 "service": {"name": foldered_name, "mesos_api_version": "V0"}
             }
         )
-        config.check_running(foldered_name)
+        sdk_tasks.check_running(foldered_name, config.DEFAULT_TASK_COUNT)
     finally:
         sdk_install.uninstall(config.PACKAGE_NAME, foldered_name)
 

--- a/frameworks/cassandra/universe/config.json
+++ b/frameworks/cassandra/universe/config.json
@@ -28,7 +28,7 @@
         "mesos_api_version" : {
           "description":"Configures the Mesos API version to use. Possible values: V0 (non-HTTP), V1 (HTTP)",
           "type":"string",
-          "default":"V0"
+          "default":"V1"
         },
         "data_center": {
           "description": "The name of the data center this cluster is running in",

--- a/frameworks/cassandra/universe/marathon.json.mustache
+++ b/frameworks/cassandra/universe/marathon.json.mustache
@@ -35,8 +35,9 @@
 
     {{#service.service_account_secret}}
     "DCOS_SERVICE_ACCOUNT_CREDENTIAL": { "secret": "serviceCredential" },
-    "MESOS_MODULES": "{\"libraries\": [{\"file\": \"libdcos_security.so\", \"modules\": [{\"name\": \"com_mesosphere_dcos_ClassicRPCAuthenticatee\"}]}]}",
+    "MESOS_MODULES": "{\"libraries\":[{\"file\":\"libmesos-bundle\/lib\/mesos\/libdcos_security.so\",\"modules\":[{\"name\": \"com_mesosphere_dcos_ClassicRPCAuthenticatee\"},{\"name\":\"com_mesosphere_dcos_http_Authenticatee\",\"parameters\":[{\"key\":\"jwt_exp_timeout\",\"value\":\"5mins\"},{\"key\":\"preemptive_refresh_duration\",\"value\":\"30mins\"}]}]}]}",
     "MESOS_AUTHENTICATEE": "com_mesosphere_dcos_ClassicRPCAuthenticatee",
+    "MESOS_HTTP_AUTHENTICATEE": "com_mesosphere_dcos_http_Authenticatee",
     {{/service.service_account_secret}}
     "MESOS_API_VERSION": "{{service.mesos_api_version}}",
 

--- a/frameworks/elastic/tests/test_sanity.py
+++ b/frameworks/elastic/tests/test_sanity.py
@@ -63,6 +63,33 @@ def test_service_health():
 
 
 @pytest.mark.sanity
+@pytest.mark.smoke
+@pytest.mark.mesos_v0
+def test_mesos_v0_api():
+    try:
+        foldered_name = sdk_utils.get_foldered_name(config.SERVICE_NAME)
+        # Install Elastic using the v0 api.
+        # Then, clean up afterwards.
+        sdk_install.uninstall(config.PACKAGE_NAME, foldered_name)
+        sdk_install.install(
+            config.PACKAGE_NAME,
+            foldered_name,
+            config.DEFAULT_TASK_COUNT,
+            additional_options={"service": {"name": foldered_name, "mesos_api_version": "V0"}}
+        )
+        config.check_running(foldered_name)
+    finally:
+        sdk_install.uninstall(config.PACKAGE_NAME, foldered_name)
+
+        # reinstall the v1 version for the following tests
+        sdk_install.install(
+            config.PACKAGE_NAME,
+            foldered_name,
+            config.DEFAULT_TASK_COUNT,
+            additional_options={"service": {"name": foldered_name}})
+
+
+@pytest.mark.sanity
 def test_endpoints():
     foldered_name = sdk_utils.get_foldered_name(config.SERVICE_NAME)
     # check that we can reach the scheduler via admin router, and that returned endpoints are sanitized:

--- a/frameworks/elastic/tests/test_sanity.py
+++ b/frameworks/elastic/tests/test_sanity.py
@@ -74,10 +74,10 @@ def test_mesos_v0_api():
         sdk_install.install(
             config.PACKAGE_NAME,
             foldered_name,
-            config.DEFAULT_TASK_COUNT,
+            current_expected_task_count,
             additional_options={"service": {"name": foldered_name, "mesos_api_version": "V0"}}
         )
-        config.check_running(foldered_name)
+        sdk_tasks.check_running(foldered_name, current_expected_task_count)
     finally:
         sdk_install.uninstall(config.PACKAGE_NAME, foldered_name)
 

--- a/frameworks/elastic/universe/config.json
+++ b/frameworks/elastic/universe/config.json
@@ -55,7 +55,7 @@
         "mesos_api_version": {
           "description": "Configures the Mesos API version to use. Possible values: V0 (non-HTTP), V1 (HTTP)",
           "type": "string",
-          "default": "V0"
+          "default": "V1"
         },
         "tls": {
           "description": "Enable TLS support (requires Enterprise DC/OS running in strict or permissive security mode).",

--- a/frameworks/elastic/universe/marathon.json.mustache
+++ b/frameworks/elastic/universe/marathon.json.mustache
@@ -44,8 +44,9 @@
 
     {{#service.service_account_secret}}
     "DCOS_SERVICE_ACCOUNT_CREDENTIAL": { "secret": "serviceCredential" },
-    "MESOS_MODULES": "{\"libraries\": [{\"file\": \"libdcos_security.so\", \"modules\": [{\"name\": \"com_mesosphere_dcos_ClassicRPCAuthenticatee\"}]}]}",
+    "MESOS_MODULES": "{\"libraries\":[{\"file\":\"libmesos-bundle\/lib\/mesos\/libdcos_security.so\",\"modules\":[{\"name\": \"com_mesosphere_dcos_ClassicRPCAuthenticatee\"},{\"name\":\"com_mesosphere_dcos_http_Authenticatee\",\"parameters\":[{\"key\":\"jwt_exp_timeout\",\"value\":\"5mins\"},{\"key\":\"preemptive_refresh_duration\",\"value\":\"30mins\"}]}]}]}",
     "MESOS_AUTHENTICATEE": "com_mesosphere_dcos_ClassicRPCAuthenticatee",
+    "MESOS_HTTP_AUTHENTICATEE": "com_mesosphere_dcos_http_Authenticatee",
     {{/service.service_account_secret}}
 
     {{#service.virtual_network_enabled}}

--- a/frameworks/elastic/universe/marathon.json.mustache
+++ b/frameworks/elastic/universe/marathon.json.mustache
@@ -37,6 +37,7 @@
     "BOOTSTRAP_URI": "{{resource.assets.uris.bootstrap-zip}}",
     "JAVA_URI": "{{resource.assets.uris.jre-tar-gz}}",
     "LIBMESOS_URI": "{{resource.assets.uris.libmesos-bundle-tar-gz}}",
+    "MESOS_API_VERSION": "{{service.mesos_api_version}}",
     "FRAMEWORK_NAME": "{{service.name}}",
     "FRAMEWORK_USER": "{{service.user}}",
     "FRAMEWORK_PRINCIPAL": "{{service.service_account}}",

--- a/frameworks/hdfs/tests/test_sanity.py
+++ b/frameworks/hdfs/tests/test_sanity.py
@@ -11,6 +11,7 @@ import sdk_plan
 import sdk_tasks
 import sdk_upgrade
 import sdk_utils
+import sdk_tasks
 import shakedown
 from tests import config
 
@@ -64,8 +65,7 @@ def test_mesos_v0_api():
             config.DEFAULT_TASK_COUNT,
             additional_options={"service": {"name": foldered_name, "mesos_api_version": "V0"}},
             timeout_seconds=30 * 60)
-        )
-        config.check_running(foldered_name)
+        sdk_tasks.check_running(foldered_name, config.DEFAULT_TASK_COUNT)
     finally:
         sdk_install.uninstall(config.PACKAGE_NAME, foldered_name)
 

--- a/frameworks/hdfs/tests/test_sanity.py
+++ b/frameworks/hdfs/tests/test_sanity.py
@@ -50,6 +50,35 @@ def pre_test_setup():
 
 
 @pytest.mark.sanity
+@pytest.mark.smoke
+@pytest.mark.mesos_v0
+def test_mesos_v0_api():
+    try:
+        foldered_name = sdk_utils.get_foldered_name(config.SERVICE_NAME)
+        # Install HDFS using the v0 api.
+        # Then, clean up afterwards.
+        sdk_install.uninstall(config.PACKAGE_NAME, foldered_name)
+        sdk_install.install(
+            config.PACKAGE_NAME,
+            foldered_name,
+            config.DEFAULT_TASK_COUNT,
+            additional_options={"service": {"name": foldered_name, "mesos_api_version": "V0"}},
+            timeout_seconds=30 * 60)
+        )
+        config.check_running(foldered_name)
+    finally:
+        sdk_install.uninstall(config.PACKAGE_NAME, foldered_name)
+
+        # reinstall the v1 version for the following tests
+        sdk_install.install(
+            config.PACKAGE_NAME,
+            foldered_name,
+            config.DEFAULT_TASK_COUNT,
+            additional_options={"service": {"name": foldered_name}},
+            timeout_seconds=30 * 60)
+
+
+@pytest.mark.sanity
 def test_endpoints():
     foldered_name = sdk_utils.get_foldered_name(config.SERVICE_NAME)
     # check that we can reach the scheduler via admin router, and that returned endpoints are sanitized:

--- a/frameworks/hdfs/universe/config.json
+++ b/frameworks/hdfs/universe/config.json
@@ -38,7 +38,7 @@
         "mesos_api_version": {
           "description": "Configures the Mesos API version to use. Possible values: V0 (non-HTTP), V1 (HTTP)",
           "type": "string",
-          "default": "V0"
+          "default": "V1"
         },
         "service_account_secret": {
           "description": "Name of the Secret Store credentials to use for DC/OS service authentication. This should be left empty unless service authentication is needed.",

--- a/frameworks/hdfs/universe/marathon.json.mustache
+++ b/frameworks/hdfs/universe/marathon.json.mustache
@@ -66,8 +66,9 @@
 
     {{#service.service_account_secret}}
     "DCOS_SERVICE_ACCOUNT_CREDENTIAL": { "secret": "serviceCredential" },
-    "MESOS_MODULES": "{\"libraries\": [{\"file\": \"libdcos_security.so\", \"modules\": [{\"name\": \"com_mesosphere_dcos_ClassicRPCAuthenticatee\"}]}]}",
+    "MESOS_MODULES": "{\"libraries\":[{\"file\":\"libmesos-bundle\/lib\/mesos\/libdcos_security.so\",\"modules\":[{\"name\": \"com_mesosphere_dcos_ClassicRPCAuthenticatee\"},{\"name\":\"com_mesosphere_dcos_http_Authenticatee\",\"parameters\":[{\"key\":\"jwt_exp_timeout\",\"value\":\"5mins\"},{\"key\":\"preemptive_refresh_duration\",\"value\":\"30mins\"}]}]}]}",
     "MESOS_AUTHENTICATEE": "com_mesosphere_dcos_ClassicRPCAuthenticatee",
+    "MESOS_HTTP_AUTHENTICATEE": "com_mesosphere_dcos_http_Authenticatee",
     {{/service.service_account_secret}}
 
     {{#service.tls.enabled}}

--- a/frameworks/hdfs/universe/marathon.json.mustache
+++ b/frameworks/hdfs/universe/marathon.json.mustache
@@ -52,6 +52,7 @@
     "DATA_DISK_TYPE": "{{data_node.disk_type}}",
     "EXECUTOR_URI": "{{resource.assets.uris.executor-zip}}",
     "LIBMESOS_URI": "{{resource.assets.uris.libmesos-bundle-tar-gz}}",
+    "MESOS_API_VERSION": "{{service.mesos_api_version}}",
     "HDFS_URI": "{{resource.assets.uris.hdfs-tar-gz}}",
     "HDFS_BIN_URI": "{{resource.assets.uris.hdfs-bin-tar-gz}}",
     "HDFS_JAVA_URI": "{{resource.assets.uris.hdfs-jre-tar-gz}}",

--- a/frameworks/helloworld/tests/test_sanity.py
+++ b/frameworks/helloworld/tests/test_sanity.py
@@ -39,24 +39,24 @@ def test_install():
 
 @pytest.mark.sanity
 @pytest.mark.smoke
-@pytest.mark.mesos_v1
-def test_mesos_v1_api():
+@pytest.mark.mesos_v0
+def test_mesos_v0_api():
     try:
         foldered_name = sdk_utils.get_foldered_name(config.SERVICE_NAME)
-        # Install Hello World using the v1 api.
+        # Install Hello World using the v0 api.
         # Then, clean up afterwards.
         sdk_install.uninstall(config.PACKAGE_NAME, foldered_name)
         sdk_install.install(
             config.PACKAGE_NAME,
             foldered_name,
             config.DEFAULT_TASK_COUNT,
-            additional_options={"service": {"name": foldered_name, "mesos_api_version": "V1"}}
+            additional_options={"service": {"name": foldered_name, "mesos_api_version": "V0"}}
         )
         config.check_running(foldered_name)
     finally:
         sdk_install.uninstall(config.PACKAGE_NAME, foldered_name)
 
-        # reinstall the v0 version for the following tests
+        # reinstall the v1 version for the following tests
         sdk_install.install(
             config.PACKAGE_NAME,
             foldered_name,

--- a/frameworks/helloworld/tests/test_sanity.py
+++ b/frameworks/helloworld/tests/test_sanity.py
@@ -37,32 +37,31 @@ def test_install():
     config.check_running(sdk_utils.get_foldered_name(config.SERVICE_NAME))
 
 
-# Note: presently the mesos v1 api does _not_ work in strict mode.
-# As such, we expect this test to fail until it does in fact work in strict mode.
 @pytest.mark.sanity
 @pytest.mark.smoke
 @pytest.mark.mesos_v1
-@pytest.mark.skipif(sdk_utils.is_strict_mode(), reason='v1 API is not yet supported in strict mode')
 def test_mesos_v1_api():
-    foldered_name = sdk_utils.get_foldered_name(config.SERVICE_NAME)
-    # Install Hello World using the v1 api.
-    # Then, clean up afterwards.
-    sdk_install.uninstall(config.PACKAGE_NAME, foldered_name)
-    sdk_install.install(
-        config.PACKAGE_NAME,
-        foldered_name,
-        config.DEFAULT_TASK_COUNT,
-        additional_options={"service": {"name": foldered_name, "mesos_api_version": "V1"}}
-    )
-    config.check_running(foldered_name)
-    sdk_install.uninstall(config.PACKAGE_NAME, foldered_name)
+    try:
+        foldered_name = sdk_utils.get_foldered_name(config.SERVICE_NAME)
+        # Install Hello World using the v1 api.
+        # Then, clean up afterwards.
+        sdk_install.uninstall(config.PACKAGE_NAME, foldered_name)
+        sdk_install.install(
+            config.PACKAGE_NAME,
+            foldered_name,
+            config.DEFAULT_TASK_COUNT,
+            additional_options={"service": {"name": foldered_name, "mesos_api_version": "V1"}}
+        )
+        config.check_running(foldered_name)
+    finally:
+        sdk_install.uninstall(config.PACKAGE_NAME, foldered_name)
 
-    # reinstall the v0 version for the following tests
-    sdk_install.install(
-        config.PACKAGE_NAME,
-        foldered_name,
-        config.DEFAULT_TASK_COUNT,
-        additional_options={"service": {"name": foldered_name}})
+        # reinstall the v0 version for the following tests
+        sdk_install.install(
+            config.PACKAGE_NAME,
+            foldered_name,
+            config.DEFAULT_TASK_COUNT,
+            additional_options={"service": {"name": foldered_name}})
 
 
 @pytest.mark.sanity

--- a/frameworks/helloworld/universe/config.json
+++ b/frameworks/helloworld/universe/config.json
@@ -24,7 +24,7 @@
             "description": "Configures the Mesos API version to use. Possible values: V0 (non-HTTP), V1 (HTTP)",
             "type": "string",
             "enum": ["V0", "V1"],
-            "default": "V0"
+            "default": "V1"
           },
           "test_boolean" : {
             "description": "A boolean value for testing purposes",

--- a/frameworks/helloworld/universe/marathon.json.mustache
+++ b/frameworks/helloworld/universe/marathon.json.mustache
@@ -22,6 +22,7 @@
   },
   {{/service.service_account_secret}}
   "env": {
+    "GLOG_v": "2",
     "PACKAGE_NAME": "{{package-name}}",
     "PACKAGE_VERSION": "{{package-version}}",
     "PACKAGE_BUILD_TIME_EPOCH_MS": "{{package-build-time-epoch-ms}}",

--- a/frameworks/helloworld/universe/marathon.json.mustache
+++ b/frameworks/helloworld/universe/marathon.json.mustache
@@ -55,8 +55,9 @@
     "LIBMESOS_URI": "{{resource.assets.uris.libmesos-bundle-tar-gz}}",
     {{#service.service_account_secret}}
     "DCOS_SERVICE_ACCOUNT_CREDENTIAL": { "secret": "serviceCredential" },
-    "MESOS_MODULES": "{\"libraries\": [{\"file\": \"libdcos_security.so\", \"modules\": [{\"name\": \"com_mesosphere_dcos_ClassicRPCAuthenticatee\"}]}]}",
+    "MESOS_MODULES": "{\"libraries\":[{\"file\":\"libmesos-bundle\/lib\/mesos\/libdcos_security.so\",\"modules\":[{\"name\":\"com_mesosphere_dcos_http_Authenticatee\",\"parameters\":[{\"key\":\"jwt_exp_timeout\",\"value\":\"5mins\"},{\"key\":\"preemptive_refresh_duration\",\"value\":\"30mins\"}]}]}]}",
     "MESOS_AUTHENTICATEE": "com_mesosphere_dcos_ClassicRPCAuthenticatee",
+    "MESOS_HTTP_AUTHENTICATEE": "com_mesosphere_dcos_http_Authenticatee",
     {{/service.service_account_secret}}
     {{#hello.secret1}}
     "HELLO_SECRET1" : "{{hello.secret1}}",

--- a/frameworks/helloworld/universe/marathon.json.mustache
+++ b/frameworks/helloworld/universe/marathon.json.mustache
@@ -56,7 +56,7 @@
     "LIBMESOS_URI": "{{resource.assets.uris.libmesos-bundle-tar-gz}}",
     {{#service.service_account_secret}}
     "DCOS_SERVICE_ACCOUNT_CREDENTIAL": { "secret": "serviceCredential" },
-    "MESOS_MODULES": "{\"libraries\":[{\"file\":\"libmesos-bundle\/lib\/mesos\/libdcos_security.so\",\"modules\":[{\"name\":\"com_mesosphere_dcos_http_Authenticatee\",\"parameters\":[{\"key\":\"jwt_exp_timeout\",\"value\":\"5mins\"},{\"key\":\"preemptive_refresh_duration\",\"value\":\"30mins\"}]}]}]}",
+    "MESOS_MODULES": "{\"libraries\":[{\"file\":\"libmesos-bundle\/lib\/mesos\/libdcos_security.so\",\"modules\":[{\"name\": \"com_mesosphere_dcos_ClassicRPCAuthenticatee\"},{\"name\":\"com_mesosphere_dcos_http_Authenticatee\",\"parameters\":[{\"key\":\"jwt_exp_timeout\",\"value\":\"5mins\"},{\"key\":\"preemptive_refresh_duration\",\"value\":\"30mins\"}]}]}]}",
     "MESOS_AUTHENTICATEE": "com_mesosphere_dcos_ClassicRPCAuthenticatee",
     "MESOS_HTTP_AUTHENTICATEE": "com_mesosphere_dcos_http_Authenticatee",
     {{/service.service_account_secret}}

--- a/frameworks/helloworld/universe/marathon.json.mustache
+++ b/frameworks/helloworld/universe/marathon.json.mustache
@@ -22,7 +22,6 @@
   },
   {{/service.service_account_secret}}
   "env": {
-    "GLOG_v": "2",
     "PACKAGE_NAME": "{{package-name}}",
     "PACKAGE_VERSION": "{{package-version}}",
     "PACKAGE_BUILD_TIME_EPOCH_MS": "{{package-build-time-epoch-ms}}",

--- a/frameworks/kafka/tests/test_sanity.py
+++ b/frameworks/kafka/tests/test_sanity.py
@@ -25,13 +25,13 @@ def install_kafka(use_v0=False):
         sdk_install.install(
             config.PACKAGE_NAME,
             foldered_name,
-            config.DEFAULT_TASK_COUNT,
+            config.DEFAULT_BROKER_COUNT,
             additional_options={"service": {"name": foldered_name, "mesos_api_version": mesos_api_version}})
     else:
         sdk_upgrade.test_upgrade(
             config.PACKAGE_NAME,
             foldered_name,
-            config.DEFAULT_TASK_COUNT,
+            config.DEFAULT_BROKER_COUNT,
             additional_options={"service": {"name": foldered_name, "mesos_api_version": mesos_api_version}, "brokers": {"cpus": 0.5}})
 
 

--- a/frameworks/kafka/tests/test_sanity.py
+++ b/frameworks/kafka/tests/test_sanity.py
@@ -46,6 +46,37 @@ def configure_package(configure_security):
         sdk_install.uninstall(config.PACKAGE_NAME, foldered_name)
 
 
+@pytest.mark.sanity
+@pytest.mark.smoke
+@pytest.mark.mesos_v0
+def test_mesos_v0_api():
+    try:
+        foldered_name = sdk_utils.get_foldered_name(config.SERVICE_NAME)
+        # Install Hello World using the v0 api.
+        # Then, clean up afterwards.
+        sdk_install.uninstall(config.PACKAGE_NAME, foldered_name)
+        sdk_install.install(
+            config.PACKAGE_NAME,
+            foldered_name,
+            config.DEFAULT_TASK_COUNT,
+            additional_options={"service": {"name": foldered_name, "mesos_api_version": "V0"}}
+        )
+        config.check_running(foldered_name)
+    finally:
+        sdk_install.uninstall(config.PACKAGE_NAME, foldered_name)
+
+        # reinstall the v1 version for the following tests
+        sdk_install.install(
+            config.PACKAGE_NAME,
+            foldered_name,
+            config.DEFAULT_TASK_COUNT,
+            additional_options={"service": {"name": foldered_name}})
+
+        # wait for brokers to finish registering before starting tests
+        test_utils.broker_count_check(config.DEFAULT_BROKER_COUNT,
+                                      service_name=foldered_name)
+
+
 # --------- Endpoints -------------
 
 

--- a/frameworks/kafka/tests/test_sanity.py
+++ b/frameworks/kafka/tests/test_sanity.py
@@ -55,12 +55,19 @@ def test_mesos_v0_api():
         # Install Hello World using the v0 api.
         # Then, clean up afterwards.
         sdk_install.uninstall(config.PACKAGE_NAME, foldered_name)
-        sdk_install.install(
-            config.PACKAGE_NAME,
-            foldered_name,
-            config.DEFAULT_TASK_COUNT,
-            additional_options={"service": {"name": foldered_name, "mesos_api_version": "V0"}}
-        )
+        if sdk_utils.dcos_version_less_than("1.9"):
+            # Last beta-kafka release (1.1.25-0.10.1.0-beta) excludes 1.8. Skip upgrade tests with 1.8 and just install
+            sdk_install.install(
+                config.PACKAGE_NAME,
+                foldered_name,
+                config.DEFAULT_TASK_COUNT,
+                additional_options={"service": {"name": foldered_name, "mesos_api_version": "V0"}})
+        else:
+            sdk_upgrade.test_upgrade(
+                config.PACKAGE_NAME,
+                foldered_name,
+                config.DEFAULT_TASK_COUNT,
+                additional_options={"service": {"name": foldered_name, "mesos_api_version": "V0"}, "brokers": {"cpus": 0.5}})
         sdk_tasks.check_running(foldered_name, config.DEFAULT_TASK_COUNT)
     finally:
         sdk_install.uninstall(config.PACKAGE_NAME, foldered_name)

--- a/frameworks/kafka/tests/test_sanity.py
+++ b/frameworks/kafka/tests/test_sanity.py
@@ -48,6 +48,12 @@ def configure_package(configure_security):
 
 @pytest.mark.sanity
 @pytest.mark.smoke
+def test_service_health():
+    assert shakedown.service_healthy(sdk_utils.get_foldered_name(config.SERVICE_NAME))
+
+
+@pytest.mark.sanity
+@pytest.mark.smoke
 @pytest.mark.mesos_v0
 def test_mesos_v0_api():
     try:

--- a/frameworks/kafka/tests/test_sanity.py
+++ b/frameworks/kafka/tests/test_sanity.py
@@ -19,6 +19,7 @@ from tests import config, test_utils
 
 def install_kafka(use_v0=False):
     mesos_api_version = "V0" if use_v0 else "V1"
+    foldered_name = sdk_utils.get_foldered_name(config.SERVICE_NAME)
     if sdk_utils.dcos_version_less_than("1.9"):
         # Last beta-kafka release (1.1.25-0.10.1.0-beta) excludes 1.8. Skip upgrade tests with 1.8 and just install
         sdk_install.install(

--- a/frameworks/kafka/tests/test_sanity.py
+++ b/frameworks/kafka/tests/test_sanity.py
@@ -61,7 +61,7 @@ def test_mesos_v0_api():
             config.DEFAULT_TASK_COUNT,
             additional_options={"service": {"name": foldered_name, "mesos_api_version": "V0"}}
         )
-        config.check_running(foldered_name)
+        sdk_tasks.check_running(foldered_name, config.DEFAULT_TASK_COUNT)
     finally:
         sdk_install.uninstall(config.PACKAGE_NAME, foldered_name)
 

--- a/frameworks/kafka/tests/test_sanity.py
+++ b/frameworks/kafka/tests/test_sanity.py
@@ -17,25 +17,29 @@ import shakedown
 from tests import config, test_utils
 
 
+def install_kafka(use_v0=False):
+    mesos_api_version = if use_v0 then "V0" else "V1"
+    if sdk_utils.dcos_version_less_than("1.9"):
+        # Last beta-kafka release (1.1.25-0.10.1.0-beta) excludes 1.8. Skip upgrade tests with 1.8 and just install
+        sdk_install.install(
+            config.PACKAGE_NAME,
+            foldered_name,
+            config.DEFAULT_TASK_COUNT,
+            additional_options={"service": {"name": foldered_name, "mesos_api_version": mesos_api_version}})
+    else:
+        sdk_upgrade.test_upgrade(
+            config.PACKAGE_NAME,
+            foldered_name,
+            config.DEFAULT_TASK_COUNT,
+            additional_options={"service": {"name": foldered_name, "mesos_api_version": mesos_api_version}, "brokers": {"cpus": 0.5}})
+
+
 @pytest.fixture(scope='module', autouse=True)
 def configure_package(configure_security):
     try:
         foldered_name = sdk_utils.get_foldered_name(config.SERVICE_NAME)
         sdk_install.uninstall(config.PACKAGE_NAME, foldered_name)
-
-        if sdk_utils.dcos_version_less_than("1.9"):
-            # Last beta-kafka release (1.1.25-0.10.1.0-beta) excludes 1.8. Skip upgrade tests with 1.8 and just install
-            sdk_install.install(
-                config.PACKAGE_NAME,
-                foldered_name,
-                config.DEFAULT_BROKER_COUNT,
-                additional_options={"service": {"name": foldered_name}})
-        else:
-            sdk_upgrade.test_upgrade(
-                config.PACKAGE_NAME,
-                foldered_name,
-                config.DEFAULT_BROKER_COUNT,
-                additional_options={"service": {"name": foldered_name}, "brokers": {"cpus": 0.5}})
+        install_kafka()
 
         # wait for brokers to finish registering before starting tests
         test_utils.broker_count_check(config.DEFAULT_BROKER_COUNT,
@@ -61,30 +65,13 @@ def test_mesos_v0_api():
         # Install Hello World using the v0 api.
         # Then, clean up afterwards.
         sdk_install.uninstall(config.PACKAGE_NAME, foldered_name)
-        if sdk_utils.dcos_version_less_than("1.9"):
-            # Last beta-kafka release (1.1.25-0.10.1.0-beta) excludes 1.8. Skip upgrade tests with 1.8 and just install
-            sdk_install.install(
-                config.PACKAGE_NAME,
-                foldered_name,
-                config.DEFAULT_TASK_COUNT,
-                additional_options={"service": {"name": foldered_name, "mesos_api_version": "V0"}})
-        else:
-            sdk_upgrade.test_upgrade(
-                config.PACKAGE_NAME,
-                foldered_name,
-                config.DEFAULT_TASK_COUNT,
-                additional_options={"service": {"name": foldered_name, "mesos_api_version": "V0"}, "brokers": {"cpus": 0.5}})
+        install_kafka(use_v0=True)
+
         sdk_tasks.check_running(foldered_name, config.DEFAULT_TASK_COUNT)
     finally:
         sdk_install.uninstall(config.PACKAGE_NAME, foldered_name)
 
-        # reinstall the v1 version for the following tests
-        sdk_install.install(
-            config.PACKAGE_NAME,
-            foldered_name,
-            config.DEFAULT_TASK_COUNT,
-            additional_options={"service": {"name": foldered_name}})
-
+        install_kafka()
         # wait for brokers to finish registering before starting tests
         test_utils.broker_count_check(config.DEFAULT_BROKER_COUNT,
                                       service_name=foldered_name)

--- a/frameworks/kafka/tests/test_sanity.py
+++ b/frameworks/kafka/tests/test_sanity.py
@@ -68,7 +68,7 @@ def test_mesos_v0_api():
         sdk_install.uninstall(config.PACKAGE_NAME, foldered_name)
         install_kafka(use_v0=True)
 
-        sdk_tasks.check_running(foldered_name, config.DEFAULT_TASK_COUNT)
+        sdk_tasks.check_running(foldered_name, config.DEFAULT_BROKER_COUNT)
     finally:
         sdk_install.uninstall(config.PACKAGE_NAME, foldered_name)
 

--- a/frameworks/kafka/tests/test_sanity.py
+++ b/frameworks/kafka/tests/test_sanity.py
@@ -19,7 +19,6 @@ from tests import config, test_utils
 
 def install_kafka(use_v0=False):
     mesos_api_version = "V0" if use_v0 else "V1"
-    foldered_name = sdk_utils.get_foldered_name(config.SERVICE_NAME)
     if sdk_utils.dcos_version_less_than("1.9"):
         # Last beta-kafka release (1.1.25-0.10.1.0-beta) excludes 1.8. Skip upgrade tests with 1.8 and just install
         sdk_install.install(
@@ -295,8 +294,6 @@ def test_no_unavailable_partitions_exist():
         config.PACKAGE_NAME, sdk_utils.get_foldered_name(config.SERVICE_NAME),
         'topic unavailable_partitions', json=True)
 
-    assert len(partition_info) == 1
-    assert partition_info['message'] == ''
 
 
 # --------- CLI -------------

--- a/frameworks/kafka/tests/test_sanity.py
+++ b/frameworks/kafka/tests/test_sanity.py
@@ -18,7 +18,7 @@ from tests import config, test_utils
 
 
 def install_kafka(use_v0=False):
-    mesos_api_version = if use_v0 then "V0" else "V1"
+    mesos_api_version = "V0" if use_v0 else "V1"
     if sdk_utils.dcos_version_less_than("1.9"):
         # Last beta-kafka release (1.1.25-0.10.1.0-beta) excludes 1.8. Skip upgrade tests with 1.8 and just install
         sdk_install.install(

--- a/frameworks/kafka/universe/config.json
+++ b/frameworks/kafka/universe/config.json
@@ -13,7 +13,7 @@
           "mesos_api_version" : {
             "description": "Configures the Mesos API version to use. Possible values: V0 (non-HTTP), V1 (HTTP)",
             "type": "string",
-            "default": "V0"
+            "default": "V1"
           },
           "user": {
             "type": "string",

--- a/frameworks/kafka/universe/marathon.json.mustache
+++ b/frameworks/kafka/universe/marathon.json.mustache
@@ -54,8 +54,9 @@
 
     {{#service.service_account_secret}}
     "DCOS_SERVICE_ACCOUNT_CREDENTIAL": { "secret": "serviceCredential" },
-    "MESOS_MODULES": "{\"libraries\": [{\"file\": \"libdcos_security.so\", \"modules\": [{\"name\": \"com_mesosphere_dcos_ClassicRPCAuthenticatee\"}]}]}",
+    "MESOS_MODULES": "{\"libraries\":[{\"file\":\"libmesos-bundle\/lib\/mesos\/libdcos_security.so\",\"modules\":[{\"name\": \"com_mesosphere_dcos_ClassicRPCAuthenticatee\"},{\"name\":\"com_mesosphere_dcos_http_Authenticatee\",\"parameters\":[{\"key\":\"jwt_exp_timeout\",\"value\":\"5mins\"},{\"key\":\"preemptive_refresh_duration\",\"value\":\"30mins\"}]}]}]}",
     "MESOS_AUTHENTICATEE": "com_mesosphere_dcos_ClassicRPCAuthenticatee",
+    "MESOS_HTTP_AUTHENTICATEE": "com_mesosphere_dcos_http_Authenticatee",
     {{/service.service_account_secret}}
 
     {{#service.virtual_network_enabled}}

--- a/frameworks/template/universe/config.json
+++ b/frameworks/template/universe/config.json
@@ -22,6 +22,12 @@
             "type": "string",
             "default": "root"
           },
+          "mesos_api_version": {
+            "description": "Configures the Mesos API version to use. Possible values: V0 (non-HTTP), V1 (HTTP)",
+            "type": "string",
+            "enum": ["V0", "V1"],
+            "default": "V1"
+          },
           "service_account": {
             "description": "The service account for DC/OS service authentication. This is typically left empty to use the default unless service authentication is needed. The value given here is passed as the principal of Mesos framework.",
             "type": "string",

--- a/frameworks/template/universe/marathon.json.mustache
+++ b/frameworks/template/universe/marathon.json.mustache
@@ -31,6 +31,7 @@
     "FRAMEWORK_USER": "{{service.user}}",
     "FRAMEWORK_PRINCIPAL": "{{service.service_account}}",
     "FRAMEWORK_LOG_LEVEL": "{{service.log_level}}",
+    "MESOS_API_VERSION": "{{service.mesos_api_version}}",
 
     "NODE_COUNT": "{{node.count}}",
     "NODE_PLACEMENT": "{{node.placement_constraint}}",
@@ -49,8 +50,9 @@
     "BOOTSTRAP_URI": "{{resource.assets.uris.bootstrap-zip}}",
     {{#service.service_account_secret}}
     "DCOS_SERVICE_ACCOUNT_CREDENTIAL": { "secret": "serviceCredential" },
-    "MESOS_MODULES": "{\"libraries\": [{\"file\": \"libdcos_security.so\", \"modules\": [{\"name\": \"com_mesosphere_dcos_ClassicRPCAuthenticatee\"}]}]}",
+    "MESOS_MODULES": "{\"libraries\":[{\"file\":\"libmesos-bundle\/lib\/mesos\/libdcos_security.so\",\"modules\":[{\"name\": \"com_mesosphere_dcos_ClassicRPCAuthenticatee\"},{\"name\":\"com_mesosphere_dcos_http_Authenticatee\",\"parameters\":[{\"key\":\"jwt_exp_timeout\",\"value\":\"5mins\"},{\"key\":\"preemptive_refresh_duration\",\"value\":\"30mins\"}]}]}]}",
     "MESOS_AUTHENTICATEE": "com_mesosphere_dcos_ClassicRPCAuthenticatee",
+    "MESOS_HTTP_AUTHENTICATEE": "com_mesosphere_dcos_http_Authenticatee",
     {{/service.service_account_secret}}
     "LIBMESOS_URI": "{{resource.assets.uris.libmesos-bundle-tar-gz}}"
   },

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/dcos/Capabilities.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/dcos/Capabilities.java
@@ -95,7 +95,7 @@ public class Capabilities {
         return hasOrExceedsVersion(1, 10);
     }
 
-    public boolean supportsStrictModeV1API() {
+    public boolean supportsV1APIByDefault() {
         // The Mesos V1 HTTP API with strict mode enabled is supported by DC/OS 1.11 upwards
         return hasOrExceedsVersion(1, 11);
     }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/dcos/Capabilities.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/dcos/Capabilities.java
@@ -95,6 +95,11 @@ public class Capabilities {
         return hasOrExceedsVersion(1, 10);
     }
 
+    public boolean supportsStrictModeV1API() {
+        // The Mesos V1 HTTP API with strict mode enabled is supported by DC/OS 1.11 upwards
+        return hasOrExceedsVersion(1, 11);
+    }
+
     private boolean hasOrExceedsVersion(int major, int minor) {
         DcosVersion.Elements versionElements = dcosVersion.getElements();
         try {

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerConfig.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerConfig.java
@@ -143,6 +143,11 @@ public class SchedulerConfig {
     private static String STATSD_UDP_PORT_ENV = "STATSD_UDP_PORT";
 
     /**
+     * Environment variables for configuring Mesos API version.
+     */
+    private static String MESOS_API_VERSION_ENV = "MESOS_API_VERSION";
+
+    /**
      * Environment variables for configuring goal state override behavior.
      */
     private static final String PAUSE_OVERRIDE_CMD_ENV = "PAUSE_OVERRIDE_CMD";
@@ -311,6 +316,13 @@ public class SchedulerConfig {
      */
     public int getStatsdPort() {
         return envStore.getRequiredInt(STATSD_UDP_PORT_ENV);
+    }
+
+    /**
+     * Returns the Mesos API version.
+     */
+    public String getMesosApiVersion() {
+        return envStore.getRequired(MESOS_API_VERSION_ENV);
     }
 
     /**

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerDriverFactory.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerDriverFactory.java
@@ -110,13 +110,11 @@ public class SchedulerDriverFactory {
                         LOGGER.warn(
                                 "Current DC/OS cluster doesn't support the Mesos V1 API in strict mode. Using V0...");
                     }
-                    return credential == null ?
-                            new V0Mesos(this, EvolverDevolver.evolve(frameworkInfo), masterUrl) :
-                            new V0Mesos(
-                                    this,
-                                    EvolverDevolver.evolve(frameworkInfo),
-                                    masterUrl,
-                                    EvolverDevolver.evolve(credential));
+                    return new V0Mesos(
+                            this,
+                            EvolverDevolver.evolve(frameworkInfo),
+                            masterUrl,
+                            EvolverDevolver.evolve(credential));
                 }
             };
         }
@@ -134,13 +132,7 @@ public class SchedulerDriverFactory {
                     LOGGER.warn(
                             "Current DC/OS cluster doesn't support the Mesos V1 API in strict mode. Using V0...");
                 }
-                return credential == null ?
-                        new V0Mesos(this, EvolverDevolver.evolve(frameworkInfo), masterUrl) :
-                        new V0Mesos(
-                                this,
-                                EvolverDevolver.evolve(frameworkInfo),
-                                masterUrl,
-                                EvolverDevolver.evolve(credential));
+                return new V0Mesos(this, EvolverDevolver.evolve(frameworkInfo), masterUrl);
             }
         };
     }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerDriverFactory.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerDriverFactory.java
@@ -86,7 +86,7 @@ public class SchedulerDriverFactory {
                     scheduler, TextFormat.shortDebugString(frameworkInfo), masterUrl);
             credential = null;
         }
-        return createInternal(scheduler, frameworkInfo, masterUrl, credential);
+        return createInternal(scheduler, frameworkInfo, masterUrl, credential, schedulerConfig.getMesosApiVersion());
     }
 
     /**
@@ -96,17 +96,18 @@ public class SchedulerDriverFactory {
             final Scheduler scheduler,
             final FrameworkInfo frameworkInfo,
             final String masterUrl,
-            final Credential credential) {
+            final Credential credential,
+            final String mesosAPIVersion) {
         Capabilities capabilities = Capabilities.getInstance();
         if (credential != null) {
             return new MesosToSchedulerDriverAdapter(scheduler, frameworkInfo, masterUrl, true, credential) {
                 @Override
                 protected Mesos startInternal() {
-                    if (capabilities.supportsStrictModeV1API()) {
+                    if (capabilities.supportsV1APIByDefault()) {
                         return super.startInternal();
                     }
 
-                    if (System.getenv("MESOS_API_VERSION").equals("V1")) {
+                    if (mesosAPIVersion.equals("V1")) {
                         LOGGER.warn(
                                 "Current DC/OS cluster doesn't support the Mesos V1 API in strict mode. Using V0...");
                     }
@@ -124,11 +125,11 @@ public class SchedulerDriverFactory {
         return new MesosToSchedulerDriverAdapter(scheduler, frameworkInfo, masterUrl, true) {
             @Override
             protected Mesos startInternal() {
-                if (capabilities.supportsStrictModeV1API()) {
+                if (capabilities.supportsV1APIByDefault()) {
                     return super.startInternal();
                 }
 
-                if (System.getenv("MESOS_API_VERSION").equals("V1")) {
+                if (mesosAPIVersion.equals("V1")) {
                     LOGGER.warn(
                             "Current DC/OS cluster doesn't support the Mesos V1 API in strict mode. Using V0...");
                 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerDriverFactory.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerDriverFactory.java
@@ -3,12 +3,16 @@ package com.mesosphere.sdk.scheduler;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.TextFormat;
 import com.mesosphere.mesos.HTTPAdapter.MesosToSchedulerDriverAdapter;
+import com.mesosphere.mesos.protobuf.EvolverDevolver;
+import com.mesosphere.sdk.dcos.Capabilities;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.mesos.MesosSchedulerDriver;
 import org.apache.mesos.Protos.Credential;
 import org.apache.mesos.Protos.FrameworkInfo;
 import org.apache.mesos.Scheduler;
 import org.apache.mesos.SchedulerDriver;
+import org.apache.mesos.v1.scheduler.Mesos;
+import org.apache.mesos.v1.scheduler.V0Mesos;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -93,11 +97,52 @@ public class SchedulerDriverFactory {
             final FrameworkInfo frameworkInfo,
             final String masterUrl,
             final Credential credential) {
-        if (credential == null) {
-            return new MesosToSchedulerDriverAdapter(scheduler, frameworkInfo, masterUrl, true);
-        } else {
-            return new MesosToSchedulerDriverAdapter(scheduler, frameworkInfo, masterUrl, true, credential);
+        Capabilities capabilities = Capabilities.getInstance();
+        if (credential != null) {
+            return new MesosToSchedulerDriverAdapter(scheduler, frameworkInfo, masterUrl, true, credential) {
+                @Override
+                protected Mesos startInternal() {
+                    if (capabilities.supportsStrictModeV1API()) {
+                        return super.startInternal();
+                    }
+
+                    if (System.getenv("MESOS_API_VERSION").equals("V1")) {
+                        LOGGER.warn(
+                                "Current DC/OS cluster doesn't support the Mesos V1 API in strict mode. Using V0...");
+                    }
+                    return credential == null ?
+                            new V0Mesos(this, EvolverDevolver.evolve(frameworkInfo), masterUrl) :
+                            new V0Mesos(
+                                    this,
+                                    EvolverDevolver.evolve(frameworkInfo),
+                                    masterUrl,
+                                    EvolverDevolver.evolve(credential));
+                }
+            };
         }
+
+        // Love too work around the fact that the MesosToSchedulerDriverAdapter both depends directly on the
+        // process environment *and* uses two unrelated constructors for the case of credential being null
+        return new MesosToSchedulerDriverAdapter(scheduler, frameworkInfo, masterUrl, true) {
+            @Override
+            protected Mesos startInternal() {
+                if (capabilities.supportsStrictModeV1API()) {
+                    return super.startInternal();
+                }
+
+                if (System.getenv("MESOS_API_VERSION").equals("V1")) {
+                    LOGGER.warn(
+                            "Current DC/OS cluster doesn't support the Mesos V1 API in strict mode. Using V0...");
+                }
+                return credential == null ?
+                        new V0Mesos(this, EvolverDevolver.evolve(frameworkInfo), masterUrl) :
+                        new V0Mesos(
+                                this,
+                                EvolverDevolver.evolve(frameworkInfo),
+                                masterUrl,
+                                EvolverDevolver.evolve(credential));
+            }
+        };
     }
 
     /**

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/dcos/CapabilitiesTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/dcos/CapabilitiesTest.java
@@ -81,6 +81,8 @@ public class CapabilitiesTest {
         Assert.assertTrue(capabilities.supportsEnvBasedSecretsDirectiveLabel());
         Assert.assertTrue(capabilities.supportsEnvBasedSecretsProtobuf());
         Assert.assertTrue(capabilities.supportsFileBasedSecrets());
+
+        Assert.assertFalse(capabilities.supportsV1APIByDefault());
     }
 
     @Test
@@ -93,6 +95,8 @@ public class CapabilitiesTest {
         Assert.assertTrue(capabilities.supportsEnvBasedSecretsDirectiveLabel());
         Assert.assertTrue(capabilities.supportsEnvBasedSecretsProtobuf());
         Assert.assertTrue(capabilities.supportsFileBasedSecrets());
+
+        Assert.assertFalse(capabilities.supportsV1APIByDefault());
     }
 
     @Test
@@ -106,7 +110,7 @@ public class CapabilitiesTest {
         Assert.assertTrue(capabilities.supportsEnvBasedSecretsProtobuf());
         Assert.assertTrue(capabilities.supportsFileBasedSecrets());
 
-        Assert.assertTrue(capabilities.supportsStrictModeV1API());
+        Assert.assertTrue(capabilities.supportsV1APIByDefault());
     }
 
     @Test
@@ -120,7 +124,7 @@ public class CapabilitiesTest {
         Assert.assertTrue(capabilities.supportsEnvBasedSecretsProtobuf());
         Assert.assertTrue(capabilities.supportsFileBasedSecrets());
 
-        Assert.assertTrue(capabilities.supportsStrictModeV1API());
+        Assert.assertTrue(capabilities.supportsV1APIByDefault());
     }
 
     @Test

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/dcos/CapabilitiesTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/dcos/CapabilitiesTest.java
@@ -96,6 +96,34 @@ public class CapabilitiesTest {
     }
 
     @Test
+    public void test_1110() throws IOException {
+        Capabilities capabilities = testCapabilities("1.11.0");
+        Assert.assertTrue(capabilities.supportsNamedVips());
+        Assert.assertTrue(capabilities.supportsGpuResource());
+        Assert.assertTrue(capabilities.supportsRLimits());
+        // Secrets
+        Assert.assertTrue(capabilities.supportsEnvBasedSecretsDirectiveLabel());
+        Assert.assertTrue(capabilities.supportsEnvBasedSecretsProtobuf());
+        Assert.assertTrue(capabilities.supportsFileBasedSecrets());
+
+        Assert.assertTrue(capabilities.supportsStrictModeV1API());
+    }
+
+    @Test
+    public void test_111dev() throws IOException {
+        Capabilities capabilities = testCapabilities("1.11-dev");
+        Assert.assertTrue(capabilities.supportsNamedVips());
+        Assert.assertTrue(capabilities.supportsGpuResource());
+        Assert.assertTrue(capabilities.supportsRLimits());
+        // Secrets
+        Assert.assertTrue(capabilities.supportsEnvBasedSecretsDirectiveLabel());
+        Assert.assertTrue(capabilities.supportsEnvBasedSecretsProtobuf());
+        Assert.assertTrue(capabilities.supportsFileBasedSecrets());
+
+        Assert.assertTrue(capabilities.supportsStrictModeV1API());
+    }
+
+    @Test
     public void test_200() throws IOException {
         Capabilities capabilities = testCapabilities("2.0.0");
         Assert.assertTrue(capabilities.supportsNamedVips());

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/SchedulerDriverFactoryTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/SchedulerDriverFactoryTest.java
@@ -159,7 +159,8 @@ public class SchedulerDriverFactoryTest {
                 final Scheduler scheduler,
                 final FrameworkInfo frameworkInfo,
                 final String masterUrl,
-                final Credential credential) {
+                final Credential credential,
+                final String mesosAPIVersion) {
             createCalls++;
             if (credential != null) {
                 lastCallHadCredential = true;

--- a/tools/universe/package_builder.py
+++ b/tools/universe/package_builder.py
@@ -17,7 +17,7 @@ logging.basicConfig(level=logging.DEBUG, format="%(message)s")
 
 _jre_url = 'https://downloads.mesosphere.com/java/jre-8u144-linux-x64.tar.gz'
 _jre_jce_unlimited_url = 'https://downloads.mesosphere.com/java/jre-8u131-linux-x64-jce-unlimited.tar.gz'
-_libmesos_bundle_url = 'https://downloads.mesosphere.io/libmesos-bundle/libmesos-bundle-1.10-1.4-63e0814.tar.gz'
+_libmesos_bundle_url = 'https://downloads.mesosphere.io/libmesos-bundle/libmesos-bundle-master-28f8827.tar.gz'
 
 _docs_root = "https://docs.mesosphere.com"
 

--- a/tools/universe/package_builder.py
+++ b/tools/universe/package_builder.py
@@ -17,7 +17,7 @@ logging.basicConfig(level=logging.DEBUG, format="%(message)s")
 
 _jre_url = 'https://downloads.mesosphere.com/java/jre-8u144-linux-x64.tar.gz'
 _jre_jce_unlimited_url = 'https://downloads.mesosphere.com/java/jre-8u131-linux-x64-jce-unlimited.tar.gz'
-_libmesos_bundle_url = 'https://downloads.mesosphere.io/libmesos-bundle/libmesos-bundle-master-28f8827.tar.gz'
+_libmesos_bundle_url = 'https://downloads.mesosphere.io/libmesos-bundle/libmesos-bundle-1.10.1.tar.gz'
 
 _docs_root = "https://docs.mesosphere.com"
 


### PR DESCRIPTION
This is based off of @elezar 's change, will rebase once that's done and then actually move each `config.json` over to use `V1` as the default value for `service.mesos_api_version`.