### PR TITLE
INFINITY-2924 Sanitize retry handling in elastic curl queries

### DIFF
--- a/frameworks/elastic/tests/config.py
+++ b/frameworks/elastic/tests/config.py
@@ -152,7 +152,7 @@ def verify_commercial_api_status(is_enabled, service_name=SERVICE_NAME):
     # "No handler found for uri [/INDEX_NAME/_xpack/graph/explore] and method [POST]"
     response = _curl_query(
         service_name, "POST",
-        "{}/_xpack/graph/_explore".format(DEFAULT_INDEX_NAME),
+        "{}/_xpack/_graph/_explore".format(DEFAULT_INDEX_NAME),
         json_data=query,
         return_json=is_enabled)
     if is_enabled:

--- a/frameworks/elastic/tests/config.py
+++ b/frameworks/elastic/tests/config.py
@@ -156,9 +156,9 @@ def verify_commercial_api_status(is_enabled, service_name=SERVICE_NAME):
         json_data=query,
         return_json=is_enabled)
     if is_enabled:
-        assert response["failures"] == []
+        return response["failures"] == []
     else:
-        assert "No handler found" in response
+        return "No handler found" in response
 
 
 def set_xpack(is_enabled, service_name=SERVICE_NAME):
@@ -226,7 +226,7 @@ def get_elasticsearch_nodes_info(service_name=SERVICE_NAME):
 def _curl_query(service_name, method, endpoint, json_data=None, role="master", https=False, return_json=True):
     protocol = 'https' if https else 'http'
     host = sdk_hosts.autoip_host(service_name, "{}-0-node".format(role), _master_zero_http_port(service_name))
-    curl_cmd = ("/opt/mesosphere/bin/curl -u elastic:changeme -X{} '{}://{}/{}'").format(method, protocol, host, endpoint)
+    curl_cmd = ("/opt/mesosphere/bin/curl -sS -u elastic:changeme -X{} '{}://{}/{}'").format(method, protocol, host, endpoint)
     if json_data:
         curl_cmd += " -H 'Content-type: application/json' -d '{}'".format(json.dumps(json_data))
     task_name = "master-0-node"

--- a/frameworks/elastic/tests/test_sanity.py
+++ b/frameworks/elastic/tests/test_sanity.py
@@ -195,7 +195,7 @@ def test_xpack_toggle_with_kibana(default_populated_index):
     sdk_install.uninstall(config.KIBANA_PACKAGE_NAME, config.KIBANA_PACKAGE_NAME)
 
     log.info("\n***** Set/verify X-Pack enabled in elasticsearch. Requires parallel upgrade strategy for full restart.")
-    config.enable_xpack(service_name=foldered_name)
+    config.set_xpack(True, service_name=foldered_name)
     config.verify_commercial_api_status(True, service_name=foldered_name)
     config.verify_xpack_license(service_name=foldered_name)
 
@@ -226,7 +226,7 @@ def test_xpack_toggle_with_kibana(default_populated_index):
     sdk_install.uninstall(config.KIBANA_PACKAGE_NAME, config.KIBANA_PACKAGE_NAME)
 
     log.info("\n***** Disable X-Pack in elasticsearch.")
-    config.disable_xpack(service_name=foldered_name)
+    config.set_xpack(False, service_name=foldered_name)
     log.info("\n***** Verify we can still read what we wrote when X-Pack was enabled.")
     config.verify_commercial_api_status(False, service_name=foldered_name)
     doc = config.get_document(config.DEFAULT_INDEX_NAME, config.DEFAULT_INDEX_TYPE, 2, service_name=foldered_name)


### PR DESCRIPTION
Consolidate (most) curl calls into `_curl_query`, and have `_curl_query` automatically retry when the command itself fails or if the response fails to parse as JSON. Callers can then have their own retry logic when the data returned isn't as expected (e.g. missing field).