### PR TITLE
[INFINITY-2927] Add missing subprocess import to conftest.py

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -9,8 +9,10 @@ import os
 import os.path
 import re
 import shutil
+import subprocess
 import sys
 import time
+
 
 import pytest
 import requests
@@ -246,8 +248,8 @@ def get_rotating_task_logs(task_id: str, task_file_timestamps: dict, task_file: 
     rotated_filenames = [task_file, ]
     rotated_filenames.extend(['{}.{}'.format(task_file, i) for i in range(1, 10)])
     for filename in rotated_filenames:
-        if not filename in task_file_timestamps:
-            return # Reached a log index that doesn't exist, exit early
+        if filename not in task_file_timestamps:
+            return  # Reached a log index that doesn't exist, exit early
         content = get_task_log_for_id(task_id, filename)
         if not content:
             log.error('Unable to fetch content of {} from task {}, giving up'.format(filename, task_id))

--- a/conftest.py
+++ b/conftest.py
@@ -13,7 +13,6 @@ import subprocess
 import sys
 import time
 
-
 import pytest
 import requests
 import sdk_cmd


### PR DESCRIPTION
This adds a missing import for `subprocess` to `conftest`.
 
This requirement was added in  #2051

Causing errors: https://teamcity.mesosphere.io/viewLog.html?tab=buildLog&logTab=tree&filter=debug&expand=all&buildId=925773&_focus=1830
  