### PR TITLE
Make task killing more reliable

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/TaskCleaner.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/TaskCleaner.java
@@ -14,13 +14,11 @@ import java.util.stream.Collectors;
  */
 public class TaskCleaner {
     private final StateStore stateStore;
-    private final TaskKiller taskKiller;
     private final ExecutorService executorService = Executors.newCachedThreadPool();
     private final boolean multithreaded;
 
-    public TaskCleaner(StateStore stateStore, TaskKiller taskKiller, boolean multithreaded) {
+    public TaskCleaner(StateStore stateStore, boolean multithreaded) {
         this.stateStore = stateStore;
-        this.taskKiller = taskKiller;
         this.multithreaded = multithreaded;
     }
 
@@ -47,7 +45,7 @@ public class TaskCleaner {
                 .collect(Collectors.toList());
 
         if (!expectedTaskIds.contains(taskStatus.getTaskId())) {
-            taskKiller.killTask(taskStatus.getTaskId());
+            TaskKiller.killTask(taskStatus.getTaskId());
         }
     }
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/TaskKiller.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/TaskKiller.java
@@ -1,31 +1,112 @@
 package com.mesosphere.sdk.scheduler;
 
+import org.apache.mesos.Protos;
 import org.apache.mesos.Protos.TaskID;
 import org.apache.mesos.SchedulerDriver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * This class is a default implementation of the TaskKiller interface.
- */
-public class TaskKiller {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
-    private final SchedulerDriver driver;
+import java.time.Duration;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
-    public TaskKiller(SchedulerDriver driver) {
-        this.driver = driver;
+/**
+ * This class implements reliable task killing in conjunction with the {@link TaskCleaner}.  Mesos does not provide
+ * reliable task killing.  This class repeatedly attempts to kill a task until Mesos declares it has been killed or that
+ * Mesos doesn't know anything about this task.
+ */
+public final class TaskKiller {
+    private static final Logger LOGGER = LoggerFactory.getLogger(TaskKiller.class);
+
+    private static final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+    private static final Duration killInterval = Duration.ofSeconds(5);
+    private static final Set<TaskID> tasksToKill = new HashSet<>();
+
+    private static TaskKiller taskKiller = new TaskKiller();
+    private static SchedulerDriver driver;
+    private static final Object lock = new Object();
+
+    private TaskKiller() {
+        executor.scheduleAtFixedRate(
+                new Runnable() {
+                    @Override
+                    public void run() {
+                        // Don't acquire the lock here.  There's no harm killing tasks more than once
+                        // and holding a lock while accessing the driver always causes deadlocks.
+                        for (TaskID taskID : tasksToKill) {
+                            killTaskInternal(taskID);
+                        }
+                    }
+                },
+                killInterval.toMillis(),
+                killInterval.toMillis(),
+                TimeUnit.MILLISECONDS);
     }
 
-    public void killTask(TaskID taskId) {
+    public static void setDriver(SchedulerDriver schedulerDriver) {
+        driver = schedulerDriver;
+    }
+
+    /**
+     * Calling this method will cause the referenced TaskID to be reliably killed.  An attempt to kill the task will be
+     * immediately made.  Continued periodic attempts will be made to kill the task until Mesos indicates that it has
+     * killed the Task or doesn't recongize the task.
+     *
+     * This is still not a guarantee that a task has been killed.  Mesos may not know about a particular TaskID at any
+     * given time.  See the {@link TaskCleaner} for the rest of the task killing system.
+     * @param taskId the TaskID of the Task to be killed.
+     */
+    public static void killTask(TaskID taskId) {
         // In order to update a podinstance its normal to kill all tasks in a pod.
         // Sometimes a task hasn't been launched ever but it has been recorded for
         // resource reservation footprint reasons, and therefore doesn't have a TaskID yet.
         if (taskId.getValue().isEmpty()) {
-            logger.warn("Attempted to kill empty TaskID.");
+            LOGGER.warn("Attempted to kill empty TaskID.");
             return;
         }
 
-        logger.info("Killing task: {}", taskId.getValue());
-        driver.killTask(taskId);
+        synchronized (lock) {
+            LOGGER.info("Enqueueing kill of task: {}", taskId.getValue());
+            tasksToKill.add(taskId);
+        }
+
+        killTaskInternal(taskId);
+    }
+
+    public static void update(Protos.TaskStatus taskStatus) {
+        // The race here is fine.  If we check for the set containing an element
+        // then try to remove it after it's already gone there's no harm.  In return
+        // for this subtlety we avoid acquiring the lock on potentially many TaskStatus
+        // updates for tasks we don't care about killing.
+        if (isDead(taskStatus) && tasksToKill.contains(taskStatus.getTaskId())) {
+            synchronized (lock) {
+                tasksToKill.remove(taskStatus.getTaskId());
+                LOGGER.info("Completed killing: {}", taskStatus.getTaskId());
+            }
+        }
+    }
+
+    private static void killTaskInternal(TaskID taskId) {
+        if (driver != null) {
+            LOGGER.info("Killing task: {}", taskId.getValue());
+            driver.killTask(taskId);
+        } else {
+            LOGGER.warn("Driver not yet set.");
+        }
+    }
+
+    private static boolean isDead(Protos.TaskStatus taskStatus) {
+        switch (taskStatus.getState()) {
+            case TASK_KILLING:
+            case TASK_RUNNING:
+            case TASK_STAGING:
+            case TASK_STARTING:
+                return false;
+            default:
+                return true;
+        }
     }
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/decommission/DecommissionPlanFactory.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/decommission/DecommissionPlanFactory.java
@@ -23,7 +23,6 @@ import com.mesosphere.sdk.offer.Constants;
 import com.mesosphere.sdk.offer.ResourceUtils;
 import com.mesosphere.sdk.offer.TaskException;
 import com.mesosphere.sdk.offer.taskdata.TaskLabelReader;
-import com.mesosphere.sdk.scheduler.TaskKiller;
 import com.mesosphere.sdk.scheduler.plan.DefaultPhase;
 import com.mesosphere.sdk.scheduler.plan.DefaultPlan;
 import com.mesosphere.sdk.scheduler.plan.Phase;
@@ -72,8 +71,8 @@ public class DecommissionPlanFactory {
 
     private final PlanInfo planInfo;
 
-    public DecommissionPlanFactory(ServiceSpec serviceSpec, StateStore stateStore, TaskKiller taskKiller) {
-        this.planInfo = buildPlanInfo(serviceSpec, stateStore, taskKiller);
+    public DecommissionPlanFactory(ServiceSpec serviceSpec, StateStore stateStore) {
+        this.planInfo = buildPlanInfo(serviceSpec, stateStore);
     }
 
     /**
@@ -105,7 +104,7 @@ public class DecommissionPlanFactory {
     /**
      * Returns a {@link Plan} for decommissioning tasks, or an empty {@link Optional} if no decommission is necessary.
      */
-    private static PlanInfo buildPlanInfo(ServiceSpec serviceSpec, StateStore stateStore, TaskKiller taskKiller) {
+    private static PlanInfo buildPlanInfo(ServiceSpec serviceSpec, StateStore stateStore) {
         // Determine which tasks should be decommissioned (and which shouldn't)
         Collection<Protos.TaskInfo> allTasks = stateStore.fetchTasks();
         SortedMap<PodKey, Collection<Protos.TaskInfo>> podsToDecommission =
@@ -148,7 +147,7 @@ public class DecommissionPlanFactory {
 
             // 1. Kill pod's tasks
             steps.addAll(entry.getValue().stream()
-                    .map(task -> new TriggerDecommissionStep(stateStore, taskKiller, task))
+                    .map(task -> new TriggerDecommissionStep(stateStore, task))
                     .collect(Collectors.toList()));
 
             // 2. Unreserve pod's resources

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/decommission/TriggerDecommissionStep.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/decommission/TriggerDecommissionStep.java
@@ -19,13 +19,11 @@ public class TriggerDecommissionStep extends UninstallStep {
     private static final Logger LOGGER = LoggerFactory.getLogger(DecommissionPlanFactory.class);
 
     private final StateStore stateStore;
-    private final TaskKiller taskKiller;
     private final Protos.TaskInfo taskInfo;
 
-    public TriggerDecommissionStep(StateStore stateStore, TaskKiller taskKiller, Protos.TaskInfo taskInfo) {
+    public TriggerDecommissionStep(StateStore stateStore,  Protos.TaskInfo taskInfo) {
         super("kill-" + taskInfo.getName(), Status.PENDING);
         this.stateStore = stateStore;
-        this.taskKiller = taskKiller;
         this.taskInfo = taskInfo;
     }
 
@@ -34,7 +32,7 @@ public class TriggerDecommissionStep extends UninstallStep {
         LOGGER.info("Marking task for decommissioning: {}", taskInfo.getName());
         setStatus(Status.IN_PROGRESS);
         stateStore.storeGoalOverrideStatus(taskInfo.getName(), DecommissionPlanFactory.DECOMMISSIONING_STATUS);
-        taskKiller.killTask(taskInfo.getTaskId());
+        TaskKiller.killTask(taskInfo.getTaskId());
         setStatus(Status.COMPLETE);
         return getPodInstanceRequirement();
     }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/DefaultPlanScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/DefaultPlanScheduler.java
@@ -28,17 +28,14 @@ public class DefaultPlanScheduler implements PlanScheduler {
     private final OfferAccepter offerAccepter;
     private final OfferEvaluator offerEvaluator;
     private final StateStore stateStore;
-    private final TaskKiller taskKiller;
 
     public DefaultPlanScheduler(
             OfferAccepter offerAccepter,
             OfferEvaluator offerEvaluator,
-            StateStore stateStore,
-            TaskKiller taskKiller) {
+            StateStore stateStore) {
         this.offerAccepter = offerAccepter;
         this.offerEvaluator = offerEvaluator;
         this.stateStore = stateStore;
-        this.taskKiller = taskKiller;
     }
 
     @Override
@@ -165,7 +162,7 @@ public class DefaultPlanScheduler implements PlanScheduler {
                 }
 
                 if (!TaskUtils.isTerminal(state)) {
-                    taskKiller.killTask(taskInfo.getTaskId());
+                    TaskKiller.killTask(taskInfo.getTaskId());
                 }
             }
         }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/uninstall/TaskKillStep.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/uninstall/TaskKillStep.java
@@ -12,19 +12,17 @@ import java.util.Optional;
  */
 public class TaskKillStep extends UninstallStep {
 
-    private final TaskKiller taskKiller;
     private final Protos.TaskID taskID;
 
-    public TaskKillStep(Protos.TaskID taskID, TaskKiller taskKiller) {
+    public TaskKillStep(Protos.TaskID taskID) {
         super("kill-task-" + taskID.getValue(), Status.PENDING);
-        this.taskKiller = taskKiller;
         this.taskID = taskID;
     }
 
     @Override
     public Optional<PodInstanceRequirement> start() {
         setStatus(Status.IN_PROGRESS);
-        taskKiller.killTask(taskID);
+        TaskKiller.killTask(taskID);
         setStatus(Status.COMPLETE);
 
         return getPodInstanceRequirement();

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/uninstall/UninstallPlanBuilder.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/uninstall/UninstallPlanBuilder.java
@@ -19,7 +19,6 @@ import com.mesosphere.sdk.dcos.clients.SecretsClient;
 import com.mesosphere.sdk.offer.Constants;
 import com.mesosphere.sdk.offer.ResourceUtils;
 import com.mesosphere.sdk.offer.TaskUtils;
-import com.mesosphere.sdk.scheduler.TaskKiller;
 import com.mesosphere.sdk.scheduler.SchedulerConfig;
 import com.mesosphere.sdk.scheduler.plan.DefaultPhase;
 import com.mesosphere.sdk.scheduler.plan.DefaultPlan;
@@ -66,10 +65,9 @@ class UninstallPlanBuilder {
         List<Phase> phases = new ArrayList<>();
 
         // First, we kill all the tasks, so that we may release their reserved resources.
-        TaskKiller taskKiller = new TaskKiller(driver);
         List<Step> taskKillSteps = stateStore.fetchTasks().stream()
                 .map(Protos.TaskInfo::getTaskId)
-                .map(taskID -> new TaskKillStep(taskID, taskKiller))
+                .map(taskID -> new TaskKillStep(taskID))
                 .collect(Collectors.toList());
         phases.add(new DefaultPhase(TASK_KILL_PHASE, taskKillSteps, new ParallelStrategy<>(), Collections.emptyList()));
 

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/http/PodResourceTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/http/PodResourceTest.java
@@ -9,11 +9,11 @@ import com.mesosphere.sdk.state.GoalStateOverride;
 import com.mesosphere.sdk.state.StateStore;
 import com.mesosphere.sdk.testutils.TaskTestUtils;
 import com.mesosphere.sdk.testutils.TestConstants;
-
 import org.apache.mesos.Protos;
 import org.apache.mesos.Protos.TaskInfo;
 import org.apache.mesos.Protos.TaskState;
 import org.apache.mesos.Protos.TaskStatus;
+import org.apache.mesos.SchedulerDriver;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.Before;
@@ -110,17 +110,17 @@ public class PodResourceTest {
             POD_1_STATUS_B,
             POD_2_STATUS_A);
 
-    @Mock private TaskKiller mockTaskKiller;
     @Mock private StateStore mockStateStore;
     @Mock private TaskFailureListener mockTaskFailureListener;
+    @Mock private SchedulerDriver driver;
 
     private PodResource resource;
 
     @Before
-    public void beforeAll() {
+    public void beforeEach() {
         MockitoAnnotations.initMocks(this);
+        TaskKiller.setDriver(driver);
         resource = new PodResource(mockStateStore, TestConstants.SERVICE_NAME, mockTaskFailureListener);
-        resource.setTaskKiller(mockTaskKiller);
     }
 
     @Test
@@ -407,11 +407,11 @@ public class PodResourceTest {
         assertEquals("test-0-c", json.getJSONArray("tasks").get(2));
         assertEquals("test-0-d", json.getJSONArray("tasks").get(3));
 
-        verify(mockTaskKiller).killTask(POD_0_TASK_A.getTaskId());
-        verify(mockTaskKiller).killTask(POD_0_TASK_B.getTaskId());
-        verify(mockTaskKiller).killTask(POD_0_TASK_C.getTaskId());
-        verify(mockTaskKiller).killTask(POD_0_TASK_D.getTaskId());
-        verifyNoMoreInteractions(mockTaskKiller);
+        verify(driver).killTask(POD_0_TASK_A.getTaskId());
+        verify(driver).killTask(POD_0_TASK_B.getTaskId());
+        verify(driver).killTask(POD_0_TASK_C.getTaskId());
+        verify(driver).killTask(POD_0_TASK_D.getTaskId());
+        verifyNoMoreInteractions(driver);
 
         verify(mockTaskFailureListener, never()).tasksFailed(any());
     }
@@ -430,9 +430,9 @@ public class PodResourceTest {
         assertEquals("test-1-a", json.getJSONArray("tasks").get(0));
         assertEquals("test-1-b", json.getJSONArray("tasks").get(1));
 
-        verify(mockTaskKiller).killTask(POD_1_TASK_A.getTaskId());
-        verify(mockTaskKiller).killTask(POD_1_TASK_B.getTaskId());
-        verifyNoMoreInteractions(mockTaskKiller);
+        verify(driver).killTask(POD_1_TASK_A.getTaskId());
+        verify(driver).killTask(POD_1_TASK_B.getTaskId());
+        verifyNoMoreInteractions(driver);
 
         verify(mockTaskFailureListener, never()).tasksFailed(any());
     }
@@ -467,11 +467,11 @@ public class PodResourceTest {
         assertEquals(podInstanceName + "-c", json.getJSONArray("tasks").get(2));
         assertEquals(podInstanceName + "-d", json.getJSONArray("tasks").get(3));
 
-        verify(mockTaskKiller).killTask(POD_0_TASK_A.getTaskId());
-        verify(mockTaskKiller).killTask(POD_0_TASK_B.getTaskId());
-        verify(mockTaskKiller).killTask(POD_0_TASK_C.getTaskId());
-        verify(mockTaskKiller).killTask(POD_0_TASK_D.getTaskId());
-        verifyNoMoreInteractions(mockTaskKiller);
+        verify(driver).killTask(POD_0_TASK_A.getTaskId());
+        verify(driver).killTask(POD_0_TASK_B.getTaskId());
+        verify(driver).killTask(POD_0_TASK_C.getTaskId());
+        verify(driver).killTask(POD_0_TASK_D.getTaskId());
+        verifyNoMoreInteractions(driver);
 
         List<Protos.TaskInfo> expectedFailedTasks = TASK_INFOS.stream()
                 .filter(taskInfo -> taskInfo.getName().startsWith(podInstanceName))
@@ -496,9 +496,9 @@ public class PodResourceTest {
         assertEquals(podInstanceName + "-a", json.getJSONArray("tasks").get(0));
         assertEquals(podInstanceName + "-b", json.getJSONArray("tasks").get(1));
 
-        verify(mockTaskKiller).killTask(POD_1_TASK_A.getTaskId());
-        verify(mockTaskKiller).killTask(POD_1_TASK_B.getTaskId());
-        verifyNoMoreInteractions(mockTaskKiller);
+        verify(driver).killTask(POD_1_TASK_A.getTaskId());
+        verify(driver).killTask(POD_1_TASK_B.getTaskId());
+        verifyNoMoreInteractions(driver);
 
         List<Protos.TaskInfo> expectedFailedTasks = TASK_INFOS.stream()
                 .filter(taskInfo -> taskInfo.getName().startsWith(podInstanceName))

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/TaskKillerTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/TaskKillerTest.java
@@ -1,0 +1,136 @@
+package com.mesosphere.sdk.scheduler;
+
+import com.mesosphere.sdk.testutils.TestConstants;
+import org.apache.mesos.Protos;
+import org.apache.mesos.SchedulerDriver;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.mockito.Mockito.*;
+
+/**
+ * This class tests the {@link TaskKiller} class.
+ */
+public class TaskKillerTest {
+    @Mock private SchedulerDriver driver;
+
+    @BeforeClass
+    public static void beforeAll() throws InterruptedException {
+        TaskKiller.shutdownScheduling();
+    }
+
+    @AfterClass
+    public static void afterAll() {
+        TaskKiller.startScheduling();
+    }
+
+    @Before
+    public void beforeEach() throws InterruptedException {
+        MockitoAnnotations.initMocks(this);
+        TaskKiller.setDriver(null);
+    }
+
+    @Test
+    public void emptyTaskId() {
+        // Set the driver
+        TaskKiller.setDriver(driver);
+        verify(driver, never()).killTask(TestConstants.TASK_ID);
+
+        TaskKiller.killTask(Protos.TaskID.newBuilder().setValue("").build());
+        verify(driver, never()).killTask(TestConstants.TASK_ID);
+
+        TaskKiller.killAllTasks();
+        verify(driver, never()).killTask(TestConstants.TASK_ID);
+    }
+
+    @Test
+    public void delayedDriverSet() throws InterruptedException {
+        // Enqueue a task to kill, but it shouldn't be killed since no driver exists
+        TaskKiller.killTask(TestConstants.TASK_ID);
+
+        // Set the driver
+        TaskKiller.setDriver(driver);
+        verify(driver, never()).killTask(TestConstants.TASK_ID);
+
+        // Perform an iteration of task killing
+        TaskKiller.killAllTasks();
+        verify(driver, times(1)).killTask(TestConstants.TASK_ID);
+
+        completeKilling(1);
+    }
+
+    @Test
+    public void normalDriverSet() {
+        // Set the driver
+        TaskKiller.setDriver(driver);
+        verify(driver, never()).killTask(TestConstants.TASK_ID);
+
+        // Enqueue a task to kill, and it should have a kill call issued immediately
+        TaskKiller.killTask(TestConstants.TASK_ID);
+        verify(driver, times(1)).killTask(TestConstants.TASK_ID);
+
+        completeKilling(1);
+    }
+
+    @Test
+    public void multipleKillAttempts() {
+        // Set the driver
+        TaskKiller.setDriver(driver);
+        verify(driver, never()).killTask(TestConstants.TASK_ID);
+
+        // Enqueue a task to kill, and it should have a kill call issued immediately
+        TaskKiller.killTask(TestConstants.TASK_ID);
+        verify(driver, times(1)).killTask(TestConstants.TASK_ID);
+
+        // Validate the next killing interation attempts to kill the task again since we haven't
+        // received a status update yet.
+        TaskKiller.killAllTasks();
+        verify(driver, times(2)).killTask(TestConstants.TASK_ID);
+
+        completeKilling(2);
+    }
+
+    @Test
+    public void multipleKillAttemptsWithNonTerminalStatus() {
+        // Set the driver
+        TaskKiller.setDriver(driver);
+        verify(driver, never()).killTask(TestConstants.TASK_ID);
+
+        // Enqueue a task to kill, and it should have a kill call issued immediately
+        TaskKiller.killTask(TestConstants.TASK_ID);
+        verify(driver, times(1)).killTask(TestConstants.TASK_ID);
+
+        // Validate the next killing interation attempts to kill the task again since we haven't
+        // received a status update yet.
+        TaskKiller.killAllTasks();
+        verify(driver, times(2)).killTask(TestConstants.TASK_ID);
+
+        // Sent a status update that doesn't stop killing
+        TaskKiller.update(
+                TestConstants.TASK_STATUS.toBuilder()
+                        .setState(Protos.TaskState.TASK_RUNNING)
+                        .build());
+
+        // Validate AGAIN that the next killing interation attempts to kill the task again since we haven't
+        // received a status update yet.
+        TaskKiller.killAllTasks();
+        verify(driver, times(3)).killTask(TestConstants.TASK_ID);
+
+        completeKilling(3);
+    }
+
+    private void completeKilling(int count) {
+        // Remove the task from the queue by reporting it as killed
+        TaskKiller.update(
+                TestConstants.TASK_STATUS.toBuilder()
+                        .setState(Protos.TaskState.TASK_KILLED)
+                        .build());
+
+        TaskKiller.killAllTasks();
+        verify(driver, times(count)).killTask(TestConstants.TASK_ID);
+    }
+}

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/decommission/DecommissionPlanFactoryTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/decommission/DecommissionPlanFactoryTest.java
@@ -14,7 +14,6 @@ import org.mockito.MockitoAnnotations;
 
 import com.mesosphere.sdk.dcos.Capabilities;
 import com.mesosphere.sdk.offer.taskdata.TaskLabelWriter;
-import com.mesosphere.sdk.scheduler.TaskKiller;
 import com.mesosphere.sdk.scheduler.decommission.DecommissionPlanFactory.PodKey;
 import com.mesosphere.sdk.scheduler.plan.Phase;
 import com.mesosphere.sdk.scheduler.plan.Plan;
@@ -53,7 +52,6 @@ public class DecommissionPlanFactoryTest {
     @Mock private PodSpec mockPodSpecE;
     @Mock private ServiceSpec mockServiceSpec;
     @Mock private StateStore mockStateStore;
-    @Mock private TaskKiller mockTaskKiller;
 
     @Before
     public void beforeEach() {
@@ -124,7 +122,7 @@ public class DecommissionPlanFactoryTest {
         when(mockPodSpecE.getCount()).thenReturn(2);
         when(mockServiceSpec.getPods()).thenReturn(
                 Arrays.asList(mockPodSpecA, mockPodSpecB, mockPodSpecC, mockPodSpecD, mockPodSpecE));
-        DecommissionPlanFactory factory = new DecommissionPlanFactory(mockServiceSpec, mockStateStore, mockTaskKiller);
+        DecommissionPlanFactory factory = new DecommissionPlanFactory(mockServiceSpec, mockStateStore);
         Assert.assertFalse(factory.getPlan().isPresent());
         Assert.assertTrue(factory.getResourceSteps().isEmpty());
 
@@ -144,7 +142,7 @@ public class DecommissionPlanFactoryTest {
     @Test
     public void testBigPlanConstruction() {
         when(mockStateStore.fetchTasks()).thenReturn(tasks);
-        DecommissionPlanFactory factory = new DecommissionPlanFactory(mockServiceSpec, mockStateStore, mockTaskKiller);
+        DecommissionPlanFactory factory = new DecommissionPlanFactory(mockServiceSpec, mockStateStore);
 
         // any tasks with existing decommission bits but which are not to be decommissioned have had their decommission bits cleared (see list above):
         for (String taskToClear : Arrays.asList("podA-0-taskA", "podB-0-taskB")) {

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/plan/DefaultPlanCoordinatorTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/plan/DefaultPlanCoordinatorTest.java
@@ -3,7 +3,6 @@ package com.mesosphere.sdk.scheduler.plan;
 import com.mesosphere.sdk.offer.OfferAccepter;
 import com.mesosphere.sdk.offer.evaluate.OfferEvaluator;
 import com.mesosphere.sdk.offer.history.OfferOutcomeTracker;
-import com.mesosphere.sdk.scheduler.TaskKiller;
 import com.mesosphere.sdk.specification.*;
 import com.mesosphere.sdk.state.ConfigStore;
 import com.mesosphere.sdk.state.StateStore;
@@ -107,8 +106,7 @@ public class DefaultPlanCoordinatorTest extends DefaultCapabilitiesTestSuite {
                         UUID.randomUUID(),
                         SchedulerConfigTestUtils.getTestSchedulerConfig(),
                         true),
-                stateStore,
-                new TaskKiller(schedulerDriver));
+                stateStore);
         serviceSpecificationB = DefaultServiceSpec.newBuilder()
                 .name(SERVICE_NAME + "-B")
                 .role(TestConstants.ROLE)

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/plan/DefaultPlanSchedulerTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/plan/DefaultPlanSchedulerTest.java
@@ -3,7 +3,6 @@ package com.mesosphere.sdk.scheduler.plan;
 import com.mesosphere.sdk.offer.*;
 import com.mesosphere.sdk.offer.evaluate.OfferEvaluator;
 import com.mesosphere.sdk.scheduler.SchedulerConfig;
-import com.mesosphere.sdk.scheduler.TaskKiller;
 import com.mesosphere.sdk.specification.DefaultServiceSpec;
 import com.mesosphere.sdk.specification.PodInstance;
 import com.mesosphere.sdk.specification.PodSpec;
@@ -43,7 +42,6 @@ public class DefaultPlanSchedulerTest {
     @Mock private OfferEvaluator mockOfferEvaluator;
     @Mock private SchedulerDriver mockSchedulerDriver;
     @Mock private StateStore mockStateStore;
-    @Mock private TaskKiller mockTaskKiller;
     @Mock private OfferRecommendation mockRecommendation;
 
     private PodInstanceRequirement podInstanceRequirement;
@@ -54,7 +52,7 @@ public class DefaultPlanSchedulerTest {
     public void beforeEach() throws Exception {
         MockitoAnnotations.initMocks(this);
         mockRecommendations = Arrays.asList(mockRecommendation);
-        scheduler = new DefaultPlanScheduler(mockOfferAccepter, mockOfferEvaluator, mockStateStore, mockTaskKiller);
+        scheduler = new DefaultPlanScheduler(mockOfferAccepter, mockOfferEvaluator, mockStateStore);
 
         ClassLoader classLoader = getClass().getClassLoader();
         File file = new File(classLoader.getResource("valid-minimal.yml").getFile());

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/recovery/DefaultRecoveryPlanManagerTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/recovery/DefaultRecoveryPlanManagerTest.java
@@ -6,7 +6,6 @@ import com.mesosphere.sdk.offer.OfferRecommendation;
 import com.mesosphere.sdk.offer.evaluate.OfferEvaluator;
 import com.mesosphere.sdk.offer.history.OfferOutcomeTracker;
 import com.mesosphere.sdk.offer.taskdata.TaskLabelWriter;
-import com.mesosphere.sdk.scheduler.TaskKiller;
 import com.mesosphere.sdk.scheduler.SchedulerConfig;
 import com.mesosphere.sdk.scheduler.plan.*;
 import com.mesosphere.sdk.scheduler.recovery.constrain.TestingLaunchConstrainer;
@@ -131,8 +130,7 @@ public class DefaultRecoveryPlanManagerTest extends DefaultCapabilitiesTestSuite
                         configTarget,
                         SchedulerConfigTestUtils.getTestSchedulerConfig(),
                         true),
-                stateStore,
-                new TaskKiller(schedulerDriver));
+                stateStore);
         planCoordinator = new DefaultPlanCoordinator(Arrays.asList(mockDeployManager, recoveryManager));
     }
 

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/uninstall/TaskKillStepTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/uninstall/TaskKillStepTest.java
@@ -3,6 +3,7 @@ package com.mesosphere.sdk.scheduler.uninstall;
 import com.mesosphere.sdk.scheduler.TaskKiller;
 import com.mesosphere.sdk.scheduler.plan.Status;
 import org.apache.mesos.Protos;
+import org.apache.mesos.SchedulerDriver;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -15,12 +16,13 @@ import java.util.Optional;
 public class TaskKillStepTest {
 
     @Mock
-    private TaskKiller mockTaskKiller;
+    private SchedulerDriver driver;
     private Protos.TaskID taskID = Protos.TaskID.newBuilder().setValue("task-1").build();
 
     @Before
     public void init() {
         MockitoAnnotations.initMocks(this);
+        TaskKiller.setDriver(driver);
     }
 
     @Test
@@ -28,11 +30,11 @@ public class TaskKillStepTest {
         TaskKillStep step = createStep();
         Assert.assertEquals(Optional.empty(), step.start());
         Assert.assertEquals(Status.COMPLETE, step.getStatus());
-        Mockito.verify(mockTaskKiller, Mockito.only()).killTask(taskID);
+        Mockito.verify(driver).killTask(taskID);
     }
 
     private TaskKillStep createStep() {
-        TaskKillStep step = new TaskKillStep(taskID, mockTaskKiller);
+        TaskKillStep step = new TaskKillStep(taskID);
         return step;
     }
 }


### PR DESCRIPTION
There were two problems to address.

1. Constructing / passing around `TaskKiller`s was messy, error prone and inconvenient (because you had to have a `SchedulerDriver` handy).
1. Killing a task in Mesos isn't "reliable".  They may drop the message without consequence at anytime so your'e on your own. 

So now we enqueue tasks to kill and periodically attempt to kill them.  This in conjunction with the `TaskCleaner` will make it very unlikely any tasks fall through the cracks.  Note that there's no anticipated task kill latency introduced here.  We still issue kill messages as fast ever.  Only in very rare obscure scenarios could some component issue a kill before a driver is available to do the killing.  For example maybe the API server comes up fast and someone very urgently wants to restart a pod.  It may be delayed slightly while we wait to register.

~~I need to add a couple tests to address those very rare cases, but this can mostly be reviewed now.  Getting it through a run of CI will also show that I haven't broken anything major.~~
EDIT:  Tests referenced above have been added.

The last piece of the puzzle will be to trigger implicit reconciliation periodically so Mesos feeds us Tasks we may need to kill, but that's not addressed in this PR.