### PR TITLE
Envvars instead of credentials file

### DIFF
--- a/frameworks/cassandra/tests/test_backup_and_restore.py
+++ b/frameworks/cassandra/tests/test_backup_and_restore.py
@@ -84,6 +84,7 @@ def test_backup_and_restore_to_s3():
     plan_parameters = {
         'AWS_ACCESS_KEY_ID': key_id,
         'AWS_SECRET_ACCESS_KEY': os.getenv('AWS_SECRET_ACCESS_KEY'),
+        'AWS_SESSION_TOKEN': os.getenv('AWS_SESSION_TOKEN'),
         'AWS_REGION': os.getenv('AWS_REGION', 'us-west-2'),
         'S3_BUCKET_NAME': os.getenv('AWS_BUCKET_NAME', 'infinity-framework-test'),
         'SNAPSHOT_NAME': str(uuid.uuid1()),

--- a/test.sh
+++ b/test.sh
@@ -203,9 +203,6 @@ fi
 docker run --rm \
     -v ${aws_credentials_path}:/root/.aws:ro \
     -e AWS_PROFILE="${aws_profile}" \
-    -e AWS_SESSION_TOKEN=$(AWS_PROFILE=$aws_profile aws configure get aws_session_token) \
-    -e AWS_ACCESS_KEY_ID=$(AWS_PROFILE=$aws_profile aws configure get aws_access_key_id) \
-    -e AWS_SECRET_ACCESS_KEY=$(AWS_PROFILE=$aws_profile aws configure get aws_secret_access_key) \
     -e DCOS_ENTERPRISE="$DCOS_ENTERPRISE" \
     -e DCOS_LOGIN_USERNAME="$DCOS_LOGIN_USERNAME" \
     -e DCOS_LOGIN_PASSWORD="$DCOS_LOGIN_PASSWORD" \

--- a/test.sh
+++ b/test.sh
@@ -203,6 +203,9 @@ fi
 docker run --rm \
     -v ${aws_credentials_path}:/root/.aws:ro \
     -e AWS_PROFILE="${aws_profile}" \
+    -e AWS_SESSION_TOKEN=$(AWS_PROFILE=$aws_profile aws configure get aws_session_token) \
+    -e AWS_ACCESS_KEY_ID=$(AWS_PROFILE=$aws_profile aws configure get aws_access_key_id) \
+    -e AWS_SECRET_ACCESS_KEY=$(AWS_PROFILE=$aws_profile aws configure get aws_secret_access_key) \
     -e DCOS_ENTERPRISE="$DCOS_ENTERPRISE" \
     -e DCOS_LOGIN_USERNAME="$DCOS_LOGIN_USERNAME" \
     -e DCOS_LOGIN_PASSWORD="$DCOS_LOGIN_PASSWORD" \


### PR DESCRIPTION
This writes the content of the selected profile to envvars in the docker container so that tests and things can consume the envvars directly.

I defer to @elezar to tell me what else to pull out. We could also rewrite the C* backup tests to not use the envvars, and instead pull from the credential file via the aws CLI.