### PR TITLE
[INFINITY-2950] Add a basic Active Directory test for Kafka

### DIFF
--- a/frameworks/kafka/docs/kerberos.md
+++ b/frameworks/kafka/docs/kerberos.md
@@ -1,6 +1,6 @@
 ---
 layout: layout.pug
-navigationTitle: 
+navigationTitle:
 excerpt:
 title: Kerberos
 menuWeight: 22
@@ -17,7 +17,7 @@ kafka/kafka-0-broker.kafka.autoip.dcos.thisdcos.directory@LOCAL
 kafka/kafka-1-broker.kafka.autoip.dcos.thisdcos.directory@LOCAL
 kafka/kafka-2-broker.kafka.autoip.dcos.thisdcos.directory@LOCAL
 ```
-(assuming a service name of `kafka`)
+(assuming a service name of `kafka` and a `LOCAL` realm)
 
 ## Create the keytab secret
 
@@ -43,6 +43,7 @@ Create the following `kerberos-options.json` file:
                     "hostname": "kdc.marathon.autoip.dcos.thisdcos.directory",
                     "port": 2500
                 },
+                "realm": "LOCAL",
                 "keytab_secret": "__dcos_base64__keytab"
             }
         }
@@ -93,6 +94,7 @@ Create a `kerberos-zookeeper-options.json` file with the following contents:
                     "hostname": "kdc.marathon.autoip.dcos.thisdcos.directory",
                     "port": 2500
                 },
+                "realm": "LOCAL",
                 "keytab_secret": "__dcos_base64__keytab"
             }
         }
@@ -108,3 +110,42 @@ Kerberized Kafka can then be deployed as follows:
 ```bash
 $ dcos package install kafka --options=kerberos-zookeeper-options.json
 ```
+
+## Active Directory
+
+Kerberized Apache Kafka also supports Active Directory as a KDC. Here the generation of principals and the relevant keytab should be adapted for the tools made available by the Active Directory installation.
+
+As an example, the `ktpass` utility can be used to generate the keytab for the Apache Kafka brokers as follows:
+```bash
+$ ktpass.exe                      /princ kafka/kafka-0-broker.kafka.autoip.dcos.thisdcos.directory@EXAMPLE.COM /mapuser kafka-0-broker@example.com /ptype KRB5_NT_PRINCIPAL +rndPass /out brokers-0.keytab
+$ ktpass.exe /in brokers-0.keytab /princ kafka/kafka-1-broker.kafka.autoip.dcos.thisdcos.directory@EXAMPLE.COM /mapuser kafka-1-broker@example.com /ptype KRB5_NT_PRINCIPAL +rndPass /out brokers-1.keytab
+$ ktpass.exe /in brokers-1.keytab /princ kafka/kafka-2-broker.kafka.autoip.dcos.thisdcos.directory@EXAMPLE.COM /mapuser kafka-2-broker@example.com /ptype KRB5_NT_PRINCIPAL +rndPass /out kafka-brokers.keytab
+```
+Here it is assumed that the domain `example.com` exists and that the domain users `kafka-0-broker`, `kafka-1-broker`, and `kafka-2-broker` have been created (using the `net user` command, for example).
+
+The generated file `kafka-brokers.keytab` can no be base64-encoded and added to the DC/OS secret store as above:
+```bash
+$ base64 -w kafka-brokers.keytab > keytab.base64
+$ dcos security secrets create  __dcos_base64__ad_keytab --value-file keytab.base64
+```
+
+Kerberized Apache Kafka can then be deployed using the following configuration options:
+```json
+{
+    "service": {
+        "name": "kafka",
+        "security": {
+            "kerberos": {
+                "enabled": true,
+                "kdc": {
+                    "hostname": "active-directory-dns.example.com",
+                    "port": 88
+                },
+                "realm": "EXAMPLE.COM",
+                "keytab_secret": "__dcos_base64__ad_keytab"
+            }
+        }
+    }
+}
+```
+This assumes that the Active Directory server is reachable from the DC/OS cluster at `active-directory-dns.example.com` and is accepting connections on port `88`. Note also the change in Kerberos realm and the DC/OS secret path used for the keytab.

--- a/frameworks/kafka/docs/kerberos.md
+++ b/frameworks/kafka/docs/kerberos.md
@@ -23,7 +23,7 @@ kafka/kafka-2-broker.kafka.autoip.dcos.thisdcos.directory@LOCAL
 
 Once the principals have been created, a keytab file must be generated and uploaded to the DC/OS secret store as a base-64-encoded value. Assuming the keytab for **all** the Kafka principals has been created as a file `keytab`, this can be added to the secret store as follows (note that the DC/OS Enterprise CLI needs to be installed to gain access to the `security` command):
 ```bash
