### PR TITLE
Handle `S3_BUCKET` being an empty string by default now.

### DIFF
--- a/tools/publish_aws.py
+++ b/tools/publish_aws.py
@@ -42,7 +42,10 @@ class AWSPublisher(object):
         self._universe_url_prefix = os.environ.get(
             'UNIVERSE_URL_PREFIX',
             'https://universe-converter.mesosphere.com/transform?url=')
-        s3_bucket = os.environ.get('S3_BUCKET') if os.environ.get('S3_BUCKET') else 'infinity-artifacts'
+        s3_bucket = os.environ.get('S3_BUCKET')
+        if not s3_bucket:
+            s3_bucket = 'infinity-artifacts'
+        logger.info('Using artifact bucket: {}'.format(s3_bucket))
         s3_dir_path = os.environ.get('S3_DIR_PATH', 'autodelete7d')
         dir_name = '{}-{}'.format(
             time.strftime("%Y%m%d-%H%M%S"),

--- a/tools/publish_aws.py
+++ b/tools/publish_aws.py
@@ -42,7 +42,7 @@ class AWSPublisher(object):
         self._universe_url_prefix = os.environ.get(
             'UNIVERSE_URL_PREFIX',
             'https://universe-converter.mesosphere.com/transform?url=')
-        s3_bucket = os.environ.get('S3_BUCKET', 'infinity-artifacts')
+        s3_bucket = os.environ.get('S3_BUCKET') if os.environ.get('S3_BUCKET') else 'infinity-artifacts'
         s3_dir_path = os.environ.get('S3_DIR_PATH', 'autodelete7d')
         dir_name = '{}-{}'.format(
             time.strftime("%Y%m%d-%H%M%S"),


### PR DESCRIPTION
This was introduced with
https://github.com/mesosphere/dcos-commons/commit/31224ec8dcddc1e5f4f090acfc38f8c6f7e275e5

`dict.get` does not return the default if the value is an empty string so
we need to check for that.