### PR TITLE
[DCOS-19854] Improve uninstall

### DIFF
--- a/frameworks/helloworld/tests/test_uninstall.py
+++ b/frameworks/helloworld/tests/test_uninstall.py
@@ -27,4 +27,4 @@ def test_uninstall():
     env['SDK_UNINSTALL'] = 'w00t'
     sdk_marathon.update_app(config.SERVICE_NAME, marathon_config)
     sdk_plan.wait_for_completed_deployment(config.SERVICE_NAME)
-    sdk_tasks.check_running(config.SERVICE_NAME, 0)
+    sdk_tasks.check_running(config.SERVICE_NAME, 0, allow_more=False)

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/DefaultScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/DefaultScheduler.java
@@ -52,6 +52,7 @@ public class DefaultScheduler extends AbstractScheduler {
     private final PlansResource plansResource;
     private final PodResource podResource;
 
+    private TaskKiller taskKiller;
     private PlanCoordinator planCoordinator;
     private PlanScheduler planScheduler;
     private TaskKiller taskKiller;

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/DefaultScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/DefaultScheduler.java
@@ -55,7 +55,6 @@ public class DefaultScheduler extends AbstractScheduler {
     private TaskKiller taskKiller;
     private PlanCoordinator planCoordinator;
     private PlanScheduler planScheduler;
-    private TaskKiller taskKiller;
 
     private final OfferOutcomeTracker offerOutcomeTracker;
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerRunner.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerRunner.java
@@ -161,6 +161,8 @@ public class SchedulerRunner implements Runnable {
             PlansResource emptyPlanResource = new PlansResource();
             emptyPlanResource.setPlanManagers(Arrays.asList(emptyPlanManager));
 
+            schedulerBuilder.getStateStore().clearAllData();
+
             SchedulerApiServer apiServer = new SchedulerApiServer(
                     schedulerConfig,
                     Arrays.asList(

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerRunner.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerRunner.java
@@ -1,11 +1,20 @@
 package com.mesosphere.sdk.scheduler;
 
 import com.google.protobuf.TextFormat;
+import com.mesosphere.sdk.api.HealthResource;
+import com.mesosphere.sdk.api.PlansResource;
 import com.mesosphere.sdk.config.validate.PodSpecsCannotUseUnsupportedFeatures;
 import com.mesosphere.sdk.curator.CuratorLocker;
 import com.mesosphere.sdk.dcos.Capabilities;
 import com.mesosphere.sdk.generated.SDKBuildInfo;
 import com.mesosphere.sdk.offer.Constants;
+import com.mesosphere.sdk.scheduler.plan.DefaultPlanManager;
+import com.mesosphere.sdk.scheduler.plan.Phase;
+import com.mesosphere.sdk.scheduler.plan.Plan;
+import com.mesosphere.sdk.scheduler.plan.PlanManager;
+import com.mesosphere.sdk.scheduler.plan.strategy.SerialStrategy;
+import com.mesosphere.sdk.scheduler.plan.strategy.Strategy;
+import com.mesosphere.sdk.scheduler.uninstall.UninstallScheduler;
 import com.mesosphere.sdk.specification.DefaultServiceSpec;
 import com.mesosphere.sdk.specification.ServiceSpec;
 import com.mesosphere.sdk.specification.yaml.RawServiceSpec;
@@ -14,6 +23,8 @@ import com.mesosphere.sdk.storage.PersisterException;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.mesos.Protos;
 import org.apache.mesos.Scheduler;
+import org.eclipse.jetty.util.component.AbstractLifeCycle;
+import org.eclipse.jetty.util.component.LifeCycle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -112,6 +123,55 @@ public class SchedulerRunner implements Runnable {
                     schedulerBuilder.getServiceSpec(),
                     schedulerBuilder.getSchedulerConfig(),
                     schedulerBuilder.getStateStore());
+        } else {
+            /**
+             * If no MesosScheduler is provided this scheduler has been deregistered and should report itself healthy
+             * and provide an empty COMPLETE deploy plan so it may complete its UNINSTALL.
+             *
+             * See {@link UninstallScheduler#getMesosScheduler()}.
+             */
+            Plan emptyDeployPlan = new Plan() {
+                @Override
+                public List<Phase> getChildren() {
+                    return Collections.emptyList();
+                }
+
+                @Override
+                public Strategy<Phase> getStrategy() {
+                    return new SerialStrategy<>();
+                }
+
+                @Override
+                public UUID getId() {
+                    return UUID.randomUUID();
+                }
+
+                @Override
+                public String getName() {
+                    return Constants.DEPLOY_PLAN_NAME;
+                }
+
+                @Override
+                public List<String> getErrors() {
+                    return Collections.emptyList();
+                }
+            };
+
+            PlanManager emptyPlanManager = DefaultPlanManager.createProceeding(emptyDeployPlan);
+            PlansResource emptyPlanResource = new PlansResource();
+            emptyPlanResource.setPlanManagers(Arrays.asList(emptyPlanManager));
+
+            SchedulerApiServer apiServer = new SchedulerApiServer(
+                    schedulerConfig,
+                    Arrays.asList(
+                            emptyPlanResource,
+                            new HealthResource()));
+            apiServer.start(new AbstractLifeCycle.AbstractLifeCycleListener() {
+                @Override
+                public void lifeCycleStarted(LifeCycle event) {
+                    LOGGER.info("Started trivially healthy API server.");
+                }
+            });
         }
     }
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/TaskKiller.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/TaskKiller.java
@@ -1,7 +1,7 @@
 package com.mesosphere.sdk.scheduler;
 
 import org.apache.mesos.Protos.TaskID;
-
+import org.apache.mesos.SchedulerDriver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/TaskKiller.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/TaskKiller.java
@@ -1,7 +1,6 @@
 package com.mesosphere.sdk.scheduler;
 
 import org.apache.mesos.Protos.TaskID;
-import org.apache.mesos.SchedulerDriver;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/uninstall/DeregisterStep.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/uninstall/DeregisterStep.java
@@ -12,24 +12,17 @@ import java.util.Optional;
  */
 public class DeregisterStep extends UninstallStep {
 
-    private SchedulerDriver schedulerDriver;
+    private SchedulerDriver driver;
     private StateStore stateStore;
 
     /**
      * Creates a new instance with initial {@code status}. The {@link SchedulerDriver} must be
      * set separately.
      */
-    DeregisterStep(StateStore stateStore) {
+    DeregisterStep(StateStore stateStore, SchedulerDriver driver) {
         super("deregister", Status.PENDING);
         this.stateStore = stateStore;
-    }
-
-    /**
-     *
-     * @param schedulerDriver Must be set before call to {@link #start()}
-     */
-    void setSchedulerDriver(SchedulerDriver schedulerDriver) {
-        this.schedulerDriver = schedulerDriver;
+        this.driver = driver;
     }
 
     @Override
@@ -40,7 +33,7 @@ public class DeregisterStep extends UninstallStep {
         // Unregisters the framework in addition to stopping the SchedulerDriver thread:
         // Calling with failover == false causes Mesos to teardown the framework.
         // This call will cause DefaultService's schedulerDriver.run() call to return DRIVER_STOPPED.
-        schedulerDriver.stop(false);
+        driver.stop(false);
         logger.info("Deleting service root path for framework...");
         stateStore.clearAllData();
         logger.info("### UNINSTALL IS COMPLETE! ###");

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/uninstall/TaskKillStep.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/uninstall/TaskKillStep.java
@@ -12,16 +12,13 @@ import java.util.Optional;
  */
 public class TaskKillStep extends UninstallStep {
 
-    private TaskKiller taskKiller;
-    private Protos.TaskID taskID;
+    private final TaskKiller taskKiller;
+    private final Protos.TaskID taskID;
 
-    public TaskKillStep(Protos.TaskID taskID) {
+    public TaskKillStep(Protos.TaskID taskID, TaskKiller taskKiller) {
         super("kill-task-" + taskID.getValue(), Status.PENDING);
-        this.taskID = taskID;
-    }
-
-    public void setTaskKiller(TaskKiller taskKiller) {
         this.taskKiller = taskKiller;
+        this.taskID = taskID;
     }
 
     @Override

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/uninstall/UninstallPlanBuilder.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/uninstall/UninstallPlanBuilder.java
@@ -96,11 +96,12 @@ class UninstallPlanBuilder {
                         && taskIdsInErrorState.contains(taskInfo.getTaskId())))
                 .collect(Collectors.toList());
 
-        List<Step> resourceSteps = ResourceUtils.getResourceIds(ResourceUtils.getAllResources(tasksNotFailedAndErrored)).stream()
-                .map(resourceId -> new ResourceCleanupStep(
-                        resourceId,
-                        resourceId.startsWith(Constants.TOMBSTONE_MARKER) ? Status.COMPLETE : Status.PENDING))
-                .collect(Collectors.toList());
+        List<Step> resourceSteps =
+                ResourceUtils.getResourceIds(ResourceUtils.getAllResources(tasksNotFailedAndErrored)).stream()
+                        .map(resourceId -> new ResourceCleanupStep(
+                                resourceId,
+                                resourceId.startsWith(Constants.TOMBSTONE_MARKER) ? Status.COMPLETE : Status.PENDING))
+                        .collect(Collectors.toList());
         LOGGER.info("Configuring resource cleanup of {}/{} tasks: {}/{} expected resources have been unreserved",
                 tasksNotFailedAndErrored.size(), allTasks.size(),
                 resourceSteps.stream().filter(step -> step.isComplete()).count(),

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/uninstall/UninstallPlanBuilder.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/uninstall/UninstallPlanBuilder.java
@@ -47,8 +47,6 @@ class UninstallPlanBuilder {
 
     private final Plan plan;
 
-    private TaskKiller taskKiller;
-
     UninstallPlanBuilder(
             ServiceSpec serviceSpec,
             StateStore stateStore,
@@ -68,7 +66,7 @@ class UninstallPlanBuilder {
         List<Phase> phases = new ArrayList<>();
 
         // First, we kill all the tasks, so that we may release their reserved resources.
-        TaskKiller taskKiller = new DefaultTaskKiller(new DefaultTaskFailureListener(stateStore, configStore), driver);
+        TaskKiller taskKiller = new TaskKiller(driver);
         List<Step> taskKillSteps = stateStore.fetchTasks().stream()
                 .map(Protos.TaskInfo::getTaskId)
                 .map(taskID -> new TaskKillStep(taskID, taskKiller))

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/uninstall/UninstallPlanBuilder.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/uninstall/UninstallPlanBuilder.java
@@ -45,9 +45,6 @@ class UninstallPlanBuilder {
     private static final String TLS_CLEANUP_PHASE = "tls-cleanup";
     private static final String DEREGISTER_PHASE = "deregister-service";
 
-    private final List<Step> taskKillSteps;
-    private final List<Step> resourceSteps;
-    private final DeregisterStep deregisterStep;
     private final Plan plan;
 
     private TaskKiller taskKiller;
@@ -64,10 +61,6 @@ class UninstallPlanBuilder {
         if (!stateStore.fetchFrameworkId().isPresent()) {
             LOGGER.info("Framework ID is unset. Clearing state data and using an empty completed plan.");
             stateStore.clearAllData();
-
-            // Fill values with stubs, and use an empty COMPLETE plan:
-            taskKillSteps = Collections.emptyList();
-            resourceSteps = Collections.emptyList();
             plan = new DefaultPlan(Constants.DEPLOY_PLAN_NAME, Collections.emptyList());
             return;
         }
@@ -75,9 +68,10 @@ class UninstallPlanBuilder {
         List<Phase> phases = new ArrayList<>();
 
         // First, we kill all the tasks, so that we may release their reserved resources.
-        taskKillSteps = stateStore.fetchTasks().stream()
+        TaskKiller taskKiller = new DefaultTaskKiller(new DefaultTaskFailureListener(stateStore, configStore), driver);
+        List<Step> taskKillSteps = stateStore.fetchTasks().stream()
                 .map(Protos.TaskInfo::getTaskId)
-                .map(taskID -> new TaskKillStep(taskID))
+                .map(taskID -> new TaskKillStep(taskID, taskKiller))
                 .collect(Collectors.toList());
         phases.add(new DefaultPhase(TASK_KILL_PHASE, taskKillSteps, new ParallelStrategy<>(), Collections.emptyList()));
 
@@ -102,7 +96,7 @@ class UninstallPlanBuilder {
                         && taskIdsInErrorState.contains(taskInfo.getTaskId())))
                 .collect(Collectors.toList());
 
-        resourceSteps = ResourceUtils.getResourceIds(ResourceUtils.getAllResources(tasksNotFailedAndErrored)).stream()
+        List<Step> resourceSteps = ResourceUtils.getResourceIds(ResourceUtils.getAllResources(tasksNotFailedAndErrored)).stream()
                 .map(resourceId -> new ResourceCleanupStep(
                         resourceId,
                         resourceId.startsWith(Constants.TOMBSTONE_MARKER) ? Status.COMPLETE : Status.PENDING))
@@ -143,7 +137,7 @@ class UninstallPlanBuilder {
         // We don't have access to the SchedulerDriver yet. That will be set via setSchedulerDriver() below.
         phases.add(new DefaultPhase(
                 DEREGISTER_PHASE,
-                Collections.singletonList(deregisterStep),
+                Collections.singletonList(new DeregisterStep(stateStore, driver)),
                 new SerialStrategy<>(),
                 Collections.emptyList()));
 
@@ -153,30 +147,7 @@ class UninstallPlanBuilder {
     /**
      * Returns the plan to be used for uninstalling the service.
      */
-    Plan getPlan() {
+    Plan build() {
         return plan;
-    }
-
-    /**
-     * Returns the resource unreservation steps for all tasks in the service. Some steps may be already marked as
-     * {@link Status#COMPLETE} when unreservation has already been performed. An empty list may be returned if no known
-     * resources need to be unreserved.
-     */
-    Collection<Step> getResourceSteps() {
-        return resourceSteps;
-    }
-
-    /**
-     * Passes the provided {@link SchedulerDriver} to underlying plan elements.
-     */
-    void registered(SchedulerDriver schedulerDriver) {
-        if (deregisterStep.isPresent()) {
-            deregisterStep.get().setSchedulerDriver(schedulerDriver);
-        }
-
-        this.taskKiller = new TaskKiller(schedulerDriver);
-        for (Step taskKillStep : taskKillSteps) {
-            ((TaskKillStep) taskKillStep).setTaskKiller(taskKiller);
-        }
     }
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/uninstall/UninstallPlanBuilder.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/uninstall/UninstallPlanBuilder.java
@@ -47,7 +47,7 @@ class UninstallPlanBuilder {
 
     private final List<Step> taskKillSteps;
     private final List<Step> resourceSteps;
-    private final Optional<DeregisterStep> deregisterStep;
+    private final DeregisterStep deregisterStep;
     private final Plan plan;
 
     private TaskKiller taskKiller;
@@ -57,6 +57,7 @@ class UninstallPlanBuilder {
             StateStore stateStore,
             ConfigStore<ServiceSpec> configStore,
             SchedulerConfig schedulerConfig,
+            SchedulerDriver driver,
             Optional<SecretsClient> customSecretsClientForTests) {
 
         // If there is no framework ID, wipe ZK and produce an empty COMPLETE plan
@@ -67,7 +68,6 @@ class UninstallPlanBuilder {
             // Fill values with stubs, and use an empty COMPLETE plan:
             taskKillSteps = Collections.emptyList();
             resourceSteps = Collections.emptyList();
-            deregisterStep = Optional.empty();
             plan = new DefaultPlan(Constants.DEPLOY_PLAN_NAME, Collections.emptyList());
             return;
         }
@@ -141,10 +141,9 @@ class UninstallPlanBuilder {
 
         // Finally, we unregister the framework from Mesos.
         // We don't have access to the SchedulerDriver yet. That will be set via setSchedulerDriver() below.
-        deregisterStep = Optional.of(new DeregisterStep(stateStore));
         phases.add(new DefaultPhase(
                 DEREGISTER_PHASE,
-                Collections.singletonList(deregisterStep.get()),
+                Collections.singletonList(deregisterStep),
                 new SerialStrategy<>(),
                 Collections.emptyList()));
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/uninstall/UninstallRecorder.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/uninstall/UninstallRecorder.java
@@ -20,9 +20,9 @@ import static com.mesosphere.sdk.offer.Constants.TOMBSTONE_MARKER;
 public class UninstallRecorder implements OperationRecorder {
     private final Logger logger = LoggerFactory.getLogger(getClass());
     private final StateStore stateStore;
-    private final Collection<Step> resourceSteps;
+    private final Collection<ResourceCleanupStep> resourceSteps;
 
-    UninstallRecorder(StateStore stateStore, Collection<Step> resourceSteps) {
+    UninstallRecorder(StateStore stateStore, Collection<ResourceCleanupStep> resourceSteps) {
         this.stateStore = stateStore;
         this.resourceSteps = resourceSteps;
     }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/uninstall/UninstallRecorder.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/uninstall/UninstallRecorder.java
@@ -2,7 +2,6 @@ package com.mesosphere.sdk.scheduler.uninstall;
 
 import com.google.protobuf.TextFormat;
 import com.mesosphere.sdk.offer.*;
-import com.mesosphere.sdk.scheduler.plan.Step;
 import com.mesosphere.sdk.state.StateStore;
 import org.apache.mesos.Protos;
 import org.slf4j.Logger;

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/uninstall/UninstallScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/uninstall/UninstallScheduler.java
@@ -1,6 +1,5 @@
 package com.mesosphere.sdk.scheduler.uninstall;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.mesosphere.sdk.api.HealthResource;
 import com.mesosphere.sdk.api.PlansResource;
 import com.mesosphere.sdk.api.types.PlanInfo;

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/uninstall/UninstallScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/uninstall/UninstallScheduler.java
@@ -1,6 +1,7 @@
 package com.mesosphere.sdk.scheduler.uninstall;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.mesosphere.sdk.api.HealthResource;
 import com.mesosphere.sdk.api.PlansResource;
 import com.mesosphere.sdk.api.types.PlanInfo;
 import com.mesosphere.sdk.config.SerializationUtils;
@@ -89,8 +90,9 @@ public class UninstallScheduler extends AbstractScheduler {
                 secretsClient)
                 .build();
         uninstallPlanManager = DefaultPlanManager.createProceeding(plan);
-        resources = Collections.singletonList(new PlansResource()
-                .setPlanManagers(Collections.singletonList(uninstallPlanManager)));
+        resources = Arrays.asList(
+                new PlansResource().setPlanManagers(Collections.singletonList(uninstallPlanManager)),
+                new HealthResource().setHealthyPlanManagers(Collections.singletonList(uninstallPlanManager)));
         List<ResourceCleanupStep> resourceCleanupSteps = plan.getChildren().stream()
                 .flatMap(phase -> phase.getChildren().stream())
                 .filter(step -> step instanceof ResourceCleanupStep)

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/uninstall/UninstallScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/uninstall/UninstallScheduler.java
@@ -1,23 +1,25 @@
 package com.mesosphere.sdk.scheduler.uninstall;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.mesosphere.sdk.api.HealthResource;
 import com.mesosphere.sdk.api.PlansResource;
+import com.mesosphere.sdk.api.types.PlanInfo;
+import com.mesosphere.sdk.config.SerializationUtils;
 import com.mesosphere.sdk.dcos.clients.SecretsClient;
 import com.mesosphere.sdk.offer.*;
-import com.mesosphere.sdk.scheduler.*;
+import com.mesosphere.sdk.scheduler.AbstractScheduler;
+import com.mesosphere.sdk.scheduler.SchedulerConfig;
 import com.mesosphere.sdk.scheduler.plan.*;
 import com.mesosphere.sdk.specification.ServiceSpec;
 import com.mesosphere.sdk.state.ConfigStore;
 import com.mesosphere.sdk.state.StateStore;
 import com.mesosphere.sdk.state.StateStoreUtils;
-
 import org.apache.mesos.Protos;
 import org.apache.mesos.Scheduler;
 import org.apache.mesos.SchedulerDriver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -26,12 +28,11 @@ import java.util.stream.Collectors;
  */
 public class UninstallScheduler extends AbstractScheduler {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(UninstallScheduler.class);
+    private final Logger logger = LoggerFactory.getLogger(getClass());
 
     private final ServiceSpec serviceSpec;
     private final Optional<SecretsClient> secretsClient;
 
-    private UninstallPlanBuilder uninstallPlanBuilder;
     private PlanManager uninstallPlanManager;
     private Collection<Object> resources = Collections.emptyList();
     private OfferAccepter offerAccepter;
@@ -63,7 +64,7 @@ public class UninstallScheduler extends AbstractScheduler {
     @Override
     public Optional<Scheduler> getMesosScheduler() {
         if (allButStateStoreUninstalled(stateStore, schedulerConfig)) {
-            LOGGER.info("Not registering framework because there are no resources left to unreserve.");
+            logger.info("Not registering framework because there are no resources left to unreserve.");
             return Optional.empty();
         }
 
@@ -77,17 +78,34 @@ public class UninstallScheduler extends AbstractScheduler {
 
     @Override
     protected PlanCoordinator initialize(SchedulerDriver driver) throws InterruptedException {
-        LOGGER.info("Initializing...");
+        logger.info("Initializing...");
 
-        uninstallPlanBuilder = new UninstallPlanBuilder(
-                serviceSpec, stateStore, configStore, schedulerConfig, driver, secretsClient);
-        uninstallPlanManager = DefaultPlanManager.createProceeding(uninstallPlanBuilder.getPlan());
+        Plan plan = new UninstallPlanBuilder(
+                serviceSpec,
+                stateStore,
+                configStore,
+                schedulerConfig,
+                driver,
+                secretsClient)
+                .build();
+        uninstallPlanManager = DefaultPlanManager.createProceeding(plan);
         resources = Collections.singletonList(new PlansResource()
                 .setPlanManagers(Collections.singletonList(uninstallPlanManager)));
+        List<ResourceCleanupStep> resourceCleanupSteps = plan.getChildren().stream()
+                .flatMap(phase -> phase.getChildren().stream())
+                .filter(step -> step instanceof ResourceCleanupStep)
+                .map(step -> (ResourceCleanupStep) step)
+                .collect(Collectors.toList());
         offerAccepter = new OfferAccepter(Collections.singletonList(
-                new UninstallRecorder(stateStore, uninstallPlanBuilder.getResourceSteps())));
+                new UninstallRecorder(stateStore, resourceCleanupSteps)));
 
-        LOGGER.info("Done initializing.");
+        try {
+            logger.info("Uninstall plan set to: {}", SerializationUtils.toJsonString(PlanInfo.forPlan(plan)));
+        } catch (IOException e) {
+            logger.error("Failed to deserialize uninstall plan.");
+        }
+
+        logger.info("Done initializing.");
 
         // Return a stub coordinator which only does work against the sole plan manager.
         return new PlanCoordinator() {
@@ -108,7 +126,7 @@ public class UninstallScheduler extends AbstractScheduler {
         List<Protos.Offer> localOffers = new ArrayList<>(offers);
         // Get candidate steps to be scheduled
         if (!steps.isEmpty()) {
-            LOGGER.info("Attempting to process {} candidates from uninstall plan: {}",
+            logger.info("Attempting to process {} candidates from uninstall plan: {}",
                     steps.size(), steps.stream().map(Element::getName).collect(Collectors.toList()));
             steps.forEach(Step::start);
         }
@@ -123,9 +141,9 @@ public class UninstallScheduler extends AbstractScheduler {
         // Decline remaining offers.
         List<Protos.Offer> unusedOffers = OfferUtils.filterOutAcceptedOffers(localOffers, offersWithReservedResources);
         if (unusedOffers.isEmpty()) {
-            LOGGER.info("No offers to be declined.");
+            logger.info("No offers to be declined.");
         } else {
-            LOGGER.info("Declining {} unused offers", unusedOffers.size());
+            logger.info("Declining {} unused offers", unusedOffers.size());
             OfferUtils.declineLong(driver, unusedOffers);
         }
     }
@@ -149,10 +167,5 @@ public class UninstallScheduler extends AbstractScheduler {
                 ResourceUtils.getResourceIds(
                         ResourceUtils.getAllResources(stateStore.fetchTasks())).stream()
                         .allMatch(resourceId -> resourceId.startsWith(Constants.TOMBSTONE_MARKER));
-    }
-
-    @VisibleForTesting
-    Plan getPlan() {
-        return uninstallPlanManager.getPlan();
     }
 }

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/uninstall/TaskKillStepTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/uninstall/TaskKillStepTest.java
@@ -32,8 +32,7 @@ public class TaskKillStepTest {
     }
 
     private TaskKillStep createStep() {
-        TaskKillStep step = new TaskKillStep(taskID);
-        step.setTaskKiller(mockTaskKiller);
+        TaskKillStep step = new TaskKillStep(taskID, mockTaskKiller);
         return step;
     }
 }


### PR DESCRIPTION
The Uninstall Scheduler had some finicky callback ordering for SchedulerDrivers / Plan construction. 
I could not debug why DCOS-19854 failed from logs.  So I've improved logging of the uninstall plan and removed the callbacks to improve reliability.

 