### PR TITLE
Disable KAFKA ssl tests on open

### DIFF
--- a/frameworks/kafka/tests/test_ssl_auth.py
+++ b/frameworks/kafka/tests/test_ssl_auth.py
@@ -21,6 +21,11 @@ from tests import test_utils
 
 log = logging.getLogger(__name__)
 
+
+pytestmark = pytest.mark.skipif(sdk_utils.is_open_dcos(),
+                                reason='Feature only supported in DC/OS EE')
+
+
 @pytest.fixture(scope='module', autouse=True)
 def service_account(configure_security):
     """

--- a/frameworks/kafka/tests/test_ssl_auth.py
+++ b/frameworks/kafka/tests/test_ssl_auth.py
@@ -1,13 +1,10 @@
-import logging
-import pytest
-import subprocess
-import uuid
 import json
-import time
-import shakedown
+import logging
+import uuid
+
+import pytest
 
 import sdk_cmd
-import sdk_hosts
 import sdk_install
 import sdk_marathon
 import sdk_tasks
@@ -18,6 +15,7 @@ from tests import config
 from tests import auth
 from tests import topics
 from tests import test_utils
+
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
This PR disables the Kafka TLS Authn/z tests at a module level so as to prevent the test fixtures being triggered.

The principals fixture was causing failures on DC/OS Open.