### PR TITLE
INFINITY-2855 Fix health check when in uninstall mode

### DIFF
--- a/frameworks/cassandra/universe/marathon.json.mustache
+++ b/frameworks/cassandra/universe/marathon.json.mustache
@@ -169,16 +169,7 @@
   "healthChecks": [
     {
       "protocol": "HTTP",
-      "path": "/v1/plans/deploy",
-      "gracePeriodSeconds": 900,
-      "intervalSeconds": 30,
-      "portIndex": 0,
-      "timeoutSeconds": 30,
-      "maxConsecutiveFailures": 0
-    },
-    {
-      "protocol": "HTTP",
-      "path": "/v1/plans/recovery",
+      "path": "/v1/health",
       "gracePeriodSeconds": 900,
       "intervalSeconds": 30,
       "portIndex": 0,

--- a/frameworks/elastic/universe/marathon.json.mustache
+++ b/frameworks/elastic/universe/marathon.json.mustache
@@ -335,16 +335,7 @@
   "healthChecks": [
     {
       "protocol": "HTTP",
-      "path": "/v1/plans/deploy",
-      "gracePeriodSeconds": 900,
-      "intervalSeconds": 30,
-      "portIndex": 0,
-      "timeoutSeconds": 30,
-      "maxConsecutiveFailures": 0
-    },
-    {
-      "protocol": "HTTP",
-      "path": "/v1/plans/recovery",
+      "path": "/v1/health",
       "gracePeriodSeconds": 900,
       "intervalSeconds": 30,
       "portIndex": 0,

--- a/frameworks/hdfs/universe/marathon.json.mustache
+++ b/frameworks/hdfs/universe/marathon.json.mustache
@@ -439,16 +439,7 @@
   "healthChecks": [
     {
       "protocol": "HTTP",
-      "path": "/v1/plans/deploy",
-      "gracePeriodSeconds": 900,
-      "intervalSeconds": 30,
-      "portIndex": 0,
-      "timeoutSeconds": 30,
-      "maxConsecutiveFailures": 0
-    },
-    {
-      "protocol": "HTTP",
-      "path": "/v1/plans/recovery",
+      "path": "/v1/health",
       "gracePeriodSeconds": 900,
       "intervalSeconds": 30,
       "portIndex": 0,

--- a/frameworks/helloworld/universe/marathon.json.mustache
+++ b/frameworks/helloworld/universe/marathon.json.mustache
@@ -99,16 +99,7 @@
   "healthChecks": [
     {
       "protocol": "HTTP",
-      "path": "/v1/plans/deploy",
-      "gracePeriodSeconds": 900,
-      "intervalSeconds": 30,
-      "portIndex": 0,
-      "timeoutSeconds": 30,
-      "maxConsecutiveFailures": 0
-    },
-    {
-      "protocol": "HTTP",
-      "path": "/v1/plans/recovery",
+      "path": "/v1/health",
       "gracePeriodSeconds": 900,
       "intervalSeconds": 30,
       "portIndex": 0,

--- a/frameworks/kafka/universe/marathon.json.mustache
+++ b/frameworks/kafka/universe/marathon.json.mustache
@@ -206,16 +206,7 @@
   "healthChecks": [
     {
       "protocol": "HTTP",
-      "path": "/v1/plans/deploy",
-      "gracePeriodSeconds": 900,
-      "intervalSeconds": 30,
-      "portIndex": 0,
-      "timeoutSeconds": 30,
-      "maxConsecutiveFailures": 0
-    },
-    {
-      "protocol": "HTTP",
-      "path": "/v1/plans/recovery",
+      "path": "/v1/health",
       "gracePeriodSeconds": 900,
       "intervalSeconds": 30,
       "portIndex": 0,

--- a/frameworks/template/universe/marathon.json.mustache
+++ b/frameworks/template/universe/marathon.json.mustache
@@ -69,16 +69,7 @@
   "healthChecks": [
     {
       "protocol": "HTTP",
-      "path": "/v1/plans/deploy",
-      "gracePeriodSeconds": 900,
-      "intervalSeconds": 30,
-      "portIndex": 0,
-      "timeoutSeconds": 30,
-      "maxConsecutiveFailures": 0
-    },
-    {
-      "protocol": "HTTP",
-      "path": "/v1/plans/recovery",
+      "path": "/v1/health",
       "gracePeriodSeconds": 900,
       "intervalSeconds": 30,
       "portIndex": 0,

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/api/HealthResource.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/api/HealthResource.java
@@ -1,0 +1,63 @@
+package com.mesosphere.sdk.api;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+
+import com.mesosphere.sdk.scheduler.plan.PlanManager;
+
+/**
+ * A read-only API for checking whether the service is healthy.
+ */
+@Path("/v1/health")
+public class HealthResource {
+
+    private final Collection<PlanManager> planManagers = new ArrayList<>();
+    private final Object planManagersLock = new Object();
+
+    /**
+     * Assigns the list of plans to be checked for completion when deciding whether the service is healthy.
+     *
+     * @return this
+     */
+    public HealthResource setHealthyPlanManagers(Collection<PlanManager> planManagers) {
+        synchronized (planManagersLock) {
+            this.planManagers.clear();
+            this.planManagers.addAll(planManagers);
+        }
+        return this;
+    }
+
+    /**
+     * Returns the health of the service as a response code:
+     * <ul><li>417 Expectation failed: Errors in plan(s)</li>
+     * <li>202 Accepted: Incomplete plan(s)</li>
+     * <li>200 OK: All plans complete/no errors</li></ul>
+     */
+    @GET
+    public Response getHealth() {
+        final boolean isAnyErrors;
+        final boolean isAnyIncomplete;
+
+        synchronized (planManagersLock) {
+            isAnyErrors = planManagers.stream()
+                    .anyMatch(planManager -> !planManager.getPlan().getErrors().isEmpty());
+            isAnyIncomplete = planManagers.stream()
+                    .anyMatch(planManager -> !planManager.getPlan().isComplete());
+        }
+
+        final Response.Status status;
+        if (isAnyErrors) {
+            status = Response.Status.EXPECTATION_FAILED;
+        } else if (isAnyIncomplete) {
+            status = Response.Status.ACCEPTED;
+        } else {
+            status = Response.Status.OK;
+        }
+        // In the future, we could return a json object providing details. For now, though, let's just go with something
+        // opaque, as there's no guarantee that we wouldn't end up changing this later.
+        return ResponseUtils.plainResponse(status.toString(), status);
+    }
+}

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/uninstall/UninstallScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/uninstall/UninstallScheduler.java
@@ -1,6 +1,7 @@
 package com.mesosphere.sdk.scheduler.uninstall;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.mesosphere.sdk.api.HealthResource;
 import com.mesosphere.sdk.api.PlansResource;
 import com.mesosphere.sdk.dcos.clients.SecretsClient;
 import com.mesosphere.sdk.offer.*;
@@ -56,8 +57,9 @@ public class UninstallScheduler extends AbstractScheduler {
         uninstallPlanBuilder = new UninstallPlanBuilder(
                 serviceSpec, stateStore, configStore, schedulerConfig, customSecretsClientForTests);
         uninstallPlanManager = DefaultPlanManager.createProceeding(uninstallPlanBuilder.getPlan());
-        resources = Collections.singletonList(new PlansResource()
-                .setPlanManagers(Collections.singletonList(uninstallPlanManager)));
+        resources = Arrays.<Object>asList(
+                new PlansResource().setPlanManagers(Collections.singletonList(uninstallPlanManager)),
+                new HealthResource().setHealthyPlanManagers(Collections.singletonList(uninstallPlanManager)));
     }
 
     @Override

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/api/HealthResourceTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/api/HealthResourceTest.java
@@ -1,0 +1,74 @@
+package com.mesosphere.sdk.api;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import javax.ws.rs.core.Response;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import com.mesosphere.sdk.scheduler.plan.DefaultPlanManager;
+import com.mesosphere.sdk.scheduler.plan.Plan;
+
+import static org.mockito.Mockito.when;
+
+public class HealthResourceTest {
+    @Mock private Plan mockPlan1;
+    @Mock private Plan mockPlan2;
+
+    private HealthResource resource;
+
+    @Before
+    public void beforeEach() {
+        MockitoAnnotations.initMocks(this);
+        resource = new HealthResource().setHealthyPlanManagers(Arrays.asList(
+                DefaultPlanManager.createProceeding(mockPlan1),
+                DefaultPlanManager.createProceeding(mockPlan2)));
+    }
+
+    @Test
+    public void testPlanErrorIncomplete() {
+        when(mockPlan1.getErrors()).thenReturn(Collections.singletonList("err"));
+        when(mockPlan1.isComplete()).thenReturn(true);
+        when(mockPlan2.getErrors()).thenReturn(Collections.emptyList());
+        when(mockPlan2.isComplete()).thenReturn(false);
+        checkHealthStatus(Response.Status.EXPECTATION_FAILED);
+    }
+
+    @Test
+    public void testPlanError() {
+        when(mockPlan1.getErrors()).thenReturn(Collections.singletonList("err"));
+        when(mockPlan1.isComplete()).thenReturn(true);
+        when(mockPlan2.getErrors()).thenReturn(Collections.emptyList());
+        when(mockPlan2.isComplete()).thenReturn(true);
+        checkHealthStatus(Response.Status.EXPECTATION_FAILED);
+    }
+
+    @Test
+    public void testPlanIncomplete() {
+        when(mockPlan1.getErrors()).thenReturn(Collections.emptyList());
+        when(mockPlan1.isComplete()).thenReturn(false);
+        when(mockPlan2.getErrors()).thenReturn(Collections.emptyList());
+        when(mockPlan2.isComplete()).thenReturn(true);
+        checkHealthStatus(Response.Status.ACCEPTED);
+    }
+
+    @Test
+    public void testPlanComplete() {
+        when(mockPlan1.getErrors()).thenReturn(Collections.emptyList());
+        when(mockPlan1.isComplete()).thenReturn(true);
+        when(mockPlan2.getErrors()).thenReturn(Collections.emptyList());
+        when(mockPlan2.isComplete()).thenReturn(true);
+        checkHealthStatus(Response.Status.OK);
+    }
+
+    private void checkHealthStatus(Response.Status status) {
+        Response response = resource.getHealth();
+        Assert.assertEquals(status, response.getStatusInfo());
+        Assert.assertEquals(status.toString(), response.getEntity());
+    }
+}


### PR DESCRIPTION
Marathon health check looks at `deploy`+`recovery` plans, but in the case of uninstall, there is no `recovery` plan. Therefore after 15 minutes the uninstall scheduler will enter an 'unhealthy' state regardless of how things are going.

Instead of patching this situation by propping up a fake/noop `recovery` plan to keep health checks happy during uninstall, lets just add a dedicated endpoint and point the health checks to that instead. For now it's kept simple and opaque, just returning the response code depending on plan states (`deploy`+`recovery` in normal scheduler, or just `deploy` in uninstall scheduler).