### PR TITLE
[INFINITY-2815] enabled kafka tests

### DIFF
--- a/frameworks/kafka/tests/test_kerberos_auth.py
+++ b/frameworks/kafka/tests/test_kerberos_auth.py
@@ -14,9 +14,6 @@ from tests import config
 from tests import test_utils
 
 
-pytestmark = pytest.mark.skip(reason="INFINITY-2815")
-
-
 log = logging.getLogger(__name__)
 
 

--- a/frameworks/kafka/tests/test_kerberos_authz.py
+++ b/frameworks/kafka/tests/test_kerberos_authz.py
@@ -15,9 +15,6 @@ from tests import topics
 from tests import test_utils
 
 
-pytestmark = pytest.mark.skip(reason="INFINITY-2815")
-
-
 log = logging.getLogger(__name__)
 
 

--- a/frameworks/kafka/tests/test_zookeeper_auth.py
+++ b/frameworks/kafka/tests/test_zookeeper_auth.py
@@ -20,9 +20,6 @@ from tests import config
 from tests import test_utils
 
 
-pytestmark = pytest.mark.skip(reason="INFINITY-2815")
-
-
 log = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
Reenable the KDC-based Kafka tests disabled in #1940 

The HDFS tests are enabled in #1942.

This includes test fixes from #1936 (which should be ready to merge soon).