### PR TITLE
Use default user for kafka-client marathon app def

### DIFF
--- a/frameworks/kafka/tests/test_kerberos_auth.py
+++ b/frameworks/kafka/tests/test_kerberos_auth.py
@@ -113,7 +113,6 @@ def kafka_client(kerberos, kafka_server):
         client = {
             "id": client_id,
             "mem": 512,
-            "user": "nobody",
             "container": {
                 "type": "MESOS",
                 "docker": {

--- a/frameworks/kafka/tests/test_kerberos_authz.py
+++ b/frameworks/kafka/tests/test_kerberos_authz.py
@@ -122,7 +122,6 @@ def kafka_client(kerberos, kafka_server):
         client = {
             "id": client_id,
             "mem": 512,
-            "user": "nobody",
             "container": {
                 "type": "MESOS",
                 "docker": {

--- a/frameworks/kafka/tests/test_ssl_auth.py
+++ b/frameworks/kafka/tests/test_ssl_auth.py
@@ -51,7 +51,6 @@ def kafka_client():
         client = {
             "id": client_id,
             "mem": 512,
-            "user": "nobody",
             "container": {
                 "type": "MESOS",
                 "docker": {

--- a/frameworks/kafka/tests/test_zookeeper_auth.py
+++ b/frameworks/kafka/tests/test_zookeeper_auth.py
@@ -188,7 +188,6 @@ def kafka_client(kerberos, kafka_server):
         client = {
             "id": client_id,
             "mem": 512,
-            "user": "nobody",
             "container": {
                 "type": "MESOS",
                 "docker": {


### PR DESCRIPTION
When attempting to run the integration tests for the Kafka framework I encountered errors with the `create_tls_artifacts` setup method in the `test_ssl_auth.py` test module.  This method uses the running `kafka-client` marathon app based on a docker image `elezar/kafka-client` to sign a certificate.  During this process, a curl command returns an OOM error at the following LoC:

https://github.com/mesosphere/dcos-commons/blob/master/frameworks/kafka/tests/test_ssl_auth.py#L344

After some troubleshooting with @elezar we discovered that when running the `kafka-client` on an agent not running CoreOS, that the `nobody` user is not assignable to an internal user within the `elezar/kafka-client`.  For some reason, this results in the OOM error with curl, although other commands seem to work fine.  Our infrastructure is based on CentOS, which has a different UID for `nobody` than provided in the `elezar/kafka-client` image.

To resolve the issue, removing the explicit `"user": "nobody"` assignment in the marathon app definition, and using the default user (root?) allowed me to run the `test_ssl_auth.py` test module successfully.  It's unclear exactly why this is the case.

Test logs:

```
____________ ERROR at setup of test_authn_client_can_read_and_write ____________
kafka_client = {'brokers': ['kafka-0-broker.kafka.autoip.dcos.thisdcos.directory', 'kafka-1-broker.kafka.autoip.dcos.thisdcos.directo....kafka.autoip.dcos.thisdcos.directory:1030', 'KAFKA_CLIENT_MODE': 'test', 'KAFKA_OPTS': ''}, 'id': 'kafka-client', ...}
    @pytest.fixture(scope='module', autouse=True)
    def setup_principals(kafka_client):
        client_id = kafka_client["id"]
    
        create_tls_artifacts(
            cn="kafka-tester",
>           task=client_id)
frameworks/kafka/tests/test_ssl_auth.py:89: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
frameworks/kafka/tests/test_ssl_auth.py:358: in create_tls_artifacts
    certificate = json.loads(output[1])["result"]["certificate"]
/usr/lib/python3.5/json/__init__.py:319: in loads
    return _default_decoder.decode(s)
/usr/lib/python3.5/json/decoder.py:339: in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
self = <json.decoder.JSONDecoder object at 0x7f667dfc0630>, s = '', idx = 0
    def raw_decode(self, s, idx=0):
        """Decode a JSON document from ``s`` (a ``str`` beginning with
            a JSON document) and return a 2-tuple of the Python
            representation and the index in ``s`` where the document ended.
    
            This can be used to decode a JSON document from a string that may
            have extraneous data at the end.
    
            """
        try:
            obj, end = self.scan_once(s, idx)
        except StopIteration as err:
>           raise JSONDecodeError("Expecting value", s, err.value) from None
E           json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
/usr/lib/python3.5/json/decoder.py:357: JSONDecodeError
------------------------------ Captured log setup ------------------------------
conftest.py                163 INFO     Entering new test suite test_ssl_auth_py: 127 preexisting tasks will be ignored on test failure.
conftest.py                169 INFO     Deleting existing test suite logs: logs/test_ssl_auth_py/
sdk_marathon.py             96 INFO     Launching kafka-client marathon app
sdk_marathon.py            100 INFO     Writing app definition to /tmp/tmpsfckdl9w/kafka-client.json
sdk_marathon.py             76 INFO     Waiting for app to be running...
sdk_security.py            136 INFO     Creating service account for account=kafka secret=kafka
sdk_security.py            138 INFO     Install cli necessary for security
sdk_security.py            141 INFO     Remove any existing service account and/or secret
sdk_security.py            144 INFO     Create keypair
sdk_security.py            147 INFO     Create service account
sdk_security.py            152 INFO     Create secret
sdk_security.py            159 INFO     Service account created for account=kafka secret=kafka
test_ssl_auth.py           328 INFO     Generating certificate. cn=kafka-tester, task=kafka-client
test_ssl_auth.py           333 INFO     (0, '', "Generating a 2048 bit RSA private key\n......................................................+++\n..............+++\nwriting new private key to 'kafka-tester_priv.key'\n-----")
test_ssl_auth.py           354 INFO     (0, '', 'curl: (27) Out of memory')
__________________ ERROR at setup of test_authz_acls_required __________________
kafka_client = {'brokers': ['kafka-0-broker.kafka.autoip.dcos.thisdcos.directory', 'kafka-1-broker.kafka.autoip.dcos.thisdcos.directo....kafka.autoip.dcos.thisdcos.directory:1030', 'KAFKA_CLIENT_MODE': 'test', 'KAFKA_OPTS': ''}, 'id': 'kafka-client', ...}
    @pytest.fixture(scope='module', autouse=True)
    def setup_principals(kafka_client):
        client_id = kafka_client["id"]
    
        create_tls_artifacts(
            cn="kafka-tester",
>           task=client_id)
frameworks/kafka/tests/test_ssl_auth.py:89: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
frameworks/kafka/tests/test_ssl_auth.py:358: in create_tls_artifacts
    certificate = json.loads(output[1])["result"]["certificate"]
/usr/lib/python3.5/json/__init__.py:319: in loads
    return _default_decoder.decode(s)
/usr/lib/python3.5/json/decoder.py:339: in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
self = <json.decoder.JSONDecoder object at 0x7f667dfc0630>, s = '', idx = 0
    def raw_decode(self, s, idx=0):
        """Decode a JSON document from ``s`` (a ``str`` beginning with
            a JSON document) and return a 2-tuple of the Python
            representation and the index in ``s`` where the document ended.
    
            This can be used to decode a JSON document from a string that may
            have extraneous data at the end.
    
            """
        try:
            obj, end = self.scan_once(s, idx)
        except StopIteration as err:
>           raise JSONDecodeError("Expecting value", s, err.value) from None
E           json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
/usr/lib/python3.5/json/decoder.py:357: JSONDecodeError
________________ ERROR at setup of test_authz_acls_not_required ________________
kafka_client = {'brokers': ['kafka-0-broker.kafka.autoip.dcos.thisdcos.directory', 'kafka-1-broker.kafka.autoip.dcos.thisdcos.directo....kafka.autoip.dcos.thisdcos.directory:1030', 'KAFKA_CLIENT_MODE': 'test', 'KAFKA_OPTS': ''}, 'id': 'kafka-client', ...}
    @pytest.fixture(scope='module', autouse=True)
    def setup_principals(kafka_client):
        client_id = kafka_client["id"]
    
        create_tls_artifacts(
            cn="kafka-tester",
>           task=client_id)
frameworks/kafka/tests/test_ssl_auth.py:89: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
frameworks/kafka/tests/test_ssl_auth.py:358: in create_tls_artifacts
    certificate = json.loads(output[1])["result"]["certificate"]
/usr/lib/python3.5/json/__init__.py:319: in loads
    return _default_decoder.decode(s)
/usr/lib/python3.5/json/decoder.py:339: in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
self = <json.decoder.JSONDecoder object at 0x7f667dfc0630>, s = '', idx = 0
    def raw_decode(self, s, idx=0):
        """Decode a JSON document from ``s`` (a ``str`` beginning with
            a JSON document) and return a 2-tuple of the Python
            representation and the index in ``s`` where the document ended.
    
            This can be used to decode a JSON document from a string that may
            have extraneous data at the end.
    
            """
        try:
            obj, end = self.scan_once(s, idx)
        except StopIteration as err:
>           raise JSONDecodeError("Expecting value", s, err.value) from None
E           json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
/usr/lib/python3.5/json/decoder.py:357: JSONDecodeError
```