-$ base64 -w keytab > keytab.base64
+$ base64 -w0 keytab > keytab.base64
 $ dcos security secrets create  __dcos_base64__keytab --value-file keytab.base64
 ```
 
@@ -123,9 +123,9 @@ $ ktpass.exe /in brokers-1.keytab /princ kafka/kafka-2-broker.kafka.autoip.dcos.
 ```
 Here it is assumed that the domain `example.com` exists and that the domain users `kafka-0-broker`, `kafka-1-broker`, and `kafka-2-broker` have been created (using the `net user` command, for example).
 
-The generated file `kafka-brokers.keytab` can no be base64-encoded and added to the DC/OS secret store as above:
+The generated file `kafka-brokers.keytab` can now be base64-encoded and added to the DC/OS secret store as above:
 ```bash
-$ base64 -w kafka-brokers.keytab > keytab.base64
+$ base64 -w0 kafka-brokers.keytab > keytab.base64
 $ dcos security secrets create  __dcos_base64__ad_keytab --value-file keytab.base64
 ```
 

--- a/frameworks/kafka/tests/active_directory.py
+++ b/frameworks/kafka/tests/active_directory.py
@@ -1,0 +1,35 @@
+import os
+
+import sdk_auth
+
+
+ACTIVE_DIRECTORY_ENVVAR = 'TESTING_ACTIVE_DIRECTORY_SERVER'
+
+
+class ActiveDirectoryKerberos(sdk_auth.KerberosEnvironment):
+
+    def __init__(self):
+        self.ad_server = os.environ.get(ACTIVE_DIRECTORY_ENVVAR)
+
+    def get_host(self):
+        return self.ad_server
+
+    @staticmethod
+    def get_port():
+        return 88
+
+    @staticmethod
+    def get_realm():
+        return "AD.MESOSPHERE.COM"
+
+    @staticmethod
+    def get_keytab_path():
+        return "__dcos_base64__kafka_ad_keytab"
+
+    @staticmethod
+    def cleanup():
+        pass
+
+
+def is_active_directory_enabled():
+    return ACTIVE_DIRECTORY_ENVVAR in os.environ

