### PR TITLE
Add environment variable to opt out of log collection

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -39,13 +39,9 @@ log = logging.getLogger(__name__)
 
 # The following environment variable allows for log collection to be turned off.
 # This is useful, for exampl in testing.
-INTEGRATION_TEST_LOG_COLLECTION = True
-try:
-    INTEGRATION_TEST_LOG_COLLECTION = bool(os.environ.get('INTEGRATION_TEST_LOG_COLLECTION', True))
-except Exception as e:
-    log.warning("Error setting or converting INTEGRATION_TEST_LOG_COLLECTION from %s\n%s",
-                os.environ.get('INTEGRATION_TEST_LOG_COLLECTION', True),
-                e)
+INTEGRATION_TEST_LOG_COLLECTION = str(
+    os.environ.get('INTEGRATION_TEST_LOG_COLLECTION', "True")
+).lower() in ["true", "1"]
 
 
 @pytest.hookimpl(tryfirst=True, hookwrapper=True)

--- a/conftest.py
+++ b/conftest.py
@@ -39,11 +39,17 @@ log = logging.getLogger(__name__)
 
 # The following environment variable allows for log collection to be turned off.
 # This is useful, for exampl in testing.
-INTEGRATION_TEST__SKIP_LOG_COLLECTION = os.environ.get('INTEGRATION_TEST__SKIP_LOG_COLLECTION', False)
+INTEGRATION_TEST_LOG_COLLECTION = True
+try:
+    INTEGRATION_TEST_LOG_COLLECTION = bool(os.environ.get('INTEGRATION_TEST_LOG_COLLECTION', True))
+except Exception as e:
+    log.warning("Error setting or converting INTEGRATION_TEST_LOG_COLLECTION from %s\n%s",
+                os.environ.get('INTEGRATION_TEST_LOG_COLLECTION', True),
+                e)
 
 
 @pytest.hookimpl(tryfirst=True, hookwrapper=True)
-def pytest_runtest_makereport(item: pytest.Item, call): # _pytest.runner.CallInfo
+def pytest_runtest_makereport(item: pytest.Item, call):  # _pytest.runner.CallInfo
     '''Hook to run after every test, before any other post-test hooks.
     See also: https://docs.pytest.org/en/latest/example/simple.html\
     #making-test-result-information-available-in-fixtures
@@ -54,10 +60,10 @@ def pytest_runtest_makereport(item: pytest.Item, call): # _pytest.runner.CallInf
 
     # Handle failures. Must be done here and not in a fixture in order to
     # properly handle post-yield fixture teardown failures.
-    if not INTEGRATION_TEST__SKIP_LOG_COLLECTION:
+    if INTEGRATION_TEST_LOG_COLLECTION:
         sdk_diag.handle_test_report(item, outcome.get_result())
     else:
-        print("INTEGRATION_TEST__SKIP_LOG_COLLECTION=True. Skipping log collection")
+        print("INTEGRATION_TEST_LOG_COLLECTION==False. Skipping log collection")
 
 
 def pytest_runtest_teardown(item: pytest.Item):
@@ -81,6 +87,6 @@ def pytest_runtest_setup(item: pytest.Item):
 ======= START: {}::{}
 =========='''.format(sdk_diag.get_test_suite_name(item), item.name))
 
-    if not INTEGRATION_TEST__SKIP_LOG_COLLECTION:
+    if INTEGRATION_TEST_LOG_COLLECTION:
         sdk_diag.handle_test_setup(item)
     sdk_utils.check_dcos_min_version_mark(item)


### PR DESCRIPTION
This PR adds an `INTEGRATION_TEST__SKIP_LOG_COLLECTION` which disables log collection. This can be quite verbose locally.

We would want to backport this too.