### PR TITLE
INFINITY-2808 Fix strict: Use v0 on releases, v1 on test builds

### DIFF
--- a/frameworks/cassandra/tests/test_sanity.py
+++ b/frameworks/cassandra/tests/test_sanity.py
@@ -5,6 +5,7 @@ import sdk_cmd as cmd
 import sdk_hosts
 import sdk_install
 import sdk_jobs
+import sdk_marathon
 import sdk_metrics
 import sdk_plan
 import sdk_tasks
@@ -54,29 +55,11 @@ def test_service_health():
 @pytest.mark.smoke
 @pytest.mark.mesos_v0
 def test_mesos_v0_api():
-    try:
-        foldered_name = config.get_foldered_service_name()
-        # Install Cassandra using the v0 api.
-        # Then, clean up afterwards.
-        sdk_install.uninstall(config.PACKAGE_NAME, foldered_name)
-        sdk_install.install(
-            config.PACKAGE_NAME,
-            config.get_foldered_service_name(),
-            config.DEFAULT_TASK_COUNT,
-            additional_options={
-                "service": {"name": foldered_name, "mesos_api_version": "V0"}
-            }
-        )
-        sdk_tasks.check_running(foldered_name, config.DEFAULT_TASK_COUNT)
-    finally:
-        sdk_install.uninstall(config.PACKAGE_NAME, foldered_name)
-
-        # reinstall the v1 version for the following tests
-        sdk_install.install(
-            config.PACKAGE_NAME,
-            foldered_name,
-            config.DEFAULT_TASK_COUNT,
-            additional_options={"service": {"name": foldered_name}})
+    service_name = config.get_foldered_service_name()
+    prior_api_version = sdk_marathon.get_mesos_api_version(service_name)
+    if prior_api_version is not "V0":
+        sdk_marathon.set_mesos_api_version(service_name, "V0")
+        sdk_marathon.set_mesos_api_version(service_name, prior_api_version)
 
 
 @pytest.mark.sanity

--- a/frameworks/elastic/tests/test_sanity.py
+++ b/frameworks/elastic/tests/test_sanity.py
@@ -85,27 +85,11 @@ def test_pod_replace_then_immediate_config_update():
 @pytest.mark.smoke
 @pytest.mark.mesos_v0
 def test_mesos_v0_api():
-    try:
-        foldered_name = sdk_utils.get_foldered_name(config.SERVICE_NAME)
-        # Install Elastic using the v0 api.
-        # Then, clean up afterwards.
-        sdk_install.uninstall(config.PACKAGE_NAME, foldered_name)
-        sdk_install.install(
-            config.PACKAGE_NAME,
-            foldered_name,
-            current_expected_task_count,
-            additional_options={"service": {"name": foldered_name, "mesos_api_version": "V0"}}
-        )
-        sdk_tasks.check_running(foldered_name, current_expected_task_count)
-    finally:
-        sdk_install.uninstall(config.PACKAGE_NAME, foldered_name)
-
-        # reinstall the v1 version for the following tests
-        sdk_install.install(
-            config.PACKAGE_NAME,
-            foldered_name,
-            config.DEFAULT_TASK_COUNT,
-            additional_options={"service": {"name": foldered_name}})
+    service_name = sdk_utils.get_foldered_name(config.SERVICE_NAME)
+    prior_api_version = sdk_marathon.get_mesos_api_version(service_name)
+    if prior_api_version is not "V0":
+        sdk_marathon.set_mesos_api_version(service_name, "V0")
+        sdk_marathon.set_mesos_api_version(service_name, prior_api_version)
 
 
 @pytest.mark.sanity

--- a/frameworks/hdfs/tests/test_sanity.py
+++ b/frameworks/hdfs/tests/test_sanity.py
@@ -53,28 +53,11 @@ def pre_test_setup():
 @pytest.mark.smoke
 @pytest.mark.mesos_v0
 def test_mesos_v0_api():
