### PR TITLE
INFINITY-2930 Resolve elastic flake: data node addition

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -134,19 +134,22 @@ def pytest_runtest_makereport(item, call):
         log.info('Test {} failed in {} phase.'.format(item.name, rep.when))
 
         try:
-            log.info('Dumping logs for {} tasks launched in this suite since last failure: {}'.format(
+            log.info('Fetching logs for {} tasks launched in this suite since last failure: {}'.format(
                 len(new_task_ids), new_task_ids))
             dump_task_logs(item, new_task_ids)
         except Exception:
             log.exception('Task log collection failed!')
         try:
+            log.info('Fetching mesos state')
             dump_mesos_state(item)
         except Exception:
             log.exception('Mesos state collection failed!')
         try:
+            log.info('Creating/fetching cluster diagnostics bundle')
             get_diagnostics_bundle(item)
         except Exception:
             log.exception("Diagnostics bundle creation failed")
+        log.info('Post-failure collection complete')
 
 
 def pytest_runtest_teardown(item):

--- a/frameworks/elastic/tests/config.py
+++ b/frameworks/elastic/tests/config.py
@@ -1,6 +1,5 @@
 import json
 import logging
-from functools import wraps
 
 import retrying
 import shakedown
@@ -18,6 +17,11 @@ SERVICE_NAME = 'elastic'
 
 KIBANA_PACKAGE_NAME = 'kibana'
 
+# sum of default pod counts, with one task each:
+# - master: 3
+# - data: 2
+# - ingest: 0
+# - coordinator: 1
 DEFAULT_TASK_COUNT = 6
 # TODO: add and use throughout a method to determine expected task count based on options .
 #       the method should provide for use cases:

--- a/frameworks/elastic/tests/test_sanity.py
+++ b/frameworks/elastic/tests/test_sanity.py
@@ -15,7 +15,8 @@ from tests import config
 
 log = logging.getLogger(__name__)
 
-current_expected_task_count = config.DEFAULT_TASK_COUNT
+# starting with one fewer data nodes than the default, see below
+current_expected_task_count = config.DEFAULT_TASK_COUNT - 1
 
 
 @pytest.fixture(scope='module', autouse=True)
@@ -31,7 +32,10 @@ def configure_package(configure_security):
             foldered_name,
             current_expected_task_count,
             additional_options={
-                "service": {"name": foldered_name} })
+                "service": {"name": foldered_name},
+                # default is 2 data nodes.
+                # we start with the minimum of 1 because we need enough room to add two more in tests.
+                "data_nodes": {"count": 1} })
 
         yield  # let the test session execute
     finally:
@@ -312,7 +316,7 @@ def test_unchanged_scheduler_restarts_without_restarting_tasks():
 
 @pytest.mark.recovery
 @pytest.mark.sanity
-def test_bump_node_counts():
+def test_bump_all_node_counts():
     foldered_name = sdk_utils.get_foldered_name(config.SERVICE_NAME)
     marathon_config = sdk_marathon.get_config(foldered_name)
     data_nodes = int(marathon_config['env']['DATA_NODE_COUNT'])
@@ -330,7 +334,7 @@ def test_bump_node_counts():
 
 @pytest.mark.recovery
 @pytest.mark.sanity
-def test_adding_data_nodes_only_restarts_masters():
+def test_adding_data_node_only_restarts_masters():
     foldered_name = sdk_utils.get_foldered_name(config.SERVICE_NAME)
     initial_master_task_ids = sdk_tasks.get_task_ids(foldered_name, "master")
     initial_data_task_ids = sdk_tasks.get_task_ids(foldered_name, "data")

--- a/frameworks/elastic/tests/test_sanity.py
+++ b/frameworks/elastic/tests/test_sanity.py
@@ -15,8 +15,7 @@ from tests import config
 
 log = logging.getLogger(__name__)
 
-# starting with one fewer data nodes than the default, see below
-current_expected_task_count = config.DEFAULT_TASK_COUNT - 1
+current_expected_task_count = config.DEFAULT_TASK_COUNT
 
 
 @pytest.fixture(scope='module', autouse=True)
