### PR TITLE
INFINITY-2871 Several improvements to test flakes and logging behavior

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -192,7 +192,7 @@ def setup_artifact_path(item: pytest.Item, artifact_name: str):
     return os.path.join(output_dir, artifact_name)
 
 
-def get_task_files_for_id(task_id: str):
+def get_task_files_for_id(task_id: str) -> set:
     try:
         return set(subprocess.check_output(['dcos', 'task', 'ls', task_id, '--all']).decode().split())
     except:
@@ -200,7 +200,7 @@ def get_task_files_for_id(task_id: str):
         return set()
 
 
-def get_task_log_for_id(task_id: str,  task_file: str='stdout', lines: int=1000000):
+def get_task_log_for_id(task_id: str,  task_file: str='stdout', lines: int=1000000) -> str:
     log.info('Fetching {} from {}'.format(task_file, task_id))
     result = subprocess.run(
         ['dcos', 'task', 'log', task_id, '--all', '--lines', str(lines), task_file],
@@ -211,7 +211,7 @@ def get_task_log_for_id(task_id: str,  task_file: str='stdout', lines: int=10000
         errmessage = result.stderr.decode()
         if not errmessage.startswith('No files exist. Exiting.'):
             log.error('Failed to get {} task log for task_id={}: {}'.format(task_file, task_id, errmessage))
-        return None
+        return ''
     return result.stdout.decode()
 
 

--- a/conftest.py
+++ b/conftest.py
@@ -15,6 +15,7 @@ import pytest
 import requests
 import sdk_security
 import sdk_utils
+import teamcity
 
 log_level = os.getenv('TEST_LOG_LEVEL', 'INFO').upper()
 log_levels = ('DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL', 'EXCEPTION')
@@ -130,7 +131,9 @@ def pytest_runtest_makereport(item, call):
 def pytest_runtest_teardown(item):
     '''Hook to run after every test.'''
     # Inject footer at end of test, may be followed by additional teardown.
-    print('''
+    # Don't do this when running in teamcity, where it's redundant.
+    if not teamcity.is_running_under_teamcity():
+        print('''
 ==========
 ======= END: {}::{}
 =========='''.format(sdk_utils.get_test_suite_name(item), item.name))
@@ -139,7 +142,9 @@ def pytest_runtest_teardown(item):
 def pytest_runtest_setup(item):
     '''Hook to run before every test.'''
     # Inject header at start of test, following automatic "path/to/test_file.py::test_name":
-    print('''
+    # Don't do this when running in teamcity, where it's redundant.
+    if not teamcity.is_running_under_teamcity():
+        print('''
 ==========
 ======= START: {}::{}
 =========='''.format(sdk_utils.get_test_suite_name(item), item.name))

--- a/conftest.py
+++ b/conftest.py
@@ -166,7 +166,7 @@ def pytest_runtest_setup(item):
         # 3 Remove any prior logs for the test suite.
         test_log_dir = sdk_utils.get_test_suite_log_directory(item)
         if os.path.exists(test_log_dir):
-            log.info('Deleting existing test suite directory: {}/'.format(test_log_dir))
+            log.info('Deleting existing test suite logs: {}/'.format(test_log_dir))
             shutil.rmtree(test_log_dir)
 
     # Increment the test index (to 1, if this is a new suite), and pass the value to sdk_utils for use internally.
@@ -193,7 +193,11 @@ def setup_artifact_path(item: pytest.Item, artifact_name: str):
 
 
 def get_task_files_for_id(task_id: str):
-    return set(subprocess.check_output(['dcos', 'task', 'ls', task_id, '--all']).decode().split())
+    try:
+        return set(subprocess.check_output(['dcos', 'task', 'ls', task_id, '--all']).decode().split())
+    except:
+        log.exception('Failed to get list of files for task: {}'.format(task_id))
+        return set()
 
 
 def get_task_log_for_id(task_id: str,  task_file: str='stdout', lines: int=1000000):

--- a/conftest.py
+++ b/conftest.py
@@ -39,10 +39,41 @@ for noise_source in [
 
 log = logging.getLogger(__name__)
 
-# limit the number of tasks that we fetch logs from:
-# 4s (time per download) * 2 (stdout + stderr) * 50 (limit) = 6m40s to download logs (or more with stdout.1/.2/...)
-task_id_limit = 50
-prior_task_ids = set([])
+# An arbitrary limit on the number of tasks that we fetch logs from following a failed test:
+#     100 (task id limit)
+#     2   (stdout + stderr file per task)
+#   x ~4s (time to retrieve each file)
+#   ---------------------
+#   max ~13m20s to download logs upon test failure (plus any .1/.2/.../.9 logs)
+testlogs_task_id_limit = 100
+
+# Keep track of task ids to collect logs at the correct times. Example scenario:
+# 1 Test suite test_sanity_py starts with 2 tasks to ignore: [test_placement-0, test_placement-1]
+# 2 test_sanity_py.health_check passes, with 3 tasks created: [test-scheduler, pod-0-task, pod-1-task]
+# 3 test_sanity_py.replace_0 fails, with 1 task created: [pod-0-task-NEWUUID]
+#   Upon failure, the following task logs should be collected: [test-scheduler, pod-0-task, pod-1-task, pod-0-task-NEWUUID]
+# 4 test_sanity_py.replace_1 succeeds, with 1 task created: [pod-1-task-NEWUUID]
+# 5 test_sanity_py.restart_1 fails, with 1 new task: [pod-1-task-NEWUUID2]
+#   Upon failure, the following task logs should be collected: [pod-1-task-NEWUUID, pod-1-task-NEWUUID2]
+#   These are the tasks which were newly created following the prior failure.
+#   Previously-collected tasks are not collected again, even though they may have additional log content.
+#   In practice this is fine -- e.g. Scheduler would restart with a new task id if it was reconfigured anyway.
+
+# The name of current test suite (e.g. 'test_sanity_py'), or an empty string if no test suite has
+# started yet. This is used to determine when the test suite has changed in a test run.
+testlogs_current_test_suite = ""
+
+# The list of all task ids to ignore when fetching task logs in future test failures:
+# - Task ids that already existed at the start of a test suite.
+#   (ignore tasks unrelated to this test suite)
+# - Task ids which have been logged following a prior failure in the current test suite.
+#   (ignore task ids which were already collected before, even if there's new content)
+testlogs_ignored_task_ids = set([])
+
+# The index of the current test, which increases as tests are run, and resets when a new test suite
+# is started. This is used to sort test logs in the order that they were executed, and is useful
+# when tracing a chain of failed tests.
+testlogs_test_index = 0
 
 
 def get_task_ids():
@@ -57,76 +88,85 @@ def get_task_ids():
         yield task[4]
 
 
-def get_task_files_for_id(task_id: str):
-    return set(subprocess.check_output(['dcos', 'task', 'ls', task_id, '--all']).decode().split())
-
-
-def get_task_logs_for_id(task_id: str,  task_file: str='stdout', lines: int=1000000):
-    log.info("Fetching {} from {}".format(task_file, task_id))
-    result = subprocess.run(
-        ['dcos', 'task', 'log', task_id, '--all', '--lines', str(lines), task_file],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-    )
-    if result.returncode:
-        errmessage = result.stderr.decode()
-        if not errmessage.startswith('No files exist. Exiting.'):
-            log.error('Failed to get {} task log for task_id={}: {}'.format(task_file, task_id, errmessage))
-        return None
-    return result.stdout.decode()
-
-
 @pytest.hookimpl(tryfirst=True, hookwrapper=True)
 def pytest_runtest_makereport(item, call):
-    """
-    See: https://docs.pytest.org/en/latest/example/simple.html\
+    '''Hook to run after every test, before any other post-test hooks.
+    See also: https://docs.pytest.org/en/latest/example/simple.html\
     #making-test-result-information-available-in-fixtures
-    """
-    # execute all other hooks to obtain the report object, then a report
-    # attribute for each phase of a call, which can be "setup", "call", "teardown"
-    # Subsequent fixtures can get the reports off of the request object like:
-    # `request.rep_setup.failed`.
+    '''
+    # Execute all other hooks to obtain the report object, then a report attribute for each phase of
+    # a call, which can be "setup", "call", "teardown".
+    # Subsequent fixtures can get the reports off of the request object like: `request.rep_setup.failed`.
     outcome = yield
     rep = outcome.get_result()
     setattr(item, "rep_" + rep.when, rep)
 
-    # Update the list of task ids that have been seen, regardless of this test's outcome.
-    global prior_task_ids
-    new_task_ids = [id for id in get_task_ids() if id not in prior_task_ids]
-    prior_task_ids = prior_task_ids.union(new_task_ids)
-
     # Handle failures. Must be done here and not in a fixture in order to
     # properly handle post-yield fixture teardown failures.
     if rep.failed:
-        # fetch logs of only those tasks that were created during the test.
-        # enforce limit on how many tasks we will fetch logs from, to avoid unbounded log fetching.
-        if len(new_task_ids) > task_id_limit:
-            log.warning('{} new tasks to fetch logs from. Pruning to {} tasks to avoid fetching logs forever: {}'.format(
-                len(new_task_ids), task_id_limit, new_task_ids))
-            del new_task_ids[task_id_limit:]
-        log.info('Test {} failed in {} phase. Dumping mesos state, and stdout/stderr logs for {} tasks: {}'.format(
-            item.name, rep.when, len(new_task_ids), new_task_ids))
-
-        # delete any preexisting log directory from a prior run of this test,
-        # to avoid overlapping mixed logs from two different tests
-        test_log_dir = sdk_utils.get_test_log_directory(item)
-        if os.path.exists(test_log_dir):
-            shutil.rmtree(test_log_dir)
+        # Fetch all logs from tasks created since the last failure, or since the start of the suite.
+        global testlogs_ignored_task_ids
+        new_task_ids = [id for id in get_task_ids() if id not in testlogs_ignored_task_ids]
+        testlogs_ignored_task_ids = testlogs_ignored_task_ids.union(new_task_ids)
+        # Enforce limit on how many tasks we will fetch logs from, to avoid unbounded log fetching.
+        if len(new_task_ids) > testlogs_task_id_limit:
+            log.warning('Truncating list of {} new tasks to size {} to avoid fetching logs forever: {}'.format(
+                len(new_task_ids), testlogs_task_id_limit, new_task_ids))
+            del new_task_ids[testlogs_task_id_limit:]
+        log.info('Test {} failed in {} phase.'.format(item.name, rep.when))
 
         try:
-            get_task_logs_on_failure(item, new_task_ids)
+            log.info('Dumping logs for {} tasks launched in this suite since last failure: {}'.format(
+                len(new_task_ids), new_task_ids))
+            dump_task_logs(item, new_task_ids)
         except Exception:
             log.exception('Task log collection failed!')
         try:
-            get_mesos_state_on_failure(item)
+            dump_mesos_state(item)
         except Exception:
             log.exception('Mesos state collection failed!')
 
 
+def pytest_runtest_teardown(item):
+    '''Hook to run after every test.'''
+    # Inject footer at end of test, may be followed by additional teardown.
+    print('''
+==========
+======= END: {}::{}
+=========='''.format(sdk_utils.get_test_suite_name(item), item.name))
+
+
 def pytest_runtest_setup(item):
-    # Initialize the list of task ids to include any entries unrelated to this run.
-    global prior_task_ids
-    prior_task_ids = prior_task_ids.union(get_task_ids())
+    '''Hook to run before every test.'''
+    # Inject header at start of test, following automatic "path/to/test_file.py::test_name":
+    print('''
+==========
+======= START: {}::{}
+=========='''.format(sdk_utils.get_test_suite_name(item), item.name))
+
+    # Check if we're entering a new test suite.
+    global testlogs_test_index
+    global testlogs_current_test_suite
+    test_suite = sdk_utils.get_test_suite_name(item)
+    if test_suite != testlogs_current_test_suite:
+        # New test suite:
+        # 1 Store all the task ids which already exist as of this point.
+        testlogs_current_test_suite = test_suite
+        global testlogs_ignored_task_ids
+        testlogs_ignored_task_ids = testlogs_ignored_task_ids.union(get_task_ids())
+        log.info('Entering new test suite {}: {} preexisting tasks will be ignored on test failure.'.format(
+            test_suite, len(testlogs_ignored_task_ids)))
+        # 2 Reset the test index.
+        testlogs_test_index = 0
+        # 3 Remove any prior logs for the test suite.
+        test_log_dir = sdk_utils.get_test_suite_log_directory(item)
+        if os.path.exists(test_log_dir):
+            log.info('Deleting existing test suite directory: {}/'.format(test_log_dir))
+            shutil.rmtree(test_log_dir)
+
+    # Increment the test index (to 1, if this is a new suite), and pass the value to sdk_utils for use internally.
+    testlogs_test_index += 1
+    sdk_utils.set_test_index(testlogs_test_index)
 
     min_version_mark = item.get_marker('dcos_min_version')
     if min_version_mark:
@@ -147,30 +187,51 @@ def setup_artifact_path(item: pytest.Item, artifact_name: str):
     return os.path.join(output_dir, artifact_name)
 
 
-def get_rotating_task_log_lines(task_id: str, known_task_files: set, task_file: str):
+def get_task_files_for_id(task_id: str):
+    return set(subprocess.check_output(['dcos', 'task', 'ls', task_id, '--all']).decode().split())
+
+
+def get_task_log_for_id(task_id: str,  task_file: str='stdout', lines: int=1000000):
+    log.info('Fetching {} from {}'.format(task_file, task_id))
+    result = subprocess.run(
+        ['dcos', 'task', 'log', task_id, '--all', '--lines', str(lines), task_file],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if result.returncode:
+        errmessage = result.stderr.decode()
+        if not errmessage.startswith('No files exist. Exiting.'):
+            log.error('Failed to get {} task log for task_id={}: {}'.format(task_file, task_id, errmessage))
+        return None
+    return result.stdout.decode()
+
+
+def get_rotating_task_logs(task_id: str, known_task_files: set, task_file: str):
     rotated_filenames = [task_file, ]
     rotated_filenames.extend(['{}.{}'.format(task_file, i) for i in range(1, 10)])
     for filename in rotated_filenames:
         if not filename in known_task_files:
-            return # hit an index that doesn't exist, exit early
-        lines = get_task_logs_for_id(task_id, filename)
-        if not lines:
+            return # Reached a log index that doesn't exist, exit early
+        content = get_task_log_for_id(task_id, filename)
+        if not content:
             log.error('Unable to fetch content of {} from task {}, giving up'.format(filename, task_id))
             return
-        yield filename, lines
+        yield filename, content
 
 
-def get_task_logs_on_failure(item: pytest.Item, task_ids: list):
+def dump_task_logs(item: pytest.Item, task_ids: list):
     for task_id in task_ids:
-        # get list of available files:
+        # Get list of available files:
         known_task_files = get_task_files_for_id(task_id)
-        for task_file in ('stderr', 'stdout'):
-            for log_filename, log_lines in get_rotating_task_log_lines(task_id, known_task_files, task_file):
-                with open(setup_artifact_path(item, '{}.{}'.format(task_id, log_filename)), 'w') as f:
-                    f.write(log_lines)
+        for task_file in ('stdout', 'stderr'):
+            for log_filename, log_content in get_rotating_task_logs(task_id, known_task_files, task_file):
+                out_path = setup_artifact_path(item, '{}.{}'.format(task_id, log_filename))
+                log.info('=> Writing {} ({} bytes)'.format(out_path, len(log_content)))
+                with open(out_path, 'w') as f:
+                    f.write(log_content)
 
 
-def get_mesos_state_on_failure(item: pytest.Item):
+def dump_mesos_state(item: pytest.Item):
     dcosurl, headers = sdk_security.get_dcos_credentials()
     for name in ['state.json', 'slaves']:
         r = requests.get('{}/mesos/{}'.format(dcosurl, name), headers=headers, verify=False)

--- a/frameworks/cassandra/tests/config.py
+++ b/frameworks/cassandra/tests/config.py
@@ -93,10 +93,10 @@ def _cqlsh(query, node_address, node_port):
 
 def get_delete_data_once_job(node_address=DEFAULT_NODE_ADDRESS, node_port=DEFAULT_NODE_PORT, dcos_ca_bundle=None):
     cql = ' '.join([
-        'TRUNCATE testspace1.testtable1;',
-        'TRUNCATE testspace2.testtable2;',
-        'DROP KEYSPACE testspace1;',
-        'DROP KEYSPACE testspace2;'])
+        'DROP TABLE IF EXISTS testspace1.testtable1;',
+        'DROP TABLE IF EXISTS testspace2.testtable2;',
+        'DROP KEYSPACE IF EXISTS testspace1;',
+        'DROP KEYSPACE IF EXISTS testspace2;'])
     return _get_test_job(
         'delete-data-once',
         [_cqlsh(cql, node_address, node_port)],
@@ -108,10 +108,10 @@ def get_delete_data_once_job(node_address=DEFAULT_NODE_ADDRESS, node_port=DEFAUL
 
 def get_delete_data_retry_job(node_address=DEFAULT_NODE_ADDRESS, node_port=DEFAULT_NODE_PORT, dcos_ca_bundle=None):
     cql = ' '.join([
-        'TRUNCATE testspace1.testtable1;',
-        'TRUNCATE testspace2.testtable2;',
-        'DROP KEYSPACE testspace1;',
-        'DROP KEYSPACE testspace2;'])
+        'DROP TABLE IF EXISTS testspace1.testtable1;',
+        'DROP TABLE IF EXISTS testspace2.testtable2;',
+        'DROP KEYSPACE IF EXISTS testspace1;',
+        'DROP KEYSPACE IF EXISTS testspace2;'])
     return _get_test_job(
         'delete-data-retry',
         [_cqlsh(cql, node_address, node_port)],

--- a/frameworks/elastic/tests/test_sanity.py
+++ b/frameworks/elastic/tests/test_sanity.py
@@ -178,10 +178,17 @@ def test_xpack_toggle_with_kibana(default_populated_index):
     config.verify_commercial_api_status(False, service_name=foldered_name)
 
     log.info("\n***** Test kibana with X-Pack disabled...")
-    shakedown.install_package(config.KIBANA_PACKAGE_NAME, options_json={
-        "kibana": {"elasticsearch_url": "http://" + sdk_hosts.vip_host(foldered_name, "coordinator", 9200)}})
-    shakedown.deployment_wait(
-        app_id="/{}".format(config.KIBANA_PACKAGE_NAME), timeout=config.DEFAULT_KIBANA_TIMEOUT)
+    elasticsearch_url = "http://" + sdk_hosts.vip_host(foldered_name, "coordinator", 9200)
+    sdk_install.install(
+        config.KIBANA_PACKAGE_NAME,
+        config.KIBANA_PACKAGE_NAME,
+        0,
+        { "kibana": {
+            "elasticsearch_url": elasticsearch_url
+        }},
+        timeout_seconds=config.DEFAULT_KIBANA_TIMEOUT,
+        wait_for_deployment=False,
+        insert_strict_options=False)
     config.check_kibana_adminrouter_integration(
         "service/{}/".format(config.KIBANA_PACKAGE_NAME))
     log.info("Uninstall kibana with X-Pack disabled")
@@ -201,14 +208,19 @@ def test_xpack_toggle_with_kibana(default_populated_index):
         service_name=foldered_name)
 
     log.info("\n***** Test kibana with X-Pack enabled...")
-    shakedown.install_package(config.KIBANA_PACKAGE_NAME, options_json={
-        "kibana": {
-            "elasticsearch_url": "http://" + sdk_hosts.vip_host(foldered_name, "coordinator", 9200),
+    log.info("\n***** Installing Kibana w/X-Pack can exceed default 15 minutes for Marathon "
+             "deployment to complete due to a configured HTTP health check. (typical: 12 minutes)")
+    sdk_install.install(
+        config.KIBANA_PACKAGE_NAME,
+        config.KIBANA_PACKAGE_NAME,
+        0,
+        { "kibana": {
+            "elasticsearch_url": elasticsearch_url,
             "xpack_enabled": True
-        }})
-    log.info("\n***** Installing Kibana w/X-Pack can take as much as 15 minutes for Marathon deployment ")
-    log.info("to complete due to a configured HTTP health check. (typical: 12 minutes)")
-    shakedown.deployment_wait(app_id="/{}".format(config.KIBANA_PACKAGE_NAME), timeout=config.DEFAULT_KIBANA_TIMEOUT)
+        }},
+        timeout_seconds=config.DEFAULT_KIBANA_TIMEOUT,
+        wait_for_deployment=False,
+        insert_strict_options=False)
     config.check_kibana_adminrouter_integration("service/{}/login".format(config.KIBANA_PACKAGE_NAME))
     log.info("\n***** Uninstall kibana with X-Pack enabled")
     sdk_install.uninstall(config.KIBANA_PACKAGE_NAME, config.KIBANA_PACKAGE_NAME)

--- a/frameworks/helloworld/tests/test_taskcfg.py
+++ b/frameworks/helloworld/tests/test_taskcfg.py
@@ -13,9 +13,13 @@ log = logging.getLogger(__name__)
 def configure_package(configure_security):
     try:
         sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
-        options = sdk_install.get_package_options({ "service": { "spec_file": "examples/taskcfg.yml" } })
         # don't wait for install to complete successfully:
-        shakedown.install_package(config.PACKAGE_NAME, options_json=options)
+        sdk_install.install(
+            config.PACKAGE_NAME,
+            config.SERVICE_NAME,
+            0,
+            { "service": { "spec_file": "examples/taskcfg.yml" } },
+            wait_for_deployment=False)
 
         yield # let the test session execute
     finally:

--- a/frameworks/kafka/tests/test_tls.py
+++ b/frameworks/kafka/tests/test_tls.py
@@ -32,6 +32,7 @@ def service_account():
 
 @pytest.fixture(scope='module')
 def kafka_service_tls(service_account):
+    sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
     config.install(
         config.PACKAGE_NAME,
         config.SERVICE_NAME,

--- a/test.sh
+++ b/test.sh
@@ -208,5 +208,5 @@ docker run --rm \
     -w /build \
     -t \
     -i \
-    mesosphere/dcos-commons:latest \
+    mesosphere/dcos-commons:uninstall_fix \
     $DOCKER_COMMAND

--- a/test.sh
+++ b/test.sh
@@ -208,5 +208,5 @@ docker run --rm \
     -w /build \
     -t \
     -i \
-    mesosphere/dcos-commons:uninstall_fix \
+    mesosphere/dcos-commons:latest \
     $DOCKER_COMMAND

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,6 +1,6 @@
 py==1.5.1
-git+https://github.com/dcos/dcos-cli.git@14f97067d971b6daa9aa67f5a876c99741a321b2#egg=dcoscli&subdirectory=cli
-git+https://github.com/dcos/dcos-cli.git@14f97067d971b6daa9aa67f5a876c99741a321b2
+git+https://github.com/dcos/dcos-cli.git@5fe1a854226702c61f36a332138f78765ca6f8c8#egg=dcoscli&subdirectory=cli
+git+https://github.com/dcos/dcos-cli.git@5fe1a854226702c61f36a332138f78765ca6f8c8
 dcos-shakedown==1.4.5
 git+https://github.com/dcos/dcos-test-utils.git@c431eb6414e003e31c865c534b2413969a6d9947
 git+https://github.com/dcos/dcos-launch.git@14ded071109ab241e70ff3ed8b22bab844f74513

--- a/testing/sdk_cmd.py
+++ b/testing/sdk_cmd.py
@@ -87,8 +87,7 @@ def get_json_output(cmd, print_output=True):
     try:
         json_stdout = jsonlib.loads(stdout)
     except Exception as e:
-        log.error("Error converting stdout=%s to json", stdout)
-        log.error(e)
+        log.warning("Error converting stdout to json:\n%s", stdout)
         raise e
 
     return json_stdout

--- a/testing/sdk_install.py
+++ b/testing/sdk_install.py
@@ -96,7 +96,7 @@ def install(
     if wait_for_deployment:
         # this can take a while, default is 15 minutes. for example with HDFS, we can hit the expected
         # total task count via FINISHED tasks, without actually completing deployment
-        log.info('Waiting for {}/{} to finish deployment plan...'.format(
+        log.info('Waiting for package={} service={} to finish deployment plan...'.format(
             package_name, service_name))
         sdk_plan.wait_for_completed_deployment(service_name, timeout_seconds)
 

--- a/testing/sdk_install.py
+++ b/testing/sdk_install.py
@@ -7,16 +7,18 @@ SHOULD ALSO BE APPLIED TO sdk_install IN ANY OTHER PARTNER REPOS
 '''
 import collections
 import logging
+import time
 
+import dcos.cosmos
 import dcos.errors
 import dcos.marathon
-import os
-import shakedown
-import time
+import dcos.packagemanager
+import dcos.subcommand
 from retrying import retry
+import shakedown
 
-import sdk_api
 import sdk_cmd
+import sdk_marathon
 import sdk_plan
 import sdk_utils
 
@@ -26,21 +28,44 @@ TIMEOUT_SECONDS = 15 * 60
 
 
 @retry(stop_max_attempt_number=3, retry_on_exception=lambda e: isinstance(e, dcos.errors.DCOSException))
-def retried_shakedown_install(
+def _retried_install_impl(
         package_name,
         service_name,
-        package_version,
-        merged_options,
-        timeout_seconds,
-        expected_running_tasks):
-    shakedown.install_package(
-        package_name,
-        package_version=package_version,
-        service_name=service_name,
-        options_json=merged_options,
-        wait_for_completion=True,
-        timeout_sec=timeout_seconds,
-        expected_running_tasks=expected_running_tasks)
+        expected_running_tasks,
+        options={},
+        package_version=None,
+        timeout_seconds=TIMEOUT_SECONDS):
+    '''Cleaned up version of shakedown's package_install().'''
+    package_manager = dcos.packagemanager.PackageManager(dcos.cosmos.get_cosmos_url())
+    pkg = package_manager.get_package_version(package_name, package_version)
+
+    if package_version is None:
+        # Get the resolved version for logging below
+        package_version = 'auto:{}'.format(pkg.version())
+
+    log.info('Installing package={} service={} with options={} version={}'.format(
+        package_name, service_name, options, package_version))
+
+    # Trigger package install, but only if it's not already installed.
+    # We expect upstream to have confirmed that it wasn't already installed beforehand.
+    if sdk_marathon.app_exists(service_name):
+        log.info('Marathon app={} exists, skipping package install call'.format(service_name))
+    else:
+        package_manager.install_app(pkg, options, service_name)
+
+    # Install CLI while package starts to install
+    if pkg.cli_definition():
+        log.info('Installing CLI for package={}'.format(package_name))
+        dcos.subcommand.install(pkg)
+
+    # Wait for expected tasks to come up
+    if expected_running_tasks > 0:
+        shakedown.wait_for_service_tasks_running(
+            service_name, expected_running_tasks, timeout_seconds)
+
+    # Wait for completed marathon deployment
+    app_id = pkg.marathon_json(options).get('id')
+    shakedown.deployment_wait(timeout_seconds, app_id)
 
 
 def install(
@@ -52,30 +77,30 @@ def install(
         timeout_seconds=TIMEOUT_SECONDS,
         wait_for_deployment=True):
     start = time.time()
-    merged_options = get_package_options(additional_options)
 
-    log.info('Installing {}:{} with options={} version={}'.format(
-        package_name, service_name, merged_options, package_version))
+    # If the package is already installed at this point, fail immediately.
+    if sdk_marathon.app_exists(service_name):
+        raise dcos.errors.DCOSException('Service is already installed: {}'.format(service_name))
 
     # 1. Install package, wait for tasks, wait for marathon deployment
-    retried_shakedown_install(
+    _retried_install_impl(
         package_name,
         service_name,
+        expected_running_tasks,
+        get_package_options(additional_options),
         package_version,
-        merged_options,
-        timeout_seconds,
-        expected_running_tasks)
+        timeout_seconds)
 
     # 2. Wait for the scheduler to be idle (as implied by deploy plan completion and suppressed bit)
     # This should be skipped ONLY when it's known that the scheduler will be stuck in an incomplete state.
     if wait_for_deployment:
         # this can take a while, default is 15 minutes. for example with HDFS, we can hit the expected
         # total task count via FINISHED tasks, without actually completing deployment
-        log.info("Waiting for {}/{} to finish deployment plan...".format(
+        log.info('Waiting for {}/{} to finish deployment plan...'.format(
             package_name, service_name))
         sdk_plan.wait_for_completed_deployment(service_name, timeout_seconds)
 
-    log.info('Installed {}/{} after {}'.format(
+    log.info('Installed package={} service={} after {}'.format(
         package_name, service_name, shakedown.pretty_duration(time.time() - start)))
 
 
@@ -102,7 +127,7 @@ def _uninstall(
         zk=None):
     start = time.time()
 
-    if sdk_utils.dcos_version_less_than("1.10"):
+    if sdk_utils.dcos_version_less_than('1.10'):
         log.info('Uninstalling/janitoring {}'.format(service_name))
         try:
             shakedown.uninstall_package_and_wait(

--- a/testing/sdk_install.py
+++ b/testing/sdk_install.py
@@ -51,7 +51,7 @@ def _retried_install_impl(
     if sdk_marathon.app_exists(service_name):
         log.info('Marathon app={} exists, skipping package install call'.format(service_name))
     else:
-        package_manager.install_app(pkg, options, service_name)
+        package_manager.install_app(pkg, options)
 
     # Install CLI while package starts to install
     if pkg.cli_definition():

--- a/testing/sdk_marathon.py
+++ b/testing/sdk_marathon.py
@@ -15,14 +15,26 @@ import shakedown
 import sdk_cmd
 import sdk_metrics
 
+TIMEOUT_SECONDS = 15 * 60
+
 log = logging.getLogger(__name__)
 
 
-def get_config(app_name):
+def _get_config_once(app_name):
+    return sdk_cmd.request('get', api_url('apps/{}'.format(app_name)), retry=False, log_args=False)
+
+
+def app_exists(app_name):
+    try:
+        _get_config_once(app_name)
+        return True
+    except:
+        return False
+
+
+def get_config(app_name, timeout=TIMEOUT_SECONDS):
     # Be permissive of flakes when fetching the app content:
-    def fn():
-        return sdk_cmd.request('get', api_url('apps/{}'.format(app_name)), retry=False, log_args=False)
-    config = shakedown.wait_for(lambda: fn()).json()['app']
+    config = shakedown.wait_for(lambda: _get_config_once(app_name), noisy=True, timeout_seconds=timeout).json()['app']
 
     # The configuration JSON that marathon returns doesn't match the configuration JSON it accepts,
     # so we have to remove some offending fields to make it re-submittable, since it's not possible to
@@ -84,7 +96,7 @@ def install_app(app_definition: dict) -> (bool, str):
         return install_app_from_file(app_name, app_def_path)
 
 
-def update_app(app_name, config, timeout=600, wait_for_completed_deployment=True):
+def update_app(app_name, config, timeout=TIMEOUT_SECONDS, wait_for_completed_deployment=True):
     if "env" in config:
         log.info("Environment for marathon app {} ({} values):".format(app_name, len(config["env"])))
         for k in sorted(config["env"]):

--- a/testing/sdk_tasks.py
+++ b/testing/sdk_tasks.py
@@ -119,7 +119,7 @@ def check_tasks_updated(service_name, prefix, old_task_ids, timeout_seconds=DEFA
         # forgive the language a bit, but len('remained') == len('launched'),
         # and similar for the rest of the label for task ids in the log line,
         # so makes for easier reading
-        log.info('Waiting for tasks{} to have updated ids:\n- Old tasks (remained): {}\n- New tasks (launched): {}'.format(
+        log.info('Waiting for tasks{} to have updated ids:\n- Old tasks (remaining): {}\n- New tasks (launched): {}'.format(
             prefix_clause,
             old_remaining_set,
             newly_launched_set))

--- a/testing/sdk_upgrade.py
+++ b/testing/sdk_upgrade.py
@@ -196,7 +196,7 @@ def _upgrade_or_downgrade(
 
         # this can take a while, default is 15 minutes. for example with HDFS, we can hit the expected
         # total task count via ONCE tasks, without actually completing deployment
-        log.info("Waiting for {}/{} to finish deployment plan...".format(
+        log.info("Waiting for package={} service={} to finish deployment plan...".format(
             package_name, service_name))
         sdk_plan.wait_for_completed_deployment(service_name, timeout_seconds)
 

--- a/testing/sdk_utils.py
+++ b/testing/sdk_utils.py
@@ -86,7 +86,8 @@ def get_test_log_directory(pytest_node):
     # - ['build', 'frameworks/template/tests/test_sanity.py', 'test_install']
     # - ['build', 'tests/test_sanity.py', 'test_install']
     # we want to turn both cases into: 'logs/test_sanity_py/test_install'
-    if test_index >= 0:
+    global test_index
+    if test_index > 0:
         # test_index is defined: get name like "05__test_placement_rules"
         test_name = '{:02d}__{}'.format(test_index, pytest_node.name)
     else:

--- a/testing/sdk_utils.py
+++ b/testing/sdk_utils.py
@@ -12,8 +12,11 @@ import dcos
 import shakedown
 import pytest
 import os
+import os.path
 
 log = logging.getLogger(__name__)
+# The index to use when constructing the test log directory.
+test_index = -1
 
 
 def get_package_name(default: str) -> str:
@@ -56,13 +59,40 @@ def dcos_version_less_than(version):
     return shakedown.dcos_version_less_than(version)
 
 
+def set_test_index(index):
+    '''Assigns the index to use for a test within a given test suite.
+    Should start at 1 for the first test in the suite.'''
+    global test_index
+    test_index = index
+
+
+def get_test_suite_name(pytest_node):
+    '''Returns the test suite name to use for a given test.'''
+    # frameworks/template/tests/test_sanity.py => test_sanity_py
+    # tests/test_sanity.py => test_sanity_py
+    return pytest_node.parent.name.split('/')[-1].replace('.','_')
+
+
+def get_test_suite_log_directory(pytest_node):
+    '''Returns the parent directory for the logs across a suite of tests.
+    For individual tests within this directory, see get_test_log_directory().'''
+    return os.path.join('logs', get_test_suite_name(pytest_node))
+
+
 def get_test_log_directory(pytest_node):
+    '''Returns the directory for the logs of a single test.
+    For the parent test suite directory, see get_test_suite_log_directory().'''
     # full item.listchain() is e.g.:
     # - ['build', 'frameworks/template/tests/test_sanity.py', 'test_install']
     # - ['build', 'tests/test_sanity.py', 'test_install']
     # we want to turn both cases into: 'logs/test_sanity_py/test_install'
-    parent_name = pytest_node.parent.name.split('/')[-1].replace('.','_')
-    return os.path.join('logs', parent_name, pytest_node.name)
+    if test_index >= 0:
+        # test_index is defined: get name like "05__test_placement_rules"
+        test_name = '{:02d}__{}'.format(test_index, pytest_node.name)
+    else:
+        # test_index is not defined: fall back to just "test_placement_rules"
+        test_name = pytest_node.name
+    return os.path.join(get_test_suite_log_directory(pytest_node), test_name)
 
 
 def is_test_failure(pytest_request):

--- a/testing/sdk_utils.py
+++ b/testing/sdk_utils.py
@@ -70,7 +70,7 @@ def get_test_suite_name(pytest_node):
     '''Returns the test suite name to use for a given test.'''
     # frameworks/template/tests/test_sanity.py => test_sanity_py
     # tests/test_sanity.py => test_sanity_py
-    return pytest_node.parent.name.split('/')[-1].replace('.','_')
+    return os.path.basename(pytest_node.parent.name).replace('.','_')
 
 
 def get_test_suite_log_directory(pytest_node):


### PR DESCRIPTION
- Avoid taking forever to fetch plans if scheduler is gone: Set a short timeout, exit early.
- Task log fetching: Fetch all tasks launched since the last failure in the same test suite. Previous logic only fetched tasks which were launched within the same test. Give better information as tasks are fetched/written.
- Task log writing: Include an index prefix in the log directory, so that test ordering is easy to follow when browsing logs.
- Logs: Include "START/END" headers before/after every test, and various other log cleanup.