### PR TITLE
Fix sidecar refinement / MOUNT volume reuse

### DIFF
--- a/frameworks/helloworld/src/main/dist/examples/pre-reserved-sidecar.yml
+++ b/frameworks/helloworld/src/main/dist/examples/pre-reserved-sidecar.yml
@@ -1,0 +1,39 @@
+name: {{FRAMEWORK_NAME}}
+scheduler:
+  principal: {{SERVICE_PRINCIPAL}}
+  user: {{SERVICE_USER}}
+pods:
+  hello:
+    pre-reserved-role: slave_public
+    count: {{HELLO_COUNT}}
+    placement: '{{{HELLO_PLACEMENT}}}'
+    volume:
+      path: pod-container-path
+      type: ROOT
+      size: {{HELLO_DISK}}
+    tasks:
+      server:
+        goal: RUNNING
+        cmd: echo hello >> hello-container-path/output && echo hello >> pod-container-path/output && sleep $SLEEP_DURATION
+        cpus: {{HELLO_CPUS}}
+        memory: {{HELLO_MEM}}
+        volume:
+          path: hello-container-path
+          type: ROOT
+          size: {{HELLO_DISK}}
+        env:
+          SLEEP_DURATION: {{SLEEP_DURATION}}
+      sidecar:
+        goal: FINISHED
+        cmd: echo sidecar >> pod-container-path/output
+        cpus: 0.1
+        memory: 256
+
+plans:
+  deploy:
+    phases:
+      hello:
+        strategy: serial
+        pod: hello
+        steps:
+          - default: [[server], [sidecar]]

--- a/frameworks/helloworld/src/main/dist/examples/pre-reserved-sidecar.yml
+++ b/frameworks/helloworld/src/main/dist/examples/pre-reserved-sidecar.yml
@@ -37,3 +37,11 @@ plans:
         pod: hello
         steps:
           - default: [[server], [sidecar]]
+  sidecar:
+    strategy: serial
+    phases:
+      sidecar-deploy:
+        strategy: parallel
+        pod: hello
+        steps:
+          - default: [[sidecar]]

