### PR TITLE
[INFINITY-2583] Fix missed envar renames

### DIFF
--- a/frameworks/hdfs/src/main/dist/core-site.xml
+++ b/frameworks/hdfs/src/main/dist/core-site.xml
@@ -555,7 +555,7 @@
     </property>
     <property>
         <name>hadoop.http.authentication.kerberos.principal</name>
-        <value>{{KERBEROS_PRIMARY_HTTP}}/{{FRAMEWORK_NAME}}.marathon.autoip.dcos.thisdcos.directory@{{KERBEROS_REALM}}</value>
+        <value>{{SECURITY_KERBEROS_PRIMARY_HTTP}}/{{FRAMEWORK_NAME}}.marathon.autoip.dcos.thisdcos.directory@{{SECURITY_KERBEROS_REALM}}</value>
     </property>
     <property>
         <name>hadoop.http.authentication.kerberos.keytab</name>

--- a/frameworks/hdfs/src/main/dist/hdfs-site.xml
+++ b/frameworks/hdfs/src/main/dist/hdfs-site.xml
@@ -818,12 +818,12 @@
         <value>{{PERMISSIONS_SUPERUSERGROUP}}</value>
     </property>
 
-    {{^KERBEROS_ENABLED}}
+    {{^SECURITY_KERBEROS_ENABLED}}
     <property>
         <name>dfs.permissions.enabled</name>
         <value>{{PERMISSIONS_ENABLED}}</value>
     </property>
-    {{/KERBEROS_ENABLED}}
+    {{/SECURITY_KERBEROS_ENABLED}}
 
 
     {{#SECURITY_KERBEROS_ENABLED}}
@@ -892,15 +892,15 @@
         </property>
         <property>
             <name>dfs.secondary.namenode.kerberos.principal</name>
-            <value>{{KERBEROS_PRIMARY}}/name-{{OTHER_NN_INDEX}}-node.{{FRAMEWORK_HOST}}@{{KERBEROS_REALM}}</value>
+            <value>{{SECURITY_KERBEROS_PRIMARY}}/name-{{OTHER_NN_INDEX}}-node.{{FRAMEWORK_HOST}}@{{SECURITY_KERBEROS_REALM}}</value>
         </property>
         <property>
             <name>dfs.secondary.namenode.kerberos.http.principal</name>
-            <value>{{KERBEROS_PRIMARY_HTTP}}/name-{{OTHER_NN_INDEX}}-node.{{FRAMEWORK_HOST}}@{{KERBEROS_REALM}}</value>
+            <value>{{SECURITY_KERBEROS_PRIMARY_HTTP}}/name-{{OTHER_NN_INDEX}}-node.{{FRAMEWORK_HOST}}@{{SECURITY_KERBEROS_REALM}}</value>
         </property>
         <property>
             <name>dfs.secondary.namenode.kerberos.internal.spnego.principal</name>
-            <value>{{KERBEROS_PRIMARY_HTTP}}/name-{{OTHER_NN_INDEX}}-node.{{FRAMEWORK_HOST}}@{{KERBEROS_REALM}}</value>
+            <value>{{SECURITY_KERBEROS_PRIMARY_HTTP}}/name-{{OTHER_NN_INDEX}}-node.{{FRAMEWORK_HOST}}@{{SECURITY_KERBEROS_REALM}}</value>
         </property>
         {{/NAMENODE}}
 

--- a/frameworks/hdfs/tests/test_auth.py
+++ b/frameworks/hdfs/tests/test_auth.py
@@ -147,7 +147,6 @@ def test_user_can_auth_and_write_and_read(kerberized_hdfs_client):
     assert stdout == config.TEST_CONTENT_SMALL
 
 
-
 @pytest.mark.dcos_min_version('1.10')
 @sdk_utils.dcos_ee_only
 @pytest.mark.auth


### PR DESCRIPTION
`SECURITY_`  should be prepended to the `KERBEROS_` envars.

(Should have been included in #1949) 