### PR TITLE
Override S3 bucket used for deploying stub universe during tests

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -207,6 +207,7 @@ docker run --rm \
     -e DCOS_LOGIN_USERNAME="$DCOS_LOGIN_USERNAME" \
     -e DCOS_LOGIN_PASSWORD="$DCOS_LOGIN_PASSWORD" \
     -e CLUSTER_URL="$CLUSTER_URL" \
+    -e S3_BUCKET="$S3_BUCKET" \
     $azure_args \
     -e SECURITY="$security" \
     -e PYTEST_ARGS="$PYTEST_ARGS" \


### PR DESCRIPTION
Pass along `S3_BUCKET` override env var to `build.sh aws`.