### PR TITLE
[INFINITY-2842] Add tls krb5 tests for HDFS

### DIFF
--- a/frameworks/hdfs/tests/auth.py
+++ b/frameworks/hdfs/tests/auth.py
@@ -1,0 +1,188 @@
+"""
+Authnz specifics for HDFS tests
+"""
+import itertools
+import logging
+import base64
+import json
+
+
+import sdk_cmd
+import sdk_hosts
+
+
+log = logging.getLogger(__name__)
+
+
+USERS = [
+    "hdfs",
+    "alice",
+    "bob",
+]
+
+
+def get_service_principals(service_name: str, realm: str) -> list:
+    """
+    Sets up the appropriate principals needed for a kerberized deployment of HDFS.
+    :return: A list of said principals
+    """
+    primaries = ["hdfs", "HTTP"]
+    fqdn = sdk_hosts.autoip_host(service_name, "")
+
+    instances = [
+        "name-0-node",
+        "name-0-zkfc",
+        "name-1-node",
+        "name-1-zkfc",
+        "journal-0-node",
+        "journal-1-node",
+        "journal-2-node",
+        "data-0-node",
+        "data-1-node",
+        "data-2-node",
+    ]
+
+    principals = []
+    for (primary, instance) in itertools.product(primaries, instances):
+        principals.append(
+            "{primary}/{instance}.{fqdn}@{REALM}".format(
+                primary=primary,
+                instance=instance,
+                fqdn=fqdn,
+                REALM=realm
+            )
+        )
+
+    for primary in USERS:
+        principals.append(
+            "{primary}@{REALM}".format(
+                primary=primary,
+                REALM=realm
+            )
+        )
+
+    http_principal = "HTTP/api.{}.marathon.l4lb.thisdcos.directory".format(service_name)
+
+    principals.append(http_principal)
+    return principals
+
+
+def get_principal_to_user_mapping() -> str:
+    """
+    Kerberized HDFS maps the primary component of a principal to local users, so
+    we need to create an appropriate mapping to test authorization functionality.
+    :return: A base64-encoded string of principal->user mappings
+    """
+    rules = [
+        "RULE:[2:$1@$0](^hdfs@.*$)s/.*/hdfs/",
+        "RULE:[1:$1@$0](^nobody@.*$)s/.*/nobody/"
+    ]
+
+    for user in USERS:
+        rules.append("RULE:[1:$1@$0](^{user}@.*$)s/.*/{user}/".format(user=user))
+
+    return base64.b64encode('\n'.join(rules).encode("utf-8")).decode("utf-8")
+
+
+def write_krb5_config_file(task: str, filename: str, krb5: object) -> str:
+    """
+    Generate a Kerberos config file.
+    TODO(elezar): This duplicates functionality in frameworks/kafka/tests/auth.py
+    TODO(elezar): Move to testing/security/kerberos.py
+    """
+    output_file = filename
+
+    log.info("Generating %s", output_file)
+    krb5_file_contents = ['[libdefaults]',
+                          'default_realm = {}'.format(krb5.get_realm()),
+                          '',
+                          '[realms]',
+                          '  {realm} = {{'.format(realm=krb5.get_realm()),
+                          '    kdc = {}'.format(krb5.get_kdc_address()),
+                          '  }', ]
+    log.info("%s", krb5_file_contents)
+
+    output = sdk_cmd.create_task_text_file(task, output_file, krb5_file_contents)
+    log.info(output)
+
+    return output_file
+
+
+def create_tls_artifacts(cn: str, task: str) -> str:
+    # TODO(elezar) Move to testing/security/ssl
+    pub_path = "{}_pub.crt".format(cn)
+    priv_path = "{}_priv.key".format(cn)
+    log.info("Generating certificate. cn={}, task={}".format(cn, task))
+
+    output = sdk_cmd.task_exec(
+        task,
+        'openssl req -nodes -newkey rsa:2048 -keyout {} -out request.csr '
+        '-subj "/C=US/ST=CA/L=SF/O=Mesosphere/OU=Mesosphere/CN={}"'.format(priv_path, cn))
+    log.info(output)
+    assert output[0] is 0
+
+    rc, raw_csr, _ = sdk_cmd.task_exec(task, 'cat request.csr')
+    assert rc is 0
+    request = {
+        "certificate_request": raw_csr
+    }
+
+    token = sdk_cmd.run_cli("config show core.dcos_acs_token")
+
+    output = sdk_cmd.task_exec(
+        task,
+        "curl --insecure -L -X POST "
+        "-H 'Authorization: token={}' "
+        "leader.mesos/ca/api/v2/sign "
+        "-d '{}'".format(token, json.dumps(request)))
+    log.info(output)
+    assert output[0] is 0
+
+    # Write the public cert to the client
+    certificate = json.loads(output[1])["result"]["certificate"]
+    output = sdk_cmd.task_exec(task, "bash -c \"echo '{}' > {}\"".format(certificate, pub_path))
+    log.info(output)
+    assert output[0] is 0
+
+    create_keystore_truststore(cn, task)
+    return "CN={},OU=Mesosphere,O=Mesosphere,L=SF,ST=CA,C=US".format(cn)
+
+
+def create_keystore_truststore(cn: str, task: str):
+    # TODO(elezar) Move to testing/security/ssl
+    pub_path = "{}_pub.crt".format(cn)
+    priv_path = "{}_priv.key".format(cn)
+    keystore_path = "{}_keystore.jks".format(cn)
+    truststore_path = "{}_truststore.jks".format(cn)
+
+    log.info("Generating keystore and truststore, task:{}".format(task))
+    output = sdk_cmd.task_exec(task, "curl -L -k -v leader.mesos/ca/dcos-ca.crt -o dcos-ca.crt")
+
+    # Convert to a PKCS12 key
+    output = sdk_cmd.task_exec(
+        task,
+        'bash -c "export RANDFILE=/mnt/mesos/sandbox/.rnd && '
+        'openssl pkcs12 -export -in {} -inkey {} '
+        '-out keypair.p12 -name keypair -passout pass:export '
+        '-CAfile dcos-ca.crt -caname root"'.format(pub_path, priv_path))
+    log.info(output)
+    assert output[0] is 0
+
+    log.info("Generating certificate: importing into keystore and truststore")
+    # Import into the keystore and truststore
+    output = sdk_cmd.task_exec(
+        task,
+        "keytool -importkeystore "
+        "-deststorepass changeit -destkeypass changeit -destkeystore {} "
+        "-srckeystore keypair.p12 -srcstoretype PKCS12 -srcstorepass export "
+        "-alias keypair".format(keystore_path))
+    log.info(output)
+    assert output[0] is 0
+
+    output = sdk_cmd.task_exec(
+        task,
+        "keytool -import -trustcacerts -noprompt "
+        "-file dcos-ca.crt -storepass changeit "
+        "-keystore {}".format(truststore_path))
+    log.info(output)
+    assert output[0] is 0

