### PR TITLE
[INFINITY-2815] disable tests that use the KDC fixture

### DIFF
--- a/frameworks/hdfs/tests/test_auth.py
+++ b/frameworks/hdfs/tests/test_auth.py
@@ -11,6 +11,10 @@ import sdk_tasks
 import sdk_utils
 from tests import config
 
+
+pytestmark = pytest.mark.skip(reason="INFINITY-2815")
+
+
 log = logging.getLogger(__name__)
 
 

--- a/frameworks/kafka/tests/test_kerberos_auth.py
+++ b/frameworks/kafka/tests/test_kerberos_auth.py
@@ -13,6 +13,10 @@ from tests import auth
 from tests import config
 from tests import test_utils
 
+
+pytestmark = pytest.mark.skip(reason="INFINITY-2815")
+
+
 log = logging.getLogger(__name__)
 
 

--- a/frameworks/kafka/tests/test_kerberos_authz.py
+++ b/frameworks/kafka/tests/test_kerberos_authz.py
@@ -14,6 +14,10 @@ from tests import config
 from tests import topics
 from tests import test_utils
 
+
+pytestmark = pytest.mark.skip(reason="INFINITY-2815")
+
+
 log = logging.getLogger(__name__)
 
 

--- a/frameworks/kafka/tests/test_ssl_auth.py
+++ b/frameworks/kafka/tests/test_ssl_auth.py
@@ -6,7 +6,6 @@ import json
 import time
 import shakedown
 
-import sdk_auth
 import sdk_cmd
 import sdk_hosts
 import sdk_install

--- a/frameworks/kafka/tests/test_zookeeper_auth.py
+++ b/frameworks/kafka/tests/test_zookeeper_auth.py
@@ -20,6 +20,9 @@ from tests import config
 from tests import test_utils
 
 
+pytestmark = pytest.mark.skip(reason="INFINITY-2815")
+
+
 log = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
This PR disables tests that use a fixture to setup KDC.

These are currently failing with (for example):

```
conftest.py 74 ERROR Test test_authz_acls_required failed in setup phase, dumping state
```