### PR TITLE
Revert "Update DC/OS CLI Version"

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,4 +1,5 @@
 py==1.4.33
+git+https://github.com/dcos/dcos-cli.git@14f97067d971b6daa9aa67f5a876c99741a321b2#egg=dcoscli&subdirectory=cli
 git+https://github.com/dcos/dcos-cli.git@14f97067d971b6daa9aa67f5a876c99741a321b2
 dcos-shakedown==1.4.5
 git+https://github.com/dcos/dcos-test-utils.git@449eb8018468c0eafbc85342b68639ac89e8f6be

--- a/tools/kdc.json
+++ b/tools/kdc.json
@@ -28,7 +28,6 @@
   ],
   "requirePorts": true,
   "env": {
-    "LOG_LEVEL": "LOG_DEBUG",
-    "ENC_TYPES": "aes256-cts des3-cbc-sha1 des-cbc-md5 des-cbc-crc"
+    "LOG_LEVEL": "LOG_DEBUG"
   }
 }

--- a/tools/kdc.json
+++ b/tools/kdc.json
@@ -28,6 +28,7 @@
   ],
   "requirePorts": true,
   "env": {
-    "LOG_LEVEL": "LOG_DEBUG"
+    "LOG_LEVEL": "LOG_DEBUG",
+    "ENC_TYPES": "aes256-cts des3-cbc-sha1 des-cbc-md5 des-cbc-crc"
   }
 }


### PR DESCRIPTION
Reverts mesosphere/dcos-commons#1856
Because of errors like this https://teamcity.mesosphere.io/viewLog.html?buildId=866935&buildTypeId=ClosedSource_MesosphereEnterpriseDcOs_IntegrationTests_DcOsCommonsSmokeTest&tab=buildLog&_focus=2796 

Copy pasting @mellenburg comments  : 

- we define a specify SHA to pull down github.com/dcos/dcos-cli
- dcos/dcos-cli only has a top-level setup.py file for the `dcos` module. The `dcoscli` module is a completely separate module that lives inside the `cli` folder. When pip3 installs the specific SHA of dcoscli, it completely ignores dcoscli because its not in setup.py and therefore effectively doesnt exist to pip
- shakedown is the next dependency on the list. It is only linked to a top-level pypi version of dcos/dcoscli. When pip3 tries to install that, it does so from PYPI, where the dcos/dcos-cli has been exported as a wheel or something. In that case, the packaging included *ALL* of the files in the repository so the dcoscli is pulled in this time as a module (edited)

Ways this could have been prevented:
* don't have two python projects in one repo (too late)
* only use the CLI as a CLI. I.E. do not invoke its python internals as this has not been maintained/published/packaged as a dcos interface library (also, too late, but we can definitely work towards the ideal here)

How we can fix this:
* work with pip to make sure it knows to pull in this additional, nonstandard module
* only use a coherent CLI, which is released as a binary and invoked only as a CLI

For now, I would suggest a revert on that CLI change so you don't have a borked dev container