--- a/frameworks/hdfs/tests/test_ssl_kerberos_auth.py
+++ b/frameworks/hdfs/tests/test_ssl_kerberos_auth.py
@@ -195,7 +195,7 @@ def test_verify_https_ports(hdfs_client, node_type, port):
 def test_user_can_auth_and_write_and_read(hdfs_client, kerberos):
     sdk_auth.kinit(hdfs_client["id"], keytab=config.KEYTAB, principal=kerberos.get_principal("hdfs"))
 
-    test_filename = "test_auth_write_read-{}".format(str(uuid.uuid4))
+    test_filename = "test_auth_write_read-{}".format(str(uuid.uuid4()))
     write_cmd = "/bin/bash -c '{}'".format(config.hdfs_write_command(config.TEST_CONTENT_SMALL, test_filename))
     sdk_cmd.task_exec(hdfs_client["id"], write_cmd)
 
@@ -223,7 +223,7 @@ def test_users_have_appropriate_permissions(hdfs_client, kerberos):
     change_permissions_cmd = config.hdfs_command("chmod 700 /users/alice")
     sdk_cmd.task_exec(hdfs_client["id"], change_permissions_cmd)
 
-    test_filename = "test_user_permissions-{}".format(str(uuid.uuid4))
+    test_filename = "test_user_permissions-{}".format(str(uuid.uuid4()))
 
     # alice has read/write access to her directory
     sdk_auth.kdestroy(hdfs_client["id"])

