### PR TITLE
Fix upgrades in stable branch

### DIFF
--- a/frameworks/cassandra/tests/test_sanity.py
+++ b/frameworks/cassandra/tests/test_sanity.py
@@ -20,7 +20,7 @@ def configure_package(configure_security):
         test_jobs = config.get_all_jobs(node_address=config.get_foldered_node_address())
         sdk_install.uninstall(config.get_foldered_service_name(), package_name=config.PACKAGE_NAME)
         sdk_upgrade.test_upgrade(
-            "beta-{}".format(config.PACKAGE_NAME),
+            config.PACKAGE_NAME,
             config.PACKAGE_NAME,
             config.DEFAULT_TASK_COUNT,
             service_name=config.get_foldered_service_name(),

--- a/frameworks/elastic/tests/test_sanity.py
+++ b/frameworks/elastic/tests/test_sanity.py
@@ -26,7 +26,7 @@ def configure_package(configure_security):
         sdk_install.uninstall(FOLDERED_SERVICE_NAME, package_name=config.PACKAGE_NAME)
 
         sdk_upgrade.test_upgrade(
-            "beta-{}".format(config.PACKAGE_NAME),
+            config.PACKAGE_NAME,
             config.PACKAGE_NAME,
             config.DEFAULT_TASK_COUNT,
             service_name=FOLDERED_SERVICE_NAME,

--- a/frameworks/hdfs/tests/test_sanity.py
+++ b/frameworks/hdfs/tests/test_sanity.py
@@ -32,7 +32,7 @@ def configure_package(configure_security):
                 timeout_seconds=30*60)
         else:
             sdk_upgrade.test_upgrade(
-                "beta-{}".format(config.PACKAGE_NAME),
+                config.PACKAGE_NAME,
                 config.PACKAGE_NAME,
                 config.DEFAULT_TASK_COUNT,
                 service_name=config.FOLDERED_SERVICE_NAME,


### PR DESCRIPTION
This PR makes it so that Elastic, HDFS, and Cassandra target the GA framework for their upgrade test in the 0.30.X branch (stable).

Kafka is taken care of in #1972.