--- a/frameworks/helloworld/tests/test_pre_reserved_sidecar.py
+++ b/frameworks/helloworld/tests/test_pre_reserved_sidecar.py
@@ -1,0 +1,55 @@
+import logging
+
+import pytest
+import retrying
+
+import sdk_cmd
+import sdk_install
+import sdk_marathon
+import sdk_plan
+import sdk_utils
+from tests import config
+
+log = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope='module', autouse=True)
+def configure_package(configure_security):
+    try:
+        sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
+        options = {
+            "service": {
+                "spec_file": "examples/pre-reserved-sidecar.yml"
+            }
+        }
+
+        # this yml has 1 hello's + 0 world's:
+        sdk_install.install(config.PACKAGE_NAME, config.SERVICE_NAME, 1, additional_options=options)
+
+        yield # let the test session execute
+    finally:
+        sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
+
+
+@pytest.mark.sanity
+@pytest.mark.dcos_min_version('1.10')
+def test_deploy():
+    sdk_plan.wait_for_completed_deployment(config.SERVICE_NAME)
+
+
+@pytest.mark.sanity
+@pytest.mark.dcos_min_version('1.10')
+def test_sidecar():
+    run_plan('sidecar')
+
+
+def run_plan(plan_name, params=None):
+    sdk_plan.start_plan(config.SERVICE_NAME, plan_name, params)
+
+    started_plan = sdk_plan.get_plan(config.SERVICE_NAME, plan_name)
+    log.info("sidecar plan: " + str(started_plan))
+    assert(len(started_plan['phases']) == 1)
+    assert(started_plan['phases'][0]['name'] == plan_name + '-deploy')
+    assert(len(started_plan['phases'][0]['steps']) == 1)
+
+    sdk_plan.wait_for_completed_plan(config.SERVICE_NAME, plan_name)

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/ResourceUtils.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/ResourceUtils.java
@@ -115,10 +115,18 @@ public class ResourceUtils {
     }
 
     public static Optional<String> getSourceRoot(Resource resource) {
-        if (resource.hasDisk() && resource.getDisk().hasSource()) {
-            return Optional.of(resource.getDisk().getSource().getMount().getRoot());
+        if (!isMountVolume(resource)) {
+            return Optional.empty();
         }
 
-        return Optional.empty();
+        return Optional.of(resource.getDisk().getSource().getMount().getRoot());
+    }
+
+    private static boolean isMountVolume(Resource resource) {
+        return resource.hasDisk()
+                && resource.getDisk().hasSource()
+                && resource.getDisk().getSource().hasType()
+                && resource.getDisk().getSource().getType()
+                .equals(Resource.DiskInfo.Source.Type.MOUNT);
     }
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/TaskUtils.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/TaskUtils.java
@@ -531,7 +531,9 @@ public class TaskUtils {
         // Tasks with a goal state of finished should never leave the purview of their original
         // plan, so they are not the responsibility of recovery.  Recovery only applies to Tasks
         // which reached their goal state of RUNNING and then later failed.
-        if (taskSpec.getGoal().equals(GoalState.ONCE) || taskSpec.getGoal().equals(GoalState.FINISH)) {
+        if (taskSpec.getGoal().equals(GoalState.ONCE)
+                || taskSpec.getGoal().equals(GoalState.FINISH)
+                || taskSpec.getGoal().equals(GoalState.FINISHED)) {
             return false;
         } else {
             return isRecoveryNeeded(taskStatus);

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluationUtils.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluationUtils.java
@@ -2,10 +2,7 @@ package com.mesosphere.sdk.offer.evaluate;
 
 import com.google.protobuf.TextFormat;
 import com.mesosphere.sdk.offer.*;
-import com.mesosphere.sdk.specification.DefaultResourceSpec;
-import com.mesosphere.sdk.specification.PodSpec;
-import com.mesosphere.sdk.specification.ResourceSpec;
-import com.mesosphere.sdk.specification.TaskSpec;
+import com.mesosphere.sdk.specification.*;
 import org.apache.mesos.Protos;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -231,5 +228,15 @@ class OfferEvaluationUtils {
         }
 
         return false;
+    }
+
+    public static VolumeSpec updateVolumeSpec(VolumeSpec original, double diskSize) {
+        return new DefaultVolumeSpec(
+                diskSize,
+                original.getType(),
+                original.getContainerPath(),
+                original.getRole(),
+                original.getPreReservedRole(),
+                original.getPrincipal());
     }
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluator.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluator.java
@@ -323,9 +323,7 @@ public class OfferEvaluator {
         }
 
         for (VolumeSpec volumeSpec : podInstanceRequirement.getPodInstance().getPod().getVolumes()) {
-            evaluationStages.add(
-                    new VolumeEvaluationStage(
-                            volumeSpec, null, Optional.empty(), Optional.empty(), useDefaultExecutor));
+            evaluationStages.add(VolumeEvaluationStage.getNew(volumeSpec, null, useDefaultExecutor));
         }
 
         String preReservedRole = null;
@@ -354,9 +352,7 @@ public class OfferEvaluator {
             }
 
             for (VolumeSpec volumeSpec : entry.getValue().getVolumes()) {
-                evaluationStages.add(
-                        new VolumeEvaluationStage(
-                                volumeSpec, taskName, Optional.empty(), Optional.empty(), useDefaultExecutor));
+                evaluationStages.add(VolumeEvaluationStage.getNew(volumeSpec, taskName, useDefaultExecutor));
             }
 
             if (shouldAddExecutorResources) {

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/ResourceLabels.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/ResourceLabels.java
@@ -9,28 +9,52 @@ import java.util.Optional;
  * Pairs a {@link ResourceSpec} definition with an existing task's labels associated with that resource.
  */
 class ResourceLabels {
-    private final ResourceSpec resourceSpec;
+    private final ResourceSpec original;
+    private final ResourceSpec updated;
+
     private final String resourceId;
     private final Optional<String> persistenceId;
     private final Optional<String> sourceRoot;
 
     public ResourceLabels(ResourceSpec resourceSpec, String resourceId) {
-        this(resourceSpec, resourceId, Optional.empty(), Optional.empty());
+        this(resourceSpec, resourceSpec, resourceId);
     }
 
+    public ResourceLabels(ResourceSpec original, ResourceSpec updated, String resourceId) {
+        this(original, updated, resourceId, Optional.empty(), Optional.empty());
+    }
+
+    /**
+     * ResourceLabels are used to map {@link com.mesosphere.sdk.specification.ServiceSpec} entities to resources which
+     * have actually been consumed.  Generally speaking there should be no difference between the resources from a Mesos
+     * perspective and the resources from a {@link com.mesosphere.sdk.specification.ServiceSpec} perspective.
+     *
+     * There is one special case in which they differ, MOUNT volume resources.  In this case the {@link ResourceSpec}
+     * and actually consumed resources differ in value.  Because MOUNT volumes are atomic if the {@link ResourceSpec}
+     * indicates a need for 25 GB of disk and 50 GB of disk are actually offered, then 50 GB must be consumed.
+     *
+     * To capture this change the concept of an "updated" ResourceSpec is needed.  We modify the ResourceSpec in this
+     * scenario to match the actually consumed resources to facilitate consistent protobuf construction.
+     */
     public ResourceLabels(
-            ResourceSpec resourceSpec,
+            ResourceSpec original,
+            ResourceSpec updated,
             String resourceId,
             Optional<String> persistenceId,
             Optional<String> sourceRoot) {
-        this.resourceSpec = resourceSpec;
+        this.original = original;
+        this.updated = updated;
         this.resourceId = resourceId;
         this.persistenceId = persistenceId;
         this.sourceRoot = sourceRoot;
     }
 
-    public ResourceSpec getResourceSpec() {
-        return resourceSpec;
+    public ResourceSpec getOriginal() {
+        return original;
+    }
+
+    public ResourceSpec getUpdated() {
+        return updated;
     }
 
     public String getResourceId() {

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/ResourceLabels.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/ResourceLabels.java
@@ -1,0 +1,52 @@
+package com.mesosphere.sdk.offer.evaluate;
+
+import com.mesosphere.sdk.specification.ResourceSpec;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+import java.util.Optional;
+
+/**
+ * Pairs a {@link ResourceSpec} definition with an existing task's labels associated with that resource.
+ */
+class ResourceLabels {
+    private final ResourceSpec resourceSpec;
+    private final String resourceId;
+    private final Optional<String> persistenceId;
+    private final Optional<String> sourceRoot;
+
+    public ResourceLabels(ResourceSpec resourceSpec, String resourceId) {
+        this(resourceSpec, resourceId, Optional.empty(), Optional.empty());
+    }
+
+    public ResourceLabels(
+            ResourceSpec resourceSpec,
+            String resourceId,
+            Optional<String> persistenceId,
+            Optional<String> sourceRoot) {
+        this.resourceSpec = resourceSpec;
+        this.resourceId = resourceId;
+        this.persistenceId = persistenceId;
+        this.sourceRoot = sourceRoot;
+    }
+
+    public ResourceSpec getResourceSpec() {
+        return resourceSpec;
+    }
+
+    public String getResourceId() {
+        return resourceId;
+    }
+
+    public Optional<String> getPersistenceId() {
+        return persistenceId;
+    }
+
+    public Optional<String> getSourceRoot() {
+        return sourceRoot;
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
+    }
+}

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/VolumeEvaluationStageTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/VolumeEvaluationStageTest.java
@@ -26,11 +26,9 @@ public class VolumeEvaluationStageTest extends DefaultCapabilitiesTestSuite {
         PodInstanceRequirement podInstanceRequirement =
                 PodInstanceRequirementTestUtils.getMountVolumeRequirement(1.0, 1000);
 
-        VolumeEvaluationStage volumeEvaluationStage = new VolumeEvaluationStage(
+        VolumeEvaluationStage volumeEvaluationStage = VolumeEvaluationStage.getNew(
                 getVolumeSpec(podInstanceRequirement.getPodInstance()),
                 getTaskName(podInstanceRequirement.getPodInstance()),
-                Optional.empty(),
-                Optional.empty(),
                 true);
         EvaluationOutcome outcome =
                 volumeEvaluationStage.evaluate(
@@ -81,11 +79,9 @@ public class VolumeEvaluationStageTest extends DefaultCapabilitiesTestSuite {
         PodInstanceRequirement podInstanceRequirement =
                 PodInstanceRequirementTestUtils.getMountVolumeRequirement(1.0, 2000);
 
-        VolumeEvaluationStage volumeEvaluationStage = new VolumeEvaluationStage(
+        VolumeEvaluationStage volumeEvaluationStage = VolumeEvaluationStage.getNew(
                 getVolumeSpec(podInstanceRequirement.getPodInstance()),
                 getTaskName(podInstanceRequirement.getPodInstance()),
-                Optional.empty(),
-                Optional.empty(),
                 true);
         EvaluationOutcome outcome =
                 volumeEvaluationStage.evaluate(


### PR DESCRIPTION
### Sidecar Resource Refinement Problem
You need to do 3 things to encounter the bug fixed here.
1. Have a volume at the pod level
1. Have a sidecar task on that pod
1. Consume pre-reserved resources for that pod

`edge-lb` does all three of those things and so can't use `0.40.X` versions of the SDK.  This should fix that.  I'll confirm with them before release of `0.40.2`.

### Fix
This change can be a little bit hard to follow.  There were a couple things that needed to happen.
1. Use the `ResourceBuilder` class to build executor volumes so you get the reservation refinement stuff.
1. Pass around the `sourceRoot` field so we can build `MOUNT` volumes for Executor reuse.

### MOUNT volume problem
We have moved to a consistent construction pattern for protobufs.  That is we don't pull them out of the StateStore and reuse them _ever_.  This had problems for mount volumes in particular, because they're atomic.  The `VolumeSpec` says use `50 GB`, but the MOUNT was `100 GB`.  When reusing an Executor volume we need to indicate `100 GB` not fifty.  That information isn't in the spec.

### Fix
When matching resources and specs, grab the size info and put it in the spec.

### Note
~~The custom executor is only supported on 1.9 and previous.  1.9 and previous clusters do not support reservation refinement.  That's why the custom executor code path remains unmodified.~~
This has been manually tested on 1.9 and 1.10.  It's been tested with DSE as well.

We have to solve the generating clusters with MOUNT volumes problem to get integration tests going again.  This PR isn't going to do that.