### PR TITLE
INFINITY-3005: Simulate default executor instead of custom executor

### DIFF
--- a/frameworks/helloworld/src/test/java/com/mesosphere/sdk/helloworld/scheduler/ServiceTest.java
+++ b/frameworks/helloworld/src/test/java/com/mesosphere/sdk/helloworld/scheduler/ServiceTest.java
@@ -19,6 +19,8 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.util.*;
@@ -39,7 +41,7 @@ public class ServiceTest {
      */
     @Test
     public void testDefaultDeployment() throws Exception {
-        runDefaultDeployment();
+        runDefaultDeployment(true);
     }
 
     /**
@@ -203,7 +205,7 @@ public class ServiceTest {
     @Test
     public void testHelloDecommissionNotAllowed() throws Exception {
         // Simulate an initial deployment with default of 2 world nodes (and 1 hello node):
-        ServiceTestResult result = runDefaultDeployment();
+        ServiceTestResult result = runDefaultDeployment(true);
         Assert.assertEquals(
                 new TreeSet<>(Arrays.asList("hello-0-server", "world-0-server", "world-1-server")),
                 result.getPersister().getChildren("/Tasks"));
@@ -239,16 +241,28 @@ public class ServiceTest {
             }
         });
 
-        new ServiceTestRunner().setOptions("hello.count", "0").setState(result).run(ticks);
+        new ServiceTestRunner()
+                .setOptions("hello.count", "0")
+                .setState(result)
+                .run(ticks);
+    }
+
+    @Test
+    public void testWorldDecommissionDefaultExecutor() throws Exception {
+        testWorldDecommission(true);
+    }
+
+    @Test
+    public void testWorldDecommissionCustomExecutor() throws Exception {
+        testWorldDecommission(false);
     }
 
     /**
      * Tests scheduler behavior when the number of {@code world} pods is reduced.
      */
-    @Test
-    public void testWorldDecommission() throws Exception {
+    private void testWorldDecommission(boolean useDefaultExecutor) throws Exception {
         // Simulate an initial deployment with default of 2 world nodes (and 1 hello node):
-        ServiceTestResult result = runDefaultDeployment();
+        ServiceTestResult result = runDefaultDeployment(useDefaultExecutor);
         Assert.assertEquals(
                 new TreeSet<>(Arrays.asList("hello-0-server", "world-0-server", "world-1-server")),
                 result.getPersister().getChildren("/Tasks"));
@@ -268,9 +282,12 @@ public class ServiceTest {
         // - a recovery plan that's COMPLETE
         // - a decommission plan that's PENDING with phases for world-1 and world-0 (in that order)
 
+        // When default executor is being used, three additional resources need to be unreserved.
+        int stepCount = useDefaultExecutor ? 9 : 6;
+
         // Check initial plan state
         ticks.add(new ExpectDecommissionPlanProgress(Arrays.asList(
-                new StepCount("world-1", 9, 0, 0), new StepCount("world-0", 9, 0, 0))));
+                new StepCount("world-1", stepCount, 0, 0), new StepCount("world-0", stepCount, 0, 0))));
 
         // Need to send an offer to trigger the implicit reconciliation.
         ticks.add(Send.offerBuilder("hello").build());
@@ -279,19 +296,19 @@ public class ServiceTest {
 
         // Check plan state after an offer came through: world-1-server killed
         ticks.add(new ExpectDecommissionPlanProgress(Arrays.asList(
-                new StepCount("world-1", 8, 0, 1), new StepCount("world-0", 9, 0, 0))));
+                new StepCount("world-1", stepCount - 1, 0, 1), new StepCount("world-0", stepCount, 0, 0))));
         ticks.add(Expect.taskNameKilled("world-1-server"));
 
         // Offer world-0 resources and check that nothing happens (haven't gotten there yet):
         ticks.add(Send.offerBuilder("world").setPodIndexToReoffer(0).build());
         ticks.add(new ExpectDecommissionPlanProgress(Arrays.asList(
-                new StepCount("world-1", 7, 1, 1), new StepCount("world-0", 9, 0, 0))));
+                new StepCount("world-1", stepCount - 2, 1, 1), new StepCount("world-0", stepCount, 0, 0))));
 
         // Offer world-1 resources and check that world-1 resources are wiped:
         ticks.add(Send.offerBuilder("world").setPodIndexToReoffer(1).build());
         ticks.add(Expect.unreservedTasks("world-1-server"));
         ticks.add(new ExpectDecommissionPlanProgress(Arrays.asList(
-                new StepCount("world-1", 1, 0, 8), new StepCount("world-0", 9, 0, 0))));
+                new StepCount("world-1", 1, 0, stepCount - 1), new StepCount("world-0", stepCount, 0, 0)))); // FAIL
         ticks.add(new ExpectEmptyResources(result.getPersister(), "world-1-server"));
 
         // Turn the crank with an arbitrary offer to finish erasing world-1:
