### PR TITLE
[INFINITY-2964]: Use insecure in curl

### DIFF
--- a/frameworks/kafka/tests/auth.py
+++ b/frameworks/kafka/tests/auth.py
@@ -245,7 +245,7 @@ def create_tls_artifacts(cn: str, task: str) -> str:
 
     output = sdk_cmd.task_exec(
         task,
-        "curl -L -X POST "
+        "curl --insecure -L -X POST "
         "-H 'Authorization: token={}' "
         "leader.mesos/ca/api/v2/sign "
         "-d '{}'".format(token, json.dumps(request)))


### PR DESCRIPTION
The strict nightly tests for Kafka are failing due to the curl command not being called with the `--insecure` option or the correct `--cacert`.

This PR adds the `--insecure` option.