### PR TITLE
Remove smoke marker from test_goal_states.py

### DIFF
--- a/frameworks/helloworld/tests/test_goal_states.py
+++ b/frameworks/helloworld/tests/test_goal_states.py
@@ -38,7 +38,6 @@ def test_install():
 
 
 @pytest.mark.sanity
-@pytest.mark.smoke
 def test_once_task_does_not_restart_on_config_update():
     foldered_name = sdk_utils.get_foldered_name(config.SERVICE_NAME)
     config.check_running(foldered_name)
@@ -56,7 +55,6 @@ def test_once_task_does_not_restart_on_config_update():
 
 
 @pytest.mark.sanity
-@pytest.mark.smoke
 def test_finish_task_restarts_on_config_update():
     foldered_name = sdk_utils.get_foldered_name(config.SERVICE_NAME)
     config.check_running(foldered_name)


### PR DESCRIPTION
Smoke tests in dcos/dcos are failing due to this test:
https://teamcity.mesosphere.io/viewLog.html?buildId=903328&buildTypeId=ClosedSource_MesosphereEnterpriseDcOs_IntegrationTests_DcOsCommonsSmokeTest&tab=buildLog&_focus=1729

However, in CI on master it does not fail.

Clearly the test is dependent on the CI sanity environment and is not safe to run in a purely smoke environment