### PR TITLE
Update Logging

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/DefaultPlanScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/DefaultPlanScheduler.java
@@ -106,7 +106,7 @@ public class DefaultPlanScheduler implements PlanScheduler {
 
         if (recommendations.isEmpty()) {
             // Log that we're not finding suitable offers, possibly due to insufficient resources.
-            logger.warn(
+            logger.error(
                     "Unable to find any offers which fulfill requirement provided by step {}: {}",
                     step.getName(), podInstanceRequirement);
             step.updateOfferStatus(Collections.emptyList());


### PR DESCRIPTION
Recommendations.isEmpty should trigger error instead of warning. 
Otherwise Instances, which cant be deployed will be ignored to easy.