### PR TITLE
java: bump JRE to the latest patchlevel

### DIFF
--- a/tools/universe/package_builder.py
+++ b/tools/universe/package_builder.py
@@ -15,7 +15,7 @@ import time
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.DEBUG, format="%(message)s")
 
-_jre_url = 'https://downloads.mesosphere.com/java/jre-8u144-linux-x64.tar.gz'
+_jre_url = 'https://downloads.mesosphere.io/java/jre-8u152-linux-x64.tar.gz'
 _jre_jce_unlimited_url = 'https://downloads.mesosphere.com/java/jre-8u131-linux-x64-jce-unlimited.tar.gz'
 _libmesos_bundle_url = 'https://downloads.mesosphere.io/libmesos-bundle/libmesos-bundle-master-28f8827.tar.gz'
 


### PR DESCRIPTION
## High-level description

This PR bump Java to the latest patchlevel.

## Corresponding DC/OS tickets (obligatory)

  - [DCOS-19399](https://jira.mesosphere.com/browse/DCOS-19399)  `Update DC/OS Java JDK 8 to latest version`