### PR TITLE
[INFINITY-2879] address kdc test instability

### DIFF
--- a/testing/sdk_auth.py
+++ b/testing/sdk_auth.py
@@ -179,18 +179,22 @@ class KerberosEnvironment:
         self._working_dir = None
         self._temp_working_dir = None
 
+        # Application settings
         self.app_id = KERBEROS_APP_ID
         self.app_definition = self.load_kdc_app_definition()
 
+        # TODO: Ideally, we should not install this service in the constructor.
         kdc_task_info = self.install()
 
-        self.kdc_realm = REALM
+        # Running task information
         self.framework_id = kdc_task_info["framework_id"]
         self.task_id = kdc_task_info["id"]
         self.kdc_host_id = kdc_task_info["slave_id"]
 
+        # Kerberos-specific information
         self.principals = []
         self.keytab_file_name = KERBEROS_KEYTAB_FILE_NAME
+        self.kdc_realm = REALM
 
     def load_kdc_app_definition(self) -> dict:
         kdc_app_def_path = "{current_file_dir}/../tools/kdc/kdc.json".format(

--- a/testing/sdk_auth.py
+++ b/testing/sdk_auth.py
@@ -354,7 +354,7 @@ class KerberosEnvironment:
         return self.kdc_realm
 
     def get_kdc_address(self):
-        return ":".join([self.get_host, self.get_port])
+        return ":".join([self.get_host(), self.get_port()])
 
     def cleanup(self):
         sdk_security.install_enterprise_cli()

--- a/testing/sdk_cmd.py
+++ b/testing/sdk_cmd.py
@@ -62,8 +62,10 @@ def run_raw_cli(cmd, print_output=True):
         stderr = result.stderr.decode('utf-8').strip()
 
     if print_output:
-        print(stdout)
-        print(stderr)
+        if stdout:
+            print("STDOUT:", stdout)
+        if stderr:
+            print("STDERR:", stderr)
 
     return result.returncode, stdout, stderr
 

--- a/testing/sdk_security.py
+++ b/testing/sdk_security.py
@@ -23,10 +23,9 @@ def install_enterprise_cli(force=False):
     log.info("Installing DC/OS enterprise CLI")
     if not force:
         cmd = "security --version"
-        rc, stdout, stderr = sdk_cmd.run_raw_cli(cmd)
-
+        _, stdout, _ = sdk_cmd.run_raw_cli(cmd, print_output=False)
         if stdout:
-            log.info("DC/OS enterprise CLI already installed")
+            log.info("DC/OS enterprise version %s CLI already installed", stdout.strip())
             return
 
     cmd = "package install --yes --cli dcos-enterprise-cli"

--- a/testing/sdk_security.py
+++ b/testing/sdk_security.py
@@ -8,12 +8,43 @@ import logging
 import os
 from typing import List, Tuple
 
+import retrying
 import requests
 import shakedown
 import sdk_cmd
 import sdk_utils
 
 log = logging.getLogger(__name__)
+
+
+def install_enterprise_cli(force=False):
+    """ Install the enterprise CLI if required """
+
+    log.info("Installing DC/OS enterprise CLI")
+    if not force:
+        cmd = "security --version"
+        rc, stdout, stderr = sdk_cmd.run_raw_cli(cmd)
+
+        if stdout:
+            log.info("DC/OS enterprise CLI already installed")
+            return
+
+    cmd = "package install --yes --cli dcos-enterprise-cli"
+
+    @retrying.retry(stop_max_attempt_number=3,
+                    wait_fixed=2000,
+                    retry_on_result=lambda result: result)
+    def _install_impl():
+        rc, stdout, stderr = sdk_cmd.run_raw_cli(cmd)
+        if rc:
+            log.error("rc=%s stdout=%s stderr=%s", rc, stdout, stderr)
+
+        return rc
+
+    try:
+        _install_impl()
+    except Exception as e:
+        raise RuntimeError("Failed to install the dcos-enterprise-cli: {}".format(repr(e)))
 
 
 def grant(dcosurl: str, headers: dict, user: str, acl: str, description: str, action: str="create") -> None:


### PR DESCRIPTION
This PR adds some improvements to the `KerberosEnvironment` class to make the Kerberos tests more stable. The changes are:

* Add retrying and better logging to the installation of the kdc marathon app.
* Use `requests` with retry to download the keytab instead of CURL.
* Reduce the number of member variables set in the constructor.