### PR TITLE
INFINITY-2796 Fix lint, refrain from passing base64 version of yaml block to tasks

### DIFF
--- a/frameworks/elastic/src/main/java/com/mesosphere/sdk/elastic/scheduler/Main.java
+++ b/frameworks/elastic/src/main/java/com/mesosphere/sdk/elastic/scheduler/Main.java
@@ -5,6 +5,7 @@ import com.mesosphere.sdk.specification.DefaultServiceSpec;
 import com.mesosphere.sdk.specification.yaml.RawServiceSpec;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Base64;
 
@@ -12,7 +13,7 @@ import java.util.Base64;
  * Main entry point for the Scheduler.
  */
 public class Main {
-    private static final String TASKCFG_ALL_CUSTOM_YAML_BLOCK_BASE64_ENV = "TASKCFG_ALL_CUSTOM_YAML_BLOCK_BASE64";
+    private static final String CUSTOM_YAML_BLOCK_BASE64_ENV = "CUSTOM_YAML_BLOCK_BASE64";
 
     public static void main(String[] args) throws Exception {
         if (args.length != 1) {
@@ -24,24 +25,25 @@ public class Main {
     }
 
     private static SchedulerBuilder createSchedulerBuilder(File yamlSpecFile) throws Exception {
-        Base64.Decoder decoder = Base64.getDecoder();
-        String base64_yaml = System.getenv(TASKCFG_ALL_CUSTOM_YAML_BLOCK_BASE64_ENV);
-        byte[] es_yaml_bytes = decoder.decode(base64_yaml);
-        String es_yaml_block = new String(es_yaml_bytes, "UTF-8");
-
         RawServiceSpec rawServiceSpec = RawServiceSpec.newBuilder(yamlSpecFile).build();
         SchedulerConfig schedulerConfig = SchedulerConfig.fromEnv();
+
         // Modify pod environments in two ways:
         // 1) Elastic is unhappy if cluster.name contains slashes. Replace any slashes with double-underscores.
         // 2) Base64 decode the custom YAML block.
 
-        return DefaultScheduler.newBuilder(
+        DefaultServiceSpec.Generator serviceSpecGenerator =
                 DefaultServiceSpec.newGenerator(
                         rawServiceSpec, schedulerConfig, yamlSpecFile.getParentFile())
-                        .setAllPodsEnv("CLUSTER_NAME", SchedulerUtils.withEscapedSlashes(rawServiceSpec.getName()))
-                        .setAllPodsEnv("CUSTOM_YAML_BLOCK", es_yaml_block)
-                        .build(),
-                schedulerConfig)
+                        .setAllPodsEnv("CLUSTER_NAME", SchedulerUtils.withEscapedSlashes(rawServiceSpec.getName()));
+
+        String yamlBase64 = System.getenv(CUSTOM_YAML_BLOCK_BASE64_ENV);
+        if (yamlBase64 != null && yamlBase64.length() > 0) {
+            String esYamlBlock = new String(Base64.getDecoder().decode(yamlBase64), StandardCharsets.UTF_8);
+            serviceSpecGenerator.setAllPodsEnv("CUSTOM_YAML_BLOCK", esYamlBlock);
+        }
+
+        return DefaultScheduler.newBuilder(serviceSpecGenerator.build(), schedulerConfig)
                 .setPlansFrom(rawServiceSpec);
     }
 }

--- a/frameworks/elastic/tests/test_sanity.py
+++ b/frameworks/elastic/tests/test_sanity.py
@@ -182,7 +182,7 @@ def test_custom_yaml_base64():
     base64_str = 'Y2x1c3RlcjoNCiAgcm91dGluZzoNCiAgICBhbGxvY2F0aW9uOg0KIC' \
                  'AgICAgbm9kZV9pbml0aWFsX3ByaW1hcmllc19yZWNvdmVyaWVzOiAz'
 
-    config.update_app(foldered_name, {'TASKCFG_ALL_CUSTOM_YAML_BLOCK_BASE64': base64_str}, current_expected_task_count)
+    config.update_app(foldered_name, {'CUSTOM_YAML_BLOCK_BASE64': base64_str}, current_expected_task_count)
     config.check_custom_elasticsearch_cluster_setting(service_name=foldered_name)
 
 

--- a/frameworks/elastic/universe/marathon.json.mustache
+++ b/frameworks/elastic/universe/marathon.json.mustache
@@ -322,7 +322,7 @@
     {{#elasticsearch.indices_requests_cache_size}}
     "TASKCFG_ALL_INDICES_REQUESTS_CACHE_SIZE": "{{elasticsearch.indices_requests_cache_size}}",
     {{/elasticsearch.indices_requests_cache_size}}
-    "TASKCFG_ALL_CUSTOM_YAML_BLOCK_BASE64": "{{elasticsearch.custom_elasticsearch_yml}}"
+    "CUSTOM_YAML_BLOCK_BASE64": "{{elasticsearch.custom_elasticsearch_yml}}"
   },
   "uris": [
     "{{resource.assets.uris.bootstrap-zip}}",

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerConfig.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerConfig.java
@@ -145,7 +145,7 @@ public class SchedulerConfig {
     /**
      * Environment variables for configuring Mesos API version.
      */
-    private static String MESOS_API_VERSION_ENV = "MESOS_API_VERSION";
+    private static final String MESOS_API_VERSION_ENV = "MESOS_API_VERSION";
 
     /**
      * Environment variables for configuring goal state override behavior.


### PR DESCRIPTION
Everything with TASKCFG_ALL_* gets forwarded to tasks automatically. In this case the BASE64 version is only used by the scheduler itself so avoid passing the BASE64 version to tasks.

Ultimately a nitpick but doesn't hurt to fix.