### PR TITLE
[INFINITY-3022] Fix ZK test to wait for kicked off recovery, not in progress recovery

### DIFF
--- a/frameworks/kafka/tests/test_zookeeper.py
+++ b/frameworks/kafka/tests/test_zookeeper.py
@@ -99,7 +99,7 @@ def test_zookeeper_reresolution():
     def restart_zookeeper_node(id: int):
         sdk_cmd.svc_cli(ZK_PACKAGE, ZK_SERVICE_NAME, "pod restart zookeeper-{}".format(id))
 
-        sdk_plan.wait_for_in_progress_recovery(ZK_SERVICE_NAME)
+        sdk_plan.wait_for_kicked_off_recovery(ZK_SERVICE_NAME)
         sdk_plan.wait_for_completed_recovery(ZK_SERVICE_NAME)
 
     # Restart each zookeeper node, so that each one receives a new IP address


### PR DESCRIPTION
Sometimes this test gets stuck like this:

```
recovery STARTING:
- zookeeper-0:[metrics, server] STARTING: zookeeper-0:[metrics, server]=STARTING
[2018-01-24 09:20:47,693|sdk_cmd|INFO]: Got 202 for GET /service/kafka-zookeeper/v1/plans/recovery
[2018-01-24 09:20:47,694|sdk_plan|INFO]: Waiting for recovery plan to have IN_PROGRESS status:
recovery STARTING:
- zookeeper-0:[metrics, server] STARTING: zookeeper-0:[metrics, server]=STARTING
[2018-01-24 09:20:48,714|sdk_cmd|INFO]: Got 202 for GET /service/kafka-zookeeper/v1/plans/recovery
[2018-01-24 09:20:48,714|sdk_plan|INFO]: Waiting for recovery plan to have IN_PROGRESS status:
...
```
It's waiting for `IN_PROGRESS`, but `STARTING` should be good enough.  We already have a test method for that.