### PR TITLE
Always, always add the bootstrap URI to paused tasks

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/PodInfoBuilder.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/PodInfoBuilder.java
@@ -243,15 +243,15 @@ public class PodInfoBuilder {
             setBootstrapConfigFileEnv(taskInfoBuilder.getCommandBuilder(), taskSpec);
             extendEnv(taskInfoBuilder.getCommandBuilder(), environment);
 
+            // Always add the bootstrap URI as the paused command depends on it
+            if (override.equals(GoalStateOverride.PAUSED)) {
+                commandBuilder.addUrisBuilder().setValue(SchedulerConfig.fromEnv().getBootstrapURI());
+            }
+
             if (useDefaultExecutor) {
                 // Any URIs defined in PodSpec itself.
                 for (URI uri : podSpec.getUris()) {
                     commandBuilder.addUrisBuilder().setValue(uri.toString());
-                }
-
-                // Always add the bootstrap URI as the paused command depends on it
-                if (override.equals(GoalStateOverride.PAUSED)) {
-                    commandBuilder.addUrisBuilder().setValue(SchedulerConfig.fromEnv().getBootstrapURI());
                 }
 
                 for (ConfigFileSpec config : taskSpec.getConfigFiles()) {


### PR DESCRIPTION
`helloworld19` tests were extremely unreliable because the paused task in integration tests was failing due to lacking a bootstrap binary. This should make those tests dependably pass, and then part 2 of fixing this will verify that pausing generates no failed tasks in the test itself.