### PR TITLE
[KAF-398] Disable vips when kerberos enabled

### DIFF
--- a/frameworks/kafka/docs/limitations.md
+++ b/frameworks/kafka/docs/limitations.md
@@ -1,6 +1,6 @@
 ---
 layout: layout.pug
-navigationTitle: 
+navigationTitle:
 excerpt:
 title: Limitations
 menuWeight: 100
@@ -13,7 +13,9 @@ The "disk" configuration value is denominated in MB. We recommend you set the co
 
 ## Security
 
-The security features introduced in Apache Kafka 0.9 are not supported at this time.
+### Kerberos
+
+When Kerberos is enabled, the broker vip is disabled as it will not function correctly.
 
 ## Out-of-band configuration
 

--- a/frameworks/kafka/docs/limitations.md
+++ b/frameworks/kafka/docs/limitations.md
@@ -15,7 +15,7 @@ The "disk" configuration value is denominated in MB. We recommend you set the co
 
 ### Kerberos
 
-When Kerberos is enabled, the broker vip is disabled as it will not function correctly.
+When Kerberos is enabled, the broker VIP is disabled as Kerberized clients will not be able to use it. This is because each Kafka broker uses a specific Kerberos principal and cannot accept connections from a single unified principal which the VIP would require.
 
 ## Out-of-band configuration
 

--- a/frameworks/kafka/src/main/dist/svc.yml
+++ b/frameworks/kafka/src/main/dist/svc.yml
@@ -38,9 +38,11 @@ pods:
             port: {{BROKER_PORT}}
             env-key: KAFKA_BROKER_PORT
             advertise: true
+            {{^TASKCFG_ALL_SECURITY_KERBEROS_ENABLED}}
             vip:
               prefix: broker
               port: 9092
+            {{/TASKCFG_ALL_SECURITY_KERBEROS_ENABLED}}
           {{/TASKCFG_ALL_SECURITY_TRANSPORT_ENCRYPTION_ENABLED}}
           {{#TASKCFG_ALL_SECURITY_TRANSPORT_ENCRYPTION_ENABLED}}
           {{#TASKCFG_ALL_SECURITY_TRANSPORT_ENCRYPTION_ALLOW_PLAINTEXT}}
@@ -48,17 +50,21 @@ pods:
             port: {{BROKER_PORT}}
             env-key: KAFKA_BROKER_PORT
             advertise: true
+            {{^TASKCFG_ALL_SECURITY_KERBEROS_ENABLED}}
             vip:
               prefix: broker
               port: 9092
+            {{/TASKCFG_ALL_SECURITY_KERBEROS_ENABLED}}
           {{/TASKCFG_ALL_SECURITY_TRANSPORT_ENCRYPTION_ALLOW_PLAINTEXT}}
           broker-tls:
             port: {{BROKER_PORT_TLS}}
             env-key: KAFKA_BROKER_PORT_TLS
             advertise: true
+            {{^TASKCFG_ALL_SECURITY_KERBEROS_ENABLED}}
             vip:
               prefix: broker-tls
               port: 9093
+            {{/TASKCFG_ALL_SECURITY_KERBEROS_ENABLED}}
           {{/TASKCFG_ALL_SECURITY_TRANSPORT_ENCRYPTION_ENABLED}}
         volume:
           path: {{BROKER_DISK_PATH}}

--- a/frameworks/kafka/tests/test_kerberos_auth.py
+++ b/frameworks/kafka/tests/test_kerberos_auth.py
@@ -127,7 +127,8 @@ def kafka_client(kerberos, kafka_server):
 @sdk_utils.dcos_ee_only
 @pytest.mark.sanity
 def test_no_vip(kafka_client, kafka_server, kerberos):
-    sdk_networks.get_and_test_endpoints(kafka_server["package_name"], kafka_server["service"]["name"], "broker", 2)
+    endpoints = sdk_networks.get_and_test_endpoints(kafka_server["package_name"], kafka_server["service"]["name"], "broker", 2)
+    assert "vip" not in endpoints
 
 
 @pytest.mark.dcos_min_version('1.10')

--- a/frameworks/kafka/tests/test_kerberos_auth.py
+++ b/frameworks/kafka/tests/test_kerberos_auth.py
@@ -7,6 +7,7 @@ import sdk_cmd
 import sdk_install
 import sdk_marathon
 import sdk_utils
+import sdk_networks
 
 from tests import auth
 from tests import config
@@ -120,6 +121,13 @@ def kafka_client(kerberos, kafka_server):
 
     finally:
         sdk_marathon.destroy_app(client_id)
+
+
+@pytest.mark.dcos_min_version('1.10')
+@sdk_utils.dcos_ee_only
+@pytest.mark.sanity
+def test_no_vip(kafka_client, kafka_server, kerberos):
+    sdk_networks.get_and_test_endpoints(kafka_server["package_name"], kafka_server["service"]["name"], "broker", 2)
 
 
 @pytest.mark.dcos_min_version('1.10')


### PR DESCRIPTION
VIPs will not work with Kerberos. Disable them when Kerberos is enabled.