### PR TITLE
Create compatibility layer in preparation for new goal states

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultServiceSpec.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultServiceSpec.java
@@ -399,15 +399,14 @@ public class DefaultServiceSpec implements ServiceSpec {
                     JsonParser p, DeserializationContext ctxt) throws IOException, JsonParseException {
                 String value = ((TextNode) p.getCodec().readTree(p)).textValue();
 
-                if (value.equals("FINISHED") || value.equals("ONCE") || value.equals("FINISH")) {
+                if (value.equals("FINISHED") || value.equals("ONCE")) {
                     return GoalState.FINISHED;
                 } else if (value.equals("RUNNING")) {
                     return GoalState.RUNNING;
-                } else if (value.equals("UNKNOWN")) {
+                } else {
+                    logger.warn("Found unknown goal state in config store: {}", value);
                     return GoalState.UNKNOWN;
                 }
-
-                throw new JsonParseException(String.format("Unknown goal state: %s", value), p.getCurrentLocation());
             }
         }
     }

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/DefaultSchedulerTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/DefaultSchedulerTest.java
@@ -674,7 +674,7 @@ public class DefaultSchedulerTest {
         Assert.assertEquals(
                 SerializationUtils.fromString("\"ONCE\"", GoalState.class, objectMapper), GoalState.FINISHED);
         Assert.assertEquals(
-                SerializationUtils.fromString("\"FINISH\"", GoalState.class, objectMapper), GoalState.FINISHED);
+                SerializationUtils.fromString("\"FINISH\"", GoalState.class, objectMapper), GoalState.UNKNOWN);
     }
 
     // Deploy plan has 2 phases, update plan has 1 for distinguishing which was chosen.


### PR DESCRIPTION
This PR enables the scheduler to parse `ONCE` and `FINISHED` goal states from the config store, enabling it to be downgraded to from a later version making use of those new states.