### PR TITLE
[INFINITY-2737] Pull down and use custom ZK lib

### DIFF
--- a/frameworks/kafka/src/main/dist/svc.yml
+++ b/frameworks/kafka/src/main/dist/svc.yml
@@ -14,6 +14,7 @@ pods:
       - {{LIBMESOS_URI}}
       - {{KAFKA_STATSD_URI}}
       - {{CLIENT_STATSD_URI}}
+      - {{ZOOKEEPER_CLIENT_URI}}
     {{#ENABLE_VIRTUAL_NETWORK}}
     networks:
       {{VIRTUAL_NETWORK_NAME}}:
@@ -73,6 +74,7 @@ pods:
 
           ./bootstrap -resolve=false &&
           mv -v *statsd*.jar $MESOS_SANDBOX/{{KAFKA_VERSION_PATH}}/libs/ &&
+          mv -v zookeeper*.jar $MESOS_SANDBOX/{{KAFKA_VERSION_PATH}}/libs/ &&
           exec $MESOS_SANDBOX/{{KAFKA_VERSION_PATH}}/bin/kafka-server-start.sh \
                $MESOS_SANDBOX/{{KAFKA_VERSION_PATH}}/config/server.properties
         configs:

--- a/frameworks/kafka/src/main/dist/svc.yml
+++ b/frameworks/kafka/src/main/dist/svc.yml
@@ -72,6 +72,10 @@ pods:
           export KAFKA_OPTS="-Djava.security.auth.login.config=$MESOS_SANDBOX/{{KAFKA_VERSION_PATH}}/config/kafka_server_jaas.conf -Djava.security.krb5.conf=$MESOS_SANDBOX/{{KAFKA_VERSION_PATH}}/config/krb5.conf -Dsun.security.krb5.debug=true $KAFKA_OPTS" &&
         {{/TASKCFG_ALL_SECURITY_KERBEROS_ENABLED}}
 
+          # We add some custom statsd libraries for statsd metrics as well
+          # as a custom zookeeper library to support our own ZK running
+          # kerberized. The custom zk library does not do DNS reverse resolution
+          # of the ZK hostnames.
           ./bootstrap -resolve=false &&
           mv -v *statsd*.jar $MESOS_SANDBOX/{{KAFKA_VERSION_PATH}}/libs/ &&
           mv -v zookeeper*.jar $MESOS_SANDBOX/{{KAFKA_VERSION_PATH}}/libs/ &&

--- a/frameworks/kafka/src/main/dist/svc.yml
+++ b/frameworks/kafka/src/main/dist/svc.yml
@@ -66,16 +66,16 @@ pods:
           KAFKA_DISK_PATH: "{{BROKER_DISK_PATH}}"
           KAFKA_HEAP_OPTS: "-Xms{{BROKER_JAVA_HEAP}}M -Xmx{{BROKER_JAVA_HEAP}}M"
         goal: RUNNING
+        # NOTE: We add some custom statsd libraries for statsd metrics as well
+        # as a custom zookeeper library to support our own ZK running
+        # kerberized. The custom zk library does not do DNS reverse resolution
+        # of the ZK hostnames.
         cmd: >
           export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jre*/) &&
         {{#TASKCFG_ALL_SECURITY_KERBEROS_ENABLED}}
           export KAFKA_OPTS="-Djava.security.auth.login.config=$MESOS_SANDBOX/{{KAFKA_VERSION_PATH}}/config/kafka_server_jaas.conf -Djava.security.krb5.conf=$MESOS_SANDBOX/{{KAFKA_VERSION_PATH}}/config/krb5.conf -Dsun.security.krb5.debug=true $KAFKA_OPTS" &&
         {{/TASKCFG_ALL_SECURITY_KERBEROS_ENABLED}}
 
-          # We add some custom statsd libraries for statsd metrics as well
-          # as a custom zookeeper library to support our own ZK running
-          # kerberized. The custom zk library does not do DNS reverse resolution
-          # of the ZK hostnames.
           ./bootstrap -resolve=false &&
           mv -v *statsd*.jar $MESOS_SANDBOX/{{KAFKA_VERSION_PATH}}/libs/ &&
           mv -v zookeeper*.jar $MESOS_SANDBOX/{{KAFKA_VERSION_PATH}}/libs/ &&

--- a/frameworks/kafka/universe/marathon.json.mustache
+++ b/frameworks/kafka/universe/marathon.json.mustache
@@ -40,6 +40,7 @@
     "MESOS_API_VERSION": "{{service.mesos_api_version}}",
     "KAFKA_STATSD_URI": "{{resource.assets.uris.kafka-statsd-jar}}",
     "CLIENT_STATSD_URI": "{{resource.assets.uris.statsd-client-jar}}",
+    "ZOOKEEPER_CLIENT_URI": "{{resource.assets.uris.zookeeper-client-jar}}",
 
     "PLACEMENT_CONSTRAINTS": "{{service.placement_constraint}}",
     "DEPLOY_STRATEGY":"{{service.deploy_strategy}}",

--- a/frameworks/kafka/universe/resource.json
+++ b/frameworks/kafka/universe/resource.json
@@ -9,7 +9,8 @@
       "kafka-scheduler-zip": "{{artifact-dir}}/kafka-scheduler.zip",
       "executor-zip": "{{artifact-dir}}/executor.zip",
       "kafka-statsd-jar": "http://downloads.mesosphere.com/kafka/assets/kafka-statsd-metrics2-0.5.3.jar",
-      "statsd-client-jar": "http://downloads.mesosphere.com/kafka/assets/java-dogstatsd-client-2.3.jar"
+      "statsd-client-jar": "http://downloads.mesosphere.com/kafka/assets/java-dogstatsd-client-2.3.jar",
+      "zookeeper-client-jar": "http://downloads.mesosphere.com/kafka/assets/zookeeper-3.4.10.jar"
     }
   },
   "images": {


### PR DESCRIPTION
This PR updates ZK to pull down, and then include a custom zookeeper library jar. This library jar is then used by Kafka's ZK client.

That jar is based on this changeset on ZK 3.4.10: https://github.com/benclarkwood/zookeeper/compare/branch-3.4...benclarkwood:release-3.4.10-mesosphere?expand=1

This allows us to run Kerberized ZK without adding principals beyond those for the autoip DNS entries as Kafka will now use the autoip DNS as the principal.