### PR TITLE
Update DC/OS CLI Version

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,5 +1,5 @@
 py==1.4.33
-git+https://github.com/dcos/dcos-cli.git@f07ef6c7ce6015ea37f490bb9d1ad4b672a53b53
+git+https://github.com/dcos/dcos-cli.git@14f97067d971b6daa9aa67f5a876c99741a321b2
 dcos-shakedown==1.4.5
 git+https://github.com/dcos/dcos-test-utils.git@449eb8018468c0eafbc85342b68639ac89e8f6be
 git+https://github.com/dcos/dcos-launch.git@a4632ef300bdce200ba634427ae64d9761d8fb49


### PR DESCRIPTION
I have added some new functionality in to DC/OS CLI ([this](https://github.com/dcos/dcos-cli/commit/d5031e0c20c4ed04f494cdf6aa4e95b1e58ff0d2)) and `dcos-commons` needs to use the latest cli in order to pass [this teamcity CI check](https://teamcity.mesosphere.io/viewLog.html?buildId=862133&buildTypeId=ClosedSource_MesosphereEnterpriseDcOs_IntegrationTests_DcOsCommonsSmokeTest&tab=buildResultsDiv) in [mesosphere/dcos-enterprise/pull/1612](https://github.com/mesosphere/dcos-enterprise/pull/1612)