### PR TITLE
INFINITY-3025: Increase namenode readiness check timeout

### DIFF
--- a/frameworks/hdfs/src/main/dist/svc.yml
+++ b/frameworks/hdfs/src/main/dist/svc.yml
@@ -206,7 +206,7 @@ pods:
             ./{{TASKCFG_ALL_HDFS_VERSION}}/bin/hdfs haadmin -getServiceState $TASK_NAME
           interval: 5
           delay: 0
-          timeout: 60
+          timeout: 180
         configs:
           {{#SECURITY_KERBEROS_ENABLED}}
           krb5-conf:


### PR DESCRIPTION
A deployment failure in CI appeared to be because the readiness check expired before the name node could finish starting. More diagnosis would depend on INFINITY-2998 (fetching executor logs)