### PR TITLE
INFINITY-[1532,1533] First pass at releasing testing/+tools/ .whl's

### DIFF
--- a/cli/client/dcoscli.go
+++ b/cli/client/dcoscli.go
@@ -115,13 +115,13 @@ func cliConfigValue(name string) (string, error) {
 	// dcos-cli allows providing a custom envvar for the config path, we honor that here:
 	configDir, err := configDir()
 	if err != nil {
-		PrintVerbose("Falling back to querying CLI: %s", err.Error())
+		PrintVerbose("Falling back to querying CLI for %s: %s", name, err.Error())
 	} else {
 		diskConfig, err := cliDiskConfig(configDir)
 		if err == nil {
 			return cliDiskConfigValue(diskConfig, name)
 		} else {
-			PrintVerbose("No cluster config found, falling back to querying CLI: %s", err.Error())
+			PrintVerbose("No cluster config found, falling back to querying CLI for %s: %s", name, err.Error())
 		}
 	}
 

--- a/cli/commands/plan_test.go
+++ b/cli/commands/plan_test.go
@@ -64,6 +64,8 @@ func (suite *PlanTestSuite) SetupTest() {
 	// set up test server
 	suite.server = httptest.NewServer(http.HandlerFunc(suite.exampleHandler))
 	os.Setenv("DCOS_URL", suite.server.URL)
+	os.Setenv("DCOS_ACS_TOKEN", "fake-token")
+	os.Setenv("DCOS_SSL_VERIFY", "False")
 }
 
 func (suite *PlanTestSuite) TearDownTest() {

--- a/cli/commands/update_test.go
+++ b/cli/commands/update_test.go
@@ -65,6 +65,9 @@ func (suite *UpdateTestSuite) SetupTest() {
 	// set up test server
 	suite.server = httptest.NewServer(http.HandlerFunc(suite.exampleHandler))
 	os.Setenv("DCOS_URL", suite.server.URL)
+	os.Setenv("DCOS_PACKAGE_COSMOS_URL", suite.server.URL)
+	os.Setenv("DCOS_ACS_TOKEN", "fake-token")
+	os.Setenv("DCOS_SSL_VERIFY", "False")
 }
 
 func (suite *UpdateTestSuite) TearDownTest() {

--- a/release.sh
+++ b/release.sh
@@ -99,6 +99,7 @@ fi
 sdk/bootstrap/build.sh # produces sdk/bootstrap/bootstrap.zip
 sdk/cli/build.sh # produces sdk/cli/[dcos-service-cli-linux, dcos-service-cli-darwin, dcos-service-cli.exe]
 ./gradlew :executor:distZip # produces sdk/executor/build/distributions/executor.zip
+tools/pip/build.sh $SDK_VERSION # produces tools/pip/[testing|tools]-[SDK_VERSION]-py3-none-any.whl
 
 # Upload artifacts to S3
 
@@ -117,3 +118,6 @@ aws s3 cp --acl public-read sdk/executor/build/distributions/executor.zip $S3_DI
 aws s3 cp --acl public-read sdk/cli/dcos-service-cli-linux $S3_DIR/dcos-service-cli-linux 1>&2
 aws s3 cp --acl public-read sdk/cli/dcos-service-cli-darwin $S3_DIR/dcos-service-cli-darwin 1>&2
 aws s3 cp --acl public-read sdk/cli/dcos-service-cli.exe $S3_DIR/dcos-service-cli.exe 1>&2
+# note: pip will refuse to install files without the extra info in the filename, so we keep it despite its redundancy:
+aws s3 cp --acl public-read tools/pip/testing-$SDK_VERSION-py3-none-any.whl $S3_DIR/testing-$SDK_VERSION-py3-none-any.whl 1>&2
+aws s3 cp --acl public-read tools/pip/tools-$SDK_VERSION-py3-none-any.whl $S3_DIR/tools-$SDK_VERSION-py3-none-any.whl 1>&2

--- a/sdk/cli/README.md
+++ b/sdk/cli/README.md
@@ -1,0 +1,10 @@
+# Default CLI
+
+This directory contains the default CLI build, used by the majority of services who don't add custom commands to their service CLIs. The default CLI builds are uploaded with every SDK release as of early 2018.
+
+Dependencies:
+- Go 1.8+
+- `../../cli` which contains the service CLI libraries
+- `../../govendor` which contains all vendored dependencies.
+
+To build, run `build.sh`. Note that no `GOPATH` is required, as an internal `GOPATH` is constructed for the build. The output will include default CLIs for Linux, OSX, and Windows.

--- a/sdk/cli/README.md
+++ b/sdk/cli/README.md
@@ -1,6 +1,6 @@
 # Default CLI
 
-This directory contains the default CLI build, used by the majority of services who don't add custom commands to their service CLIs. The default CLI builds are uploaded with every SDK release as of early 2018.
+This directory contains the default CLI build, used by the majority of services who don't add custom commands to their service CLIs. As of Jan 2018, default CLI builds are uploaded with every SDK release, along with a SHA256SUMS file in the same directory.
 
 Dependencies:
 - Go 1.8+

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/TemplateUtils.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/TemplateUtils.java
@@ -3,6 +3,7 @@ package com.mesosphere.sdk.specification.yaml;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -110,6 +111,17 @@ public class TemplateUtils {
             String templateName, String templateContent, Map<String, String> values) throws MustacheException {
         List<MissingValue> missingValues = new ArrayList<>();
         String rendered = renderMustache(templateName, templateContent, values, missingValues);
+        validateMissingValues(templateName, values, missingValues);
+        return rendered;
+    }
+
+    /**
+     * Throws a descriptive exception if {@code missingValues} is non-empty. Exposed as a utility function to allow
+     * custom filtering of missing values before the validation occurs.
+     */
+    public static void validateMissingValues(
+            String templateName, Map<String, String> values, Collection<MissingValue> missingValues)
+                    throws MustacheException {
         if (!missingValues.isEmpty()) {
             Map<String, String> orderedValues = new TreeMap<>();
             orderedValues.putAll(values);
@@ -121,7 +133,6 @@ public class TemplateUtils {
                     missingValues,
                     orderedValues));
         }
-        return rendered;
     }
 
     /**

--- a/tools/pip/.gitignore
+++ b/tools/pip/.gitignore
@@ -1,0 +1,6 @@
+*.egg-info/
+*.pyc
+*.whl
+dist/
+build/
+venv/

--- a/tools/pip/README.md
+++ b/tools/pip/README.md
@@ -1,0 +1,5 @@
+# .whl tooling
+
+Tooling to release the contents of `tools/` and `testing/` as `.whl` packages. These are uploaded in SDK releases from early 2018 onwards.
+
+To build, run `build.sh <release_version>`. The output will include two `.whl` packages with the provided version, containing the respective content of `tools/` and `testing/`. See output from `build.sh` for example usage of the built artifacts.

--- a/tools/pip/build.sh
+++ b/tools/pip/build.sh
@@ -7,7 +7,8 @@ if [ $# -ne 1 ]; then
     echo "Syntax: $0 <version>"
     exit 1
 fi
-export VERSION=$1
+# convert snapshot releases from e.g. '1.2.3-SNAPSHOT' to '1.2.3+snapshot' to keep python happy. see also PEP-440.
+export VERSION=$(echo $1 | sed 's/-/+/g' | tr '[:upper:]' '[:lower:]')
 
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd $THIS_DIR

--- a/tools/pip/build.sh
+++ b/tools/pip/build.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -e
+
+# This script builds .whl files for the tools/ and testing/ directories, to be published as part of an SDK release.
+
+if [ $# -ne 1 ]; then
+    echo "Syntax: $0 <version>"
+    exit 1
+fi
+export VERSION=$1
+
+THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd $THIS_DIR
+
+build_dir() {
+    rm -rf dist/ binaries/
+    OUTPUT_NAME=$1 INPUT_DIR=$2 python3 setup.py -q bdist_wheel
+}
+
+build_dir tools ..
+build_dir testing ../../testing
+
+cat <<EOF
+-----
+Init test environment with:
+
+rm -rf venv/
+virtualenv -p python3 venv
+. venv/bin/activate
+pip3 install $(pwd)/testing-$VERSION-*.whl
+pip3 install $(pwd)/tools-$VERSION-*.whl
+
+Then run tools using:
+
+tools <tool_exe_filename> [args ...]
+
+Or import testing as a library with:
+
+python3
+import sys, os.path, testing
+sys.path.append(os.path.dirname(testing.__file__))
+import <thing in testing>
+EOF

--- a/tools/pip/cmd_wrapper/__init__.py
+++ b/tools/pip/cmd_wrapper/__init__.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+
+import os
+import os.path
+import subprocess
+import sys
+
+__PARENT_DIR_PATH = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
+__PARENT_DIR_NAME = os.path.basename(__PARENT_DIR_PATH)
+
+def __log(msg):
+    sys.stderr.write(msg + '\n')
+
+
+def __get_file_error(file_path):
+    if not os.path.exists(file_path):
+        return 'Path does not exist: {}'.format(file_path)
+    if not os.path.isfile(file_path):
+        return 'Path is not a regular file: {}'.format(file_path)
+    if not os.access(file_path, os.X_OK):
+        return 'Path is not executable: {}'.format(file_path)
+    return None
+
+
+def __syntax():
+    available_files = []
+    for root, dirs, files in os.walk(__PARENT_DIR_PATH):
+        for f in files:
+            file_path = os.path.join(root, f)
+            # ignore self:
+            if file_path == os.path.join(__PARENT_DIR_PATH, '__init__.py'):
+                continue
+            # ignore files that aren't regular+executable:
+            file_error = __get_file_error(file_path)
+            if file_error:
+                continue
+            # get path relative to this dir:
+            available_files.append(file_path[len(__PARENT_DIR_PATH) + 1:])
+    available_files.sort()
+
+    __log('''Syntax: {} <file> [args]
+{} executable files in {}:
+  {}'''.format(__PARENT_DIR_NAME, len(available_files), __PARENT_DIR_PATH, '\n  '.join(available_files)))
+
+
+def main():
+    if len(sys.argv) < 2:
+        __syntax()
+        return 1
+
+    file_to_run = sys.argv[1]
+    path_to_run = os.path.join(__PARENT_DIR_PATH, file_to_run)
+    file_error = __get_file_error(path_to_run)
+    if file_error:
+        __log(file_error)
+        __syntax()
+        return 1
+
+    return subprocess.call([path_to_run] + sys.argv[2:])
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tools/pip/setup.py
+++ b/tools/pip/setup.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+
+import os
+import os.path
+import setuptools
+import shutil
+import subprocess
+import sys
+
+def syntax():
+    print('Syntax: OUTPUT_NAME=foo INPUT_DIR=path/to/foo VERSION=0.123.0 {} -q bdist_wheel'.format(sys.argv[0]))
+
+def main():
+    output_name = os.getenv('OUTPUT_NAME')
+    input_dir_path = os.getenv('INPUT_DIR')
+    version = os.getenv('VERSION')
+    if not output_name or not input_dir_path or not version:
+        print('Missing OUTPUT_NAME, INPUT_DIR, or VERSION envvars.')
+        syntax()
+        return 1
+
+    if not os.path.isdir(input_dir_path):
+        print('Provided input path is not a directory: {}'.format(input_dir_path))
+        syntax()
+        return 1
+
+    # only include files that are tracked by git
+    input_relative_file_paths = subprocess.check_output(['git', 'ls-files'], cwd=input_dir_path).decode('utf-8').split()
+    print('Packing {} files from {} into {}-{}:\n  {}'.format(
+        len(input_relative_file_paths), input_dir_path, output_name, version, '\n  '.join(input_relative_file_paths)))
+
+    # wipe/recreate output directory
+    script_dir = os.path.abspath(os.path.dirname(__file__))
+    output_dir_path = os.path.join(script_dir, output_name)
+    if os.path.exists(output_dir_path):
+        shutil.rmtree(output_dir_path)
+    os.makedirs(output_dir_path)
+    build_dir_path = os.path.join(script_dir, 'build')
+    if os.path.exists(build_dir_path):
+        shutil.rmtree(build_dir_path)
+    # copy all input files to ./<outname>/...
+    for input_relative_file_path in input_relative_file_paths:
+        src_path = os.path.join(input_dir_path, input_relative_file_path)
+        dest_path = os.path.join(output_dir_path, input_relative_file_path)
+        dest_dir = os.path.dirname(dest_path)
+        if not os.path.isdir(dest_dir):
+            os.makedirs(dest_dir)
+        shutil.copy(src_path, dest_path)
+
+    init_filename = '__init__.py'
+
+    # ensure that a root-level ./<outname>/__init__.py exists, so that the python module has a __file__ attribute
+    open(os.path.join(output_dir_path, init_filename), 'a').close()
+
+    # copy cmd_wrapper entrypoint into ./<outname>/cmd_wrapper/ as well
+    entrypoint_package = 'cmd_wrapper'
+    endpoint_output_dir = os.path.join(output_dir_path, entrypoint_package)
+    os.makedirs(endpoint_output_dir)
+    shutil.copy(
+        os.path.join(script_dir, entrypoint_package, init_filename),
+        os.path.join(endpoint_output_dir, init_filename))
+    input_relative_file_paths.append(os.path.join(entrypoint_package, init_filename))
+
+    # run setup with list of files to include
+    setuptools.setup(
+        name=output_name,
+        version=version,
+        url='http://github.com/mesosphere/dcos-commons',
+        packages=[output_name],
+        entry_points={ 'console_scripts': [
+            '{} = {}.{}:main'.format(output_name, output_name, entrypoint_package) ] },
+        package_data={ output_name: input_relative_file_paths })
+
+    # clean up build detritus:
+    shutil.rmtree(build_dir_path)
+    shutil.rmtree(os.path.join(script_dir, '{}.egg-info'.format(output_name)))
+    shutil.rmtree(output_dir_path)
+    # move whl file into script dir:
+    output_file = '{}-{}-py3-none-any.whl'.format(output_name, version)
+    output_path = os.path.join(script_dir, output_file)
+    os.rename(os.path.join(script_dir, 'dist', output_file), output_path)
+    shutil.rmtree(os.path.join(script_dir, 'dist'))
+
+    print('''Built {}-{}: {}'''.format(output_name, version, output_path))
+    return 0
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tools/release_builder.py
+++ b/tools/release_builder.py
@@ -201,15 +201,15 @@ Artifact output: {}
 
     def _download_unpack_stub_universe(self, scratchdir):
         '''Returns the path to the package directory in the stub universe.'''
-        stub_universe_file = urllib.request.urlopen(self._stub_universe_url)
-
         _, stub_universe_extension = os.path.splitext(self._stub_universe_url)
         if stub_universe_extension == '.zip':
             # stub universe zip package (universe 2.x only)
-            return self._unpack_stub_universe_zip(scratchdir, stub_universe_file)
+            with urllib.request.urlopen(self._stub_universe_url) as stub_universe_file:
+                return self._unpack_stub_universe_zip(scratchdir, stub_universe_file)
         elif stub_universe_extension == '.json':
             # stub universe json file (universe 3.x+ only)
-            return self._unpack_stub_universe_json(scratchdir, stub_universe_file)
+            with urllib.request.urlopen(self._stub_universe_url) as stub_universe_file:
+                return self._unpack_stub_universe_json(scratchdir, stub_universe_file)
         else:
             raise Exception('Expected .zip or .json extension for stub universe: {}'.format(
                 self._stub_universe_url))


### PR DESCRIPTION
Adds tooling which builds a `.whl` file for each of `testing/` and `tools/`, and updates the release script to upload these `.whl` files to S3.

The provided `tools/pip/build.sh` includes example steps for both executing tools and for importing testing libs. In theory external repos can just point their builds to these `.whl`s and avoid the need to manually copy `testing/` and `tools/`, but for now this is really just setting up a source of truth for use in future tooling.
  