### PR TITLE
INFINITY-2877 Replace delete_once job with delete_retry job

### DIFF
--- a/frameworks/cassandra/tests/test_overlay.py
+++ b/frameworks/cassandra/tests/test_overlay.py
@@ -5,7 +5,6 @@ import sdk_install
 import sdk_jobs
 import sdk_networks
 import sdk_plan
-import sdk_utils
 import shakedown
 from tests import config
 
@@ -67,7 +66,7 @@ def test_functionality():
                 config.get_verify_data_job()
             ],
             after_jobs=[
-                config.get_delete_data_retry_job(),
+                config.get_delete_data_job(),
                 config.get_verify_deletion_job()
             ]):
 

--- a/frameworks/cassandra/tests/test_sanity.py
+++ b/frameworks/cassandra/tests/test_sanity.py
@@ -8,9 +8,7 @@ import sdk_jobs
 import sdk_marathon
 import sdk_metrics
 import sdk_plan
-import sdk_tasks
 import sdk_upgrade
-import sdk_utils
 import shakedown
 from tests import config
 
@@ -87,7 +85,7 @@ def test_repair_cleanup_plans_complete():
                     node_address=config.get_foldered_node_address())
             ],
             after_jobs=[
-                config.get_delete_data_retry_job(
+                config.get_delete_data_job(
                     node_address=config.get_foldered_node_address()),
                 config.get_verify_deletion_job(
                     node_address=config.get_foldered_node_address())

--- a/frameworks/cassandra/tests/test_soak.py
+++ b/frameworks/cassandra/tests/test_soak.py
@@ -28,7 +28,7 @@ def test_backup_and_restore():
     with sdk_jobs.InstallJobContext([
             config.get_write_data_job(),
             config.get_verify_data_job(),
-            config.get_delete_data_retry_job(),
+            config.get_delete_data_job(),
             config.get_verify_deletion_job()]):
         config.run_backup_and_restore(
             config.SERVICE_NAME,
@@ -61,7 +61,7 @@ def test_cassandra_migration():
 
     backup_write_data_job = config.get_write_data_job(backup_node_address, backup_node_port)
     backup_verify_data_job = config.get_verify_data_job(backup_node_address, backup_node_port)
-    backup_delete_data_job = config.get_delete_data_retry_job(backup_node_address, backup_node_port)
+    backup_delete_data_job = config.get_delete_data_job(backup_node_address, backup_node_port)
     backup_verify_deletion_job = config.get_verify_deletion_job(backup_node_address, backup_node_port)
 
     plan_parameters = {
@@ -106,7 +106,7 @@ def test_cassandra_migration():
 
     restore_write_data_job = config.get_write_data_job(restore_node_address, restore_node_port)
     restore_verify_data_job = config.get_verify_data_job(restore_node_address, restore_node_port)
-    restore_delete_data_job = config.get_delete_data_retry_job(restore_node_address, restore_node_port)
+    restore_delete_data_job = config.get_delete_data_job(restore_node_address, restore_node_port)
     restore_verify_deletion_job = config.get_verify_deletion_job(restore_node_address, restore_node_port)
 
     restore_install_job_context = sdk_jobs.InstallJobContext(

--- a/frameworks/cassandra/tests/test_tls.py
+++ b/frameworks/cassandra/tests/test_tls.py
@@ -85,7 +85,7 @@ def test_tls_connection(cassandra_service_tls, dcos_ca_bundle):
     with sdk_jobs.InstallJobContext([
             config.get_write_data_job(dcos_ca_bundle=dcos_ca_bundle),
             config.get_verify_data_job(dcos_ca_bundle=dcos_ca_bundle),
-            config.get_delete_data_retry_job(dcos_ca_bundle=dcos_ca_bundle)]):
+            config.get_delete_data_job(dcos_ca_bundle=dcos_ca_bundle)]):
 
         sdk_jobs.run_job(config.get_write_data_job(dcos_ca_bundle=dcos_ca_bundle))
         sdk_jobs.run_job(config.get_verify_data_job(dcos_ca_bundle=dcos_ca_bundle))
@@ -106,7 +106,7 @@ def test_tls_connection(cassandra_service_tls, dcos_ca_bundle):
         sdk_plan.start_plan(config.SERVICE_NAME, 'backup-s3', parameters=plan_parameters)
         sdk_plan.wait_for_completed_plan(config.SERVICE_NAME, 'backup-s3')
 
-        sdk_jobs.run_job(config.get_delete_data_retry_job(dcos_ca_bundle=dcos_ca_bundle))
+        sdk_jobs.run_job(config.get_delete_data_job(dcos_ca_bundle=dcos_ca_bundle))
 
         # Run backup plan, uploading snapshots and schema to the cloudddd
         sdk_plan.start_plan(config.SERVICE_NAME, 'restore-s3', parameters=plan_parameters)
@@ -114,7 +114,7 @@ def test_tls_connection(cassandra_service_tls, dcos_ca_bundle):
 
     with sdk_jobs.InstallJobContext([
             config.get_verify_data_job(dcos_ca_bundle=dcos_ca_bundle),
-            config.get_delete_data_retry_job(dcos_ca_bundle=dcos_ca_bundle)]):
+            config.get_delete_data_job(dcos_ca_bundle=dcos_ca_bundle)]):
 
         sdk_jobs.run_job(config.get_verify_data_job(dcos_ca_bundle=dcos_ca_bundle))
-        sdk_jobs.run_job(config.get_delete_data_retry_job(dcos_ca_bundle=dcos_ca_bundle))
+        sdk_jobs.run_job(config.get_delete_data_job(dcos_ca_bundle=dcos_ca_bundle))


### PR DESCRIPTION
- Now that the delete job is idempotent anyway, there isnt any reason for a separate `delete_once` attempt.
- Running jobs with `restart_policy=NEVER` is apparently flaky, often producing this error in the CLI. Not clear if it's the CLI's fault or Metronome's fault:
  `Service likely misconfigured. Please check your proxy or Service URL settings. See dcos config --help.`