### PR TITLE
Use user and gh token for git over https when cloning universe

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -231,7 +231,8 @@ $ ./release_builder.py \
 Example:
 
 ```
-$ GITHUB_TOKEN=yourGithubAuthToken \
+$ GITHUB_USER=yourGithubUsername \
+GITHUB_TOKEN=yourGithubAuthToken \
 AWS_ACCESS_KEY_ID=yourAwsKeyId \
 AWS_SECRET_ACCESS_KEY=yourAwsKeySecret \
 MIN_DCOS_RELEASE_VERSION=1.7 \


### PR DESCRIPTION
While setting up release automation I noticed that `release_builder.py` was inconsistent between using SSH auth and the GH token when interfacing with GitHub.

This PR changes `release_builder.py` to use the already provided token during the `git clone` step of the process.  This resolves several first time/automation issues such as.

* Pre-approving the OpenSSH server fingerprint
* Providing an SSH profile and setting up an SSH agent

A new environment var, `GITHUB_USER` can be provided to specify the GitHub user associated with a token, required when doing basic AUTH with the git CLI.  I took care to make the default user `mesosphere-ci`, which I think will allow this PR to be merged without breaking your infrastructure.