### PR TITLE
Fix grep matching and subshell output expansion.

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -134,7 +134,7 @@ if [ ! -f "${aws_credentials_path}/credentials" ]; then
 else
     CREDENTIALS_FILE=${aws_credentials_path}/credentials
     PROFILES=$( grep -oE "^\[\S+\]" $CREDENTIALS_FILE )
-    if [ $( echo "$PROFILES" | grep [${aws_profile}]) != "[${aws_profile}]" ]; then
+    if [ "$( echo "$PROFILES" | grep "\[${aws_profile}\]" )" != "[${aws_profile}]" ]; then
         echo "The specified profile (${aws_profile}) was not found in the file $CREDENTIALS_FILE"
 
         if [ $( echo "$PROFILES" | wc -l ) == "1" ]; then


### PR DESCRIPTION
`grep [${aws_profile}]` was matching a bracket regular expression instead of a
string with literal brackets.

Also the expansion of `$( echo "$PROFILES" | grep "\[${aws_profile}\]" )`
needs to be enclosed in double quotes so that the != operator works and
doesn't give us "unary operator expected" errors when the output is empty.