--- a/frameworks/kafka/tests/test_active_directory_zookeeper_auth.py
+++ b/frameworks/kafka/tests/test_active_directory_zookeeper_auth.py
@@ -1,0 +1,198 @@
+"""
+This module tests the interaction of Kafka with Zookeeper with authentication enabled
+"""
+import logging
+import uuid
+import pytest
+
+import sdk_cmd
+import sdk_install
+import sdk_marathon
+import sdk_utils
+
+from tests import active_directory
+from tests import auth
+from tests import config
+from tests import test_utils
+
+
+pytestmark = pytest.mark.skipif(not active_directory.is_active_directory_enabled(),
+                                reason="This test requires TESTING_ACTIVE_DIRECTORY_SERVER to be set")
+
+
+log = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope='module', autouse=True)
+def kerberos(configure_security):
+    try:
+        kerberos_env = active_directory.ActiveDirectoryKerberos()
+        yield kerberos_env
+
+    finally:
+        kerberos_env.cleanup()
+
+
+@pytest.fixture(scope='module')
+def zookeeper_server(kerberos):
+    service_kerberos_options = {
+        "service": {
+            "name": "kafka-zookeeper",
+            "security": {
+                "kerberos": {
+                    "enabled": True,
+                    "kdc": {
+                        "hostname": kerberos.get_host(),
+                        "port": int(kerberos.get_port())
+                    },
+                    "realm": kerberos.get_realm(),
+                    "keytab_secret": kerberos.get_keytab_path(),
+                }
+            }
+        }
+    }
+
+    try:
+        sdk_install.uninstall("beta-kafka-zookeeper", "kafka-zookeeper")
+        sdk_install.install(
+            "beta-kafka-zookeeper",
+            "kafka-zookeeper",
+            6,
+            additional_options=service_kerberos_options,
+            timeout_seconds=30 * 60)
+
+        yield {**service_kerberos_options, **{"package_name": "beta-kafka-zookeeper"}}
+
+    finally:
+        sdk_install.uninstall("beta-kafka-zookeeper", "kafka-zookeeper")
+
+
+@pytest.fixture(scope='module', autouse=True)
+def kafka_server(kerberos, zookeeper_server):
+
+    # Get the zookeeper DNS values
+    zookeeper_dns = sdk_cmd.svc_cli(zookeeper_server["package_name"],
+                                    zookeeper_server["service"]["name"],
+                                    "endpoint clientport", json=True)["dns"]
+
+    service_kerberos_options = {
+        "service": {
+            "name": config.SERVICE_NAME,
+            "security": {
+                "kerberos": {
+                    "enabled": True,
+                    "enabled_for_zookeeper": True,
+                    "kdc": {
+                        "hostname": kerberos.get_host(),
+                        "port": int(kerberos.get_port())
+                    },
+                    "realm": kerberos.get_realm(),
+                    "keytab_secret": kerberos.get_keytab_path(),
+                }
+            }
+        },
+        "kafka": {
+            "kafka_zookeeper_uri": ",".join(zookeeper_dns)
+        }
+    }
+
+    sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
+    try:
+        sdk_install.install(
+            config.PACKAGE_NAME,
+            config.SERVICE_NAME,
+            config.DEFAULT_BROKER_COUNT,
+            additional_options=service_kerberos_options,
+            timeout_seconds=30 * 60)
+
+        yield {**service_kerberos_options, **{"package_name": config.PACKAGE_NAME}}
+    finally:
+        sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
+
+
+@pytest.fixture(scope='module', autouse=True)
+def kafka_client(kerberos, kafka_server):
+
+    brokers = sdk_cmd.svc_cli(
+        kafka_server["package_name"],
+        kafka_server["service"]["name"],
+        "endpoint broker", json=True)["dns"]
+
+    try:
+        client_id = "kafka-client"
+        client = {
+            "id": client_id,
+            "mem": 512,
+            "container": {
+                "type": "MESOS",
+                "docker": {
+                    "image": "elezar/kafka-client:latest",
+                    "forcePullImage": True
+                },
+                "volumes": [
+                    {
+                        "containerPath": "/tmp/kafkaconfig/kafka-client.keytab",
+                        "secret": "kafka_keytab"
+                    }
+                ]
+            },
+            "secrets": {
+                "kafka_keytab": {
+                    "source": kerberos.get_keytab_path(),
+
+                }
+            },
+            "networks": [
+                {
+                    "mode": "host"
+                }
+            ],
+            "env": {
+                "JVM_MaxHeapSize": "512",
+                "KAFKA_CLIENT_MODE": "test",
+                "KAFKA_TOPIC": "securetest",
+                "KAFKA_BROKER_LIST": ",".join(brokers)
+            }
+        }
+
+        sdk_marathon.install_app(client)
+        yield {**client, **{"brokers": list(map(lambda x: x.split(':')[0], brokers))}}
+
+    finally:
+        sdk_marathon.destroy_app(client_id)
+
+
+@pytest.mark.dcos_min_version('1.10')
+@sdk_utils.dcos_ee_only
+@pytest.mark.sanity
+def test_client_can_read_and_write(kafka_client, kafka_server, kerberos):
+    client_id = kafka_client["id"]
+
+    auth.wait_for_brokers(kafka_client["id"], kafka_client["brokers"])
+
+    topic_name = "authn.test"
+    sdk_cmd.svc_cli(kafka_server["package_name"], kafka_server["service"]["name"],
+                    "topic create {}".format(topic_name),
+                    json=True)
+
+    test_utils.wait_for_topic(kafka_server["package_name"], kafka_server["service"]["name"], topic_name)
+
+    message = str(uuid.uuid4())
+
+    assert write_to_topic("client", client_id, topic_name, message, kerberos)
+
+    assert message in read_from_topic("client", client_id, topic_name, 1, kerberos)
+
+
+def write_to_topic(cn: str, task: str, topic: str, message: str, krb5: object) -> bool:
+
+    return auth.write_to_topic(cn, task, topic, message,
+                               auth.get_kerberos_client_properties(ssl_enabled=False),
+                               auth.setup_krb5_env(cn, task, krb5))
+
+
+def read_from_topic(cn: str, task: str, topic: str, message: str, krb5: object) -> str:
+
+    return auth.read_from_topic(cn, task, topic, message,
+                                auth.get_kerberos_client_properties(ssl_enabled=False),
+                                auth.setup_krb5_env(cn, task, krb5))

