### PR TITLE
Fix zone validation and add validation to Elastic

### DIFF
--- a/frameworks/cassandra/src/main/java/com/mesosphere/sdk/cassandra/scheduler/CassandraZoneValidator.java
+++ b/frameworks/cassandra/src/main/java/com/mesosphere/sdk/cassandra/scheduler/CassandraZoneValidator.java
@@ -16,10 +16,9 @@ import java.util.*;
  */
 public class CassandraZoneValidator implements ConfigValidator<ServiceSpec> {
     static final String POD_TYPE = "node";
-    static final String TASK_NAME = "server";
 
     @Override
     public Collection<ConfigValidationError> validate(Optional<ServiceSpec> oldConfig, ServiceSpec newConfig) {
-        return ZoneValidator.validate(oldConfig, newConfig, POD_TYPE, TASK_NAME);
+        return ZoneValidator.validate(oldConfig, newConfig, POD_TYPE);
     }
 }

--- a/frameworks/elastic/src/main/java/com/mesosphere/sdk/elastic/scheduler/ElasticZoneValidator.java
+++ b/frameworks/elastic/src/main/java/com/mesosphere/sdk/elastic/scheduler/ElasticZoneValidator.java
@@ -1,0 +1,34 @@
+package com.mesosphere.sdk.elastic.scheduler;
+
+import com.mesosphere.sdk.config.validate.ConfigValidationError;
+import com.mesosphere.sdk.config.validate.ConfigValidator;
+import com.mesosphere.sdk.specification.ServiceSpec;
+import com.mesosphere.sdk.specification.validation.ZoneValidator;
+
+import java.util.Collection;
+import java.util.Optional;
+
+/**
+ * This class validates that referencing Zones in placement constraints can only support the following transitions.
+ *
+ * 1. null  --> false
+ * 2. true  --> true
+ * 3. false --> false
+ */
+public class ElasticZoneValidator implements ConfigValidator<ServiceSpec> {
+    static final String MASTER_POD_TYPE = "master";
+    static final String DATA_POD_TYPE = "data";
+    static final String INGEST_POD_TYPE = "ingest";
+    static final String COORDINATOR_POD_TYPE = "coordinator";
+
+    @Override
+    public Collection<ConfigValidationError> validate(Optional<ServiceSpec> oldConfig, ServiceSpec newConfig) {
+        return ZoneValidator.validate(
+                oldConfig,
+                newConfig,
+                MASTER_POD_TYPE,
+                DATA_POD_TYPE,
+                INGEST_POD_TYPE,
+                COORDINATOR_POD_TYPE);
+    }
+}

--- a/frameworks/elastic/src/main/java/com/mesosphere/sdk/elastic/scheduler/Main.java
+++ b/frameworks/elastic/src/main/java/com/mesosphere/sdk/elastic/scheduler/Main.java
@@ -44,6 +44,7 @@ public class Main {
         }
 
         return DefaultScheduler.newBuilder(serviceSpecGenerator.build(), schedulerConfig)
+                .setCustomConfigValidators(Arrays.asList(new ElasticZoneValidator()))
                 .setPlansFrom(rawServiceSpec);
     }
 }

--- a/frameworks/elastic/src/test/java/com/mesosphere/sdk/elastic/scheduler/ServiceTest.java
+++ b/frameworks/elastic/src/test/java/com/mesosphere/sdk/elastic/scheduler/ServiceTest.java
@@ -1,27 +1,109 @@
 package com.mesosphere.sdk.elastic.scheduler;
 
+import com.mesosphere.sdk.offer.Constants;
+import com.mesosphere.sdk.scheduler.plan.Status;
+import com.mesosphere.sdk.testing.*;
 import org.junit.Test;
 
