### PR TITLE
Fix the build environment to go 1.8.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,10 +14,14 @@ RUN apt-get update && apt-get install -y \
     libssl-dev \
     wget \
     zip && \
-    # install go 1.7
-    add-apt-repository -y ppa:longsleep/golang-backports && \
-    apt-get update && apt-get install -y golang-go && \
     rm -rf /var/lib/apt/lists/*
+
+# Install go 1.8.5
+RUN curl -O https://storage.googleapis.com/golang/go1.8.5.linux-amd64.tar.gz && \
+    tar -xf go1.8.5.linux-amd64.tar.gz && \
+    mv go /usr/local
+ENV PATH=$PATH:/usr/local/go/bin
+RUN go version
 # AWS CLI for uploading build artifacts
 RUN pip install awscli
 # Install the testing dependencies


### PR DESCRIPTION
The current approach doesn't set the version to 1.7.  That repo changed underneath us.  It was falling back to 1.9.2 or something from Ubuntu.

There appears to be some problems with using go 1.9 when building bootstrap.