### PR TITLE
ELASTIC-153: Make sure zone information is available.

### DIFF
--- a/frameworks/elastic/src/main/dist/elasticsearch.yml
+++ b/frameworks/elastic/src/main/dist/elasticsearch.yml
@@ -20,8 +20,10 @@ metrics.statsd.host: {{STATSD_UDP_HOST}}
 metrics.statsd.port: {{STATSD_UDP_PORT}}
 
 {{#DETECT_ZONES}}
+{{#ZONE}}
 node.attr.zone: {{ZONE}}
 cluster.routing.allocation.awareness.attributes: zone
+{{/ZONE}}
 {{/DETECT_ZONES}}
 
 {{#MASTER_ENABLED}}


### PR DESCRIPTION
This makes the Elasticsearch rack awareness configuration only be set when `ZONE` is available.