--- a/frameworks/kafka/tests/test_kerberos_auth.py
+++ b/frameworks/kafka/tests/test_kerberos_auth.py
@@ -155,7 +155,7 @@ def kafka_client(kerberos, kafka_server):
 @pytest.mark.dcos_min_version('1.10')
 @sdk_utils.dcos_ee_only
 @pytest.mark.sanity
-def test_client_can_read_and_write(kafka_client, kafka_server):
+def test_client_can_read_and_write(kafka_client, kafka_server, kerberos):
     client_id = kafka_client["id"]
 
     auth.wait_for_brokers(kafka_client["id"], kafka_client["brokers"])
@@ -169,20 +169,20 @@ def test_client_can_read_and_write(kafka_client, kafka_server):
 
     message = str(uuid.uuid4())
 
-    assert write_to_topic("client", client_id, topic_name, message)
+    assert write_to_topic("client", client_id, topic_name, message, kerberos)
 
-    assert message in read_from_topic("client", client_id, topic_name, 1)
+    assert message in read_from_topic("client", client_id, topic_name, 1, kerberos)
 
 
-def write_to_topic(cn: str, task: str, topic: str, message: str) -> bool:
+def write_to_topic(cn: str, task: str, topic: str, message: str, krb5: object) -> bool:
 
     return auth.write_to_topic(cn, task, topic, message,
                                auth.get_kerberos_client_properties(ssl_enabled=False),
-                               auth.setup_env(cn, task))
+                               auth.setup_krb5_env(cn, task, krb5))
 
 
-def read_from_topic(cn: str, task: str, topic: str, messages: int) -> str:
+def read_from_topic(cn: str, task: str, topic: str, messages: int, krb5: object) -> str:
 
     return auth.read_from_topic(cn, task, topic, messages,
                                 auth.get_kerberos_client_properties(ssl_enabled=False),
-                                auth.setup_env(cn, task))
+                                auth.setup_krb5_env(cn, task, krb5))

--- a/frameworks/kafka/tests/test_ssl_kerberos_auth.py
+++ b/frameworks/kafka/tests/test_ssl_kerberos_auth.py
@@ -187,7 +187,7 @@ def kafka_client(kerberos, kafka_server):
 @pytest.mark.dcos_min_version('1.10')
 @sdk_utils.dcos_ee_only
 @pytest.mark.sanity
-def test_client_can_read_and_write(kafka_client, kafka_server):
+def test_client_can_read_and_write(kafka_client, kafka_server, kerberos):
     client_id = kafka_client["id"]
 
     auth.wait_for_brokers(kafka_client["id"], kafka_client["brokers"])
@@ -201,9 +201,9 @@ def test_client_can_read_and_write(kafka_client, kafka_server):
 
     message = str(uuid.uuid4())
 