-    try:
-        foldered_name = sdk_utils.get_foldered_name(config.SERVICE_NAME)
-        # Install HDFS using the v0 api.
-        # Then, clean up afterwards.
-        sdk_install.uninstall(config.PACKAGE_NAME, foldered_name)
-        sdk_install.install(
-            config.PACKAGE_NAME,
-            foldered_name,
-            config.DEFAULT_TASK_COUNT,
-            additional_options={"service": {"name": foldered_name, "mesos_api_version": "V0"}},
-            timeout_seconds=30 * 60)
-        sdk_tasks.check_running(foldered_name, config.DEFAULT_TASK_COUNT)
-    finally:
-        sdk_install.uninstall(config.PACKAGE_NAME, foldered_name)
-
-        # reinstall the v1 version for the following tests
-        sdk_install.install(
-            config.PACKAGE_NAME,
-            foldered_name,
-            config.DEFAULT_TASK_COUNT,
-            additional_options={"service": {"name": foldered_name}},
-            timeout_seconds=30 * 60)
+    service_name = sdk_utils.get_foldered_name(config.SERVICE_NAME)
+    prior_api_version = sdk_marathon.get_mesos_api_version(service_name)
+    if prior_api_version is not "V0":
+        sdk_marathon.set_mesos_api_version(service_name, "V0")
+        sdk_marathon.set_mesos_api_version(service_name, prior_api_version)
 
 
 @pytest.mark.sanity

--- a/frameworks/helloworld/tests/test_sanity.py
+++ b/frameworks/helloworld/tests/test_sanity.py
@@ -42,27 +42,11 @@ def test_install():
 @pytest.mark.smoke
 @pytest.mark.mesos_v0
 def test_mesos_v0_api():
-    try:
-        foldered_name = sdk_utils.get_foldered_name(config.SERVICE_NAME)
-        # Install Hello World using the v0 api.
-        # Then, clean up afterwards.
-        sdk_install.uninstall(config.PACKAGE_NAME, foldered_name)
-        sdk_install.install(
-            config.PACKAGE_NAME,
-            foldered_name,
-            config.DEFAULT_TASK_COUNT,
-            additional_options={"service": {"name": foldered_name, "mesos_api_version": "V0"}}
-        )
-        config.check_running(foldered_name)
-    finally:
-        sdk_install.uninstall(config.PACKAGE_NAME, foldered_name)
-
-        # reinstall the v1 version for the following tests
-        sdk_install.install(
-            config.PACKAGE_NAME,
-            foldered_name,
-            config.DEFAULT_TASK_COUNT,
-            additional_options={"service": {"name": foldered_name}})
+    service_name = sdk_utils.get_foldered_name(config.SERVICE_NAME)
+    prior_api_version = sdk_marathon.get_mesos_api_version(service_name)
+    if prior_api_version is not "V0":
+        sdk_marathon.set_mesos_api_version(service_name, "V0")
+        sdk_marathon.set_mesos_api_version(service_name, prior_api_version)
 
 
 @pytest.mark.sanity

--- a/frameworks/kafka/tests/test_sanity.py
+++ b/frameworks/kafka/tests/test_sanity.py
@@ -48,31 +48,11 @@ def test_service_health():
 @pytest.mark.smoke
 @pytest.mark.mesos_v0
 def test_mesos_v0_api():
-    try:
-        foldered_name = sdk_utils.get_foldered_name(config.SERVICE_NAME)
-        # Install Kafka using the v0 api.
-        # Then, clean up afterwards.
-        sdk_install.uninstall(config.PACKAGE_NAME, foldered_name)
-        sdk_install.install(
-            config.PACKAGE_NAME,
-            foldered_name,
-            config.DEFAULT_BROKER_COUNT,
-            additional_options={"service": {"name": foldered_name, "mesos_api_version": "V0"}, "brokers": {"cpus": 0.5}})
-
-        sdk_tasks.check_running(foldered_name, config.DEFAULT_BROKER_COUNT)
-    finally:
-        sdk_install.uninstall(config.PACKAGE_NAME, foldered_name)
-
-        # reinstall the v1 version for the following tests
-        sdk_install.install(
-            config.PACKAGE_NAME,
-            foldered_name,
-            config.DEFAULT_BROKER_COUNT,
-            additional_options={"service": {"name": foldered_name}, "brokers": {"cpus": 0.5}})
-
-        # wait for brokers to finish registering before starting tests
-        test_utils.broker_count_check(config.DEFAULT_BROKER_COUNT,
-                                      service_name=foldered_name)
+    service_name = sdk_utils.get_foldered_name(config.SERVICE_NAME)
+    prior_api_version = sdk_marathon.get_mesos_api_version(service_name)
+    if prior_api_version is not "V0":
+        sdk_marathon.set_mesos_api_version(service_name, "V0")
+        sdk_marathon.set_mesos_api_version(service_name, prior_api_version)
 
 
 # --------- Endpoints -------------

