### PR TITLE
[INFINITY-2995] Fix transient to custom permanent recovery transition

### DIFF
--- a/frameworks/hdfs/src/main/dist/svc.yml
+++ b/frameworks/hdfs/src/main/dist/svc.yml
@@ -93,19 +93,13 @@ pods:
               exit 0
             else
               curl journal-$POD_INSTANCE_INDEX-node.$FRAMEWORK_HOST:$JOURNAL_NODE_HTTP_PORT/jmx > tmpJmx.json &&
-              echo curl JMX exit code: $? &&
               export LAGGING_TX_COUNT=$(grep "CurrentLagTxns" tmpJmx.json | sed s/,//g | awk '{print $3}') &&
-              echo LAGGING_TX_COUNT=$LAGGING_TX_COUNT &&
               export WRITTEN_TX_COUNT=$(grep "TxnsWritten" tmpJmx.json | sed s/,//g | awk '{print $3}') &&
-              echo WRITTEN_TX_COUNT=$WRITTEN_TX_COUNT &&
               if [ -f journal-data/hdfs/current/VERSION ] && [ ! -f journal-data/uploadedVersionFile ]; then
-                echo Uploading VERSION file
                 curl -X PUT -F 'file=@journal-data/hdfs/current/VERSION' $SCHEDULER_API_HOSTNAME/v1/state/files/VERSION &&
-                echo curl files/VERSION exit code: $? &&
                 touch journal-data/uploadedVersionFile
               fi &&
               [[ $LAGGING_TX_COUNT -eq {{JOURNAL_LAGGING_TX_COUNT}} ]] && [[ $WRITTEN_TX_COUNT -gt 0 ]]
-              echo [[ $LAGGING_TX_COUNT -eq {{JOURNAL_LAGGING_TX_COUNT}} ]] && [[ $WRITTEN_TX_COUNT -gt 0 ]]
             fi
           delay: 30
           interval: 5

--- a/frameworks/hdfs/src/main/dist/svc.yml
+++ b/frameworks/hdfs/src/main/dist/svc.yml
@@ -93,13 +93,19 @@ pods:
               exit 0
             else
               curl journal-$POD_INSTANCE_INDEX-node.$FRAMEWORK_HOST:$JOURNAL_NODE_HTTP_PORT/jmx > tmpJmx.json &&
+              echo curl JMX exit code: $? &&
               export LAGGING_TX_COUNT=$(grep "CurrentLagTxns" tmpJmx.json | sed s/,//g | awk '{print $3}') &&
+              echo LAGGING_TX_COUNT=$LAGGING_TX_COUNT &&
               export WRITTEN_TX_COUNT=$(grep "TxnsWritten" tmpJmx.json | sed s/,//g | awk '{print $3}') &&
+              echo WRITTEN_TX_COUNT=$WRITTEN_TX_COUNT &&
               if [ -f journal-data/hdfs/current/VERSION ] && [ ! -f journal-data/uploadedVersionFile ]; then
+                echo Uploading VERSION file
                 curl -X PUT -F 'file=@journal-data/hdfs/current/VERSION' $SCHEDULER_API_HOSTNAME/v1/state/files/VERSION &&
+                echo curl files/VERSION exit code: $? &&
                 touch journal-data/uploadedVersionFile
               fi &&
               [[ $LAGGING_TX_COUNT -eq {{JOURNAL_LAGGING_TX_COUNT}} ]] && [[ $WRITTEN_TX_COUNT -gt 0 ]]
+              echo [[ $LAGGING_TX_COUNT -eq {{JOURNAL_LAGGING_TX_COUNT}} ]] && [[ $WRITTEN_TX_COUNT -gt 0 ]]
             fi
           delay: 30
           interval: 5

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/AbstractScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/AbstractScheduler.java
@@ -186,7 +186,7 @@ public abstract class AbstractScheduler {
      * Returns a list of API resources to be served by the scheduler to the local cluster.
      * This may be called before {@link #initialize(SchedulerDriver)} has been called.
      */
-    protected abstract Collection<Object> getResources();
+    public abstract Collection<Object> getResources();
 
     /**
      * Performs any additional Scheduler initialization after registration has completed. The provided

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/AbstractSchedulerTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/AbstractSchedulerTest.java
@@ -179,7 +179,7 @@ public class AbstractSchedulerTest {
         }
 
         @Override
-        protected Collection<Object> getResources() {
+        public Collection<Object> getResources() {
             return Collections.emptyList();
         }
 

--- a/sdk/testing/src/main/java/com/mesosphere/sdk/testing/ClusterState.java
+++ b/sdk/testing/src/main/java/com/mesosphere/sdk/testing/ClusterState.java
@@ -58,6 +58,10 @@ public class ClusterState {
         return scheduler.getPlans();
     }
 
+    public Collection<Object> getResources() {
+        return scheduler.getResources();
+    }
+
     /**
      * Adds the provided offer to the list of sent offers.
      */


### PR DESCRIPTION
1. A task has failed transiently
1. A service provides custom permanent recovery logic
1. A user initiates a permanent replacement of the transiently failed task
1. BOOM!

Here `BOOM!` means that the recovery plan contains phases for both the transient recovery and permanent recovery of the same pod.  The recovery manager doesn't like that and it's also the wrong outcome.

The user initiated permanent replacement should override the previously detected transient failure.  This PR makes that happen.

Note:
The new ServiceTest failed without the fix.  It contained both permanent and transient recovery phases for `hello-0` as expected.