### PR TITLE
INFINITY-2795 Fix resource increment when using pre-reserved roles

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/MesosResourcePool.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/MesosResourcePool.java
@@ -167,7 +167,8 @@ public class MesosResourcePool {
     public Optional<MesosResource> consumeReservableMerged(String name, Value desiredValue, String preReservedRole) {
         Map<String, Value> pool = reservableMergedPoolByRole.get(preReservedRole);
         if (pool == null) {
-            logger.info("No unreserved resources available in role: {}", preReservedRole);
+            logger.info("No unreserved resources available for role '{}'. Reservable roles are: {}",
+                    preReservedRole, reservableMergedPoolByRole.keySet());
             return Optional.empty();
         }
 
@@ -189,10 +190,11 @@ public class MesosResourcePool {
             return Optional.of(new MesosResource(builder.build()));
         } else {
             if (availableValue == null) {
-                logger.info("Offer lacks any unreserved resources named {}", name);
+                logger.info("Offer lacks any unreserved {} resources for role {}", name, preReservedRole);
             } else {
-                logger.info("Offered quantity of {} is insufficient: desired {}, offered {}",
+                logger.info("Offered quantity of {} for role {} is insufficient: desired {}, offered {}",
                         name,
+                        preReservedRole,
                         TextFormat.shortDebugString(desiredValue),
                         TextFormat.shortDebugString(availableValue));
             }

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluatorTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluatorTest.java
@@ -142,13 +142,13 @@ public class OfferEvaluatorTest extends OfferEvaluatorTestBase {
 
     @Test
     public void testIncreaseReservationScalar() throws Exception {
-        // Launch for the first time.
+        // Launch for the first time with 2.0 cpus offered, 1.0 cpus required.
         String resourceId = getFirstResourceId(
                 recordLaunchWithCompleteOfferedResources(
                         PodInstanceRequirementTestUtils.getCpuRequirement(1.0),
                         ResourceTestUtils.getUnreservedCpus(2.0)));
 
-        // Launch again with more resources.
+        // Launch again with 1.0 cpus reserved, 1.0 cpus unreserved, and 2.0 cpus required.
         PodInstanceRequirement podInstanceRequirement = PodInstanceRequirementTestUtils.getCpuRequirement(2.0);
         Resource offeredResource = ResourceTestUtils.getReservedCpus(1.0, resourceId);
         Resource unreservedResource = ResourceTestUtils.getUnreservedCpus(1.0);
@@ -191,6 +191,53 @@ public class OfferEvaluatorTest extends OfferEvaluatorTestBase {
         } finally {
             context.reset();
         }
+    }
+
+    @Test
+    public void testIncreasePreReservedReservationScalar() throws Exception {
+        final String preReservedRole = "slave_public";
+
+        // Launch for the first time with 2.0 cpus offered, 1.0 cpus required.
+        String resourceId = getFirstResourceId(
+                recordLaunchWithCompleteOfferedResources(
+                        PodInstanceRequirementTestUtils.getCpuRequirement(1.0, preReservedRole),
+                        preReservedRole,
+                        ResourceTestUtils.getUnreservedCpus(2.0, preReservedRole)));
+
+        // Launch again with 1.0 cpus reserved, 1.0 cpus unreserved, and 2.0 cpus required.
+        PodInstanceRequirement podInstanceRequirement =
+                PodInstanceRequirementTestUtils.getCpuRequirement(2.0, preReservedRole);
+        Resource offeredResource = ResourceTestUtils.getReservedCpus(1.0, resourceId);
+        Resource unreservedResource = ResourceTestUtils.getUnreservedCpus(1.0, preReservedRole);
+
+        Collection<Resource> expectedResources = getExpectedExecutorResources(
+                stateStore.fetchTasks().iterator().next().getExecutor());
+        expectedResources.addAll(Arrays.asList(offeredResource, unreservedResource));
+
+        List<OfferRecommendation> recommendations = evaluator.evaluate(
+                podInstanceRequirement,
+                Arrays.asList(OfferTestUtils.getOffer(expectedResources)));
+        Assert.assertEquals(2, recommendations.size());
+
+        // Validate RESERVE Operation
+        Operation reserveOperation = recommendations.get(0).getOperation();
+        Resource reserveResource = reserveOperation.getReserve().getResources(0);
+
+        Resource.ReservationInfo reservation = ResourceUtils.getReservation(reserveResource).get();
+        Assert.assertEquals(Operation.Type.RESERVE, reserveOperation.getType());
+        Assert.assertEquals(1.0, reserveResource.getScalar().getValue(), 0.0);
+        validateRole(reserveResource);
+        Assert.assertEquals(TestConstants.ROLE, ResourceUtils.getRole(reserveResource));
+        Assert.assertEquals(TestConstants.PRINCIPAL, reservation.getPrincipal());
+        Assert.assertEquals(resourceId, getResourceId(reserveResource));
+
+        // Validate LAUNCH Operation
+        Operation launchOperation = recommendations.get(1).getOperation();
+        Resource launchResource = launchOperation.getLaunchGroup().getTaskGroup().getTasks(0).getResources(0);
+
+        Assert.assertEquals(Operation.Type.LAUNCH_GROUP, launchOperation.getType());
+        Assert.assertEquals(resourceId, getResourceId(launchResource));
+        Assert.assertEquals(2.0, launchResource.getScalar().getValue(), 0.0);
     }
 
     @Test

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluatorTestBase.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluatorTestBase.java
@@ -50,8 +50,14 @@ public class OfferEvaluatorTestBase extends DefaultCapabilitiesTestSuite {
     protected List<Resource> recordLaunchWithCompleteOfferedResources(
             PodInstanceRequirement podInstanceRequirement, Resource... offeredResources)
             throws InvalidRequirementException, IOException {
+        return recordLaunchWithCompleteOfferedResources(podInstanceRequirement, Constants.ANY_ROLE, offeredResources);
+    }
+
+    protected List<Resource> recordLaunchWithCompleteOfferedResources(
+            PodInstanceRequirement podInstanceRequirement, String preReservedRole, Resource... offeredResources)
+            throws InvalidRequirementException, IOException {
         return recordLaunchWithOfferedResources(
-                OfferTestUtils.getCompleteOffer(Arrays.asList(offeredResources)),
+                OfferTestUtils.getCompleteOffer(Arrays.asList(offeredResources), preReservedRole),
                 podInstanceRequirement,
                 offeredResources);
     }

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/plan/PodInstanceRequirementTestUtils.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/plan/PodInstanceRequirementTestUtils.java
@@ -21,6 +21,10 @@ public class PodInstanceRequirementTestUtils {
         return getCpuRequirement(value, 0);
     }
 
+    public static PodInstanceRequirement getCpuRequirement(double value, String preReservedRole) {
+        return getRequirement(getCpuResourceSet(value, preReservedRole), 0);
+    }
+
     public static PodInstanceRequirement getCpuRequirement(double value, int index) {
         return getRequirement(getCpuResourceSet(value), index);
     }
@@ -59,7 +63,11 @@ public class PodInstanceRequirementTestUtils {
     }
 
     public static ResourceSet getCpuResourceSet(double value) {
-        return DefaultResourceSet.newBuilder(TestConstants.ROLE, Constants.ANY_ROLE, TestConstants.PRINCIPAL)
+        return getCpuResourceSet(value, Constants.ANY_ROLE);
+    }
+
+    public static ResourceSet getCpuResourceSet(double value, String preReservedRole) {
+        return DefaultResourceSet.newBuilder(TestConstants.ROLE, preReservedRole, TestConstants.PRINCIPAL)
                 .id(TestConstants.RESOURCE_SET_ID)
                 .cpus(value)
                 .build();

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/testutils/OfferTestUtils.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/testutils/OfferTestUtils.java
@@ -5,6 +5,8 @@ import org.apache.mesos.Protos.Offer;
 import org.apache.mesos.Protos.Resource;
 import org.apache.mesos.Protos.Value;
 
+import com.mesosphere.sdk.offer.Constants;
+
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -49,14 +51,21 @@ public class OfferTestUtils {
      * @return An offer with both executor resources and the supplied resources available
      */
     public static Protos.Offer getCompleteOffer(List<Protos.Resource> resources) {
-        return getEmptyOfferBuilder().addAllResources(getExecutorResources()).addAllResources(resources).build();
+        return getCompleteOffer(resources, Constants.ANY_ROLE);
     }
 
-    public static Collection<Resource> getExecutorResources() {
+    public static Protos.Offer getCompleteOffer(List<Protos.Resource> resources, String preReservedRole) {
+        return getEmptyOfferBuilder()
+                .addAllResources(getExecutorResources(preReservedRole))
+                .addAllResources(resources)
+                .build();
+    }
+
+    private static Collection<Resource> getExecutorResources(String preReservedRole) {
         return Arrays.asList(
-                ResourceTestUtils.getUnreservedCpus(0.1),
-                ResourceTestUtils.getUnreservedMem(256),
-                ResourceTestUtils.getUnreservedDisk(512));
+                ResourceTestUtils.getUnreservedCpus(0.1, preReservedRole),
+                ResourceTestUtils.getUnreservedMem(256, preReservedRole),
+                ResourceTestUtils.getUnreservedDisk(512, preReservedRole));
     }
 
     public static List<Protos.Offer> getCompleteOffers(Protos.Resource resource) {


### PR DESCRIPTION
The section of code handling increasing an existing reservation was always passing ANY_ROLE (aka "\*"), instead of the desired pre-reserved role. This would cause problems in the common "slave_public" case where there are no resources available under "\*". The fix is a one-liner, but testing that fix needed some additional support for pre-reserved roles in the test code.

This only affects increasing reservations after initial deployment. Initial deployment is handled by a separate section of code which was passing the correct role.

In addition, this PR makes some small improvements to offer eval logging to provide better information.