### PR TITLE
[KAF-399][Backport] ensure correct zk library

### DIFF
--- a/frameworks/kafka/src/main/dist/svc.yml
+++ b/frameworks/kafka/src/main/dist/svc.yml
@@ -102,6 +102,8 @@ pods:
           #
           # Additionally, we include a custom principal builder
           mv -v *statsd*.jar $MESOS_SANDBOX/{{KAFKA_VERSION_PATH}}/libs/
+          # Clean up any pre-existing zookeeper library
+          rm $MESOS_SANDBOX/{{KAFKA_VERSION_PATH}}/libs/zookeeper*.jar
           mv -v zookeeper*.jar $MESOS_SANDBOX/{{KAFKA_VERSION_PATH}}/libs/
           mv -v kafka-custom-principal-builder* $MESOS_SANDBOX/{{KAFKA_VERSION_PATH}}/libs/
 


### PR DESCRIPTION
This is a backport of #2162 to remove existing `zookeeper-*.jar` files in the target library path so as to prevent issues when more than one ZooKeeper library exists in the class path.


