### PR TITLE
[INFINITY-2736] Remove kinit dependency for kerberized HDFS service spec

### DIFF
--- a/frameworks/hdfs/src/main/dist/jaas.conf
+++ b/frameworks/hdfs/src/main/dist/jaas.conf
@@ -1,0 +1,6 @@
+HDFSJaas {
+  com.sun.security.auth.module.Krb5LoginModule required
+  useKeyTab=true
+  keyTab="hdfs.keytab"
+  principal="{{KERBEROS_PRIMARY}}/{{TASK_NAME}}.{{FRAMEWORK_HOST}}@{{KERBEROS_REALM}}";
+};

--- a/frameworks/hdfs/src/main/dist/krb5.conf
+++ b/frameworks/hdfs/src/main/dist/krb5.conf
@@ -1,14 +1,14 @@
 [libdefaults]
-default_realm = LOCAL
-dns_lookup_realm = true
-dns_lookup_kdc = true
-udp_preference_limit = 1
+  default_realm = {{KERBEROS_REALM}}
+  dns_lookup_realm = true
+  dns_lookup_kdc = true
+  udp_preference_limit = 1
 
 [realms]
-  LOCAL = {
+  {{KERBEROS_REALM}} = {
     kdc = {{KDC_HOST_NAME}}:{{KDC_HOST_PORT}}
   }
 
 [domain_realm]
-  .hdfs.dcos = LOCAL
-  hdfs.dcos = LOCAL
+  .hdfs.dcos = {{KERBEROS_REALM}}
+  hdfs.dcos = {{KERBEROS_REALM}}

--- a/frameworks/hdfs/src/main/dist/svc.yml
+++ b/frameworks/hdfs/src/main/dist/svc.yml
@@ -159,7 +159,7 @@ pods:
           cmd: >
             export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jre*/) &&
           {{#KERBEROS_ENABLED}}
-            KRB5_CONFIG={{JRE_VERSION}}/lib/security/krb5.conf kinit -k -t $MESOS_SANDBOX/hdfs.keytab $KERBEROS_PRIMARY/$TASK_NAME.$FRAMEWORK_HOST@$KERBEROS_REALM &&
+            export HADOOP_OPTS="-Djava.security.auth.login.config=$MESOS_SANDBOX/{{HDFS_VERSION}}/etc/hadoop/jaas.conf $HADOOP_OPTS" &&
           {{/KERBEROS_ENABLED}}
             ./{{HDFS_VERSION}}/bin/hdfs haadmin -getServiceState $TASK_NAME
           interval: 5
@@ -167,6 +167,9 @@ pods:
           timeout: 60
         configs:
           {{#KERBEROS_ENABLED}}
+          jaas-conf:
+            template: jaas.conf
+            dest: {{HDFS_VERSION}}/etc/hadoop/jaas.conf
           krb5-conf:
             template: krb5.conf
             dest: {{JRE_VERSION}}/lib/security/krb5.conf
@@ -360,6 +363,9 @@ pods:
           type: {{DATA_DISK_TYPE}}
         configs:
           {{#KERBEROS_ENABLED}}
+          jaas-conf:
+            template: jaas.conf
+            dest: {{HDFS_VERSION}}/etc/hadoop/jaas.conf
           krb5-conf:
             template: krb5.conf
             dest: {{JRE_VERSION}}/lib/security/krb5.conf
@@ -385,7 +391,7 @@ pods:
           cmd: >
             export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jre*/) &&
           {{#KERBEROS_ENABLED}}
-            KRB5_CONFIG={{JRE_VERSION}}/lib/security/krb5.conf kinit -k -t $MESOS_SANDBOX/hdfs.keytab $KERBEROS_PRIMARY/$TASK_NAME.$FRAMEWORK_HOST@$KERBEROS_REALM &&
+            export HADOOP_OPTS="-Djava.security.auth.login.config=$MESOS_SANDBOX/{{HDFS_VERSION}}/etc/hadoop/jaas.conf $HADOOP_OPTS" &&
           {{/KERBEROS_ENABLED}}
             export TASK_IP=$(./bootstrap --get-task-ip) && MATCH="$(./{{HDFS_VERSION}}/bin/hdfs dfsadmin -report | grep $TASK_IP | wc -l)" &&
             [[ $MATCH -ge 1 ]]


### PR DESCRIPTION
This PR moves away from using `kinit` (as it might not be in the task's environment) and relies on JAAS to auth.