### PR TITLE
[INFINITY-2805] fix kafka authz tests

### DIFF
--- a/frameworks/kafka/tests/auth.py
+++ b/frameworks/kafka/tests/auth.py
@@ -116,16 +116,17 @@ def write_to_topic(cn: str, task: str, topic: str, message: str, cmd: str=None) 
     def write_failed(output) -> bool:
         LOG.info("Checking write output: %s", output)
         rc = output[0]
-        stderr = output[1]
+        stderr = output[2]
 
         if rc:
             LOG.error("Write failed with non-zero return code")
             return True
-        if "ERROR Error when sending message to topic" in stderr:
-            unknown = "Error: UNKNOWN_TOPIC_OR_PARTITION" in stderr
-
-            LOG.error("Write failed due to stderr. unknown=%s", unknown)
-            return unknown
+        if "UNKNOWN_TOPIC_OR_PARTITION" in stderr:
+            LOG.error("Write failed due to stderr: UNKNOWN_TOPIC_OR_PARTITION")
+            return True
+        if "LEADER_NOT_AVAILABLE" in stderr:
+            LOG.error("Write failed due to stderr: LEADER_NOT_AVAILABLE")
+            return True
 
         LOG.info("Output check passed")
 
@@ -165,7 +166,7 @@ def read_from_topic(cn: str, task: str, topic: str, messages: int, cmd: str=None
     def read_failed(output) -> bool:
         LOG.info("Checking read output: %s", output)
         rc = output[0]
-        stderr = output[1]
+        stderr = output[2]
 
         if rc:
             LOG.error("Read failed with non-zero return code")

--- a/frameworks/kafka/tests/auth.py
+++ b/frameworks/kafka/tests/auth.py
@@ -161,7 +161,7 @@ def read_from_topic(cn: str, task: str, topic: str, messages: int) -> str:
             LOG.error("Read failed with non-zero return code")
             return True
         if "kafka.consumer.ConsumerTimeoutException" in stderr:
-            True
+            return True
 
         LOG.info("Output check passed")
 

--- a/frameworks/kafka/tests/auth.py
+++ b/frameworks/kafka/tests/auth.py
@@ -98,14 +98,20 @@ def setup_env(primary: str, task: str) -> str:
     return env_setup_string
 
 
-def write_to_topic(cn: str, task: str, topic: str, message: str) -> str:
-    env_str = setup_env(cn, task)
-    client_properties = write_client_properties(cn, task)
+def write_to_topic(cn: str, task: str, topic: str, message: str, cmd: str=None) -> str:
+    if not cmd:
+        env_str = setup_env(cn, task)
+        client_properties = write_client_properties(cn, task)
 
-    write_cmd = "bash -c \"{} && echo {} | kafka-console-producer \
-        --topic {} \
-        --producer.config {} \
-        --broker-list \$KAFKA_BROKER_LIST\"".format(env_str, message, topic, client_properties)
+        write_cmd = "bash -c \"{} && echo {} | kafka-console-producer \
+            --topic {} \
+            --producer.config {} \
+            --broker-list \$KAFKA_BROKER_LIST\"".format(env_str,
+                                                        message,
+                                                        topic,
+                                                        client_properties)
+    else:
+        write_cmd = cmd
 
     def write_failed(output) -> bool:
         LOG.info("Checking write output: %s", output)
@@ -141,16 +147,20 @@ def write_to_topic(cn: str, task: str, topic: str, message: str) -> str:
     return " ".join(str(o) for o in output)
 
 
-def read_from_topic(cn: str, task: str, topic: str, messages: int) -> str:
-    env_str = setup_env(cn, task)
-    timeout_ms = 60000
-    read_cmd = "bash -c \"{} && kafka-console-consumer \
-        --topic {} \
-        --consumer.config {} \
-        --bootstrap-server \$KAFKA_BROKER_LIST \
-        --from-beginning --max-messages {} \
-        --timeout-ms {} \
-        \"".format(env_str, topic, write_client_properties(cn, task), messages, timeout_ms)
+def read_from_topic(cn: str, task: str, topic: str, messages: int, cmd: str=None) -> str:
+    if not cmd:
+        env_str = setup_env(cn, task)
+        client_properties = write_client_properties(cn, task)
+        timeout_ms = 60000
+        read_cmd = "bash -c \"{} && kafka-console-consumer \
+            --topic {} \
+            --consumer.config {} \
+            --bootstrap-server \$KAFKA_BROKER_LIST \
+            --from-beginning --max-messages {} \
+            --timeout-ms {} \
+            \"".format(env_str, topic, client_properties, messages, timeout_ms)
+    else:
+        read_cmd = cmd
 
     def read_failed(output) -> bool:
         LOG.info("Checking read output: %s", output)

--- a/frameworks/kafka/tests/test_kerberos_auth.py
+++ b/frameworks/kafka/tests/test_kerberos_auth.py
@@ -153,7 +153,6 @@ def kafka_client(kerberos, kafka_server):
 @pytest.mark.dcos_min_version('1.10')
 @sdk_utils.dcos_ee_only
 @pytest.mark.sanity
-@pytest.mark.skip(reason="INFINITY-2805")
 def test_client_can_read_and_write(kafka_client, kafka_server):
     client_id = kafka_client["id"]
 

--- a/frameworks/kafka/tests/test_kerberos_authz.py
+++ b/frameworks/kafka/tests/test_kerberos_authz.py
@@ -162,7 +162,6 @@ def kafka_client(kerberos, kafka_server):
 @pytest.mark.dcos_min_version('1.10')
 @sdk_utils.dcos_ee_only
 @pytest.mark.sanity
-@pytest.mark.skip(reason="INFINITY-2805")
 def test_authz_acls_required(kafka_client, kafka_server):
     client_id = kafka_client["id"]
 

--- a/frameworks/kafka/tests/test_ssl_auth.py
+++ b/frameworks/kafka/tests/test_ssl_auth.py
@@ -99,7 +99,6 @@ def setup_principals(kafka_client):
 @pytest.mark.dcos_min_version('1.10')
 @pytest.mark.ee_only
 @pytest.mark.sanity
-@pytest.mark.skip(reason="INFINITY-2805")
 def test_authn_client_can_read_and_write(kafka_client, service_account, setup_principals):
     try:
         sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
@@ -150,7 +149,6 @@ def test_authn_client_can_read_and_write(kafka_client, service_account, setup_pr
 @pytest.mark.dcos_min_version('1.10')
 @pytest.mark.ee_only
 @pytest.mark.sanity
-@pytest.mark.skip(reason="INFINITY-2805")
 def test_authz_acls_required(kafka_client, service_account, setup_principals):
     client_id = kafka_client["id"]
 
@@ -224,7 +222,6 @@ def test_authz_acls_required(kafka_client, service_account, setup_principals):
 @pytest.mark.dcos_min_version('1.10')
 @pytest.mark.ee_only
 @pytest.mark.sanity
-@pytest.mark.skip(reason="INFINITY-2805")
 def test_authz_acls_not_required(kafka_client, service_account, setup_principals):
     client_id = kafka_client["id"]
 
@@ -414,34 +411,26 @@ EOL\"""".format(cn=cn))
 
 
 def write_to_topic(cn: str, task: str, topic: str, message: str) -> str:
-    output = sdk_tasks.task_exec(task,
-        "bash -c \"echo {} | kafka-console-producer \
-        --topic {} \
-        --producer.config {} \
-        --broker-list \$KAFKA_BROKER_LIST\"".format(message, topic, write_client_properties(cn, task)))
-    log.info(output)
-    assert output[0] is 0
-    return " ".join(str(o) for o in output)
+    client_properties = write_client_properties(cn, task)
+    cmd = "bash -c \"echo {} | kafka-console-producer \
+            --topic {} \
+            --producer.config {} \
+            --broker-list \$KAFKA_BROKER_LIST\"".format(message,
+                                                        topic,
+                                                        client_properties)
+
+    return auth.write_to_topic(cn, task, topic, message, cmd=cmd)
 
 
 def read_from_topic(cn: str, task: str, topic: str, messages: int) -> str:
-    output = sdk_tasks.task_exec(task,
-        "bash -c \"kafka-console-consumer \
-        --topic {} --from-beginning --max-messages {} \
-        --timeout-ms 10000 \
-        --consumer.config {} \
-        --bootstrap-server \$KAFKA_BROKER_LIST\"".format(topic, messages, write_client_properties(cn, task)))
-    log.info(output)
-    assert output[0] is 0
-    return " ".join(str(o) for o in output)
+    client_properties = write_client_properties(cn, task)
+    timeout_ms = 60000
+    cmd = "bash -c \"kafka-console-consumer \
+            --topic {} \
+            --consumer.config {} \
+            --bootstrap-server \$KAFKA_BROKER_LIST \
+            --from-beginning --max-messages {} \
+            --timeout-ms {} \
+            \"".format(topic, client_properties, messages, timeout_ms)
 
-def read_from_topic(cn: str, task: str, topic: str, messages: int) -> str:
-    output = sdk_tasks.task_exec(task,
-        "bash -c \"kafka-console-consumer \
-        --topic {} --from-beginning --max-messages {} \
-        --timeout-ms 10000 \
-        --consumer.config {} \
-        --bootstrap-server \$KAFKA_BROKER_LIST\"".format(topic, messages, write_client_properties(cn, task)))
-    log.info(output)
-    assert output[0] is 0
-    return " ".join(str(o) for o in output)
+    return auth.read_from_topic(cn, task, topic, messages, cmd)

--- a/frameworks/kafka/tests/test_zookeeper_auth.py
+++ b/frameworks/kafka/tests/test_zookeeper_auth.py
@@ -234,7 +234,6 @@ def kafka_client(kerberos, kafka_server):
 @pytest.mark.dcos_min_version('1.10')
 @sdk_utils.dcos_ee_only
 @pytest.mark.sanity
-@pytest.mark.skip(reason="INFINITY-2805")
 def test_client_can_read_and_write(kafka_client, kafka_server):
     client_id = kafka_client["id"]
 


### PR DESCRIPTION
This PR adds retries to the write and read operations for Kafka tests.

* write is retried if `"Error: UNKNOWN_TOPIC_OR_PARTITION"` is found in STDERR.
* read is retried if `"kafka.consumer.ConsumerTimeoutException"` is in STDERR (i.e. the consumer timesout)