-import com.mesosphere.sdk.testing.ServiceTestRunner;
+import java.util.ArrayList;
+import java.util.Collection;
 
 public class ServiceTest {
+    private static final String HOST_RULE = "[[\"@hostname\", \"UNIQUE\"]]";
+    private static final String MAX_PER_ZONE_RULE = "[[\"@zone\", \"MAX_PER\", \"3\"]]";
+    private static final String GROUP_BY_ZONE_RULE = "[[\"@zone\", \"GROUP_BY\", \"3\"]]";
 
     @Test
     public void testSpec() throws Exception {
+        getDefaultRunner().run();
+    }
+
+    @Test
+    public void rejectRackEnablement() throws Exception {
+        rejectRackEnablement("MASTER_NODE_PLACEMENT");
+        rejectRackEnablement("DATA_NODE_PLACEMENT");
+        rejectRackEnablement("INGEST_NODE_PLACEMENT");
+        rejectRackEnablement("COORDINATOR_NODE_PLACEMENT");
+    }
+
+    @Test
+    public void rejectRackDisablement() throws Exception {
+        rejectRackDisablement("MASTER_NODE_PLACEMENT");
+        rejectRackDisablement("DATA_NODE_PLACEMENT");
+        rejectRackDisablement("INGEST_NODE_PLACEMENT");
+        rejectRackDisablement("COORDINATOR_NODE_PLACEMENT");
+    }
+
+    @Test
+    public void allowRackChanges() throws Exception {
+        allowRackChanges("MASTER_NODE_PLACEMENT");
+        allowRackChanges("DATA_NODE_PLACEMENT");
+        allowRackChanges("INGEST_NODE_PLACEMENT");
+        allowRackChanges("COORDINATOR_NODE_PLACEMENT");
+    }
+
+    private void allowRackChanges(String placementEnvKey) throws Exception {
+        validateZoneTransition(placementEnvKey, MAX_PER_ZONE_RULE, GROUP_BY_ZONE_RULE, Status.IN_PROGRESS);
+    }
+
+    private void rejectRackEnablement(String placementEnvKey) throws Exception {
+        validateZoneTransition(placementEnvKey, HOST_RULE, GROUP_BY_ZONE_RULE, Status.ERROR);
+    }
+
+    private void rejectRackDisablement(String placementEnvKey) throws Exception {
+        validateZoneTransition(placementEnvKey, GROUP_BY_ZONE_RULE, HOST_RULE, Status.ERROR);
+    }
+
+    private void validateZoneTransition(
+            String placementEnvKey,
+            String originalPlacement,
+            String newPlacement,
+            Status expectedStatus) throws Exception {
+
+        ServiceTestResult result = getDefaultRunner()
+                .setSchedulerEnv(placementEnvKey, originalPlacement)
+                .run();
+
+        Collection<SimulationTick> ticks = new ArrayList<>();
+        ticks.add(Send.register());
+        ticks.add(Expect.planStatus(Constants.DEPLOY_PLAN_NAME, expectedStatus));
+
+        getDefaultRunner()
+                .setSchedulerEnv(placementEnvKey, newPlacement)
+                .setCustomValidators(new ElasticZoneValidator())
+                .setState(result)
+                .run(ticks);
+
+    }
+
+    private ServiceTestRunner getDefaultRunner() {
         // `CLUSTER_NAME` and `CUSTOM_YAML_BLOCK` are set in our Main.java.
         // `ZONE` is set during offer evaluation.
         // `elastic-version` and `support-diagnostics-version` would normally be provided via elastic's
         // build.sh/versions.sh.
-        new ServiceTestRunner()
-                .setPodEnv("master", "CLUSTER_NAME", "cluster-foo", "CUSTOM_YAML_BLOCK", "some.thing=true",
-                           "ZONE", "us-east-1a")
-                .setPodEnv("data", "CLUSTER_NAME", "cluster-foo", "CUSTOM_YAML_BLOCK", "some.thing=true",
-                           "ZONE", "us-east-1a")
-                .setPodEnv("ingest", "CLUSTER_NAME", "cluster-foo", "CUSTOM_YAML_BLOCK", "some.thing=true",
-                           "ZONE", "us-east-1a")
-                .setPodEnv("coordinator", "CLUSTER_NAME", "cluster-foo", "CUSTOM_YAML_BLOCK", "some.thing=true",
-                           "ZONE", "us-east-1a")
-                .setBuildTemplateParams("elastic-version", "1.2.3", "support-diagnostics-version", "4.5.6")
-                .run();
+        return new ServiceTestRunner()
+                .setPodEnv(
+                        "master", "CLUSTER_NAME",
+                        "cluster-foo", "CUSTOM_YAML_BLOCK",
+                        "some.thing=true",
+                        "ZONE", "us-east-1a")
+                .setPodEnv(
+                        "data", "CLUSTER_NAME",
+                        "cluster-foo", "CUSTOM_YAML_BLOCK",
+                        "some.thing=true",
+                        "ZONE", "us-east-1a")
+                .setPodEnv(
+                        "ingest", "CLUSTER_NAME",
+                        "cluster-foo", "CUSTOM_YAML_BLOCK",
+                        "some.thing=true",
+                        "ZONE", "us-east-1a")
+                .setPodEnv(
+                        "coordinator", "CLUSTER_NAME",
+                        "cluster-foo", "CUSTOM_YAML_BLOCK",
+                        "some.thing=true",
+                        "ZONE", "us-east-1a")
+                .setBuildTemplateParams(
+                        "elastic-version", "1.2.3",
+                        "support-diagnostics-version", "4.5.6");
     }
 }

