### PR TITLE
[INFINITY-3065] Make hello-world test more resilient to unexpected failures

### DIFF
--- a/frameworks/helloworld/tests/test_sidecar.py
+++ b/frameworks/helloworld/tests/test_sidecar.py
@@ -84,11 +84,11 @@ def wait_for_toxic_sidecar():
 def test_toxic_sidecar_doesnt_trigger_recovery():
     # 1. Run the toxic sidecar plan that will never succeed.
     # 2. Restart the scheduler.
-    # 3. Verify that its recovery plan is empty, as a failed ONCE task should
+    # 3. Verify that its recovery plan has not changed, as a failed ONCE task should
     # never trigger recovery
-    recovery_plan = sdk_plan.get_plan(config.SERVICE_NAME, 'recovery')
-    assert(len(recovery_plan['phases']) == 0)
-    log.info(recovery_plan)
+    initial_recovery_plan = sdk_plan.get_plan(config.SERVICE_NAME, 'recovery')
+    assert(initial_recovery_plan['status'] == "COMPLETE")
+    log.info(initial_recovery_plan)
     sdk_plan.start_plan(config.SERVICE_NAME, 'sidecar-toxic')
     wait_for_toxic_sidecar()
 
@@ -96,10 +96,9 @@ def test_toxic_sidecar_doesnt_trigger_recovery():
     sdk_marathon.restart_app(config.SERVICE_NAME)
     sdk_plan.wait_for_completed_deployment(config.SERVICE_NAME)
 
-    # Now, verify that its recovery plan is empty.
-    sdk_plan.wait_for_completed_plan(config.SERVICE_NAME, 'recovery')
-    recovery_plan = sdk_plan.get_plan(config.SERVICE_NAME, 'recovery')
-    assert(len(recovery_plan['phases']) == 0)
+    # Now, verify that its recovery plan hasn't changed.
+    final_recovery_plan = sdk_plan.get_plan(config.SERVICE_NAME, 'recovery')
+    assert(initial_recovery_plan['status'] == final_recovery_plan['status'])
 
 
 def run_plan(plan_name, params=None):


### PR DESCRIPTION
Unexpected failures such as
```
2018-01-31 03:43:10: E0131 03:43:10.656471 8137 fetcher.cpp:600] EXIT with status 1: Failed to fetch 'https://infinity-artifacts-ci.s3.amazonaws.com/autodelete7d/hello-world/20180131-014315-YPFWH5iTn8Bmw85E/executor.zip': Error downloading resource, received HTTP return code 500
2018-01-31 03:43:10: End fetcher log for container cd517841-d8f2-4f3b-8550-758e295ea620.04393fc7-4d95-4d59-a9a0-83bd5d94f5fd
2018-01-31 03:43:10: E0131 03:43:10.756141 4011 fetcher.cpp:568] Failed to run mesos-fetcher: Failed to fetch all URIs for container 'cd517841-d8f2-4f3b-8550-758e295ea620.04393fc7-4d95-4d59-a9a0-83bd5d94f5fd': exited with status 1
```
aren't expected in the current implementation of this test. _Any_ failure can throw off the test even if the failure is not relevant to the functionality being tested in this test.

This makes sure the test is not concerned about external failures that have been recorded in the state of the service.