### PR TITLE
Correct setDriver call to use Driver singleton

### DIFF
--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/DefaultSchedulerTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/DefaultSchedulerTest.java
@@ -192,7 +192,7 @@ public class DefaultSchedulerTest {
     @Before
     public void beforeEach() throws Exception {
         MockitoAnnotations.initMocks(this);
-        TaskKiller.setDriver(mockSchedulerDriver);
+        Driver.setDriver(mockSchedulerDriver);
 
         when(mockSchedulerConfig.isStateCacheEnabled()).thenReturn(true);
         ServiceSpec serviceSpec = getServiceSpec(podA, podB);


### PR DESCRIPTION
This fixes a testing bug introduced in #2201 (as a follow-up to #2193) which causes the SDK builds to fail.

I have tested locally with `./gradlew clean build`.

The `TaskKiller` now interacts with the **global** `Driver` and does not maintain its own reference to a `SchedulerDriver`.