### PR TITLE
[INFINITY-2876] Fix backup/restore metronome job definition

### DIFF
--- a/frameworks/cassandra/tests/config.py
+++ b/frameworks/cassandra/tests/config.py
@@ -70,7 +70,7 @@ def _get_test_job(name, commands, node_address, node_port, restart_policy='ON_FA
         'id': 'test.cassandra.' + name,
         'run': {
             'cmd': ' && '.join(commands),
-            'docker': {'image': 'cassandra:3.0.13'},
+            'docker': {'image': 'cassandra:3.0.13', 'forcePullImage': False},
             'cpus': 1,
             'mem': 512,
             'user': 'nobody',


### PR DESCRIPTION
Metronome unintentionally made the `forcePullImage` field required