### PR TITLE
Cherrypick: Bump pytest (#1897)

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,7 +1,7 @@
-py==1.4.33
-pyasn1==0.3.2
-git+https://github.com/dcos/dcos-cli.git@f07ef6c7ce6015ea37f490bb9d1ad4b672a53b53
+py==1.5.1
+git+https://github.com/dcos/dcos-cli.git@14f97067d971b6daa9aa67f5a876c99741a321b2#egg=dcoscli&subdirectory=cli
+git+https://github.com/dcos/dcos-cli.git@14f97067d971b6daa9aa67f5a876c99741a321b2
 dcos-shakedown==1.4.5
-git+https://github.com/dcos/dcos-test-utils.git@449eb8018468c0eafbc85342b68639ac89e8f6be
-git+https://github.com/dcos/dcos-launch.git@a4632ef300bdce200ba634427ae64d9761d8fb49
+git+https://github.com/dcos/dcos-test-utils.git@c431eb6414e003e31c865c534b2413969a6d9947
+git+https://github.com/dcos/dcos-launch.git@14ded071109ab241e70ff3ed8b22bab844f74513
 teamcity-messages

--- a/testing/sdk_jobs.py
+++ b/testing/sdk_jobs.py
@@ -78,14 +78,16 @@ def run_job(job_dict, timeout_seconds=600, raise_on_failure=True):
     def fun():
         # catch errors from CLI: ensure that the only error raised is our own:
         try:
-            runs = json.loads(sdk_cmd.run_cli(
-                'job history --show-failures --json {}'.format(job_name), print_output=False))
+            successful_runs = json.loads(sdk_cmd.run_cli(
+                'job history --json {}'.format(job_name), print_output=False))
+            failed_runs = json.loads(sdk_cmd.run_cli(
+                'job history --failures --json {}'.format(job_name), print_output=False))
         except:
             log.info(traceback.format_exc())
             return False
 
-        successful_ids = [r['id'] for r in runs['history']['successfulFinishedRuns']]
-        failed_ids = [r['id'] for r in runs['history']['failedFinishedRuns']]
+        successful_ids = [r['id'] for r in successful_runs]
+        failed_ids = [r['id'] for r in failed_runs]
 
         log.info('Job {} run history (waiting for successful {}): successful={} failed={}'.format(
             job_name, run_id, successful_ids, failed_ids))


### PR DESCRIPTION
* Bump py

* Bump dcos-launch

* Update job history command for new behavior

--show-failures has been replaced with --failures
which only will return the failure as to both the
failures and successes