### PR TITLE
[KAF-384] Make the advertised listeners consistent.

### DIFF
--- a/frameworks/kafka/src/main/dist/server.properties.mustache
+++ b/frameworks/kafka/src/main/dist/server.properties.mustache
@@ -27,10 +27,18 @@ broker.id={{POD_INSTANCE_INDEX}}
 #     listeners = security_protocol://host_name:port
 #   EXAMPLE:
 #     listeners = PLAINTEXT://your.host.name:9092
+#
+# Hostname and port the broker will advertise to producers and consumers. If not set,
+# it uses the value for "listeners" if configured.  Otherwise, it will use the value
+# returned from java.net.InetAddress.getCanonicalHostName().
+#
+# advertised.listeners=PLAINTEXT://your.host.name:9092
+
 {{^SECURITY_KERBEROS_ENABLED}}
 {{^KAFKA_ENABLE_TLS}}
-listeners=PLAINTEXT://:{{KAFKA_BROKER_PORT}}
+listeners=PLAINTEXT://{{MESOS_CONTAINER_IP}}:{{KAFKA_BROKER_PORT}}
 port={{KAFKA_BROKER_PORT}}
+advertised.listeners=PLAINTEXT://{{TASK_NAME}}.{{FRAMEWORK_HOST}}:{{KAFKA_BROKER_PORT}}
 {{/KAFKA_ENABLE_TLS}}
 {{/SECURITY_KERBEROS_ENABLED}}
 
@@ -38,10 +46,10 @@ port={{KAFKA_BROKER_PORT}}
 {{#KAFKA_ENABLE_TLS}}
 ############################# TLS Settings #############################
 {{#KAFKA_ALLOW_PLAINTEXT}}
-listeners=PLAINTEXT://:{{KAFKA_BROKER_PORT}},SSL://:{{KAFKA_BROKER_PORT_TLS}}
+listeners=PLAINTEXT://{{MESOS_CONTAINER_IP}}:{{KAFKA_BROKER_PORT}},SSL://{{MESOS_CONTAINER_IP}}:{{KAFKA_BROKER_PORT_TLS}}
 {{/KAFKA_ALLOW_PLAINTEXT}}
 {{^KAFKA_ALLOW_PLAINTEXT}}
-listeners=SSL://:{{KAFKA_BROKER_PORT_TLS}}
+listeners=SSL://{{MESOS_CONTAINER_IP}}:{{KAFKA_BROKER_PORT_TLS}}
 {{/KAFKA_ALLOW_PLAINTEXT}}
 
 ssl.keystore.location={{MESOS_SANDBOX}}/broker.keystore
@@ -55,10 +63,10 @@ ssl.enabled.protocols=TLSv1.2
 
 security.inter.broker.protocol=SSL
 {{#KAFKA_ALLOW_PLAINTEXT}}
-advertised.listeners=PLAINTEXT://kafka-{{POD_INSTANCE_INDEX}}-broker.{{FRAMEWORK_NAME}}.autoip.dcos.thisdcos.directory:{{KAFKA_BROKER_PORT}},SSL://kafka-{{POD_INSTANCE_INDEX}}-broker.{{FRAMEWORK_NAME}}.autoip.dcos.thisdcos.directory:{{KAFKA_BROKER_PORT_TLS}}
+advertised.listeners=PLAINTEXT://{{TASK_NAME}}.{{FRAMEWORK_HOST}}:{{KAFKA_BROKER_PORT}},SSL://{{TASK_NAME}}.{{FRAMEWORK_HOST}}:{{KAFKA_BROKER_PORT_TLS}}
 {{/KAFKA_ALLOW_PLAINTEXT}}
 {{^KAFKA_ALLOW_PLAINTEXT}}
-advertised.listeners=SSL://kafka-{{POD_INSTANCE_INDEX}}-broker.{{FRAMEWORK_NAME}}.autoip.dcos.thisdcos.directory:{{KAFKA_BROKER_PORT_TLS}}
+advertised.listeners=SSL://{{TASK_NAME}}.{{FRAMEWORK_HOST}}:{{KAFKA_BROKER_PORT_TLS}}
 {{/KAFKA_ALLOW_PLAINTEXT}}
 
 {{#KAFKA_ALLOW_PLAINTEXT}}
@@ -71,7 +79,7 @@ port={{KAFKA_BROKER_PORT_TLS}}
 
 {{#SECURITY_KERBEROS_ENABLED}}
 ############################# SASL Settings #############################
-listeners=SASL_PLAINTEXT://:{{KAFKA_BROKER_PORT}}
+listeners=SASL_PLAINTEXT://{{MESOS_CONTAINER_IP}}:{{KAFKA_BROKER_PORT}}
 advertised.listeners=SASL_PLAINTEXT://{{TASK_NAME}}.{{FRAMEWORK_HOST}}:{{KAFKA_BROKER_PORT}}
 security.inter.broker.protocol=SASL_PLAINTEXT
 
@@ -80,11 +88,6 @@ sasl.enabled.mechanisms=GSSAPI
 sasl.kerberos.service.name={{SECURITY_KERBEROS_PRIMARY}}
 
 {{/SECURITY_KERBEROS_ENABLED}}
-
-# Hostname and port the broker will advertise to producers and consumers. If not set,
-# it uses the value for "listeners" if configured.  Otherwise, it will use the value
-# returned from java.net.InetAddress.getCanonicalHostName().
-#advertised.listeners=PLAINTEXT://your.host.name:9092
 
 # The number of threads handling network requests
 num.network.threads={{KAFKA_NUM_NETWORK_THREADS}}
@@ -174,10 +177,6 @@ external.kafka.statsd.host={{STATSD_UDP_HOST}}
 external.kafka.statsd.reporter.enabled=true
 external.kafka.statsd.tag.enabled=true
 external.kafka.statsd.metrics.exclude_regex=
-
-{{#KAFKA_ADVERTISE_HOST}}
-advertised.host.name={{MESOS_CONTAINER_IP}}
-{{/KAFKA_ADVERTISE_HOST}}
 
 auto.create.topics.enable={{KAFKA_AUTO_CREATE_TOPICS_ENABLE}}
 auto.leader.rebalance.enable={{KAFKA_AUTO_LEADER_REBALANCE_ENABLE}}


### PR DESCRIPTION
0. Drop the legacy `advertised.host.name` parameter.
1. Make all `listeners` bind to `MESOS_CONTAINER_IP`.
2. Make all `advertised.listeners` bind to `<broker-dns>`.