--- a/frameworks/kafka/tests/test_sanity.py
+++ b/frameworks/kafka/tests/test_sanity.py
@@ -17,30 +17,17 @@ import shakedown
 from tests import config, test_utils
 
 
-def install_kafka(use_v0=False):
-    mesos_api_version = "V0" if use_v0 else "V1"
-    foldered_name = sdk_utils.get_foldered_name(config.SERVICE_NAME)
-    if sdk_utils.dcos_version_less_than("1.9"):
-        # Last beta-kafka release (1.1.25-0.10.1.0-beta) excludes 1.8. Skip upgrade tests with 1.8 and just install
-        sdk_install.install(
-            config.PACKAGE_NAME,
-            foldered_name,
-            config.DEFAULT_BROKER_COUNT,
-            additional_options={"service": {"name": foldered_name, "mesos_api_version": mesos_api_version}})
-    else:
-        sdk_upgrade.test_upgrade(
-            config.PACKAGE_NAME,
-            foldered_name,
-            config.DEFAULT_BROKER_COUNT,
-            additional_options={"service": {"name": foldered_name, "mesos_api_version": mesos_api_version}, "brokers": {"cpus": 0.5}})
-
-
 @pytest.fixture(scope='module', autouse=True)
 def configure_package(configure_security):
     try:
         foldered_name = sdk_utils.get_foldered_name(config.SERVICE_NAME)
         sdk_install.uninstall(config.PACKAGE_NAME, foldered_name)
-        install_kafka()
+
+        sdk_upgrade.test_upgrade(
+            config.PACKAGE_NAME,
+            foldered_name,
+            config.DEFAULT_BROKER_COUNT,
+            additional_options={"service": {"name": foldered_name}, "brokers": {"cpus": 0.5}})
 
         # wait for brokers to finish registering before starting tests
         test_utils.broker_count_check(config.DEFAULT_BROKER_COUNT,
@@ -63,16 +50,26 @@ def test_service_health():
 def test_mesos_v0_api():
     try:
         foldered_name = sdk_utils.get_foldered_name(config.SERVICE_NAME)
-        # Install Hello World using the v0 api.
+        # Install Kafka using the v0 api.
         # Then, clean up afterwards.
         sdk_install.uninstall(config.PACKAGE_NAME, foldered_name)
-        install_kafka(use_v0=True)
+        sdk_install.install(
+            config.PACKAGE_NAME,
+            foldered_name,
+            config.DEFAULT_BROKER_COUNT,
+            additional_options={"service": {"name": foldered_name, "mesos_api_version": "V0"}, "brokers": {"cpus": 0.5}})
 
         sdk_tasks.check_running(foldered_name, config.DEFAULT_BROKER_COUNT)
     finally:
         sdk_install.uninstall(config.PACKAGE_NAME, foldered_name)
 
-        install_kafka()
+        # reinstall the v1 version for the following tests
+        sdk_install.install(
+            config.PACKAGE_NAME,
+            foldered_name,
+            config.DEFAULT_BROKER_COUNT,
+            additional_options={"service": {"name": foldered_name}, "brokers": {"cpus": 0.5}})
+
         # wait for brokers to finish registering before starting tests
         test_utils.broker_count_check(config.DEFAULT_BROKER_COUNT,
                                       service_name=foldered_name)

--- a/testing/sdk_install.py
+++ b/testing/sdk_install.py
@@ -186,8 +186,7 @@ def get_package_options(additional_options={}):
                 'service_account': 'service-acct',
                 'principal': 'service-acct',
                 'service_account_secret': 'secret',
-                'secret_name': 'secret',
-                'mesos_api_version': 'V0'
+                'secret_name': 'secret'
             }
         }, additional_options)
     else:

