### PR TITLE
Only pass docker run -i when running interactive mode

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -177,12 +177,14 @@ if [ -z $interactive ]; then
     fi
     FRAMEWORK_ARGS="-e FRAMEWORK=$framework"
     DOCKER_COMMAND="bash test-runner.sh"
+    DOCKER_INTERACTIVE_FLAGS=""
 else
 # interactive mode
     FRAMEWORK_ARGS="-u $(id -u):$(id -g) -e DCOS_DIR=/build/.dcos-in-docker"
     FRAMEWORK_ARGS=""
     framework="NOT_SPECIFIED"
     DOCKER_COMMAND="bash"
+    DOCKER_INTERACTIVE_FLAGS="-i"
 fi
 
 if [ -n "$pytest_k" ]; then
@@ -216,6 +218,6 @@ docker run --rm \
     -v $ssh_path:/ssh/key \
     -w /build \
     -t \
-    -i \
+    $DOCKER_INTERACTIVE_FLAGS \
     mesosphere/dcos-commons:latest \
     $DOCKER_COMMAND


### PR DESCRIPTION
Don't use interactive mode `-i` with `docker run` when not running `test.sh --interactive`.  When STDIN is not available you will get the error `the input device is not a TTY` in an automation context, such as Jenkins.

`the input device is not a TTY`