### PR TITLE
[INFINITY-2673] kerberos for zookeeper

### DIFF
--- a/frameworks/kafka/docs/kerberos.md
+++ b/frameworks/kafka/docs/kerberos.md
@@ -1,224 +1,98 @@
-# Setting up Kafka with Kerberos
+# Setting up Apache Kafka with Kerberos
 
-Still TODO:
-1. We need a better way to get the Keytab into the clients
+## Create principals
 
-## Deploy KDC
-Create a file (e.g. `kafka-principals.txt`) contiaining a list of principals required for Kafka. For example:
+In order to run Apache Kafka with Kerberos security enabled, a principal needs to be added for every broker in the cluster. For example, a three node cluster with the default service primary (`service.security.kerberos.primary`) of `kafka` will require to following principals:
 ```
-kafka/kafka-0-broker.secure-kafka.autoip.dcos.thisdcos.directory@LOCAL
-kafka/kafka-1-broker.secure-kafka.autoip.dcos.thisdcos.directory@LOCAL
-kafka/kafka-2-broker.secure-kafka.autoip.dcos.thisdcos.directory@LOCAL
-client@LOCAL
+kafka/kafka-0-broker.kafka.autoip.dcos.thisdcos.directory@LOCAL
+kafka/kafka-1-broker.kafka.autoip.dcos.thisdcos.directory@LOCAL
+kafka/kafka-2-broker.kafka.autoip.dcos.thisdcos.directory@LOCAL
 ```
+(assuming a default service name of `kafka`)
 
-Note that this assumes that `kafka` will be deployed with 3 brokers and with as service name of `secure-kafka`. An additional principal `client@LOCAL` has also been added for client authentication.
+## Create the keytab secret
 
