### PR TITLE
[KAF-341] Use the correct scheduler task ID

### DIFF
--- a/frameworks/kafka/tests/auth.py
+++ b/frameworks/kafka/tests/auth.py
@@ -124,7 +124,7 @@ def write_to_topic(cn: str, task: str, topic: str, message: str, cmd: str=None) 
         if "UNKNOWN_TOPIC_OR_PARTITION" in stderr:
             LOG.error("Write failed due to stderr: UNKNOWN_TOPIC_OR_PARTITION")
             return True
-        if "LEADER_NOT_AVAILABLE" in stderr:
+        if "LEADER_NOT_AVAILABLE" in stderr and "ERROR Error when sending message" in stderr:
             LOG.error("Write failed due to stderr: LEADER_NOT_AVAILABLE")
             return True
 


### PR DESCRIPTION
This PR uses the scheduler task ID (which is not returned from `sdk_tasks.get_task_ids`) to perform the wait for the broker DNS.

This fixes this function for services where the service name is not `kafka*`.