@@ -32,10 +31,7 @@ def configure_package(configure_security):
             foldered_name,
             current_expected_task_count,
             additional_options={
-                "service": {"name": foldered_name},
-                # default is 2 data nodes.
-                # we start with the minimum of 1 because we need enough room to add two more in tests.
-                "data_nodes": {"count": 1} })
+                "service": {"name": foldered_name} })
 
         yield  # let the test session execute
     finally:
@@ -316,11 +312,11 @@ def test_unchanged_scheduler_restarts_without_restarting_tasks():
 
 @pytest.mark.recovery
 @pytest.mark.sanity
-def test_bump_all_node_counts():
+def test_bump_node_counts():
+    # bump ingest and coordinator, but NOT data, which is bumped in the following test.
+    # we want to avoid adding two data nodes because the cluster sometimes won't have enough room for it
     foldered_name = sdk_utils.get_foldered_name(config.SERVICE_NAME)
     marathon_config = sdk_marathon.get_config(foldered_name)
-    data_nodes = int(marathon_config['env']['DATA_NODE_COUNT'])
-    marathon_config['env']['DATA_NODE_COUNT'] = str(data_nodes + 1)
     ingest_nodes = int(marathon_config['env']['INGEST_NODE_COUNT'])
     marathon_config['env']['INGEST_NODE_COUNT'] = str(ingest_nodes + 1)
     coordinator_nodes = int(marathon_config['env']['COORDINATOR_NODE_COUNT'])
@@ -328,7 +324,7 @@ def test_bump_all_node_counts():
     sdk_marathon.update_app(foldered_name, marathon_config)
     sdk_plan.wait_for_completed_deployment(foldered_name)
     global current_expected_task_count
-    current_expected_task_count += 3
+    current_expected_task_count += 2
     sdk_tasks.check_running(foldered_name, current_expected_task_count)
 
 

--- a/testing/sdk_install.py
+++ b/testing/sdk_install.py
@@ -14,7 +14,7 @@ import dcos.errors
 import dcos.marathon
 import dcos.packagemanager
 import dcos.subcommand
-from retrying import retry
+import retrying
 import shakedown
 
 import sdk_cmd
@@ -27,7 +27,8 @@ log = logging.getLogger(__name__)
 TIMEOUT_SECONDS = 15 * 60
 
 
-@retry(stop_max_attempt_number=3, retry_on_exception=lambda e: isinstance(e, dcos.errors.DCOSException))
+@retrying.retry(stop_max_attempt_number=3,
+                retry_on_exception=lambda e: isinstance(e, dcos.errors.DCOSException))
 def _retried_install_impl(
         package_name,
         service_name,
@@ -120,7 +121,9 @@ def install(
         package_name, service_name, shakedown.pretty_duration(time.time() - start)))
 
 
-@retry(stop_max_attempt_number=5, wait_fixed=5000, retry_on_exception=lambda e: isinstance(e, dcos.errors.DCOSException))
+@retrying.retry(stop_max_attempt_number=5,
+                wait_fixed=5000,
+                retry_on_exception=lambda e: isinstance(e, dcos.errors.DCOSException))
 def uninstall(
         package_name,
         service_name,

--- a/testing/sdk_upgrade.py
+++ b/testing/sdk_upgrade.py
@@ -217,7 +217,13 @@ def _get_pkg_version(package_name):
         log.warning('Failed to run "{}":\nSTDOUT:\n{}\nSTDERR:\n{}'.format(cmd, stdout, stderr))
         return None
     try:
-        return json.loads(stdout)['package']['version']
+        describe = json.loads(stdout)
+        # New location (either 1.10+ or 1.11+):
+        version = describe.get('package', {}).get('version', None)
+        if version is None:
+            # Old location (until 1.9 or until 1.10):
+            version = describe['version']
+        return version
     except:
         log.warning('Failed to extract package version from "{}":\nSTDOUT:\n{}\nSTDERR:\n{}'.format(cmd, stdout, stderr))
         log.warning(traceback.format_exc())


### PR DESCRIPTION
Adding a 4th data node can sometimes fail due to bad resource packing on the cluster. To get around this, only add one data node in `test_sanity`.
Also cleans up some test logging and upgrade handling.
  