--- a/frameworks/hdfs/src/main/java/com/mesosphere/sdk/hdfs/scheduler/HDFSZoneValidator.java
+++ b/frameworks/hdfs/src/main/java/com/mesosphere/sdk/hdfs/scheduler/HDFSZoneValidator.java
@@ -5,7 +5,6 @@ import com.mesosphere.sdk.config.validate.ConfigValidator;
 import com.mesosphere.sdk.specification.ServiceSpec;
 import com.mesosphere.sdk.specification.validation.ZoneValidator;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Optional;
 
@@ -20,16 +19,9 @@ public class HDFSZoneValidator implements ConfigValidator<ServiceSpec> {
     static final String NAME_POD_TYPE = "name";
     static final String JOURNAL_POD_TYPE = "journal";
     static final String DATA_POD_TYPE = "data";
-    static final String TASK_NAME = "node";
 
     @Override
     public Collection<ConfigValidationError> validate(Optional<ServiceSpec> oldConfig, ServiceSpec newConfig) {
-        Collection<ConfigValidationError> errors = new ArrayList<>();
-
-        errors.addAll(ZoneValidator.validate(oldConfig, newConfig, NAME_POD_TYPE, TASK_NAME));
-        errors.addAll(ZoneValidator.validate(oldConfig, newConfig, JOURNAL_POD_TYPE, TASK_NAME));
-        errors.addAll(ZoneValidator.validate(oldConfig, newConfig, DATA_POD_TYPE, TASK_NAME));
-
-        return errors;
+        return ZoneValidator.validate(oldConfig, newConfig,  NAME_POD_TYPE, JOURNAL_POD_TYPE, DATA_POD_TYPE);
     }
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/validation/ZoneValidator.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/validation/ZoneValidator.java
@@ -1,12 +1,13 @@
 package com.mesosphere.sdk.specification.validation;
 
 import com.mesosphere.sdk.config.validate.ConfigValidationError;
-import com.mesosphere.sdk.offer.TaskUtils;
-import com.mesosphere.sdk.offer.taskdata.EnvConstants;
+import com.mesosphere.sdk.offer.evaluate.placement.PlacementRule;
+import com.mesosphere.sdk.offer.evaluate.placement.PlacementUtils;
+import com.mesosphere.sdk.specification.PodSpec;
 import com.mesosphere.sdk.specification.ServiceSpec;
-import com.mesosphere.sdk.specification.TaskSpec;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * This class validates that referencing Zones in placement constraints can only support the following transitions.
@@ -16,56 +17,54 @@ import java.util.*;
  * 3. false --> false
  */
 public class ZoneValidator {
-
     public static Collection<ConfigValidationError> validate(
             Optional<ServiceSpec> oldConfig,
             ServiceSpec newConfig,
-            String podType,
-            String taskName) {
+            String... podTypes) {
+        return Arrays.asList(podTypes).stream()
+                .flatMap(p -> validate(oldConfig, newConfig, p).stream())
+                .collect(Collectors.toList());
+    }
+
+    private static Collection<ConfigValidationError> validate(
+            Optional<ServiceSpec> oldConfig,
+            ServiceSpec newConfig,
+            String podType) {
         if (!oldConfig.isPresent()) {
             return Collections.emptyList();
         }
 
-        Optional<TaskSpec> oldTask = TaskUtils.getTaskSpec(oldConfig.get(), podType, taskName);
-        if (!oldTask.isPresent()) {
+        Optional<PodSpec> oldPod = getPodSpec(oldConfig.get(), podType);
+        if (!oldPod.isPresent()) {
             // Maybe the pod or task was renamed? Lets avoid enforcing whether those are rename- able and assume it's OK
             return Collections.emptyList();
         }
 
-        Optional<TaskSpec> newTask = TaskUtils.getTaskSpec(newConfig, podType, taskName);
-        if (!newTask.isPresent()) {
-            throw new IllegalArgumentException(String.format("Unable to find requested pod=%s, task=%s in config: %s",
-                    podType, taskName, newConfig));
+        Optional<PodSpec> newPod = getPodSpec(newConfig, podType);
+        if (!newPod.isPresent()) {
+            throw new IllegalArgumentException(String.format("Unable to find requested pod=%s, in config: %s",
+                    podType, newConfig));
         }
 
-        String oldEnv = oldTask.get()
-                .getCommand().get()
-                .getEnvironment()
-                .get(EnvConstants.PLACEMENT_REFERENCED_ZONE_ENV);
-        String newEnv = newTask.get()
-                .getCommand().get()
-                .getEnvironment()
-                .get(EnvConstants.PLACEMENT_REFERENCED_ZONE_ENV);
+        boolean oldReferencesZones = PlacementUtils.placementRuleReferencesZone(oldPod.get());
+        boolean newReferencesZones = PlacementUtils.placementRuleReferencesZone(newPod.get());
 
-        return validateTransition(oldEnv, newEnv, podType, taskName);
-    }
-
-    static List<ConfigValidationError> validateTransition(
-            String oldEnv, String newEnv, String podType, String taskName) {
-        boolean oldZones = Boolean.valueOf(oldEnv);
-        boolean newZones = Boolean.valueOf(newEnv);
-
-        ConfigValidationError error = ConfigValidationError.transitionError(
-                String.format("%s.%s.env.%s", podType, taskName, EnvConstants.PLACEMENT_REFERENCED_ZONE_ENV),
-                oldEnv, newEnv,
-                String.format(
-                        "Env value %s cannot change from %s to %s",
-                        EnvConstants.PLACEMENT_REFERENCED_ZONE_ENV, oldEnv, newEnv));
-
-        if (oldZones != newZones) {
+        if (oldReferencesZones != newReferencesZones) {
+            Optional<PlacementRule> oldRule = oldPod.get().getPlacementRule();
+            Optional<PlacementRule> newRule = newPod.get().getPlacementRule();
+            ConfigValidationError error = ConfigValidationError.transitionError(
+                    String.format("%s.PlacementRule", podType),
+                    oldRule.toString(), newRule.toString(),
+                    String.format("PlacementRule cannot change from %s to %s", oldRule, newRule));
             return Arrays.asList(error);
         }
 
         return Collections.emptyList();
+    }
+
+    private static Optional<PodSpec> getPodSpec(ServiceSpec serviceSpecification, String podType) {
+        return serviceSpecification.getPods().stream()
+                .filter(pod -> pod.getType().equals(podType))
+                .findFirst();
     }
 }

--- a/sdk/testing/src/main/java/com/mesosphere/sdk/testing/Expect.java
+++ b/sdk/testing/src/main/java/com/mesosphere/sdk/testing/Expect.java
@@ -310,6 +310,23 @@ public interface Expect extends SimulationTick {
         };
     }
 
+    public static Expect planStatus(String planName, Status status) {
+        return new Expect() {
+            @Override
+            public void expect(ClusterState state, SchedulerDriver mockDriver) throws AssertionError {
+                Plan plan = state.getPlans().stream()
+                        .filter(p -> p.getName().equals(planName))
+                        .findFirst().get();
+                Assert.assertEquals(status, plan.getStatus());
+            }
+
+            @Override
+            public String getDescription() {
+                return String.format("Plan %s has status %s", planName, status);
+            }
+        };
+    }
+
     /**
      * Verifies that the indicated recovery phase.step has the expected status.
      */

--- a/sdk/testing/src/main/java/com/mesosphere/sdk/testing/ServiceTestRunner.java
+++ b/sdk/testing/src/main/java/com/mesosphere/sdk/testing/ServiceTestRunner.java
@@ -1,5 +1,6 @@
 package com.mesosphere.sdk.testing;
 
+import com.mesosphere.sdk.config.validate.ConfigValidator;
 import com.mesosphere.sdk.dcos.Capabilities;
 import com.mesosphere.sdk.offer.evaluate.PodInfoBuilder;
 import com.mesosphere.sdk.scheduler.AbstractScheduler;
@@ -54,6 +55,7 @@ public class ServiceTestRunner {
     private final Map<String, Map<String, String>> customPodEnvs = new HashMap<>();
     private RecoveryPlanOverriderFactory recoveryManagerFactory;
     private boolean supportsDefaultExecutor = true;
+    private List<ConfigValidator<ServiceSpec>> validators = Collections.emptyList();
 
     /**
      * Returns a {@link File} object for the service's {@code src/main/dist} directory. Does not check if the directory
@@ -239,6 +241,11 @@ public class ServiceTestRunner {
         return this;
     }
 
+    public ServiceTestRunner setCustomValidators(ConfigValidator<ServiceSpec>... validators) {
+        this.validators = Arrays.asList(validators);
+        return this;
+    }
+
     /**
      * Simulates DC/OS 1.9 behavior of using a custom executor instead of the default executor.
      *
@@ -308,6 +315,7 @@ public class ServiceTestRunner {
                 .setConfigStore(new ConfigStore<>(DefaultServiceSpec.getConfigurationFactory(serviceSpec), persister))
                 .setPlansFrom(rawServiceSpec)
                 .setRecoveryManagerFactory(recoveryManagerFactory)
+                .setCustomConfigValidators(validators)
                 .build()
                 .disableThreading()
                 .disableApiServer();


### PR DESCRIPTION
I was originally just supposed to be adding zone transition validation to Elastic.  While writing a test validating it worked I found out Zone Validation is broken everywhere.

So this PR:
1. Fixes Zone validation
1. Adds it to Elastic
1. Fixes bad original zone validation tests (they shouldn't reference tasks at all)

I'll add more PRs for more extensive testing of Cassandra and HDFS which already had validation turned on.

I have validated manually that C* and Elastic now act as they're supposed to. 