-Run the KDC utility to setup the KDC (this assume that you're in the `dcos-commons` root folder):
+Once the principals have been created, a keytab file must be generated and uploaded to the DC/OS secret store as a base-64-encoded value. Assuming the keytab for **all** the Kafka principals has been created as a file `keytab`, this can be added to the secret store as follows (note that the DC/OS Enterprise CLI needs to be installed to gain access to the `security` command):
 ```bash
-$ PYTHONPATH=testing ./tools/kdc.py deploy kafka-principals.txt
+$ base64 -w keytab > keytab.base64
+$ dcos security secrets create  __dcos_base64__keytab --value-file keytab.base64
 ```
-(where `kafka-principals.txt` is the file created in the first step)
 
-*Note:* this assumes that the environement is set up to be able to run the SDK integration test suite. If this is not the case, the `./test.sh -i` interactive mode can be used.
+The name of the secret created (`__dcos_base64__keytab`) can be changed, as long as the `__dcos__base64__` prefix is maintained.
 
-This performs the following actions:
-1. Deploys a KDC Marathon application named `kdc`
-1. Adds the principals in `kafka-principals.txt` to the KDC store
-1. Saves the generated keytab as the DC/OS secret `__dcos_base64___keytab`
-
-## Deploy Kerberized kafka
+## Deploy kerberized Kafka
 
 Create the following `kerberos-options.json` file:
 ```json
 {
     "service": {
-        "name": "secure-kafka",
+        "name": "kafka",
         "security": {
             "kerberos": {
                 "enabled": true,
                 "kdc_host_name": "kdc.marathon.autoip.dcos.thisdcos.directory",
                 "kdc_host_port": 2500,
-                "keytab_secret": "__dcos_base64___keytab"
+                "keytab_secret": "__dcos_base64__keytab"
             }
         }
     }
 }
 ```
-(Here `kdc.marathon.autoip.dcos.thisdcos.directory` and `2500` are the IP and port of the KDC Marathon app)
+Note the specification of the secret name as created in the previous step.
 
-and deploy Apache Kafka:
+The kerberized Apache Kafka service is then deployed by running:
 ```bash
-$ dcos package install beta-kafka --yes --options=kerberos-options.json
+$ dcos package install kafka --options=kerberos-options.json
 ```
 
-This should show the Kafka tasks starting up:
-```bash
-$ dcos task
-NAME            HOST         USER   STATE  ID                                                    MESOS ID
-kafka-0-broker  10.0.3.129  nobody    R    kafka-0-broker__6cd0d1fe-c72f-4725-aebe-0e88e9ec74ed  83acb270-f32a-408a-9548-26b0d2f2b95f-S2
-kafka-1-broker  10.0.2.202  nobody    R    kafka-1-broker__1bbd14aa-5b66-435a-9d11-1777bb80c88a  83acb270-f32a-408a-9548-26b0d2f2b95f-S1
-kafka-2-broker  10.0.2.91   nobody    R    kafka-2-broker__a2975665-a21d-4882-99f5-80da5b55d1a6  83acb270-f32a-408a-9548-26b0d2f2b95f-S4
-kdc             10.0.0.245   root     R    kdc.0128cb11-c3ef-11e7-821b-7e246f9e43a9              83acb270-f32a-408a-9548-26b0d2f2b95f-S3
-secure-kafka    10.0.0.145   root     R    secure-kafka.53b7ef94-c3f0-11e7-821b-7e246f9e43a9     83acb270-f32a-408a-9548-26b0d2f2b95f-S0
-```
-and show the logs:
-```bash
-$ dcos task log kafka-0
-[2017-11-07 19:18:41,149] INFO Successfully authenticated client: authenticationID=kafka/kafka-0-broker.secure-kafka.autoip.dcos.thisdcos.directory@LOCAL; authorizationID=kafka/kafka-0-broker.secure-kafka.autoip.dcos.thisdcos.directory@LOCAL. (org.apache.kafka.common.security.authenticator.SaslServerCallbackHandler)
-[2017-11-07 19:18:41,188] INFO Setting authorizedID: kafka (org.apache.kafka.common.security.authenticator.SaslServerCallbackHandler)
-```
+## Deploy with kerberized ZooKeeper
 
-## Testing with a Kerberized client
+If a kerberized `kafka-zookeeper` ensemble is available for use with this Apache Kafka cluster, the authentication between Kafka and ZooKeeper can also be secured using Kerberos.
 
-### Using the pre-built client
-Starting a Marathon app with the following definition:
+In order to determine the endpoints for the ZooKeeper ensemble, the following command can be used:
+```bash
+$ dcos kafka-zookeeper endpoint clientport
+```
+resulting in output resembling:
 ```json
 {
-    "id": "kafka-producer",
-    "mem": 512,
-    "user": "nobody",
-    "container": {
-        "type": "MESOS",
-        "docker": {
-            "image": "elezar/kafka-client:latest",
-            "forcePullImage": true
-        },
-        "volumes": [
-            {
-                "containerPath": "/tmp/kafkaconfig/kafka-client.keytab",
-                "secret": "kafka_keytab"
+  "address": [
+    "10.0.0.49:1140",
+    "10.0.2.253:1140",
+    "10.0.1.27:1140"
+  ],
+  "dns": [
+    "zookeeper-0-server.kafka-zookeeper.autoip.dcos.thisdcos.directory:1140",
+    "zookeeper-1-server.kafka-zookeeper.autoip.dcos.thisdcos.directory:1140",
+    "zookeeper-2-server.kafka-zookeeper.autoip.dcos.thisdcos.directory:1140"
+  ]
+}
+```
+
+Create a `kerberos-zookeeper-options.json` file with the following contents:
+```json
+{
+    "service": {
+        "name": "kafka",
+        "security": {
+            "kerberos": {
+                "enabled": true,
+                "enabled_for_zookeeper": true,
+                "kdc_host_name": "kdc.marathon.autoip.dcos.thisdcos.directory",
+                "kdc_host_port": 2500,
+                "keytab_secret": "__dcos_base64__keytab"
             }
-        ]
-    },
-    "secrets": {
-        "kafka_keytab": {
-            "source": "__dcos_base64___keytab"
         }
+
     },
-    "networks": [
-        {
-            "mode": "host"
-        }
-    ],
-    "env": {
-        "JVM_MaxHeapSize": "512",
-        "KAFKA_CLIENT_MODE": "producer"
+    "kafka": {
+        "kafka_zookeeper_uri": "zookeeper-0-server.kafka-zookeeper.autoip.dcos.thisdcos.directory:1140,zookeeper-1-server.kafka-zookeeper.autoip.dcos.thisdcos.directory:1140,zookeeper-2-server.kafka-zookeeper.autoip.dcos.thisdcos.directory:1140"
     }
 }
 ```
-Will start a Kafka console producer which publishes a message on the `securetest` topic every 10 seconds.
+Note that `service.security.enabled_for_zookeeper` is now set to true and that `kafka.kafka_zookeeper_uri` is set to the `"dns"` output of the `dcos kafka-zookeeper endpoint clientport` command.
 
-Running:
+Kerberized Kafka can then be deployed as follows:
 ```bash
-$ dcos task log kafka-producer
-```
-should show the messages being written to the topic.
-
-Changing the `KAFAK_CLIENT_MODE` environment variable to `consumer` (and adjusting the name accordingly) will start a Kafka console consumer subscribed to the same `securetest` topic.
-
-### Building your own client
-In order to configure a Kerberized Kafka client, three things are needed:
-1. The Kerberos keytab as a file `kafka-client.keytab` (This can be downloaded from the KDC application)
-1. A file `client-jaas.conf` containing:
-    ```
-    KafkaClient {
-        com.sun.security.auth.module.Krb5LoginModule required
-        doNotPrompt=true
-        useTicketCache=true
-        principal="client@LOCAL"
-        useKeyTab=true
-        serviceName="kafka"
-        keyTab="/tmp/kafkaconfig/kafka-client.keytab"
-        client=true;
-    };
-    ```
-1. A file `krb5.conf` containing (TODO: This could be simplified):
-    ```
-    [logging]
-        default = STDERR
-        kdc = STDERR
-        admin_server = STDERR
-
-    [libdefaults]
-        default_realm = LOCAL
-        dns_lookup_realm = false
-        dns_lookup_kdc = false
-        ticket_lifetime = 24h
-        renew_lifetime = 7d
-        forwardable = true
-
-    [realms]
-        LOCAL = {
-            kdc = kdc.marathon.autoip.dcos.thisdcos.directory:2500
-        }
-
-    [domain_realm]
-        .secure-kafka.autoip.dcos.thisdcos.directory = LOCAL
-        secure-kafka.autoip.dcos.thisdcos.directory = LOCAL
-    ```
-1. A file `client.properties` containing:
-    ```
-    security.protocol=SASL_PLAINTEXT
-    sasl.mechanism=GSSAPI
-    sasl.kerberos.service.name=kafka
-    ```
-
-For these examples, it is assumed that these files are in the folder `/tmp/kafkaconfig` on one of the nodes of the DC/OS cluster and that we have connected to the node as follows:
-```bash
-$ dcos node ssh --master-proxy --mesos-id=83acb270-f32a-408a-9548-26b0d2f2b95f-S4
-```
-
-### Download the JCE:
-```bash
-$ cd /tmp/kafkaconfig && \
-    wget https://downloads.mesosphere.com/java/jre-8u131-linux-x64-jce-unlimited.tar.gz && \
-    tar -xzvf jre-8u131-linux-x64-jce-unlimited.tar.gz && \
-    rm jre-8u131-linux-x64-jce-unlimited.tar.gz
-```
-
-### Launch a Docker container containing the Confluent Kafka Client:
-```bash
-$ docker run --rm -ti \
-    -v /tmp/kafkaconfig:/tmp/kafkaconfig:ro \
-    -e KAFKA_OPTS="-Djava.security.auth.login.config=/tmp/kafkaconfig/client-jaas.conf -Djava.security.krb5.conf=/tmp/kafkaconfig/krb5.conf -Dsun.security.krb5.debug=true" \
-    -e JAVA_HOME="/tmp/kafkaconfig/jre1.8.0_131 \
-    confluentinc/cp-kafka:3.3.0 \
-    bash
-```
-Note that we set the JAAS config as well as the Kerberos Java options to point to the files that were created in the previous step.
-
-### Run the Kafka producer:
-```bash
-$ echo "This is a secure test at $(date)" | kafka-console-producer --broker-list kafka-0-broker.secure-kafka.autoip.dcos.thisdcos.directory:1025,kafka-1-broker.secure-kafka.autoip.dcos.thisdcos.directory:1025,kafka-2-broker.secure-kafka.autoip.dcos.thisdcos.directory:1025 \
-    --topic securetest \
-    --producer.config /tmp/kafkaconfig/client.properties
-```
-
-### Run the Kafa consumer:
-```bash
-$ kafka-console-consumer --bootstrap-server kafka-0-broker.secure-kafka.autoip.dcos.thisdcos.directory:1025 \
-    --topic securetest --from-beginning \
-    --consumer.config /tmp/kafkaconfig/client.properties
-```
-
-
-# TODO: Document raw instructions:
-
-Which assumes that kdc is running on the host `10.0.0.95`. It also assumes that the keytab for the brokers has been generated and the secret added as follows:
-```bash
-$ dcos task exec kdc /usr/sbin/kadmin -l add --use-defaults --random-password kafka/kafka-0-broker.secure-kafka.autoip.dcos.thisdcos.directory@LOCAL kafka/kafka-1-broker.secure-kafka.autoip.dcos.thisdcos.directory@LOCAL kafka/kafka-1-broker.secure-kafka.autoip.dcos.thisdcos.directory@LOCAL
-```
-```bash
-$ dcos task exec kdc /usr/sbin/kadmin -l ext -k kafka.keytab kafka/kafka-0-broker.secure-kafka.autoip.dcos.thisdcos.directory@LOCAL kafka/kafka-1-broker.secure-kafka.autoip.dcos.thisdcos.directory@LOCAL kafka/kafka-2-broker.secure-kafka.autoip.dcos.thisdcos.directory@LOCAL
-```
-
-* Download the keytab file
-
-```bash
-$ base64 -w 0 kafka.keytab > kafka.keytab.base64
-```
-
-```bash
-$ dcos security secrets create __dcos_base64__kafka_keytab --value-file kafka.keytab.base64
+$ dcos package install kafka --options=kerberos-zookeeper-options.json
 ```

--- a/frameworks/kafka/src/main/dist/kafka_server_jaas.conf.mustache
+++ b/frameworks/kafka/src/main/dist/kafka_server_jaas.conf.mustache
@@ -6,4 +6,16 @@ KafkaServer {
     keyTab="kafka.keytab"
     principal="{{SECURITY_KERBEROS_PRIMARY}}/{{TASK_NAME}}.{{FRAMEWORK_HOST}}@{{SECURITY_KERBEROS_REALM}}";
 };
+
+{{#SECURITY_KERBEROS_ENABLED_FOR_ZOOKEEPER}}
+// Zookeeper client authentication
+Client {
+    com.sun.security.auth.module.Krb5LoginModule required
+    useKeyTab=true
+    storeKey=true
+    keyTab="kafka.keytab"
+    principal="{{SECURITY_KERBEROS_PRIMARY}}/{{TASK_NAME}}.{{FRAMEWORK_HOST}}@{{SECURITY_KERBEROS_REALM}}";
+};
+{{/SECURITY_KERBEROS_ENABLED_FOR_ZOOKEEPER}}
+
 {{/SECURITY_KERBEROS_ENABLED}}

--- a/frameworks/kafka/universe/config.json
+++ b/frameworks/kafka/universe/config.json
@@ -85,6 +85,11 @@
                       "type": "boolean",
                       "default": false
                     },
+                    "enabled_for_zookeeper": {
+                      "description": "Enabled Kerberos authentication for communication with Apache Zookeeper",
+                      "type": "boolean",
+                      "default": false
+                    },
                     "kdc_host_name": {
                       "type": "string",
                       "description": "The name or address of a host running a KDC for the realm.",

--- a/frameworks/kafka/universe/marathon.json.mustache
+++ b/frameworks/kafka/universe/marathon.json.mustache
@@ -75,6 +75,7 @@
     {{#service.security.kerberos.enabled}}
     "SECURITY_KERBEROS_KEYTAB_SECRET": "{{service.security.kerberos.keytab_secret}}",
     "TASKCFG_ALL_SECURITY_KERBEROS_ENABLED": "{{service.security.kerberos.enabled}}",
+    "TASKCFG_ALL_SECURITY_KERBEROS_ENABLED_FOR_ZOOKEEPER": "{{service.security.kerberos.enabled_for_zookeeper}}",
     "TASKCFG_ALL_SECURITY_KERBEROS_PRIMARY": "{{service.security.kerberos.primary}}",
     "TASKCFG_ALL_SECURITY_KERBEROS_REALM": "{{service.security.kerberos.realm}}",
     "TASKCFG_ALL_KDC_HOST_NAME": "{{service.security.kerberos.kdc_host_name}}",

--- a/testing/sdk_auth.py
+++ b/testing/sdk_auth.py
@@ -234,19 +234,19 @@ class KerberosEnvironment:
         """
         # TODO: Perform sanitation check against validity of format for all given principals and raise an
         # exception when the format of a principal is invalid.
-        self.principals = principals
+        self.principals = list(map(lambda x: x.strip(), principals))
 
-        log.info("Adding the following list of principals to the KDC: {principals}".format(principals=principals))
+        log.info("Adding the following list of principals to the KDC: {principals}".format(principals=self.principals))
         kadmin_options = ["-l"]
         kadmin_cmd = "add"
         kadmin_args = ["--use-defaults", "--random-password"]
 
         try:
-            kadmin_args.extend(principals)
+            kadmin_args.extend(self.principals)
             self.__run_kadmin(kadmin_options, kadmin_cmd, kadmin_args)
         except Exception as e:
             raise RuntimeError("Failed to add principals {principals}: {err_msg}".format(
-                principals=principals, err_msg=repr(e)))
+                principals=self.principals, err_msg=repr(e)))
 
         log.info("Principals successfully added to KDC")
 

--- a/tools/kdc.py
+++ b/tools/kdc.py
@@ -37,7 +37,7 @@ def parse_principals(principals_file: str) -> list:
         raise RuntimeError("The provided principal file path is invalid")
 
     with open(principals_file) as f:
-        principals = f.readlines()
+        principals = list(filter(lambda x: x, map(lambda line: line.strip(), f.readlines())))
 
     print("Successfully parsed principals")
     for principal in principals:

--- a/tools/kdc.py
+++ b/tools/kdc.py
@@ -6,12 +6,46 @@ Wrapper script around sdk_auth.py used to ad-hoc setup and tear down a KDC envir
 This assumes there will be only one KDC in the cluster at any time, and thus that only instance
 of the KDC will be aptly named `kdc`.
 
-If invoked from the repo root, PYTHONPATH must also be set. For eg
-`PYTHONPATH=testing ./tools/kdc.py deploy PRINCIPALS_FILE`
+In order to run the script from the `dcos-commons` repo root, the `PYTHONPATH` environment
+variable must also be set:
+```bash
+$ PYTHONPATH=testing ./tools/kdc.py SUBCOMMAND
+```
 
-This tool expects as its arguments:
-    - subcommand for setup or teardown
-    - path to file holding principals as newline-separated strings
+## Deploying KDC
+
+This tool can be used to deploy a KDC applciation for testing.
+
+First create a principals file containing a newline-separated list of principals.
+As an example, a file (`kafka-principals.txt`) for Apache Kafka would contain:
+```
+kafka/kafka-0-broker.kafka.autoip.dcos.thisdcos.directory@LOCAL
+kafka/kafka-1-broker.kafka.autoip.dcos.thisdcos.directory@LOCAL
+kafka/kafka-2-broker.kafka.autoip.dcos.thisdcos.directory@LOCAL
+client@LOCAL
+```
+(assuming three Kafka brokers and a single client principal)
+
+Running this utility as follows:
+```bash
+$ PYTHONPATH=testing ./tools/kdc.py deploy kafka-principals.txt
+```
+will perform the following actions:
+1. Deploys a KDC Marathon application named `kdc` as defined in `tools/kdc.json`
+2. Adds the principals in `kafka-principals.txt` to the KDC store
+3. Saves the generated keytab as the DC/OS secret `__dcos_base64___keytab`
+
+## Removing KDC
+
+This tool can be used to remove an existing KDC deployment.
+
+Running this utility as follows:
+```bash
+$ PYTHONPATH=testing ./tools/kdc.py
+```
+will perform the following actions:
+1. Remove the KDC Marathoin application named `kdc`
+2. Remove the DC/OS secret `__dcos_base64___keytab`
 """
 import argparse
 import logging


### PR DESCRIPTION
This PR enables Kerberos support for ZooKeeper from Kafka and fixes some minor issues with the KDC utility.

See mesosphere/dcos-zookeeper#38

@benclarkwood @NimaVaziri what do you think of where the ZooKeeper setting is currently enabled? I'm not 100% happy with it, and feel that a `kafka.zookeeper.uri` and `kafka.zookeeper.kerberos.enabled` may be better. Thoughts?