### PR TITLE
[INFINITY-3076] Fix uninstall documentation link in hello-world postUninstallNotes.

### DIFF
--- a/frameworks/helloworld/universe/package.json
+++ b/frameworks/helloworld/universe/package.json
@@ -12,5 +12,5 @@
   "tags": ["example", "reference", "hello-world"],
   "preInstallNotes": "This DC/OS Service is currently in preview.",
   "postInstallNotes": "The DC/OS hello-world service is being installed!\n\n\tDocumentation: {{documentation-path}}\n\tIssues: {{issues-path}}",
-  "postUninstallNotes": "The DC/OS hello-world service is being uninstalled.\n\nFor DC/OS versions from 1.10 no further action is required. For older DC/OS versions follow the instructions at https://docs.mesosphere.com/deploying-services/uninstall/#framework-cleaner to remove any persistent state if required."
+  "postUninstallNotes": "The DC/OS hello-world service is being uninstalled.\n\nFor DC/OS versions from 1.10 no further action is required. For older DC/OS versions follow the instructions at https://docs.mesosphere.com/1.9/deploying-services/uninstall/#framework-cleaner to remove any persistent state if required."
 }


### PR DESCRIPTION
A quick pre-weekend fix for a hello-world documentation link that was invalid.

There is also a universe PR at mesosphere/universe#1692 to correct the link in the packages that have already been released.

