### PR TITLE
[INFINITY-3003] Fix multiple different constructions of ExecutorInfo

### DIFF
--- a/frameworks/helloworld/tests/test_zzzrecovery.py
+++ b/frameworks/helloworld/tests/test_zzzrecovery.py
@@ -288,6 +288,7 @@ def test_pod_replace():
 # WARNING: THIS MUST BE THE LAST TEST IN THIS FILE. ANY TEST THAT FOLLOWS WILL BE FLAKY.
 # @@@@@@@
 @pytest.mark.sanity
+@pytest.mark.skip(reason="INFINITY-3023")
 def test_shutdown_host():
     replace_task = sdk_tasks.get_task_avoiding_scheduler(
         config.SERVICE_NAME, re.compile('^(hello|world)-[0-9]+-server$'))

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/ResourceBuilder.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/ResourceBuilder.java
@@ -197,7 +197,9 @@ public class ResourceBuilder {
         // In the post-resource-refinement world (1.10+), Mesos will expect
         // reserved Resources to have reservations (and ONLY reservations) set.
         Resource.Builder builder =
-                mesosResource == null ? Resource.newBuilder() : mesosResource.getResource().toBuilder();
+                mesosResource == null ?
+                        Resource.newBuilder() :
+                        mesosResource.getResource().toBuilder().clearAllocationInfo();
         builder.setName(resourceName)
                 .setRole(Constants.ANY_ROLE)
                 .setType(value.getType());

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/ExecutorEvaluationStage.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/ExecutorEvaluationStage.java
@@ -14,15 +14,16 @@ import static com.mesosphere.sdk.offer.evaluate.EvaluationOutcome.pass;
  * and setting the executor ID for a newly-launching pod.
  */
 public class ExecutorEvaluationStage implements OfferEvaluationStage {
-    private final Optional<Protos.ExecutorInfo> executorInfo;
+
+    private final Optional<Protos.ExecutorID> id;
 
     /**
      * Instantiate with an expected {@link org.apache.mesos.Protos.ExecutorID} to check for in offers. If not found,
      * the offer will be rejected by this stage.
-     * @param executorInfo the executor ID to look for in incoming offers
+     * @param id the executor ID to look for in incoming offers
      */
-    public ExecutorEvaluationStage(Optional<Protos.ExecutorInfo> executorInfo) {
-        this.executorInfo = executorInfo;
+    public ExecutorEvaluationStage(Optional<Protos.ExecutorID> id) {
+        this.id = id;
     }
 
     @Override
@@ -33,18 +34,18 @@ public class ExecutorEvaluationStage implements OfferEvaluationStage {
 
         if (!hasExpectedExecutorId(mesosResourcePool.getOffer())) {
             return fail(this,
-                    "Offer does not contain the needed Executor ID: '%s'",
-                    executorInfo.get().getExecutorId().getValue()).build();
+                    "Offer does not contain the needed Executor ID: '%s'", id)
+                    .build();
         }
 
-        if (executorInfo.isPresent()) {
-            podInfoBuilder.setExecutorBuilder(executorInfo.get().toBuilder());
+        Protos.ExecutorInfo.Builder executorBuilder = podInfoBuilder.getExecutorBuilder().get();
+        if (id.isPresent()) {
+            executorBuilder.setExecutorId(id.get());
             return pass(
                     this,
-                    "Offer contains the matching Executor ID: '%s'",
-                    executorInfo.get().getExecutorId().getValue()).build();
+                    "Offer contains the matching Executor ID: '%s'", id)
+                    .build();
         } else {
-            Protos.ExecutorInfo.Builder executorBuilder = podInfoBuilder.getExecutorBuilder().get();
             Protos.ExecutorID executorID = CommonIdUtils.toExecutorId(executorBuilder.getName());
             executorBuilder.setExecutorId(executorID);
             return pass(
@@ -55,12 +56,12 @@ public class ExecutorEvaluationStage implements OfferEvaluationStage {
     }
 
     private boolean hasExpectedExecutorId(Protos.Offer offer) {
-        if (!executorInfo.isPresent()) {
+        if (!id.isPresent()) {
             return true;
         }
 
         for (Protos.ExecutorID execId : offer.getExecutorIdsList()) {
-            if (execId.equals(executorInfo.get().getExecutorId())) {
+            if (execId.equals(id.get())) {
                 return true;
             }
         }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/ExecutorResourceMapper.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/ExecutorResourceMapper.java
@@ -75,18 +75,10 @@ public class ExecutorResourceMapper {
 
     private List<OfferEvaluationStage> getEvaluationStagesInternal() {
         List<ResourceSpec> remainingResourceSpecs = new ArrayList<>();
-
-        // When using a NEW executor add the appropriate evaluation stages.  If the executor ID is NOT empty then the
-        // executor is already running.  Therefore you can't expect cpu, mem or disk resources to be offered as the
-        // executor is already running and consuming those resources.
-        if (useDefaultExecutor && executorInfo.getExecutorId().getValue().isEmpty()) {
+        remainingResourceSpecs.addAll(volumeSpecs);
+        if (useDefaultExecutor) {
             remainingResourceSpecs.addAll(resourceSpecs);
         }
-
-        // Always add volumes for evaluation.  The VolumeEvaluationStage is smart enough to pass even when resources are
-        // not offered because the executor is already running.  It must be added always to make sure that the volume
-        // protobuf is constructed and added appropriately.
-        remainingResourceSpecs.addAll(volumeSpecs);
 
         List<ResourceLabels> matchingResources = new ArrayList<>();
         for (Protos.Resource resource : resources) {
@@ -128,7 +120,7 @@ public class ExecutorResourceMapper {
         }
 
         if (!remainingResourceSpecs.isEmpty()) {
-            LOGGER.info("Missing volumes not found in executor: {}", remainingResourceSpecs);
+            LOGGER.info("Missing resources not found in executor: {}", remainingResourceSpecs);
             for (ResourceSpec missingResource : remainingResourceSpecs) {
                 stages.add(newCreateEvaluationStage(missingResource));
             }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluationUtils.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluationUtils.java
@@ -218,4 +218,18 @@ class OfferEvaluationUtils {
             return pool.consumeReserved(resourceSpec.getName(), resourceSpec.getValue(), resourceId.get());
         }
     }
+
+    public static boolean isRunningExecutor(PodInfoBuilder podInfoBuilder, Protos.Offer offer) {
+        if (!podInfoBuilder.getExecutorBuilder().isPresent()) {
+            return false;
+        }
+
+        for (Protos.ExecutorID execId : offer.getExecutorIdsList()) {
+            if (execId.equals(podInfoBuilder.getExecutorBuilder().get().getExecutorId())) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluator.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluator.java
@@ -160,8 +160,9 @@ public class OfferEvaluator {
                 .filter(resourceId -> !resourceId.isEmpty())
                 .count() == 0;
 
-        boolean allTasksFailed = thisPodTasks.values().stream()
-                .allMatch(taskInfo -> FailureUtils.isPermanentlyFailed(taskInfo));
+        boolean allTasksFailed =
+                thisPodTasks.size() > 0 &&
+                thisPodTasks.values().stream().allMatch(taskInfo -> FailureUtils.isPermanentlyFailed(taskInfo));
 
         final String description;
         final boolean shouldGetNewRequirement;

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/PodInfoBuilder.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/PodInfoBuilder.java
@@ -183,6 +183,7 @@ public class PodInfoBuilder {
 
         Protos.Resource.ReservationInfo.Builder reservationBuilder = resourceBuilder.addReservationsBuilder();
         reservationBuilder
+                .setType(Protos.Resource.ReservationInfo.Type.DYNAMIC)
                 .setPrincipal(volumeSpec.getPrincipal())
                 .setRole(volumeSpec.getRole());
         AuxLabelAccess.setResourceId(reservationBuilder, resourceId);

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/PodInfoBuilder.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/PodInfoBuilder.java
@@ -167,19 +167,46 @@ public class PodInfoBuilder {
     }
 
     public static Protos.Resource getExistingExecutorVolume(
-            VolumeSpec volumeSpec, String resourceId, String persistenceId) {
-        Protos.Resource.Builder resourceBuilder = Protos.Resource.newBuilder()
-                .setName("disk")
-                .setType(Protos.Value.Type.SCALAR)
-                .setScalar(volumeSpec.getValue().getScalar());
+            VolumeSpec volumeSpec, String resourceId, String persistenceId, boolean useDefaultExecutor) {
+        Protos.Resource.Builder builder;
+        if (useDefaultExecutor) {
+            builder = getExistingDefaultExecutorVolume(volumeSpec, resourceId, persistenceId);
+        } else {
+            builder = getExistingCustomExecutorVolume(volumeSpec, resourceId, persistenceId);
+        }
 
-        Protos.Resource.DiskInfo.Builder diskInfoBuilder = resourceBuilder.getDiskBuilder();
+        Protos.Resource.DiskInfo.Builder diskInfoBuilder = builder.getDiskBuilder();
         diskInfoBuilder.getPersistenceBuilder()
                 .setId(persistenceId)
                 .setPrincipal(volumeSpec.getPrincipal());
         diskInfoBuilder.getVolumeBuilder()
                 .setContainerPath(volumeSpec.getContainerPath())
                 .setMode(Protos.Volume.Mode.RW);
+
+        return builder.build();
+    }
+
+    private static Protos.Resource.Builder getExistingCustomExecutorVolume(
+            VolumeSpec volumeSpec, String resourceId, String persistenceId) {
+        Protos.Resource.Builder resourceBuilder = Protos.Resource.newBuilder()
+                .setName("disk")
+                .setType(Protos.Value.Type.SCALAR)
+                .setScalar(volumeSpec.getValue().getScalar())
+                .setRole(volumeSpec.getRole());
+
+        Protos.Resource.ReservationInfo.Builder reservationBuilder = resourceBuilder.getReservationBuilder();
+        reservationBuilder.setPrincipal(volumeSpec.getPrincipal());
+        AuxLabelAccess.setResourceId(reservationBuilder, resourceId);
+
+        return resourceBuilder;
+    }
+
+    private static Protos.Resource.Builder getExistingDefaultExecutorVolume(
+            VolumeSpec volumeSpec, String resourceId, String persistenceId) {
+        Protos.Resource.Builder resourceBuilder = Protos.Resource.newBuilder()
+                .setName("disk")
+                .setType(Protos.Value.Type.SCALAR)
+                .setScalar(volumeSpec.getValue().getScalar());
 
         Protos.Resource.ReservationInfo.Builder reservationBuilder = resourceBuilder.addReservationsBuilder();
         reservationBuilder
@@ -188,7 +215,7 @@ public class PodInfoBuilder {
                 .setRole(volumeSpec.getRole());
         AuxLabelAccess.setResourceId(reservationBuilder, resourceId);
 
-        return resourceBuilder.build();
+        return resourceBuilder;
     }
 
     private static Protos.Volume getVolume(VolumeSpec volumeSpec) {

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/VolumeEvaluationStage.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/VolumeEvaluationStage.java
@@ -58,8 +58,11 @@ public class VolumeEvaluationStage implements OfferEvaluationStage {
             // add it to the ExecutorInfo.
             podInfoBuilder.setExecutorVolume(volumeSpec);
 
-            Resource volume =
-                    PodInfoBuilder.getExistingExecutorVolume(volumeSpec, resourceId.get(), persistenceId.get());
+            Resource volume = PodInfoBuilder.getExistingExecutorVolume(
+                    volumeSpec,
+                    resourceId.get(),
+                    persistenceId.get(),
+                    useDefaultExecutor);
             podInfoBuilder.getExecutorBuilder().get().addResources(volume);
 
             return pass(

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/VolumeEvaluationStage.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/VolumeEvaluationStage.java
@@ -3,7 +3,6 @@ package com.mesosphere.sdk.offer.evaluate;
 import com.google.protobuf.TextFormat;
 import com.mesosphere.sdk.offer.*;
 import com.mesosphere.sdk.specification.VolumeSpec;
-import org.apache.mesos.Protos;
 import org.apache.mesos.Protos.Resource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,25 +51,24 @@ public class VolumeEvaluationStage implements OfferEvaluationStage {
         Resource resource;
         final MesosResource mesosResource;
 
-        boolean isRunningExecutor = podInfoBuilder.getExecutorBuilder().isPresent() &&
-                isRunningExecutor(podInfoBuilder.getExecutorBuilder().get().build(), mesosResourcePool.getOffer());
+        boolean isRunningExecutor =
+                OfferEvaluationUtils.isRunningExecutor(podInfoBuilder, mesosResourcePool.getOffer());
         if (taskName == null && isRunningExecutor && resourceId.isPresent() && persistenceId.isPresent()) {
             // This is a volume on a running executor, so it isn't present in the offer, but we need to make sure to
-            // add it to the ExecutorInfo as well as whatever task is being launched.
+            // add it to the ExecutorInfo.
             podInfoBuilder.setExecutorVolume(volumeSpec);
 
             Resource volume =
                     PodInfoBuilder.getExistingExecutorVolume(volumeSpec, resourceId.get(), persistenceId.get());
             podInfoBuilder.getExecutorBuilder().get().addResources(volume);
-            mesosResource = new MesosResource(volume);
 
             return pass(
                     this,
                     Collections.emptyList(),
-                    "Offer contains executor with existing volume with resourceId: '%s' and persistenceId: '%s'",
+                    "Setting info for already running Executor with existing volume " +
+                            "with resourceId: '%s' and persistenceId: '%s'",
                     resourceId,
                     persistenceId)
-                    .mesosResource(mesosResource)
                     .build();
         }
 
@@ -155,15 +153,5 @@ public class VolumeEvaluationStage implements OfferEvaluationStage {
 
     private Optional<String> getTaskName() {
         return Optional.ofNullable(taskName);
-    }
-
-    private static boolean isRunningExecutor(Protos.ExecutorInfo executorInfo, Protos.Offer offer) {
-        for (Protos.ExecutorID execId : offer.getExecutorIdsList()) {
-            if (execId.equals(executorInfo.getExecutorId())) {
-                return true;
-            }
-        }
-
-        return false;
     }
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/VolumeEvaluationStage.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/VolumeEvaluationStage.java
@@ -58,8 +58,11 @@ public class VolumeEvaluationStage implements OfferEvaluationStage {
             // This is a volume on a running executor, so it isn't present in the offer, but we need to make sure to
             // add it to the ExecutorInfo as well as whatever task is being launched.
             podInfoBuilder.setExecutorVolume(volumeSpec);
-            mesosResource = new MesosResource(
-                    PodInfoBuilder.getExistingExecutorVolume(volumeSpec, resourceId.get(), persistenceId.get()));
+
+            Resource volume =
+                    PodInfoBuilder.getExistingExecutorVolume(volumeSpec, resourceId.get(), persistenceId.get());
+            podInfoBuilder.getExecutorBuilder().get().addResources(volume);
+            mesosResource = new MesosResource(volume);
 
             return pass(
                     this,

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/ExecutorEvaluationStageTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/ExecutorEvaluationStageTest.java
@@ -45,7 +45,7 @@ public class ExecutorEvaluationStageTest extends OfferEvaluatorTestBase {
                 Optional.of(Constants.ANY_ROLE));
 
         ExecutorEvaluationStage executorEvaluationStage =
-                new ExecutorEvaluationStage(Optional.of(taskInfo.getExecutor()));
+                new ExecutorEvaluationStage(Optional.of(taskInfo.getExecutor().getExecutorId()));
         EvaluationOutcome outcome =
                 executorEvaluationStage.evaluate(
                         resources,
@@ -87,7 +87,7 @@ public class ExecutorEvaluationStageTest extends OfferEvaluatorTestBase {
                 Optional.of(Constants.ANY_ROLE));
 
         ExecutorEvaluationStage executorEvaluationStage =
-                new ExecutorEvaluationStage(Optional.of(taskInfo.getExecutor()));
+                new ExecutorEvaluationStage(Optional.of(taskInfo.getExecutor().getExecutorId()));
         EvaluationOutcome outcome =
                 executorEvaluationStage.evaluate(
                         resources,
@@ -130,7 +130,7 @@ public class ExecutorEvaluationStageTest extends OfferEvaluatorTestBase {
         MesosResourcePool resources = new MesosResourcePool(offer, Optional.of(Constants.ANY_ROLE));
 
         ExecutorEvaluationStage executorEvaluationStage =
-                new ExecutorEvaluationStage(Optional.of(taskInfo.getExecutor()));
+                new ExecutorEvaluationStage(Optional.of(taskInfo.getExecutor().getExecutorId()));
         PodInfoBuilder podInfoBuilder =
                 new PodInfoBuilder(
                         podInstanceRequirement,
@@ -177,7 +177,7 @@ public class ExecutorEvaluationStageTest extends OfferEvaluatorTestBase {
         MesosResourcePool resources = new MesosResourcePool(offer, Optional.of(Constants.ANY_ROLE));
 
         ExecutorEvaluationStage executorEvaluationStage =
-                new ExecutorEvaluationStage(Optional.of(taskInfo.getExecutor()));
+                new ExecutorEvaluationStage(Optional.of(taskInfo.getExecutor().getExecutorId()));
         PodInfoBuilder podInfoBuilder =
                 new PodInfoBuilder(
                         podInstanceRequirement,


### PR DESCRIPTION
1. Stop constructing ExecutorInfo twice
1. Make the ExecutorEvaluationStage care solely about the ExecutorId
1. Make the VolumeEvaluationStage take care of setting correct protobufs always
1. Make the ResourceEvaluationStages take care of setting correct protobufs always
1. Construct volume protobufs correctly (w/ DYNAMIC type)