@@ -300,13 +317,13 @@ public class ServiceTest {
         ticks.add(Expect.declinedLastOffer());
         ticks.add(Expect.knownTasks(result.getPersister(), "hello-0-server", "world-0-server"));
         ticks.add(new ExpectDecommissionPlanProgress(Arrays.asList(
-                new StepCount("world-1", 0, 0, 9), new StepCount("world-0", 9, 0, 0))));
+                new StepCount("world-1", 0, 0, stepCount), new StepCount("world-0", stepCount, 0, 0))));
 
         // Now let's proceed with decommissioning world-0. This time a single offer with the correct resources results
         // in both killing/flagging the task, and clearing its resources:
         ticks.add(Send.offerBuilder("world").setPodIndexToReoffer(0).build());
         ticks.add(new ExpectDecommissionPlanProgress(Arrays.asList(
-                new StepCount("world-1", 0, 0, 9), new StepCount("world-0", 1, 0, 8))));
+                new StepCount("world-1", 0, 0, stepCount), new StepCount("world-0", 1, 0, stepCount - 1))));
         ticks.add(Expect.taskNameKilled("world-0-server"));
         ticks.add(new ExpectEmptyResources(result.getPersister(), "world-0-server"));
 
@@ -316,11 +333,17 @@ public class ServiceTest {
         ticks.add(Expect.declinedLastOffer());
         ticks.add(Expect.knownTasks(result.getPersister(), "hello-0-server"));
         ticks.add(new ExpectDecommissionPlanProgress(Arrays.asList(
-                new StepCount("world-1", 0, 0, 9), new StepCount("world-0", 0, 0, 9))));
+                new StepCount("world-1", 0, 0, stepCount), new StepCount("world-0", 0, 0, stepCount))));
 
         ticks.add(Expect.allPlansComplete());
 
-        new ServiceTestRunner().setOptions("world.count", "0").setState(result).run(ticks);
+        ServiceTestRunner runner = new ServiceTestRunner()
+                .setOptions("world.count", "0")
+                .setState(result);
+        if (!useDefaultExecutor) {
+            runner.setUseCustomExecutor();
+        }
+        runner.run(ticks);
     }
 
     @Test
@@ -463,7 +486,8 @@ public class ServiceTest {
 
         @Override
         public String toString() {
-            return String.format("phase=%s,completed=%d", phaseName, completedCount);
+            return String.format("phase=%s[pending=%d,prepared=%d,completed=%d]",
+                    phaseName, pendingCount, preparedCount, completedCount);
         }
     }
 
@@ -544,15 +568,23 @@ public class ServiceTest {
                 expectedPlanStatus = Status.IN_PROGRESS;
             }
             Assert.assertEquals(expectedPlanStatus, plan.getStatus());
