### PR TITLE
Centralize access to the Mesos SchedulerDriver

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/OfferAccepter.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/OfferAccepter.java
@@ -44,8 +44,7 @@ public class OfferAccepter {
 
         Optional<SchedulerDriver> driver = Driver.getDriver();
         if (!driver.isPresent()) {
-            LOGGER.error("No driver present for accepting offers.  This should never happen.");
-            return Collections.emptyList();
+            throw new IllegalStateException("No driver present for accepting offers.  This should never happen.");
         }
 
         List<OfferID> offerIds = getOfferIds(recommendations);

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/OfferUtils.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/OfferUtils.java
@@ -67,8 +67,7 @@ public class OfferUtils {
     private static void declineOffers(Collection<Protos.Offer> unusedOffers, int refuseSeconds) {
         Optional<SchedulerDriver> driver = Driver.getDriver();
         if (!driver.isPresent()) {
-            LOGGER.error("No driver present for declining offers.  This should never happen.");
-            return;
+            throw new IllegalStateException("No driver present for declining offers.  This should never happen.");
         }
 
         Collection<Protos.OfferID> offerIds = unusedOffers.stream()

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/OfferUtils.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/OfferUtils.java
@@ -1,5 +1,6 @@
 package com.mesosphere.sdk.offer;
 
+import com.mesosphere.sdk.scheduler.Driver;
 import com.mesosphere.sdk.scheduler.Metrics;
 import org.apache.mesos.Protos;
 import org.apache.mesos.SchedulerDriver;
@@ -8,6 +9,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -46,25 +48,29 @@ public class OfferUtils {
                 .anyMatch(acceptedOfferId -> acceptedOfferId.equals(offer.getId()));
     }
 
-    public static void declineShort(SchedulerDriver driver, Collection<Protos.Offer> unusedOffers) {
-        OfferUtils.declineOffers(driver, unusedOffers, Constants.SHORT_DECLINE_SECONDS);
+    public static void declineShort(Collection<Protos.Offer> unusedOffers) {
+        OfferUtils.declineOffers(unusedOffers, Constants.SHORT_DECLINE_SECONDS);
         Metrics.incrementDeclinesShort(unusedOffers.size());
     }
 
-    public static void declineLong(SchedulerDriver driver, Collection<Protos.Offer> unusedOffers) {
-        OfferUtils.declineOffers(driver, unusedOffers, Constants.LONG_DECLINE_SECONDS);
+    public static void declineLong(Collection<Protos.Offer> unusedOffers) {
+        OfferUtils.declineOffers(unusedOffers, Constants.LONG_DECLINE_SECONDS);
         Metrics.incrementDeclinesLong(unusedOffers.size());
     }
 
     /**
      * Decline unused {@link org.apache.mesos.Protos.Offer}s.
      *
-     * @param driver The {@link SchedulerDriver} that will receive the declineOffer() calls
      * @param unusedOffers The collection of Offers to decline
      * @param refuseSeconds The number of seconds for which the offers should be refused
      */
-    private static void declineOffers(
-            SchedulerDriver driver, Collection<Protos.Offer> unusedOffers, int refuseSeconds) {
+    private static void declineOffers(Collection<Protos.Offer> unusedOffers, int refuseSeconds) {
+        Optional<SchedulerDriver> driver = Driver.getDriver();
+        if (!driver.isPresent()) {
+            LOGGER.error("No driver present for declining offers.  This should never happen.");
+            return;
+        }
+
         Collection<Protos.OfferID> offerIds = unusedOffers.stream()
                 .map(offer -> offer.getId())
                 .collect(Collectors.toList());
@@ -76,6 +82,6 @@ public class OfferUtils {
         final Protos.Filters filters = Protos.Filters.newBuilder()
                 .setRefuseSeconds(refuseSeconds)
                 .build();
-        offerIds.forEach(offerId -> driver.declineOffer(offerId, filters));
+        offerIds.forEach(offerId -> driver.get().declineOffer(offerId, filters));
     }
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/ResourceCleanerScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/ResourceCleanerScheduler.java
@@ -3,7 +3,6 @@ package com.mesosphere.sdk.offer;
 import org.apache.mesos.Protos;
 import org.apache.mesos.Protos.Offer;
 import org.apache.mesos.Protos.OfferID;
-import org.apache.mesos.SchedulerDriver;
 
 import java.util.*;
 
@@ -22,7 +21,7 @@ public class ResourceCleanerScheduler {
         this.offerAccepter = offerAccepter;
     }
 
-    public List<OfferID> resourceOffers(SchedulerDriver driver, List<Offer> offers) {
+    public List<OfferID> resourceOffers(List<Offer> offers) {
         final List<OfferRecommendation> recommendations = resourceCleaner.evaluate(offers);
 
         // Recommendations should be grouped by agent, as Mesos enforces processing of acceptOffers Operations
@@ -32,7 +31,7 @@ public class ResourceCleanerScheduler {
 
         final List<OfferID> processedOffers = new ArrayList<>(offers.size());
         for (Map.Entry<Protos.SlaveID, List<OfferRecommendation>> entry : recommendationsGroupedByAgents.entrySet()) {
-            processedOffers.addAll(offerAccepter.accept(driver, recommendationsGroupedByAgents.get(entry.getKey())));
+            processedOffers.addAll(offerAccepter.accept(recommendationsGroupedByAgents.get(entry.getKey())));
         }
 
         return processedOffers;

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/reconciliation/Reconciler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/reconciliation/Reconciler.java
@@ -91,8 +91,7 @@ public class Reconciler {
 
         Optional<SchedulerDriver> driver = Driver.getDriver();
         if (!driver.isPresent()) {
-            LOGGER.error("No driver present for reconciliation.  This should never happen.");
-            return;
+            throw new IllegalStateException("No driver present for reconciliation.  This should never happen.");
         }
 
         /**

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/AbstractScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/AbstractScheduler.java
@@ -238,7 +238,7 @@ public abstract class AbstractScheduler {
             Driver.setDriver(driver);
 
             LOGGER.info("Registered framework with frameworkId: {}", frameworkId.getValue());
-            this.reviveManager = new ReviveManager(driver);
+            this.reviveManager = new ReviveManager();
             this.reconciler = new Reconciler(stateStore);
             this.taskCleaner = new TaskCleaner(stateStore, multithreaded);
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/Driver.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/Driver.java
@@ -1,0 +1,29 @@
+package com.mesosphere.sdk.scheduler;
+
+import org.apache.mesos.SchedulerDriver;
+
+import java.util.Optional;
+
+/**
+ * This class provides global access to a SchedulerDriver.
+ */
+public final class Driver {
+    private static SchedulerDriver driver;
+    private static Object lock = new Object();
+
+    private Driver() {
+        // Don't instantiate this class.
+    }
+
+    public static Optional<SchedulerDriver> getDriver() {
+        synchronized (lock) {
+            return Optional.ofNullable(driver);
+        }
+    }
+
+    public static void setDriver(SchedulerDriver driver) {
+        synchronized (lock) {
+            Driver.driver = driver;
+        }
+    }
+}

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/ReviveManager.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/ReviveManager.java
@@ -19,16 +19,14 @@ import java.util.stream.Collectors;
  */
 public class ReviveManager {
     private final Logger logger = LoggerFactory.getLogger(getClass());
-    private final SchedulerDriver driver;
     private final TokenBucket tokenBucket;
     private Set<WorkItem> candidates = new HashSet<>();
 
-    public ReviveManager(SchedulerDriver driver) {
-        this(driver, TokenBucket.newBuilder().build());
+    public ReviveManager() {
+        this(TokenBucket.newBuilder().build());
     }
 
-    public ReviveManager(SchedulerDriver driver, TokenBucket tokenBucket) {
-        this.driver = driver;
+    public ReviveManager(TokenBucket tokenBucket) {
         this.tokenBucket = tokenBucket;
     }
 
@@ -80,7 +78,13 @@ public class ReviveManager {
                         this.candidates,
                         currCandidates,
                         newCandidates);
-                driver.reviveOffers();
+                Optional<SchedulerDriver> driver = Driver.getDriver();
+                if (driver.isPresent()) {
+                    driver.get().reviveOffers();
+                } else {
+                    throw new IllegalStateException(
+                            "No driver present for reviving offers.  This should never happen.");
+                }
                 Metrics.incrementRevives();
             } else {
                 logger.warn("Revive attempt has been throttled.");

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerRunner.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerRunner.java
@@ -118,6 +118,14 @@ public class SchedulerRunner implements Runnable {
         scheduler.start();
         Optional<Scheduler> mesosScheduler = scheduler.getMesosScheduler();
         if (mesosScheduler.isPresent()) {
+            SchedulerApiServer apiServer = new SchedulerApiServer(schedulerConfig, scheduler.getResources());
+            apiServer.start(new AbstractLifeCycle.AbstractLifeCycleListener() {
+                @Override
+                public void lifeCycleStarted(LifeCycle event) {
+                    scheduler.markApiServerStarted();
+                }
+            });
+
             runScheduler(
                     mesosScheduler.get(),
                     schedulerBuilder.getServiceSpec(),

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/TaskKiller.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/TaskKiller.java
@@ -114,6 +114,13 @@ public final class TaskKiller {
         }
     }
 
+    @VisibleForTesting
+    static void killAllTasks() {
+        for (TaskID taskId : tasksToKill) {
+            killTaskInternal(taskId);
+        }
+    }
+
     private static void killTaskInternal(TaskID taskId) {
         if (driver != null) {
             LOGGER.info("Killing task: {}", taskId.getValue());

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/TaskKiller.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/TaskKiller.java
@@ -116,7 +116,12 @@ public final class TaskKiller {
 
     @VisibleForTesting
     static void killAllTasks() {
-        for (TaskID taskId : tasksToKill) {
+        Set<TaskID> copy;
+        synchronized (lock) {
+            copy = new HashSet<>(tasksToKill);
+        }
+
+        for (TaskID taskId : copy) {
             killTaskInternal(taskId);
         }
     }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/TaskKiller.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/TaskKiller.java
@@ -9,6 +9,7 @@ import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -29,7 +30,6 @@ public final class TaskKiller {
 
     private static ScheduledExecutorService executor;
     private static TaskKiller taskKiller = new TaskKiller();
-    private static SchedulerDriver driver;
 
     private TaskKiller() {
         startScheduling();
@@ -54,10 +54,6 @@ public final class TaskKiller {
                 killInterval.toMillis(),
                 killInterval.toMillis(),
                 TimeUnit.MILLISECONDS);
-    }
-
-    public static void setDriver(SchedulerDriver schedulerDriver) {
-        driver = schedulerDriver;
     }
 
     /**
@@ -127,9 +123,11 @@ public final class TaskKiller {
     }
 
     private static void killTaskInternal(TaskID taskId) {
-        if (driver != null) {
+        Optional<SchedulerDriver> driver = Driver.getDriver();
+
+        if (driver.isPresent()) {
             LOGGER.info("Killing task: {}", taskId.getValue());
-            driver.killTask(taskId);
+            driver.get().killTask(taskId);
         } else {
             LOGGER.warn("Can't kill '{}', driver not yet set.", taskId.getValue());
         }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/TaskKiller.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/TaskKiller.java
@@ -110,18 +110,6 @@ public final class TaskKiller {
         }
     }
 
-    @VisibleForTesting
-    static void killAllTasks() {
-        Set<TaskID> copy;
-        synchronized (lock) {
-            copy = new HashSet<>(tasksToKill);
-        }
-
-        for (TaskID taskId : copy) {
-            killTaskInternal(taskId);
-        }
-    }
-
     private static void killTaskInternal(TaskID taskId) {
         Optional<SchedulerDriver> driver = Driver.getDriver();
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/DefaultPlanScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/DefaultPlanScheduler.java
@@ -10,7 +10,6 @@ import org.apache.mesos.Protos;
 import org.apache.mesos.Protos.Offer;
 import org.apache.mesos.Protos.OfferID;
 import org.apache.mesos.Protos.TaskInfo;
-import org.apache.mesos.SchedulerDriver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,23 +28,16 @@ public class DefaultPlanScheduler implements PlanScheduler {
     private final OfferEvaluator offerEvaluator;
     private final StateStore stateStore;
 
-    public DefaultPlanScheduler(
-            OfferAccepter offerAccepter,
-            OfferEvaluator offerEvaluator,
-            StateStore stateStore) {
+    public DefaultPlanScheduler(OfferAccepter offerAccepter, OfferEvaluator offerEvaluator, StateStore stateStore) {
         this.offerAccepter = offerAccepter;
         this.offerEvaluator = offerEvaluator;
         this.stateStore = stateStore;
     }
 
     @Override
-    public Collection<OfferID> resourceOffers(
-            final SchedulerDriver driver,
-            final List<Offer> offers,
-            final Collection<? extends Step> steps) {
-        if (driver == null || offers == null || steps == null) {
-            logger.error("Unexpected null argument(s) encountered: driver='{}' offers='{}', steps='{}'",
-                    driver, offers, steps);
+    public Collection<OfferID> resourceOffers(final List<Offer> offers, final Collection<? extends Step> steps) {
+        if (offers == null || steps == null) {
+            logger.error("Unexpected null argument(s) encountered: offers='{}', steps='{}'", offers, steps);
             return Collections.emptyList();
         }
 
@@ -53,17 +45,17 @@ public class DefaultPlanScheduler implements PlanScheduler {
         List<Offer> availableOffers = new ArrayList<>(offers);
 
         for (Step step : steps) {
-            acceptedOfferIds.addAll(resourceOffers(driver, availableOffers, step));
+            acceptedOfferIds.addAll(resourceOffers(availableOffers, step));
             availableOffers = PlanUtils.filterAcceptedOffers(availableOffers, acceptedOfferIds);
         }
 
         return acceptedOfferIds;
     }
 
-    private Collection<OfferID> resourceOffers(SchedulerDriver driver, List<Offer> offers, Step step) {
+    private Collection<OfferID> resourceOffers(List<Offer> offers, Step step) {
 
-        if (driver == null || offers == null) {
-            logger.error("Unexpected null argument encountered: driver='{}' offers='{}'", driver, offers);
+        if (offers == null) {
+            logger.error("Unexpected null argument: 'offers'");
             return Collections.emptyList();
         }
 
@@ -110,7 +102,7 @@ public class DefaultPlanScheduler implements PlanScheduler {
             return Collections.emptyList();
         }
 
-        List<OfferID> acceptedOffers = offerAccepter.accept(driver, recommendations);
+        List<OfferID> acceptedOffers = offerAccepter.accept(recommendations);
 
         // Notify step of offer outcome:
         if (acceptedOffers.isEmpty()) {

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/PlanScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/PlanScheduler.java
@@ -2,7 +2,6 @@ package com.mesosphere.sdk.scheduler.plan;
 
 import org.apache.mesos.Protos.Offer;
 import org.apache.mesos.Protos.OfferID;
-import org.apache.mesos.SchedulerDriver;
 
 import java.util.Collection;
 import java.util.List;
@@ -21,7 +20,6 @@ public interface PlanScheduler {
      *         requirements returned by the {@link Step}
      */
     Collection<OfferID> resourceOffers(
-            final SchedulerDriver driver,
             final List<Offer> offers,
             final Collection<? extends Step> steps);
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/uninstall/DeregisterStep.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/uninstall/DeregisterStep.java
@@ -1,5 +1,6 @@
 package com.mesosphere.sdk.scheduler.uninstall;
 
+import com.mesosphere.sdk.scheduler.Driver;
 import com.mesosphere.sdk.scheduler.plan.PodInstanceRequirement;
 import com.mesosphere.sdk.scheduler.plan.Status;
 import com.mesosphere.sdk.state.StateStore;
@@ -12,17 +13,15 @@ import java.util.Optional;
  */
 public class DeregisterStep extends UninstallStep {
 
-    private SchedulerDriver driver;
     private StateStore stateStore;
 
     /**
      * Creates a new instance with initial {@code status}. The {@link SchedulerDriver} must be
      * set separately.
      */
-    DeregisterStep(StateStore stateStore, SchedulerDriver driver) {
+    DeregisterStep(StateStore stateStore) {
         super("deregister", Status.PENDING);
         this.stateStore = stateStore;
-        this.driver = driver;
     }
 
     @Override
@@ -33,12 +32,21 @@ public class DeregisterStep extends UninstallStep {
         // Unregisters the framework in addition to stopping the SchedulerDriver thread:
         // Calling with failover == false causes Mesos to teardown the framework.
         // This call will cause DefaultService's schedulerDriver.run() call to return DRIVER_STOPPED.
-        driver.stop(false);
-        logger.info("Deleting service root path for framework...");
-        stateStore.clearAllData();
-        logger.info("### UNINSTALL IS COMPLETE! ###");
-        logger.info("Scheduler should be cleaned up shortly...");
-        setStatus(Status.COMPLETE);
+        Optional<SchedulerDriver> driver = Driver.getDriver();
+        if (driver.isPresent()) {
+            driver.get().stop(false);
+            logger.info("Deleting service root path for framework...");
+            stateStore.clearAllData();
+            logger.info("### UNINSTALL IS COMPLETE! ###");
+            logger.info("Scheduler should be cleaned up shortly...");
+            setStatus(Status.COMPLETE);
+        } else {
+            logger.error("No driver is present for deregistering the framework.");
+
+            // The state should already be PENDING, but we do this out of an abundance of caution.
+            setStatus(Status.PENDING);
+        }
+
         return Optional.empty();
     }
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/uninstall/UninstallPlanBuilder.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/uninstall/UninstallPlanBuilder.java
@@ -9,7 +9,6 @@ import java.util.stream.Collectors;
 
 import org.apache.http.impl.client.LaxRedirectStrategy;
 import org.apache.mesos.Protos;
-import org.apache.mesos.SchedulerDriver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,7 +50,6 @@ class UninstallPlanBuilder {
             StateStore stateStore,
             ConfigStore<ServiceSpec> configStore,
             SchedulerConfig schedulerConfig,
-            SchedulerDriver driver,
             Optional<SecretsClient> customSecretsClientForTests) {
 
         // If there is no framework ID, wipe ZK and produce an empty COMPLETE plan
@@ -134,7 +132,7 @@ class UninstallPlanBuilder {
         // We don't have access to the SchedulerDriver yet. That will be set via setSchedulerDriver() below.
         phases.add(new DefaultPhase(
                 DEREGISTER_PHASE,
-                Collections.singletonList(new DeregisterStep(stateStore, driver)),
+                Collections.singletonList(new DeregisterStep(stateStore)),
                 new SerialStrategy<>(),
                 Collections.emptyList()));
 

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/http/PodResourceTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/http/PodResourceTest.java
@@ -3,7 +3,7 @@ package com.mesosphere.sdk.http;
 import com.mesosphere.sdk.http.types.TaskInfoAndStatus;
 import com.mesosphere.sdk.offer.CommonIdUtils;
 import com.mesosphere.sdk.offer.taskdata.TaskLabelWriter;
-import com.mesosphere.sdk.scheduler.TaskKiller;
+import com.mesosphere.sdk.scheduler.Driver;
 import com.mesosphere.sdk.scheduler.recovery.TaskFailureListener;
 import com.mesosphere.sdk.state.GoalStateOverride;
 import com.mesosphere.sdk.state.StateStore;
@@ -119,7 +119,7 @@ public class PodResourceTest {
     @Before
     public void beforeEach() {
         MockitoAnnotations.initMocks(this);
-        TaskKiller.setDriver(driver);
+        Driver.setDriver(driver);
         resource = new PodResource(mockStateStore, TestConstants.SERVICE_NAME, mockTaskFailureListener);
     }
 

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/OfferAccepterTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/OfferAccepterTest.java
@@ -1,6 +1,7 @@
 package com.mesosphere.sdk.offer;
 
 import com.mesosphere.sdk.offer.taskdata.TaskLabelWriter;
+import com.mesosphere.sdk.scheduler.Driver;
 import com.mesosphere.sdk.testutils.OfferTestUtils;
 import com.mesosphere.sdk.testutils.TestConstants;
 import org.apache.mesos.Protos;
@@ -43,8 +44,8 @@ public class OfferAccepterTest {
 
         TestOperationRecorder recorder = new TestOperationRecorder();
         OfferAccepter accepter = new OfferAccepter(Arrays.asList(recorder));
+        Driver.setDriver(driver);
         accepter.accept(
-                driver,
                 Arrays.asList(new LaunchOfferRecommendation(
                         offer,
                         taskInfoBuilder.build(),
@@ -67,8 +68,8 @@ public class OfferAccepterTest {
 
         TestOperationRecorder recorder = new TestOperationRecorder();
         OfferAccepter accepter = new OfferAccepter(Arrays.asList(recorder));
+        Driver.setDriver(driver);
         accepter.accept(
-                driver,
                 Arrays.asList(new LaunchOfferRecommendation(
                         offer,
                         taskInfoBuilder.build(),

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/OfferUtilsTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/OfferUtilsTest.java
@@ -1,5 +1,6 @@
 package com.mesosphere.sdk.offer;
 
+import com.mesosphere.sdk.scheduler.Driver;
 import com.mesosphere.sdk.testutils.OfferTestUtils;
 import com.mesosphere.sdk.testutils.ResourceTestUtils;
 import org.apache.mesos.Protos;
@@ -75,7 +76,8 @@ public class OfferUtilsTest {
     public void testDeclineOffers() {
         final List<Protos.Offer> offers = getOffers(SUFFICIENT_CPUS, SUFFICIENT_MEM, SUFFICIENT_DISK);
         final List<Protos.OfferID> offerIds = offers.stream().map(Protos.Offer::getId).collect(Collectors.toList());
-        OfferUtils.declineLong(mockSchedulerDriver, offers);
+        Driver.setDriver(mockSchedulerDriver);
+        OfferUtils.declineLong(offers);
         verify(mockSchedulerDriver).declineOffer(eq(offerIds.get(0)), any());
         verify(mockSchedulerDriver).declineOffer(eq(offerIds.get(1)), any());
     }

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/ResourceCleanerSchedulerTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/ResourceCleanerSchedulerTest.java
@@ -65,8 +65,8 @@ public class ResourceCleanerSchedulerTest {
 
     @Test
     public void testResourceOffers() {
-        scheduler.resourceOffers(driver, offers);
-        verify(offerAccepter, times(2)).accept(any(), any());
+        scheduler.resourceOffers(offers);
+        verify(offerAccepter, times(2)).accept(any());
     }
 
     @Test

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/reconciliation/ReconcilerTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/reconciliation/ReconcilerTest.java
@@ -3,6 +3,7 @@ package com.mesosphere.sdk.reconciliation;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
+import com.mesosphere.sdk.scheduler.Driver;
 import org.apache.mesos.Protos;
 import org.apache.mesos.SchedulerDriver;
 import com.mesosphere.sdk.state.StateStore;
@@ -44,6 +45,7 @@ public class ReconcilerTest {
     @Before
     public void beforeAll() {
         MockitoAnnotations.initMocks(this);
+        Driver.setDriver(mockDriver);
         reconciler = new TestReconciler(mockStateStore, DEFAULT_TIME_MS);
     }
 
@@ -57,7 +59,7 @@ public class ReconcilerTest {
         assertTrue(reconciler.isReconciled());
         assertEquals(0, reconciler.remaining().size());
 
-        reconciler.reconcile(mockDriver);
+        reconciler.reconcile();
 
         verify(mockDriver).reconcileTasks(eq(Arrays.asList()));
         assertTrue(reconciler.isReconciled()); // implicit reconciliation has occurred
@@ -121,14 +123,14 @@ public class ReconcilerTest {
         assertTrue(reconciler.isReconciled());
         assertEquals(0, reconciler.remaining().size());
 
-        reconciler.reconcile(mockDriver); // trigger implicit reconciliation
+        reconciler.reconcile(); // trigger implicit reconciliation
         verify(mockDriver).reconcileTasks(taskStatusCaptor.capture());
 
         assertEquals(0, taskStatusCaptor.getValue().size());
         assertTrue(reconciler.isReconciled());
         assertEquals(0, reconciler.remaining().size());
 
-        reconciler.reconcile(mockDriver); // no-op
+        reconciler.reconcile(); // no-op
         verifyNoMoreInteractions(mockDriver);
     }
 
@@ -137,7 +139,7 @@ public class ReconcilerTest {
         when(mockStateStore.fetchStatuses()).thenReturn(TASK_STATUSES);
         reconciler.start();
 
-        reconciler.reconcile(mockDriver); // first call to reconcileTasks: 2 values
+        reconciler.reconcile(); // first call to reconcileTasks: 2 values
 
         assertFalse(reconciler.isReconciled());
         assertEquals(2, reconciler.remaining().size());
@@ -155,7 +157,7 @@ public class ReconcilerTest {
         assertEquals(TASK_STATUS_1.getTaskId().getValue(), reconciler.remaining().iterator().next());
 
         // still have a task left, but the time is still the same so driver.reconcile is skipped:
-        reconciler.reconcile(mockDriver); // doesn't call reconcileTasks due to timer
+        reconciler.reconcile(); // doesn't call reconcileTasks due to timer
 
         assertFalse(reconciler.isReconciled());
         assertEquals(1, reconciler.remaining().size());
@@ -163,7 +165,7 @@ public class ReconcilerTest {
 
         // bump time forward and try again:
         reconciler.setNowMs(DEFAULT_TIME_MS + 30000);
-        reconciler.reconcile(mockDriver); // second call to reconcileTasks: 1 values
+        reconciler.reconcile(); // second call to reconcileTasks: 1 values
 
         assertFalse(reconciler.isReconciled());
         assertEquals(1, reconciler.remaining().size());
@@ -174,12 +176,12 @@ public class ReconcilerTest {
         assertTrue(reconciler.isReconciled());
         assertEquals(0, reconciler.remaining().size());
 
-        reconciler.reconcile(mockDriver); // third call to reconcileTasks: 0 values (implicit)
+        reconciler.reconcile(); // third call to reconcileTasks: 0 values (implicit)
 
         assertTrue(reconciler.isReconciled());
         assertEquals(0, reconciler.remaining().size());
 
-        reconciler.reconcile(mockDriver); // no-op
+        reconciler.reconcile(); // no-op
 
         // we need to validate all calls at once due to how mockito deals with Collection calls.
         // otherwise it incorrectly throws "TooManyActualInvocations"
@@ -199,14 +201,14 @@ public class ReconcilerTest {
         assertFalse(reconciler.isReconciled());
         assertEquals(1, reconciler.remaining().size());
 
-        reconciler.reconcile(mockDriver);
+        reconciler.reconcile();
 
         final Protos.TaskStatus updatedTaskStatus = Protos.TaskStatus.newBuilder(TASK_STATUS_2)
                 .setState(Protos.TaskState.TASK_RUNNING)
                 .build();
 
         reconciler.update(updatedTaskStatus);
-        reconciler.reconcile(mockDriver);
+        reconciler.reconcile();
 
         assertTrue(reconciler.isReconciled());
         assertEquals(0, reconciler.remaining().size());

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/AbstractSchedulerTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/AbstractSchedulerTest.java
@@ -184,12 +184,12 @@ public class AbstractSchedulerTest {
         }
 
         @Override
-        protected PlanCoordinator initialize(SchedulerDriver driver) throws Exception {
+        protected PlanCoordinator getPlanCoordinator() throws Exception {
             return mockPlanCoordinator;
         }
 
         @Override
-        protected void processOffers(SchedulerDriver driver, List<Protos.Offer> offers, Collection<Step> steps) {
+        protected void processOffers(List<Protos.Offer> offers, Collection<Step> steps) {
             receivedOfferIds.addAll(offers.stream()
                     .map(o -> o.getId().getValue())
                     .collect(Collectors.toList()));

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/DefaultSchedulerTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/DefaultSchedulerTest.java
@@ -255,14 +255,14 @@ public class DefaultSchedulerTest {
     }
 
     @Test
-    public void testLaunchA() throws InterruptedException {
+    public void testLaunchA() throws Exception {
         installStep(0, 0, getSufficientOfferForTaskA());
         Assert.assertEquals(Arrays.asList(Status.COMPLETE, Status.PENDING, Status.PENDING),
                 getStepStatuses(getDeploymentPlan()));
     }
 
     @Test
-    public void testLaunchB() throws InterruptedException {
+    public void testLaunchB() throws Exception {
         // Launch A-0
         testLaunchA();
         installStep(1, 0, getSufficientOfferForTaskB());
@@ -271,7 +271,7 @@ public class DefaultSchedulerTest {
     }
 
     @Test
-    public void testFailLaunchA() throws InterruptedException {
+    public void testFailLaunchA() throws Exception {
         // Get first Step associated with Task A-0
         Plan plan = getDeploymentPlan();
         Step stepTaskA0 = plan.getChildren().get(0).getChildren().get(0);
@@ -578,7 +578,7 @@ public class DefaultSchedulerTest {
     }
 
     @Test
-    public void testTaskIpIsStoredOnInstall() throws InterruptedException {
+    public void testTaskIpIsStoredOnInstall() throws Exception {
         install();
 
         // Verify the TaskIP (TaskInfo, strictly speaking) has been stored in the StateStore.
@@ -589,7 +589,7 @@ public class DefaultSchedulerTest {
     }
 
     @Test
-    public void testTaskIpIsUpdatedOnStatusUpdate() throws InterruptedException {
+    public void testTaskIpIsUpdatedOnStatusUpdate() throws Exception {
         List<Protos.TaskID> taskIds = install();
         String updateIp = "1.1.1.1";
 
@@ -616,7 +616,7 @@ public class DefaultSchedulerTest {
     }
 
     @Test
-    public void testTaskIpIsNotOverwrittenByEmptyOnUpdate() throws InterruptedException {
+    public void testTaskIpIsNotOverwrittenByEmptyOnUpdate() throws Exception {
         List<Protos.TaskID> taskIds = install();
 
         // Verify the TaskIP (TaskInfo, strictly speaking) has been stored in the StateStore.
@@ -767,7 +767,7 @@ public class DefaultSchedulerTest {
         });
     }
 
-    private Protos.TaskID installStep(int phaseIndex, int stepIndex, Protos.Offer offer) {
+    private Protos.TaskID installStep(int phaseIndex, int stepIndex, Protos.Offer offer) throws Exception {
         // Get first Step associated with Task A-0
         List<Protos.Offer> offers = Arrays.asList(offer);
         Protos.OfferID offerId = offer.getId();
@@ -823,7 +823,7 @@ public class DefaultSchedulerTest {
     /**
      * Installs the service.
      */
-    private List<Protos.TaskID> install() throws InterruptedException {
+    private List<Protos.TaskID> install() throws Exception {
         List<Protos.TaskID> taskIds = new ArrayList<>();
 
         taskIds.add(installStep(0, 0, getSufficientOfferForTaskA()));
@@ -900,15 +900,15 @@ public class DefaultSchedulerTest {
         return (DefaultScheduler) scheduler;
     }
 
-    private Plan getDeploymentPlan() {
+    private Plan getDeploymentPlan() throws Exception {
         return getPlan(Constants.DEPLOY_PLAN_NAME);
     }
 
-    private Plan getRecoveryPlan() {
+    private Plan getRecoveryPlan() throws Exception {
         return getPlan("recovery");
     }
 
-    private Plan getPlan(String planName) {
+    private Plan getPlan(String planName) throws Exception {
         for (PlanManager planManager : defaultScheduler.getPlanCoordinator().getPlanManagers()) {
             if (planManager.getPlan().getName().equals(planName)) {
                 return planManager.getPlan();

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/ReviveManagerTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/ReviveManagerTest.java
@@ -29,6 +29,7 @@ public class ReviveManagerTest {
     @Before
     public void beforeEach() {
         MockitoAnnotations.initMocks(this);
+        Driver.setDriver(driver);
         manager = null;
     }
 
@@ -66,7 +67,7 @@ public class ReviveManagerTest {
 
     @Test
     public void dontReviveWhenThrottled() {
-        ReviveManager manager = new ReviveManager(driver);
+        ReviveManager manager = new ReviveManager();
         manager.revive(getSteps(0));
         manager.revive(getSteps(1));
         verify(driver, times(1)).reviveOffers();
@@ -80,7 +81,7 @@ public class ReviveManagerTest {
     }
 
     private ReviveManager getReviveManager() {
-        return new ReviveManager(driver, TokenBucket.newBuilder().acquireInterval(Duration.ZERO).build());
+        return new ReviveManager(TokenBucket.newBuilder().acquireInterval(Duration.ZERO).build());
     }
 
     private List<Step> getSteps(Integer index) {

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/TaskCleanerTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/TaskCleanerTest.java
@@ -26,7 +26,7 @@ public class TaskCleanerTest {
     @Before
     public void beforeEach() {
         MockitoAnnotations.initMocks(this);
-        TaskKiller.setDriver(driver);
+        Driver.setDriver(driver);
         taskCleaner = new TaskCleaner(stateStore, false);
     }
 

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/TaskKillerTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/TaskKillerTest.java
@@ -31,13 +31,12 @@ public class TaskKillerTest {
     @Before
     public void beforeEach() throws InterruptedException {
         MockitoAnnotations.initMocks(this);
-        TaskKiller.setDriver(null);
+        Driver.setDriver(null);
     }
 
     @Test
     public void emptyTaskId() {
-        // Set the driver
-        TaskKiller.setDriver(driver);
+        Driver.setDriver(driver);
         verify(driver, never()).killTask(TestConstants.TASK_ID);
 
         TaskKiller.killTask(Protos.TaskID.newBuilder().setValue("").build());
@@ -52,8 +51,7 @@ public class TaskKillerTest {
         // Enqueue a task to kill, but it shouldn't be killed since no driver exists
         TaskKiller.killTask(TestConstants.TASK_ID);
 
-        // Set the driver
-        TaskKiller.setDriver(driver);
+        Driver.setDriver(driver);
         verify(driver, never()).killTask(TestConstants.TASK_ID);
 
         // Perform an iteration of task killing
@@ -65,8 +63,7 @@ public class TaskKillerTest {
 
     @Test
     public void normalDriverSet() {
-        // Set the driver
-        TaskKiller.setDriver(driver);
+        Driver.setDriver(driver);
         verify(driver, never()).killTask(TestConstants.TASK_ID);
 
         // Enqueue a task to kill, and it should have a kill call issued immediately
@@ -78,8 +75,7 @@ public class TaskKillerTest {
 
     @Test
     public void multipleKillAttempts() {
-        // Set the driver
-        TaskKiller.setDriver(driver);
+        Driver.setDriver(driver);
         verify(driver, never()).killTask(TestConstants.TASK_ID);
 
         // Enqueue a task to kill, and it should have a kill call issued immediately
@@ -96,8 +92,7 @@ public class TaskKillerTest {
 
     @Test
     public void multipleKillAttemptsWithNonTerminalStatus() {
-        // Set the driver
-        TaskKiller.setDriver(driver);
+        Driver.setDriver(driver);
         verify(driver, never()).killTask(TestConstants.TASK_ID);
 
         // Enqueue a task to kill, and it should have a kill call issued immediately

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/plan/DefaultPlanCoordinatorTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/plan/DefaultPlanCoordinatorTest.java
@@ -9,7 +9,6 @@ import com.mesosphere.sdk.state.StateStore;
 import com.mesosphere.sdk.storage.MemPersister;
 import com.mesosphere.sdk.testutils.*;
 import org.apache.mesos.Protos;
-import org.apache.mesos.SchedulerDriver;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -76,7 +75,6 @@ public class DefaultPlanCoordinatorTest extends DefaultCapabilitiesTestSuite {
     private DefaultServiceSpec serviceSpecificationB;
     private StateStore stateStore;
     private DefaultPlanScheduler planScheduler;
-    private SchedulerDriver schedulerDriver;
     private StepFactory stepFactory;
     private PhaseFactory phaseFactory;
 
@@ -84,7 +82,6 @@ public class DefaultPlanCoordinatorTest extends DefaultCapabilitiesTestSuite {
     public void setupTest() throws Exception {
         MockitoAnnotations.initMocks(this);
 
-        schedulerDriver = mock(SchedulerDriver.class);
         serviceSpecification = DefaultServiceSpec.newBuilder()
                 .name(SERVICE_NAME)
                 .role(TestConstants.ROLE)
@@ -154,7 +151,6 @@ public class DefaultPlanCoordinatorTest extends DefaultCapabilitiesTestSuite {
         Assert.assertEquals(
                 Arrays.asList(TestConstants.OFFER_ID),
                 planScheduler.resourceOffers(
-                        schedulerDriver,
                         getOffers(SUFFICIENT_CPUS, SUFFICIENT_MEM, SUFFICIENT_DISK),
                         coordinator.getCandidates()));
     }
@@ -227,7 +223,6 @@ public class DefaultPlanCoordinatorTest extends DefaultCapabilitiesTestSuite {
         Assert.assertEquals(
                 Collections.emptyList(),
                 planScheduler.resourceOffers(
-                        schedulerDriver,
                         getOffers(SUFFICIENT_CPUS, INSUFFICIENT_MEM, INSUFFICIENT_DISK),
                         coordinator.getCandidates()));
     }
@@ -241,7 +236,6 @@ public class DefaultPlanCoordinatorTest extends DefaultCapabilitiesTestSuite {
         Assert.assertEquals(
                 Collections.emptyList(),
                 planScheduler.resourceOffers(
-                        schedulerDriver,
                         getOffers(SUFFICIENT_CPUS, SUFFICIENT_MEM, SUFFICIENT_DISK),
                         coordinator.getCandidates()));
     }
@@ -255,7 +249,6 @@ public class DefaultPlanCoordinatorTest extends DefaultCapabilitiesTestSuite {
         Assert.assertEquals(
                 Arrays.asList(TestConstants.OFFER_ID, OTHER_ID),
                 planScheduler.resourceOffers(
-                        schedulerDriver,
                         getOffers(SUFFICIENT_CPUS, SUFFICIENT_MEM, SUFFICIENT_DISK),
                         coordinator.getCandidates()));
     }
@@ -272,7 +265,6 @@ public class DefaultPlanCoordinatorTest extends DefaultCapabilitiesTestSuite {
         Assert.assertEquals(
                 Arrays.asList(TestConstants.OFFER_ID),
                 planScheduler.resourceOffers(
-                        schedulerDriver,
                         getOffers(SUFFICIENT_CPUS, SUFFICIENT_MEM, SUFFICIENT_DISK),
                         coordinator.getCandidates()));
     }
@@ -292,7 +284,6 @@ public class DefaultPlanCoordinatorTest extends DefaultCapabilitiesTestSuite {
         Assert.assertEquals(
                 Collections.emptyList(),
                 planScheduler.resourceOffers(
-                        schedulerDriver,
                         getOffers(SUFFICIENT_CPUS, SUFFICIENT_MEM, SUFFICIENT_DISK),
                         coordinator.getCandidates()));
     }
@@ -314,7 +305,6 @@ public class DefaultPlanCoordinatorTest extends DefaultCapabilitiesTestSuite {
         Assert.assertEquals(
                 Arrays.asList(TestConstants.OFFER_ID),
                 planScheduler.resourceOffers(
-                        schedulerDriver,
                         getOffers(SUFFICIENT_CPUS, SUFFICIENT_MEM, SUFFICIENT_DISK),
                         coordinator.getCandidates()));
 

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/plan/strategy/CanaryStrategyTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/plan/strategy/CanaryStrategyTest.java
@@ -47,7 +47,7 @@ public class CanaryStrategyTest {
     public void beforeEach() {
         MockitoAnnotations.initMocks(this);
 
-        // (re)initialize as pending:
+        // (re)getPlanCoordinator as pending:
         step0 = new TestStep("step0", podInstanceRequirements.get(0));
         step1 = new TestStep("step1", podInstanceRequirements.get(1));
         step2 = new TestStep("step2", podInstanceRequirements.get(2));

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/uninstall/TaskKillStepTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/uninstall/TaskKillStepTest.java
@@ -1,6 +1,6 @@
 package com.mesosphere.sdk.scheduler.uninstall;
 
-import com.mesosphere.sdk.scheduler.TaskKiller;
+import com.mesosphere.sdk.scheduler.Driver;
 import com.mesosphere.sdk.scheduler.plan.Status;
 import org.apache.mesos.Protos;
 import org.apache.mesos.SchedulerDriver;
@@ -22,7 +22,7 @@ public class TaskKillStepTest {
     @Before
     public void init() {
         MockitoAnnotations.initMocks(this);
-        TaskKiller.setDriver(driver);
+        Driver.setDriver(driver);
     }
 
     @Test

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/uninstall/UninstallSchedulerTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/uninstall/UninstallSchedulerTest.java
@@ -95,7 +95,7 @@ public class UninstallSchedulerTest extends DefaultCapabilitiesTestSuite {
     @Test
     public void testInitialPlan() throws Exception {
         UninstallScheduler uninstallScheduler = getUninstallScheduler();
-        PlanCoordinator planCoordinator = uninstallScheduler.initialize(mockSchedulerDriver);
+        PlanCoordinator planCoordinator = uninstallScheduler.getPlanCoordinator();
         Plan plan = planCoordinator.getPlanManagers().stream().findFirst().get().getPlan();
         // 1 task kill + 3 unique resources + deregister step
         List<Status> expected = Arrays.asList(Status.PENDING, Status.PENDING, Status.PENDING, Status.PENDING, Status.PENDING);
@@ -108,7 +108,7 @@ public class UninstallSchedulerTest extends DefaultCapabilitiesTestSuite {
         stateStore.storeTasks(Arrays.asList(TASK_B));
 
         UninstallScheduler uninstallScheduler = getUninstallScheduler();
-        PlanCoordinator planCoordinator = uninstallScheduler.initialize(mockSchedulerDriver);
+        PlanCoordinator planCoordinator = uninstallScheduler.getPlanCoordinator();
         Plan plan = planCoordinator.getPlanManagers().stream().findFirst().get().getPlan();
         // 2 task kills + 4 unique resources + deregister step.
         List<Status> expected = Arrays.asList(
@@ -124,7 +124,7 @@ public class UninstallSchedulerTest extends DefaultCapabilitiesTestSuite {
         stateStore.storeStatus(TASK_B.getName(), TASK_B_STATUS_ERROR);
 
         UninstallScheduler uninstallScheduler = getUninstallScheduler();
-        PlanCoordinator planCoordinator = uninstallScheduler.initialize(mockSchedulerDriver);
+        PlanCoordinator planCoordinator = uninstallScheduler.getPlanCoordinator();
         Plan plan = planCoordinator.getPlanManagers().stream().findFirst().get().getPlan();
         // 2 task kills + 3 unique resources (from task A, not task B) + deregister step.
         List<Status> expected = Arrays.asList(
@@ -137,7 +137,7 @@ public class UninstallSchedulerTest extends DefaultCapabilitiesTestSuite {
         // Initial call to resourceOffers() will return all steps from resource phase as candidates
         // regardless of the offers sent in, and will start the steps.
         UninstallScheduler uninstallScheduler = getUninstallScheduler();
-        PlanCoordinator planCoordinator = uninstallScheduler.initialize(mockSchedulerDriver);
+        PlanCoordinator planCoordinator = uninstallScheduler.getPlanCoordinator();
         uninstallScheduler.getMesosScheduler().get()
                 .resourceOffers(mockSchedulerDriver, Arrays.asList(getOffer()));
         uninstallScheduler.awaitOffersProcessed();
@@ -159,7 +159,7 @@ public class UninstallSchedulerTest extends DefaultCapabilitiesTestSuite {
     public void testUninstallStepsComplete() throws Exception {
         Protos.Offer offer = OfferTestUtils.getOffer(Arrays.asList(RESERVED_RESOURCE_1, RESERVED_RESOURCE_2));
         UninstallScheduler uninstallScheduler = getUninstallScheduler();
-        PlanCoordinator planCoordinator = uninstallScheduler.initialize(mockSchedulerDriver);
+        PlanCoordinator planCoordinator = uninstallScheduler.getPlanCoordinator();
         uninstallScheduler.getMesosScheduler().get()
                 .resourceOffers(mockSchedulerDriver, Collections.singletonList(offer));
         uninstallScheduler.awaitOffersProcessed();
@@ -180,7 +180,7 @@ public class UninstallSchedulerTest extends DefaultCapabilitiesTestSuite {
         Protos.Offer offer = OfferTestUtils.getOffer(Arrays.asList(
                 RESERVED_RESOURCE_1, RESERVED_RESOURCE_2, RESERVED_RESOURCE_3));
         UninstallScheduler uninstallScheduler = getUninstallScheduler();
-        PlanCoordinator planCoordinator = uninstallScheduler.initialize(mockSchedulerDriver);
+        PlanCoordinator planCoordinator = uninstallScheduler.getPlanCoordinator();
         uninstallScheduler.getMesosScheduler().get()
                 .resourceOffers(mockSchedulerDriver, Collections.singletonList(offer));
         uninstallScheduler.awaitOffersProcessed();
@@ -208,7 +208,7 @@ public class UninstallSchedulerTest extends DefaultCapabilitiesTestSuite {
                 SchedulerConfigTestUtils.getTestSchedulerConfig(),
                 Optional.of(mockSecretsClient));
         // Returns a simple placeholder plan with status COMPLETE
-        PlanCoordinator planCoordinator = uninstallScheduler.initialize(mockSchedulerDriver);
+        PlanCoordinator planCoordinator = uninstallScheduler.getPlanCoordinator();
         Plan plan = planCoordinator.getPlanManagers().stream().findFirst().get().getPlan();
         Assert.assertTrue(plan.toString(), plan.isComplete());
         Assert.assertTrue(plan.getChildren().isEmpty());
@@ -228,7 +228,7 @@ public class UninstallSchedulerTest extends DefaultCapabilitiesTestSuite {
         when(serviceSpecWithTLSTasks.getPods()).thenReturn(Arrays.asList(mockPod));
 
         UninstallScheduler uninstallScheduler = getUninstallScheduler(serviceSpecWithTLSTasks);
-        PlanCoordinator planCoordinator = uninstallScheduler.initialize(mockSchedulerDriver);
+        PlanCoordinator planCoordinator = uninstallScheduler.getPlanCoordinator();
         Plan plan = planCoordinator.getPlanManagers().stream().findFirst().get().getPlan();
 
         when(mockSecretsClient.list(TestConstants.SERVICE_NAME)).thenReturn(Collections.emptyList());


### PR DESCRIPTION
This PR depends on #2191 and so is WIP until that merges.

A desire for a minor improvement has driven the construction of both that PR and this one.  We wanted to start the API server as soon as possible since its startup blocks the acceptance of offers (for good reason).  However the construction of any entity which must communicate with Mesos is tied up with registration and a need to gain access to a Mesos `SchedulerDriver`.

So I made a single global way to get or set a `SchedulerDriver`.  It's in the new `Driver` class.

This allows us to:
1. Construct objects when it makes sense, independent of our access to the `SchedulerDriver`.
1. Simplify method signatures (including constructors) by not having to pass around and store `SchedulerDriver`s in many places.
1. Continue simplification of construction of the "top of the stack" `SchedulerRunner`, `AbstractScheduler`, `DefaultScheduler`, `DefaultPlanScheduler` etc. components.

This PR ultimately does allow the API server to start sooner, but the core change is how we access the `SchedulerDriver`.