### PR TITLE
Add configurable encryption types to KDC

### DIFF
--- a/tools/kdc.json
+++ b/tools/kdc.json
@@ -28,6 +28,7 @@
   ],
   "requirePorts": true,
   "env": {
-    "LOG_LEVEL": "LOG_DEBUG"
+    "LOG_LEVEL": "LOG_DEBUG",
+    "ENC_TYPES": "aes256-cts des3-cbc-sha1 des-cbc-md5 des-cbc-crc"
   }
 }


### PR DESCRIPTION
This env var gets injected into the krb5.conf file that's picked up at runtime.