-            Assert.assertEquals(Arrays.asList("world-1", "world-0"),
+            Assert.assertEquals(stepCounts.stream().map(s -> s.phaseName).collect(Collectors.toList()),
                     plan.getChildren().stream().map(Phase::getName).collect(Collectors.toList()));
             phases = plan.getChildren().stream()
                     .collect(Collectors.toMap(Phase::getName, p -> p));
             Assert.assertEquals(stepCounts.size(), phases.size());
             for (StepCount stepCount : stepCounts) {
-                Assert.assertEquals(getExpectedStepStatuses(state, stepCount),
-                        phases.get(stepCount.phaseName).getChildren().stream()
-                                .collect(Collectors.toMap(Step::getName, Step::getStatus)));
+                Phase phase = phases.get(stepCount.phaseName);
+                Map<String, Status> stepStatuses = phase.getChildren().stream()
+                        .collect(Collectors.toMap(Step::getName, Step::getStatus));
+                Assert.assertEquals(
+                        String.format("Number of steps doesn't match expectation in %s: %s", stepCount, stepStatuses),
+                        stepCount.pendingCount + stepCount.preparedCount + stepCount.completedCount,
+                        phase.getChildren().size());
+                Assert.assertEquals(
+                        String.format("Step statuses don't match expectation in %s", stepCount),
+                        getExpectedStepStatuses(state, stepCount),
+                        stepStatuses);
             }
         }
 