--- a/frameworks/hdfs/tests/test_ssl_kerberos_auth.py
+++ b/frameworks/hdfs/tests/test_ssl_kerberos_auth.py
@@ -26,15 +26,17 @@ def service_account(configure_security):
     """
     Creates service account and yields the name.
     """
-    name = config.SERVICE_NAME
-    sdk_security.create_service_account(
-        service_account_name=name, service_account_secret=name)
-    # TODO(mh): Fine grained permissions needs to be addressed in DCOS-16475
-    sdk_cmd.run_cli(
-        "security org groups add_user superusers {name}".format(name=name))
-    yield name
-    sdk_security.delete_service_account(
-        service_account_name=name, service_account_secret=name)
+    try:
+        name = config.SERVICE_NAME
+        sdk_security.create_service_account(
+            service_account_name=name, service_account_secret=name)
+        # TODO(mh): Fine grained permissions needs to be addressed in DCOS-16475
+        sdk_cmd.run_cli(
+            "security org groups add_user superusers {name}".format(name=name))
+        yield name
+    finally:
+        sdk_security.delete_service_account(
+            service_account_name=name, service_account_secret=name)
 
 
 @pytest.fixture(scope='module', autouse=True)

--- a/frameworks/hdfs/tests/test_ssl_kerberos_auth.py
+++ b/frameworks/hdfs/tests/test_ssl_kerberos_auth.py
@@ -1,0 +1,221 @@
+import logging
+import uuid
+import pytest
+
+import sdk_auth
+import sdk_cmd
+import sdk_install
+import sdk_marathon
+import sdk_security
+import sdk_utils
+
+from tests import auth
+from tests import config
+
+
+log = logging.getLogger(__name__)
+
+
+pytestmark = pytest.mark.skipif(sdk_utils.is_open_dcos(),
+                                reason='Feature only supported in DC/OS EE')
+
+
+@pytest.fixture(scope='module', autouse=True)
+def service_account(configure_security):
+    """
+    Creates service account and yields the name.
+    """
+    name = config.SERVICE_NAME
+    sdk_security.create_service_account(
+        service_account_name=name, service_account_secret=name)
+    # TODO(mh): Fine grained permissions needs to be addressed in DCOS-16475
+    sdk_cmd.run_cli(
+        "security org groups add_user superusers {name}".format(name=name))
+    yield name
+    sdk_security.delete_service_account(
+        service_account_name=name, service_account_secret=name)
+
+
+@pytest.fixture(scope='module', autouse=True)
+def kerberos(configure_security):
+    try:
+        principals = auth.get_service_principals(config.SERVICE_NAME, sdk_auth.REALM)
+
+        kerberos_env = sdk_auth.KerberosEnvironment()
+        kerberos_env.add_principals(principals)
+        kerberos_env.finalize()
+
+        yield kerberos_env
+
+    finally:
+        kerberos_env.cleanup()
+
+
+@pytest.fixture(scope='module', autouse=True)
+def hdfs_server(kerberos, service_account):
+    """
+    A pytest fixture that installs a Kerberized HDFS service.
+
+    On teardown, the service is uninstalled.
+    """
+    service_kerberos_options = {
+        "service": {
+            "name": config.SERVICE_NAME,
+            "service_account": service_account,
+            "service_account_secret": service_account,
+            "security": {
+                "kerberos": {
+                    "enabled": True,
+                    "kdc": {
+                        "hostname": kerberos.get_host(),
+                        "port": int(kerberos.get_port())
+                    },
+                    "realm": kerberos.get_realm(),
+                    "keytab_secret": kerberos.get_keytab_path(),
+                },
+                "transport_encryption": {
+                    "enabled": True
+                }
+            }
+        },
+        "hdfs": {
+            "security_auth_to_local": auth.get_principal_to_user_mapping()
+        }
+    }
+
+    sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
+    try:
+        sdk_install.install(
+            config.PACKAGE_NAME,
+            config.SERVICE_NAME,
+            config.DEFAULT_TASK_COUNT,
+            additional_options=service_kerberos_options,
+            timeout_seconds=30 * 60)
+
+        yield {**service_kerberos_options, **{"package_name": config.PACKAGE_NAME}}
+    finally:
+        sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
+
+
+@pytest.fixture(scope='module', autouse=True)
+def hdfs_client(kerberos, hdfs_server):
+    try:
+        client_id = "hdfs-client"
+        client = {
+            "id": client_id,
+            "mem": 1024,
+            "user": "nobody",
+            "container": {
+                "type": "MESOS",
+                "docker": {
+                    "image": "nvaziri/hdfs-client:dev",
+                    "forcePullImage": True
+                },
+                "volumes": [
+                    {
+                        "containerPath": "/hadoop-2.6.0-cdh5.9.1/hdfs.keytab",
+                        "secret": "hdfs_keytab"
+                    }
+                ]
+            },
+            "secrets": {
+                "hdfs_keytab": {
+                    "source": kerberos.get_keytab_path()
+                }
+            },
+            "networks": [
+                {
+                    "mode": "host"
+                }
+            ],
+            "env": {
+                "REALM": kerberos.get_realm(),
+                "KDC_ADDRESS": kerberos.get_kdc_address(),
+                "JAVA_HOME": "/usr/lib/jvm/default-java",
+                "KRB5_CONFIG": "/etc/krb5.conf",
+                "HDFS_SERVICE_NAME": config.SERVICE_NAME,
+            }
+        }
+
+        sdk_marathon.install_app(client)
+
+        auth.write_krb5_config_file(client_id, "/etc/krb5.conf", kerberos)
+        auth.create_tls_artifacts(
+            cn="client",
+            task=client_id)
+
+        yield client
+
+    finally:
+        sdk_marathon.destroy_app(client_id)
+
+
+@pytest.mark.dcos_min_version('1.10')
+@sdk_utils.dcos_ee_only
+@pytest.mark.auth
+@pytest.mark.sanity
+def test_user_can_auth_and_write_and_read(hdfs_client, kerberos):
+    sdk_auth.kinit(hdfs_client["id"], keytab=config.KEYTAB, principal=kerberos.get_principal("hdfs"))
+
+    test_filename = "test_auth_write_read-{}".format(str(uuid.uuid4))
+    write_cmd = "/bin/bash -c '{}'".format(config.hdfs_write_command(config.TEST_CONTENT_SMALL, test_filename))
+    sdk_cmd.task_exec(hdfs_client["id"], write_cmd)
+
+    read_cmd = "/bin/bash -c '{}'".format(config.hdfs_read_command(test_filename))
+    _, stdout, _ = sdk_cmd.task_exec(hdfs_client["id"], read_cmd)
+    assert stdout == config.TEST_CONTENT_SMALL
+
+
+@pytest.mark.dcos_min_version('1.10')
+@sdk_utils.dcos_ee_only
+@pytest.mark.auth
+@pytest.mark.sanity
+def test_users_have_appropriate_permissions(hdfs_client, kerberos):
+    # "hdfs" is a superuser
+
+    sdk_auth.kinit(hdfs_client["id"], keytab=config.KEYTAB, principal=kerberos.get_principal("hdfs"))
+
+    log.info("Creating directory for alice")
+    make_user_directory_cmd = config.hdfs_command("mkdir -p /users/alice")
+    sdk_cmd.task_exec(hdfs_client["id"], make_user_directory_cmd)
+
+    change_ownership_cmd = config.hdfs_command("chown alice:users /users/alice")
+    sdk_cmd.task_exec(hdfs_client["id"], change_ownership_cmd)
+
+    change_permissions_cmd = config.hdfs_command("chmod 700 /users/alice")
+    sdk_cmd.task_exec(hdfs_client["id"], change_permissions_cmd)
+
+    test_filename = "test_user_permissions-{}".format(str(uuid.uuid4))
+
+    # alice has read/write access to her directory
+    sdk_auth.kdestroy(hdfs_client["id"])
+    sdk_auth.kinit(hdfs_client["id"], keytab=config.KEYTAB, principal=kerberos.get_principal("alice"))
+    write_access_cmd = "/bin/bash -c \"{}\"".format(config.hdfs_write_command(
+        config.TEST_CONTENT_SMALL,
+        "/users/alice/{}".format(test_filename)))
+    log.info("Alice can write: %s", write_access_cmd)
+    rc, stdout, _ = sdk_cmd.task_exec(hdfs_client["id"], write_access_cmd)
+    assert stdout == '' and rc == 0
+
+    read_access_cmd = config.hdfs_read_command("/users/alice/{}".format(test_filename))
+    log.info("Alice can read: %s", read_access_cmd)
+    _, stdout, _ = sdk_cmd.task_exec(hdfs_client["id"], read_access_cmd)
+    assert stdout == config.TEST_CONTENT_SMALL
+
+    ls_cmd = config.hdfs_command("ls /users/alice")
+    _, stdout, _ = sdk_cmd.task_exec(hdfs_client["id"], ls_cmd)
+    assert "/users/alice/{}".format(test_filename) in stdout
+
+    # bob doesn't have read/write access to alice's directory
+    sdk_auth.kdestroy(hdfs_client["id"])
+    sdk_auth.kinit(hdfs_client["id"], keytab=config.KEYTAB, principal=kerberos.get_principal("bob"))
+
+    log.info("Bob tries to wrtie to alice's directory: %s", write_access_cmd)
+    _, _, stderr = sdk_cmd.task_exec(hdfs_client["id"], write_access_cmd)
+    log.info("Bob can't write to alice's directory: %s", write_access_cmd)
+    assert "put: Permission denied: user=bob" in stderr
+
+    log.info("Bob tries to read from alice's directory: %s", read_access_cmd)
+    _, _, stderr = sdk_cmd.task_exec(hdfs_client["id"], read_access_cmd)
+    log.info("Bob can't read from alice's directory: %s", read_access_cmd)
+    assert "cat: Permission denied: user=bob" in stderr

--- a/testing/sdk_auth.py
+++ b/testing/sdk_auth.py
@@ -395,6 +395,15 @@ class KerberosEnvironment:
     def get_kdc_address(self):
         return ":".join(str(p) for p in [self.get_host(), self.get_port()])
 
+    def get_principal(self, primary: str, instance: str=None) -> str:
+
+        if instance:
+            principal = "{}/{}".format(primary, instance)
+        else:
+            principal = primary
+
+        return "{}@{}".format(principal, self.get_realm())
+
     def cleanup(self):
         sdk_security.install_enterprise_cli()
 


### PR DESCRIPTION
This PR adds a basic test for HDFS when both TLS and Kerberos are enabled.

The following basic checks are performed:
* The correct certificate is presented to the client for the `name`, `journal`, and `data` nodes (TLS test)
* Kerberos user authnz behaves as expected. 

I will follow up wit a second PR to remove some duplication for handling TLS. (See #2126)