### PR TITLE
INFINITY-3034 Fix azure backup parameters

### DIFF
--- a/frameworks/cassandra/tests/test_backup_and_restore.py
+++ b/frameworks/cassandra/tests/test_backup_and_restore.py
@@ -52,9 +52,9 @@ def test_backup_and_restore_to_azure():
     if not client_id:
         assert False, 'Azure credentials are required for this test. Disable test with e.g. TEST_TYPES="sanity and not azure"'
     plan_parameters = {
-        'AZURE_CLIENT_ID': client_id,
-        'AZURE_CLIENT_SECRET': os.getenv('AZURE_CLIENT_SECRET'),
-        'AZURE_TENANT_ID': os.getenv('AZURE_TENANT_ID'),
+        'CLIENT_ID': client_id,
+        'CLIENT_SECRET': os.getenv('AZURE_CLIENT_SECRET'),
+        'TENANT_ID': os.getenv('AZURE_TENANT_ID'),
         'AZURE_STORAGE_ACCOUNT': os.getenv('AZURE_STORAGE_ACCOUNT'),
         'AZURE_STORAGE_KEY': os.getenv('AZURE_STORAGE_KEY'),
         'CONTAINER_NAME': os.getenv('CONTAINER_NAME', 'cassandra-test'),


### PR DESCRIPTION
Not clear how this could have been passing before, but it's failing now! Remove AZURE_ prefix from some parameters per [documentation](https://mesosphere.github.io/dcos-commons/services/cassandra/disaster-recovery.html) and svc.yml content.