@@ -578,7 +610,7 @@ public class ServiceTest {
     /**
      * Runs a default hello world deployment and returns the persisted state that resulted.
      */
-    private ServiceTestResult runDefaultDeployment() throws Exception {
+    private ServiceTestResult runDefaultDeployment(boolean useDefaultExecutor) throws Exception {
         Collection<SimulationTick> ticks = new ArrayList<>();
 
         ticks.add(Send.register());
@@ -621,7 +653,12 @@ public class ServiceTest {
 
         ticks.add(Expect.allPlansComplete());
 
-        return new ServiceTestRunner().run(ticks);
+        ServiceTestRunner runner = new ServiceTestRunner();
+        if (!useDefaultExecutor) {
+            runner.setUseCustomExecutor();
+        }
+
+        return runner.run(ticks);
     }
 
     /**

--- a/frameworks/helloworld/src/test/java/com/mesosphere/sdk/helloworld/scheduler/ServiceTest.java
+++ b/frameworks/helloworld/src/test/java/com/mesosphere/sdk/helloworld/scheduler/ServiceTest.java
@@ -19,8 +19,6 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.util.*;

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/Constants.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/Constants.java
@@ -29,6 +29,23 @@ public class Constants {
     public static final String MEMORY_RESOURCE_TYPE = "mem";
 
 
+    /**
+     * The amount of additional CPU to require for the default executor.
+     * Not applicable for the old custom executor.
+     */
+    public static final double DEFAULT_EXECUTOR_CPUS = 0.1;
+    /**
+     * The amount of additional memory (in MB) to require for the default executor.
+     * Not applicable for the old custom executor.
+     */
+    public static final double DEFAULT_EXECUTOR_MEMORY = 32;
+    /**
+     * The amount of additional disk (in MB) to require for the default executor.
+     * Not applicable for the old custom executor.
+     */
+    public static final double DEFAULT_EXECUTOR_DISK = 256;
+
+
     /** The "any role" wildcard resource role. */
     public static final String ANY_ROLE = "*";
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluator.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluator.java
@@ -377,39 +377,37 @@ public class OfferEvaluator {
         List<ResourceSpec> resources = new ArrayList<>();
 
         resources.add(DefaultResourceSpec.newBuilder()
-                .name("cpus")
+                .name(Constants.CPUS_RESOURCE_TYPE)
                 .preReservedRole(preReservedRole)
                 .role(role)
                 .principal(principal)
-                .value(Protos.Value.newBuilder()
-                        .setType(Protos.Value.Type.SCALAR)
-                        .setScalar(Protos.Value.Scalar.newBuilder().setValue(0.1))
-                        .build())
+                .value(scalar(Constants.DEFAULT_EXECUTOR_CPUS))
                 .build());
 
         resources.add(DefaultResourceSpec.newBuilder()
-                .name("mem")
+                .name(Constants.MEMORY_RESOURCE_TYPE)
                 .preReservedRole(preReservedRole)
                 .role(role)
                 .principal(principal)
-                .value(Protos.Value.newBuilder()
-                        .setType(Protos.Value.Type.SCALAR)
-                        .setScalar(Protos.Value.Scalar.newBuilder().setValue(32.0))
-                        .build())
+                .value(scalar(Constants.DEFAULT_EXECUTOR_MEMORY))
                 .build());
 
         resources.add(DefaultResourceSpec.newBuilder()
-                .name("disk")
+                .name(Constants.DISK_RESOURCE_TYPE)
                 .preReservedRole(preReservedRole)
                 .role(role)
                 .principal(principal)
-                .value(Protos.Value.newBuilder()
-                        .setType(Protos.Value.Type.SCALAR)
-                        .setScalar(Protos.Value.Scalar.newBuilder().setValue(256.0))
-                        .build())
+                .value(scalar(Constants.DEFAULT_EXECUTOR_DISK))
                 .build());
 
         return resources;
+    }
+
+    private static Protos.Value scalar(double val) {
+        Protos.Value.Builder builder = Protos.Value.newBuilder()
+                .setType(Protos.Value.Type.SCALAR);
+        builder.getScalarBuilder().setValue(val);
+        return builder.build();
     }
 
     private List<OfferEvaluationStage> getExistingEvaluationPipeline(

--- a/sdk/testing/src/main/java/com/mesosphere/sdk/testing/ClusterState.java
+++ b/sdk/testing/src/main/java/com/mesosphere/sdk/testing/ClusterState.java
@@ -25,7 +25,7 @@ public class ClusterState {
     private final ServiceSpec serviceSpec;
     private final AbstractScheduler scheduler;
     private final List<Protos.Offer> sentOffers = new ArrayList<>();
-    private final List<Collection<Protos.TaskInfo>> createdPods = new ArrayList<>();
+    private final List<LaunchedPod> createdPods = new ArrayList<>();
 
     private ClusterState(ServiceSpec serviceSpec, AbstractScheduler scheduler) {
         this.serviceSpec = serviceSpec;
@@ -85,8 +85,8 @@ public class ClusterState {
     /**
      * Adds the provided pod to the list of launched pods.
      */
-    public void addLaunchedPod(Collection<Protos.TaskInfo> pod) {
-        if (pod.isEmpty()) {
+    public void addLaunchedPod(LaunchedPod pod) {
+        if (pod.getTasks().isEmpty()) {
             throw new IllegalArgumentException("Refusing to record an empty pod");
         }
         createdPods.add(pod);
@@ -99,7 +99,7 @@ public class ClusterState {
      * @throws IllegalStateException if no pods had been launched
      * @see #getLastLaunchedPod(String)
      */
-    public Collection<Protos.TaskInfo> getLastLaunchedPod() {
+    public LaunchedPod getLastLaunchedPod() {
         if (createdPods.isEmpty()) {
             throw new IllegalStateException("No pods were created yet");
         }
@@ -114,11 +114,12 @@ public class ClusterState {
      * @throws IllegalStateException if no such pod was found
      * @see #getLastLaunchedPod()
      */
-    public Collection<Protos.TaskInfo> getLastLaunchedPod(String podName) {
+    public LaunchedPod getLastLaunchedPod(String podName) {
         Set<String> allPodNames = new TreeSet<>();
-        Collection<Protos.TaskInfo> foundPod = null;
-        for (Collection<Protos.TaskInfo> pod : createdPods) {
-            final Protos.TaskInfo task = pod.iterator().next(); // sample from the first task. should all be the same.
+        LaunchedPod foundPod = null;
+        for (LaunchedPod pod : createdPods) {
+            // Sample pod info from the first task. All tasks should share the same pod info:
+            final Protos.TaskInfo task = pod.getTasks().iterator().next();
             final TaskLabelReader reader = new TaskLabelReader(task);
             final String thisPod;
             try {
@@ -146,7 +147,7 @@ public class ClusterState {
      * @return the task's info
      * @throws IllegalStateException if no such task was found
      */
-    public Protos.TaskInfo getLastLaunchedTask(String taskName) {
+    public LaunchedTask getLastLaunchedTask(String taskName) {
         // Iterate over pods in sequential order, so that the newer version of a given task (by name) takes precedence
         // over an older version.
         // For example, given two versions of podX:
@@ -156,18 +157,18 @@ public class ClusterState {
         //   {A: 2, B: 1, C: 3}
         // Note: We COULD have just filtered against the task name up-front here, but it'd be more helpful to have a
         // mapping of all tasks available for the error message below.
-        Map<String, Protos.TaskInfo> taskInfosByName = new HashMap<>();
-        for (Collection<Protos.TaskInfo> pod : createdPods) {
-            for (Protos.TaskInfo task : pod) {
-                taskInfosByName.put(task.getName(), task);
+        Map<String, LaunchedTask> tasksByName = new HashMap<>();
+        for (LaunchedPod pod : createdPods) {
+            for (Protos.TaskInfo task : pod.getTasks()) {
+                tasksByName.put(task.getName(), new LaunchedTask(pod.getExecutor(), task));
             }
         }
-        Protos.TaskInfo taskInfo = taskInfosByName.get(taskName);
-        if (taskInfo == null) {
+        LaunchedTask task = tasksByName.get(taskName);
+        if (task == null) {
             throw new IllegalStateException(String.format(
-                    "Unable to find task named %s, known tasks were: %s", taskName, taskInfosByName.keySet()));
+                    "Unable to find task named %s, known tasks were: %s", taskName, tasksByName.keySet()));
         }
-        return taskInfo;
+        return task;
     }
 
     /**
@@ -178,6 +179,6 @@ public class ClusterState {
      * @throws IllegalStateException if no such task was found
      */
     public Protos.TaskID getTaskId(String taskName) {
-        return getLastLaunchedTask(taskName).getTaskId();
+        return getLastLaunchedTask(taskName).getTask().getTaskId();
     }
 }

--- a/sdk/testing/src/main/java/com/mesosphere/sdk/testing/LaunchedPod.java
+++ b/sdk/testing/src/main/java/com/mesosphere/sdk/testing/LaunchedPod.java
@@ -1,0 +1,38 @@
+package com.mesosphere.sdk.testing;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+import org.apache.mesos.Protos;
+
+import com.google.protobuf.TextFormat;
+
+/**
+ * Grouping of a set of tasks that were launched in a pod, along with their associated executor.
+ */
+public class LaunchedPod {
+    private final Protos.ExecutorInfo executorInfo;
+    private final Collection<Protos.TaskInfo> taskInfos;
+
+    public LaunchedPod(Protos.ExecutorInfo executorInfo, Collection<Protos.TaskInfo> taskInfos) {
+        this.executorInfo = executorInfo;
+        this.taskInfos = taskInfos;
+    }
+
+    public Protos.ExecutorInfo getExecutor() {
+        return executorInfo;
+    }
+
+    public Collection<Protos.TaskInfo> getTasks() {
+        return taskInfos;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("Executor: %s%nTasks: %s",
+                TextFormat.shortDebugString(executorInfo),
+                taskInfos.stream()
+                        .map(t -> TextFormat.shortDebugString(t))
+                        .collect(Collectors.toList()));
+    }
+}

--- a/sdk/testing/src/main/java/com/mesosphere/sdk/testing/LaunchedTask.java
+++ b/sdk/testing/src/main/java/com/mesosphere/sdk/testing/LaunchedTask.java
@@ -1,0 +1,32 @@
+package com.mesosphere.sdk.testing;
+
+import org.apache.mesos.Protos;
+
+import com.google.protobuf.TextFormat;
+
+/**
+ * Grouping of a launched task along with its associated executor.
+ */
+public class LaunchedTask {
+    private final Protos.ExecutorInfo executorInfo;
+    private final Protos.TaskInfo taskInfo;
+
+    public LaunchedTask(Protos.ExecutorInfo executorInfo, Protos.TaskInfo taskInfo) {
+        this.executorInfo = executorInfo;
+        this.taskInfo = taskInfo;
+    }
+
+    public Protos.ExecutorInfo getExecutor() {
+        return executorInfo;
+    }
+
+    public Protos.TaskInfo getTask() {
+        return taskInfo;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("Executor: %s%nTask: %s",
+                TextFormat.shortDebugString(executorInfo), TextFormat.shortDebugString(taskInfo));
+    }
+}

--- a/sdk/testing/src/main/java/com/mesosphere/sdk/testing/SendOffer.java
+++ b/sdk/testing/src/main/java/com/mesosphere/sdk/testing/SendOffer.java
@@ -1,6 +1,7 @@
 package com.mesosphere.sdk.testing;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -9,6 +10,7 @@ import org.apache.mesos.Protos;
 import org.apache.mesos.Scheduler;
 import org.apache.mesos.SchedulerDriver;
 
+import com.mesosphere.sdk.offer.Constants;
 import com.mesosphere.sdk.specification.PodSpec;
 import com.mesosphere.sdk.specification.ResourceSpec;
 import com.mesosphere.sdk.specification.TaskSpec;
@@ -20,6 +22,14 @@ import com.mesosphere.sdk.testutils.TestConstants;
  * test.
  */
 public class SendOffer implements Send {
+
+    /**
+     * Default executors have an additional overhead of 0.1 CPU, 32MB RAM, and 256MB disk.
+     */
+    private static final List<Protos.Resource> DEFAULT_EXECUTOR_RESOURCES = Arrays.asList(
+            toUnreservedResource(Constants.CPUS_RESOURCE_TYPE, scalar(0.1), false),
+            toUnreservedResource(Constants.MEMORY_RESOURCE_TYPE, scalar(32.0), false),
+            toUnreservedResource(Constants.DISK_RESOURCE_TYPE, scalar(256.0), false));
 
     private final String podType;
     private final Optional<String> podToReuse;
@@ -120,15 +130,14 @@ public class SendOffer implements Send {
         // Include task-level resources (note: resources are not merged, e.g. 1.5cpu+1.0 cpu instead of 2.5cpu):
         for (TaskSpec taskSpec : podSpec.getTasks()) {
             if (podToReuse.isPresent()) {
-                // Copy resources from prior pod launch:
-                for (Protos.TaskInfo task : state.getLastLaunchedPod(podToReuse.get())) {
+                // Copy executor id and resources from prior pod launch:
+                LaunchedPod pod = state.getLastLaunchedPod(podToReuse.get());
+                offerBuilder
+                        .addExecutorIds(pod.getExecutor().getExecutorId())
+                        .addAllResources(pod.getExecutor().getResourcesList());
+                for (Protos.TaskInfo task : pod.getTasks()) {
                     offerBuilder.addAllResources(task.getResourcesList());
                 }
-                // Copy executor id(s) from prior pod launch, if tasks are marked as running:
-                offerBuilder.addAllExecutorIds(state.getLastLaunchedPod(podToReuse.get()).stream()
-                        .map(taskInfo -> taskInfo.getExecutor().getExecutorId())
-                        .distinct()
-                        .collect(Collectors.toList()));
             } else {
                 // Create new unreserved resources:
                 for (ResourceSpec resourceSpec : taskSpec.getResourceSet().getResources()) {
@@ -139,35 +148,55 @@ public class SendOffer implements Send {
                 }
             }
         }
+
+        // In addition to the resources required by the tasks, add some resources for the Default Executor overhead.
+        if (!podToReuse.isPresent()) {
+            offerBuilder.addAllResources(DEFAULT_EXECUTOR_RESOURCES);
+        }
+
         return offerBuilder.build();
     }
 
-    @SuppressWarnings("deprecation") // for Resource.setRole()
     private static Protos.Resource toUnreservedResource(ResourceSpec resourceSpec) {
+        boolean isMountDisk = resourceSpec instanceof VolumeSpec &&
+                ((VolumeSpec) resourceSpec).getType() == VolumeSpec.Type.MOUNT;
+        return toUnreservedResource(resourceSpec.getName(), resourceSpec.getValue(), isMountDisk);
+    }
+
+    @SuppressWarnings("deprecation") // for Resource.setRole()
+    private static Protos.Resource toUnreservedResource(String resourceName, Protos.Value value, boolean isMountDisk) {
         Protos.Resource.Builder resourceBuilder = Protos.Resource.newBuilder()
                 .setRole("*")
-                .setName(resourceSpec.getName())
-                .setType(resourceSpec.getValue().getType());
-        switch (resourceSpec.getValue().getType()) {
+                .setName(resourceName)
+                .setType(value.getType());
+
+        switch (value.getType()) {
             case SCALAR:
-                resourceBuilder.setScalar(resourceSpec.getValue().getScalar());
+                resourceBuilder.setScalar(value.getScalar());
                 break;
             case RANGES:
-                resourceBuilder.setRanges(resourceSpec.getValue().getRanges());
+                resourceBuilder.setRanges(value.getRanges());
                 break;
             case SET:
-                resourceBuilder.setSet(resourceSpec.getValue().getSet());
+                resourceBuilder.setSet(value.getSet());
                 break;
             default:
-                throw new IllegalArgumentException("Unsupported value type: " + resourceSpec.getValue());
+                throw new IllegalArgumentException("Unsupported value type: " + value);
         }
 
-        if (resourceSpec instanceof VolumeSpec &&
-                ((VolumeSpec) resourceSpec).getType() == VolumeSpec.Type.MOUNT) {
+        if (isMountDisk) {
             resourceBuilder.getDiskBuilder().getSourceBuilder()
                     .setType(Protos.Resource.DiskInfo.Source.Type.MOUNT)
                     .getMountBuilder().setRoot(TestConstants.MOUNT_ROOT);
         }
+
         return resourceBuilder.build();
+    }
+
+    private static Protos.Value scalar(double val) {
+        Protos.Value.Builder builder = Protos.Value.newBuilder()
+                .setType(Protos.Value.Type.SCALAR);
+        builder.getScalarBuilder().setValue(val);
+        return builder.build();
     }
 }

--- a/sdk/testing/src/main/java/com/mesosphere/sdk/testing/SendOffer.java
+++ b/sdk/testing/src/main/java/com/mesosphere/sdk/testing/SendOffer.java
@@ -27,9 +27,9 @@ public class SendOffer implements Send {
      * Default executors have an additional overhead of 0.1 CPU, 32MB RAM, and 256MB disk.
      */
     private static final List<Protos.Resource> DEFAULT_EXECUTOR_RESOURCES = Arrays.asList(
-            toUnreservedResource(Constants.CPUS_RESOURCE_TYPE, scalar(0.1), false),
-            toUnreservedResource(Constants.MEMORY_RESOURCE_TYPE, scalar(32.0), false),
-            toUnreservedResource(Constants.DISK_RESOURCE_TYPE, scalar(256.0), false));
+            toUnreservedResource(Constants.CPUS_RESOURCE_TYPE, scalar(Constants.DEFAULT_EXECUTOR_CPUS), false),
+            toUnreservedResource(Constants.MEMORY_RESOURCE_TYPE, scalar(Constants.DEFAULT_EXECUTOR_MEMORY), false),
+            toUnreservedResource(Constants.DISK_RESOURCE_TYPE, scalar(Constants.DEFAULT_EXECUTOR_DISK), false));
 
     private final String podType;
     private final Optional<String> podToReuse;
@@ -150,6 +150,8 @@ public class SendOffer implements Send {
         }
 
         // In addition to the resources required by the tasks, add some resources for the Default Executor overhead.
+        // Note that if custom executors are being exercised, these marginal resources are not used and are effectively
+        // just ignored.
         if (!podToReuse.isPresent()) {
             offerBuilder.addAllResources(DEFAULT_EXECUTOR_RESOURCES);
         }

--- a/sdk/testing/src/main/java/com/mesosphere/sdk/testing/ServiceTestRunner.java
+++ b/sdk/testing/src/main/java/com/mesosphere/sdk/testing/ServiceTestRunner.java
@@ -53,6 +53,7 @@ public class ServiceTestRunner {
     private final Map<String, String> customSchedulerEnv = new HashMap<>();
     private final Map<String, Map<String, String>> customPodEnvs = new HashMap<>();
     private RecoveryPlanOverriderFactory recoveryManagerFactory;
+    private boolean supportsDefaultExecutor = true;
 
     /**
      * Returns a {@link File} object for the service's {@code src/main/dist} directory. Does not check if the directory
@@ -239,6 +240,16 @@ public class ServiceTestRunner {
     }
 
     /**
+     * Simulates DC/OS 1.9 behavior of using a custom executor instead of the default executor.
+     *
+     * Individual services shouldn't need to use this, it's more for testing of the SDK itself.
+     */
+    public ServiceTestRunner setUseCustomExecutor() {
+        this.supportsDefaultExecutor = false;
+        return this;
+    }
+
+    /**
      * Exercises the service's packaging and resulting Service Specification YAML file without running any simulation
      * afterwards.
      *
@@ -275,7 +286,7 @@ public class ServiceTestRunner {
         Mockito.when(mockCapabilities.supportsEnvBasedSecretsProtobuf()).thenReturn(true);
         Mockito.when(mockCapabilities.supportsEnvBasedSecretsDirectiveLabel()).thenReturn(true);
         Mockito.when(mockCapabilities.supportsDomains()).thenReturn(true);
-        Mockito.when(mockCapabilities.supportsDefaultExecutor()).thenReturn(true);
+        Mockito.when(mockCapabilities.supportsDefaultExecutor()).thenReturn(supportsDefaultExecutor);
         Capabilities.overrideCapabilities(mockCapabilities);
 
         Map<String, String> schedulerEnvironment =

--- a/sdk/testing/src/main/java/com/mesosphere/sdk/testing/ServiceTestRunner.java
+++ b/sdk/testing/src/main/java/com/mesosphere/sdk/testing/ServiceTestRunner.java
@@ -275,6 +275,7 @@ public class ServiceTestRunner {
         Mockito.when(mockCapabilities.supportsEnvBasedSecretsProtobuf()).thenReturn(true);
         Mockito.when(mockCapabilities.supportsEnvBasedSecretsDirectiveLabel()).thenReturn(true);
         Mockito.when(mockCapabilities.supportsDomains()).thenReturn(true);
+        Mockito.when(mockCapabilities.supportsDefaultExecutor()).thenReturn(true);
         Capabilities.overrideCapabilities(mockCapabilities);
 
         Map<String, String> schedulerEnvironment =


### PR DESCRIPTION
Needed some changes to the simulation handling:
- Include additional overhead resources for the default executor to use.
- Use the ExecutorInfo from the parent LaunchGroup, rather than one of the TaskInfos.
- Hello world: Account for the added resources when checking the decommission plan