### PR TITLE
Avoid unnecessary construction of validator

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/validation/ValidationUtils.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/validation/ValidationUtils.java
@@ -7,15 +7,14 @@ import java.util.Set;
  * Various utilities for spec validation.
  */
 public class ValidationUtils {
+    private static final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
 
     private ValidationUtils() {
         // do not instantiate
     }
 
     public static <T> void validate(T object) {
-        ValidatorFactory validatorFactory = Validation.buildDefaultValidatorFactory();
-        Set<ConstraintViolation<T>> violations = validatorFactory.getValidator().validate(object);
-        validatorFactory.close();
+        Set<ConstraintViolation<T>> violations = validator.validate(object);
 
         if (!violations.isEmpty()) {
             throw new ConstraintViolationException(

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/RawServiceSpec.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/RawServiceSpec.java
@@ -23,14 +23,14 @@ import org.slf4j.LoggerFactory;
  * Root of the parsed YAML object model.
  */
 public class RawServiceSpec {
+    private static final Logger LOGGER = LoggerFactory.getLogger(Builder.class);
+    private static final ObjectMapper YAML_MAPPER = new ObjectMapper(new YAMLFactory());
 
     /**
      * Handles rendering of {@link RawServiceSpec}s based on the Scheduler's environment variables.
      */
     public static class Builder {
 
-        private static final Logger LOGGER = LoggerFactory.getLogger(Builder.class);
-        private static final ObjectMapper YAML_MAPPER = new ObjectMapper(new YAMLFactory());
         static {
             // If the user provides duplicate fields (e.g. 'count' twice), throw an error instead of silently dropping
             // data:


### PR DESCRIPTION
There are two changes:

1. I used `testEssentialTaskFailure` from the hello-world ServiceTest as a profiler test.  `ValidationUtils.validate` was taking significant time.  Repeated construction of the factory and validator seemed wasteful, and it was.

Before:
```
ValidationUtils.validate(Object) 1691 ms
ValidationUtils.validate(Object) 1657 ms
ValidationUtils.validate(Object) 1569 ms
Average: 1639 ms
```

After:
```
ValidationUtils.validate(Object) ValidationUtils.java 622 ms
ValidationUtils.validate(Object) ValidationUtils.java 435 ms
ValidationUtils.validate(Object) ValidationUtils.java 417 ms
Average: 491 ms
```

2. Construction of the Object mapper is expensive.  No need to do it for every RawServiceSpec.Builder construction.

I also did some tests of Cassandra start up time.  This change makes things a bit faster.

Cassandra `scheduler start time` to `first task start time`.  I performed install and update 3 times on this branch and on the `master` branch.
```
faster_validation install:
2018-01-28T11:03:14-0800 - 2018-01-28T11:03:28-0800 --> 14.0 seconds
2018-01-28T11:12:54-0800 - 2018-01-28T11:13:13-0800 --> 19.0 seconds
2018-01-28T11:15:01-0800 - 2018-01-28T11:15:20-0800 --> 19.0 seconds
                                            Average     17.3 seconds

faster_validation update:
2018-01-28T11:44:05-0800 - 2018-01-28T11:44:27-0800 --> 22.0 seconds
2018-01-28T11:45:18-0800 - 2018-01-28T11:45:41-0800 --> 23.0 seconds
2018-01-28T11:46:23-0800 - 2018-01-28T11:46:44-0800 --> 21.0 seconds
                                            Average     22.0 seconds
```
```
master install:
2018-01-28T11:19:39-0800 - 2018-01-28T11:20:02-0800 --> 23.0 seconds
2018-01-28T11:23:16-0800 - 2018-01-28T11:23:40-0800 --> 24.0 seconds
2018-01-28T11:25:24-0800 - 2018-01-28T11:25:46-0800 --> 22.0 seconds
                                            Average --> 23.0 seconds

master update:
2018-01-28T11:31:59-0800 - 2018-01-28T11:32:28-0800 --> 29.0 seconds
2018-01-28T12:00:30-0800 - 2018-01-28T12:00:58-0800 --> 28.0 seconds
2018-01-28T12:01:43-0800 - 2018-01-28T12:02:10-0800 --> 27.0 seconds
                                            Average     28.0 seconds
```
```
average install improvement --> 5.7 seconds
average update  improvement --> 6.0 seconds
```