### PR TITLE
[KAF-399] Remove existing ZK jar before moving in the new one

### DIFF
--- a/frameworks/kafka/src/main/dist/svc.yml
+++ b/frameworks/kafka/src/main/dist/svc.yml
@@ -102,6 +102,8 @@ pods:
           #
           # Additionally, we include a custom principal builder
           mv -v *statsd*.jar $MESOS_SANDBOX/{{KAFKA_VERSION_PATH}}/libs/
+          # Clean up any pre-existing zookeeper library
+          rm $MESOS_SANDBOX/{{KAFKA_VERSION_PATH}}/libs/zookeeper*.jar
           mv -v zookeeper*.jar $MESOS_SANDBOX/{{KAFKA_VERSION_PATH}}/libs/
           mv -v kafka-custom-principal-builder* $MESOS_SANDBOX/{{KAFKA_VERSION_PATH}}/libs/
 


### PR DESCRIPTION
It is nice to be able to label the custom ZK lib we inject as something different than what is already there. 

By removing the pre-existing one, we make sure we aren't simply relying on luck vis a vis the classpath.