### PR TITLE
[INFINITY-2740] Explicitly set useTicketCache to false in Kafka JAAS config

### DIFF
--- a/frameworks/kafka/src/main/dist/kafka_server_jaas.conf.mustache
+++ b/frameworks/kafka/src/main/dist/kafka_server_jaas.conf.mustache
@@ -3,6 +3,7 @@ KafkaServer {
     com.sun.security.auth.module.Krb5LoginModule required
     useKeyTab=true
     storeKey=true
+    useTicketCache=false
     keyTab="kafka.keytab"
     principal="{{SECURITY_KERBEROS_PRIMARY}}/{{TASK_NAME}}.{{FRAMEWORK_HOST}}@{{SECURITY_KERBEROS_REALM}}";
 };
@@ -13,6 +14,7 @@ Client {
     com.sun.security.auth.module.Krb5LoginModule required
     useKeyTab=true
     storeKey=true
+    useTicketCache=false
     keyTab="kafka.keytab"
     principal="{{SECURITY_KERBEROS_PRIMARY}}/{{TASK_NAME}}.{{FRAMEWORK_HOST}}@{{SECURITY_KERBEROS_REALM}}";
 };


### PR DESCRIPTION
This PR adds `useTicketCache=false` to the JAAS config for Kafka. This makes the setting explicit instead of relying on the default.