### PR TITLE
INFINITY 2583 ensure uniform security settings

### DIFF
--- a/frameworks/hdfs/tests/test_auth.py
+++ b/frameworks/hdfs/tests/test_auth.py
@@ -79,7 +79,7 @@ def kerberos(configure_security):
                         "enabled": True,
                         "kdc": {
                             "hostname": kerberos_env.get_host(),
-                            "port": kerberos_env.get_port()
+                            "port": int(kerberos_env.get_port())
                         },
                         "keytab_secret": kerberos_env.get_keytab_path(),
                         "realm": sdk_auth.REALM


### PR DESCRIPTION
This should fix the current kafka test failure: https://teamcity.mesosphere.io/viewLog.html?buildId=892018&buildTypeId=DcosIo_DcosCommons_Hdfs_BuildAndTestPr

Edit: HDFS, not kafka.