### PR TITLE
[INFINITY-3063] Document valid zone transitions for rack-aware schedulers

### DIFF
--- a/docs/pages/ops-guide/overview.md
+++ b/docs/pages/ops-guide/overview.md
@@ -352,6 +352,20 @@ Placement constraints can be applied to zones by referring to the `@zone` key. F
 
 When the region awareness feature is enabled (currently in beta), the `@region` key can also be referenced for defining placement constraints. Any placement constraints that do not reference the `@region` key are constrained to the local region.
 
+#### Rack aware services
+
+Many rack aware services do not support reliable migration between rack-aware and non-rack-aware operation.  These services can choose to restrict the set of placement constraint transitions which are valid through use of the `ZoneValidator`.  The allowed placement constraint transitions when using the `ZoneValidator` are as follows:
+```
+Placement Constraint References Zones
+
+| Original Constraint | New Constraint |
+|---------------------|----------------|
+| None                | False          |
+| False               | False          |
+| True                | True           |
+|                     |                |
+```
+
 ### Updating placement constraints
 
 Clusters change, and as such so should your placement constraints. We recommend using the following procedure to do this:

--- a/docs/pages/ops-guide/overview.md
+++ b/docs/pages/ops-guide/overview.md
@@ -355,16 +355,14 @@ When the region awareness feature is enabled (currently in beta), the `@region` 
 #### Rack aware services
 
 Many rack aware services do not support reliable migration between rack-aware and non-rack-aware operation.  These services can choose to restrict the set of placement constraint transitions which are valid through use of the `ZoneValidator`.  The allowed placement constraint transitions when using the `ZoneValidator` are as follows:
-```
-Placement Constraint References Zones
 
+#####Placement Constraint References Zones
 | Original Constraint | New Constraint |
 |---------------------|----------------|
 | None                | False          |
 | False               | False          |
 | True                | True           |
 |                     |                |
-```
 
 ### Updating placement constraints
 

--- a/docs/pages/ops-guide/overview.md
+++ b/docs/pages/ops-guide/overview.md
@@ -357,6 +357,7 @@ When the region awareness feature is enabled (currently in beta), the `@region` 
 Many rack aware services do not support reliable migration between rack-aware and non-rack-aware operation.  These services can choose to restrict the set of placement constraint transitions which are valid through use of the `ZoneValidator`.  The allowed placement constraint transitions when using the `ZoneValidator` are as follows:
 
 #####Placement Constraint References Zones
+
 | Original Constraint | New Constraint |
 |---------------------|----------------|
 | None                | False          |

--- a/docs/pages/ops-guide/overview.md
+++ b/docs/pages/ops-guide/overview.md
@@ -356,7 +356,7 @@ When the region awareness feature is enabled (currently in beta), the `@region` 
 
 Many rack aware services do not support reliable migration between rack-aware and non-rack-aware operation.  These services can choose to restrict the set of placement constraint transitions which are valid through use of the `ZoneValidator`.  The allowed placement constraint transitions when using the `ZoneValidator` are as follows:
 
-#####Placement Constraint References Zones
+##### Placement Constraint References Zones
 
 | Original Constraint | New Constraint |
 |---------------------|----------------|


### PR DESCRIPTION
After this is merged and released to the [docs site](https://docs.mesosphere.com/services/ops-guide/overview/), we can add references to it from the individual service docs.
