### PR TITLE
HDFS-493 Disable broken HDFS tests

### DIFF
--- a/frameworks/hdfs/tests/test_auth.py
+++ b/frameworks/hdfs/tests/test_auth.py
@@ -116,6 +116,7 @@ def kerberos(configure_security):
 @pytest.mark.dcos_min_version('1.10')
 @sdk_utils.dcos_ee_only
 @pytest.mark.smoke
+@pytest.mark.sanity
 def test_health_of_kerberized_hdfs():
     config.check_healthy(service_name=config.FOLDERED_SERVICE_NAME)
 
@@ -141,6 +142,7 @@ def kerberized_hdfs_client(kerberos):
 @sdk_utils.dcos_ee_only
 @pytest.mark.auth
 @pytest.mark.sanity
+@pytest.mark.skip(reason="HDFS-493")
 def test_user_can_auth_and_write_and_read(kerberized_hdfs_client):
     sdk_auth.kinit(kerberized_hdfs_client, keytab=config.KEYTAB, principal=config.CLIENT_PRINCIPALS["hdfs"])
 
@@ -156,6 +158,7 @@ def test_user_can_auth_and_write_and_read(kerberized_hdfs_client):
 @sdk_utils.dcos_ee_only
 @pytest.mark.auth
 @pytest.mark.sanity
+@pytest.mark.skip(reason="HDFS-493")
 def test_users_have_appropriate_permissions(kerberized_hdfs_client):
     # "hdfs" is a superuser
     sdk_auth.kinit(kerberized_hdfs_client, keytab=config.KEYTAB, principal=config.CLIENT_PRINCIPALS["hdfs"])


### PR DESCRIPTION
Until fix is found. Current guess is kdc producing bad keytabs.