-    assert write_to_topic("client", client_id, topic_name, message)
+    assert write_to_topic("client", client_id, topic_name, message, kerberos)
 
-    assert message in read_from_topic("client", client_id, topic_name, 1)
+    assert message in read_from_topic("client", client_id, topic_name, 1, kerberos)
 
 
 def get_client_properties(cn: str) -> str:
@@ -214,15 +214,15 @@ def get_client_properties(cn: str) -> str:
     return client_properties_lines
 
 
-def write_to_topic(cn: str, task: str, topic: str, message: str) -> bool:
+def write_to_topic(cn: str, task: str, topic: str, message: str, krb5: object) -> bool:
 
     return auth.write_to_topic(cn, task, topic, message,
                                get_client_properties(cn),
-                               environment=auth.setup_env(cn, task))
+                               environment=auth.setup_krb5_env(cn, task, krb5))
 
 
-def read_from_topic(cn: str, task: str, topic: str, messages: int, cmd: str=None) -> str:
+def read_from_topic(cn: str, task: str, topic: str, messages: int, krb5: object) -> str:
 
     return auth.read_from_topic(cn, task, topic, messages,
                                 get_client_properties(cn),
-                                environment=auth.setup_env(cn, task))
+                                environment=auth.setup_krb5_env(cn, task, krb5))

--- a/frameworks/kafka/tests/test_zookeeper_auth.py
+++ b/frameworks/kafka/tests/test_zookeeper_auth.py
@@ -230,7 +230,7 @@ def kafka_client(kerberos, kafka_server):
 @pytest.mark.dcos_min_version('1.10')
 @sdk_utils.dcos_ee_only
 @pytest.mark.sanity
-def test_client_can_read_and_write(kafka_client, kafka_server):
+def test_client_can_read_and_write(kafka_client, kafka_server, kerberos):
     client_id = kafka_client["id"]
 
     auth.wait_for_brokers(kafka_client["id"], kafka_client["brokers"])
@@ -244,20 +244,20 @@ def test_client_can_read_and_write(kafka_client, kafka_server):
 
     message = str(uuid.uuid4())
 
-    assert write_to_topic("client", client_id, topic_name, message)
+    assert write_to_topic("client", client_id, topic_name, message, kerberos)
 
-    assert message in read_from_topic("client", client_id, topic_name, 1)
+    assert message in read_from_topic("client", client_id, topic_name, 1, kerberos)
 
 
-def write_to_topic(cn: str, task: str, topic: str, message: str) -> bool:
+def write_to_topic(cn: str, task: str, topic: str, message: str, krb5: object) -> bool:
 
     return auth.write_to_topic(cn, task, topic, message,
                                auth.get_kerberos_client_properties(ssl_enabled=False),
-                               auth.setup_env(cn, task))
+                               auth.setup_krb5_env(cn, task, krb5))
 
 
-def read_from_topic(cn: str, task: str, topic: str, message: str) -> str:
+def read_from_topic(cn: str, task: str, topic: str, message: str, krb5: object) -> str:
 
     return auth.read_from_topic(cn, task, topic, message,
                                 auth.get_kerberos_client_properties(ssl_enabled=False),
-                                auth.setup_env(cn, task))
+                                auth.setup_krb5_env(cn, task, krb5))

--- a/testing/sdk_auth.py
+++ b/testing/sdk_auth.py
@@ -366,7 +366,7 @@ class KerberosEnvironment:
         return self.kdc_realm
 
     def get_kdc_address(self):
-        return ":".join([self.get_host(), self.get_port()])
+        return ":".join(str(p) for p in [self.get_host(), self.get_port()])
 
     def cleanup(self):
         sdk_security.install_enterprise_cli()


### PR DESCRIPTION
This PR adds:
- optional Active Directory tests for Kafka and Zookeeper
- an Active Directory to the Kafka Kerberos docs
- parameterisation of the krb5 environment setup for the creation of the JAAS and Kerberos config files

The tests are controlled by setting the `TESTING_ACTIVE_DIRECTORY_SERVER` to the address of the active directory server where the relevant principals have been created.