--- a/testing/sdk_marathon.py
+++ b/testing/sdk_marathon.py
@@ -154,5 +154,5 @@ def set_mesos_api_version(service_name, api_version, timeout=600):
     config = get_config(service_name)
     config['env']['MESOS_API_VERSION'] = api_version
     update_app(service_name, config, timeout=timeout)
-    # wait for scheduler to come back and successfully process some offers:
-    sdk_metrics.wait_for_scheduler_counter_value(service_name, 'offers.processed', 5, timeout_seconds=timeout)
+    # wait for scheduler to come back and successfully receive/process offers:
+    sdk_metrics.wait_for_scheduler_counter_value(service_name, 'offers.processed', 1, timeout_seconds=timeout)

--- a/testing/sdk_marathon.py
+++ b/testing/sdk_marathon.py
@@ -13,6 +13,7 @@ import tempfile
 import shakedown
 
 import sdk_cmd
+import sdk_metrics
 
 log = logging.getLogger(__name__)
 
@@ -117,9 +118,9 @@ def api_url_with_param(basename, path_param):
     return '{}/{}'.format(api_url(basename), path_param)
 
 
-def get_scheduler_host(package_name):
+def get_scheduler_host(service_name):
     # Marathon mangles foldered paths as follows: "/path/to/svc" => "svc.to.path"
-    task_name_elems = package_name.lstrip('/').split('/')
+    task_name_elems = service_name.lstrip('/').split('/')
     task_name_elems.reverse()
     app_name = '.'.join(task_name_elems)
     ips = shakedown.get_service_ips('marathon', app_name)
@@ -129,16 +130,29 @@ def get_scheduler_host(package_name):
     return ips.pop()
 
 
-def bump_cpu_count_config(package_name, key_name, delta=0.1):
-    config = get_config(package_name)
+def bump_cpu_count_config(service_name, key_name, delta=0.1):
+    config = get_config(service_name)
     updated_cpus = float(config['env'][key_name]) + delta
     config['env'][key_name] = str(updated_cpus)
-    update_app(package_name, config)
+    update_app(service_name, config)
     return updated_cpus
 
 
-def bump_task_count_config(package_name, key_name, delta=1):
-    config = get_config(package_name)
+def bump_task_count_config(service_name, key_name, delta=1):
+    config = get_config(service_name)
     updated_node_count = int(config['env'][key_name]) + delta
     config['env'][key_name] = str(updated_node_count)
-    update_app(package_name, config)
+    update_app(service_name, config)
+
+
+def get_mesos_api_version(service_name):
+    return get_config(service_name)['env']['MESOS_API_VERSION']
+
+
+def set_mesos_api_version(service_name, api_version, timeout=600):
+    '''Sets the mesos API version to the provided value, and then verifies that the scheduler comes back successfully'''
+    config = get_config(service_name)
+    config['env']['MESOS_API_VERSION'] = api_version
+    update_app(service_name, config, timeout=timeout)
+    # wait for scheduler to come back and successfully process some offers:
+    sdk_metrics.wait_for_scheduler_counter_value(service_name, 'offers.processed', 5, timeout_seconds=timeout)


### PR DESCRIPTION
Released builds only work on strict clusters with V0 of the Mesos API (their default), while test builds work with V1 (their default).

- Update strict-mode tests to use whatever Mesos API default is declared by the package, rather than overriding with V0 all the time.
- Update Kafka upgrade test to not force V1. This breaks Kafka's strict tests as the released version won't work with V1. Instead we should just use the declared default in each respective version.