### PR TITLE
INFINITY-2975 Make plan status behave better in a race (#2174)

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/Element.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/Element.java
@@ -3,7 +3,6 @@ package com.mesosphere.sdk.scheduler.plan;
 import com.mesosphere.sdk.scheduler.plan.strategy.Strategy;
 import org.apache.mesos.Protos.TaskStatus;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -97,13 +96,6 @@ public interface Element {
      */
     default boolean isRunning() {
         return getStatus().isRunning();
-    }
-
-    /**
-     * Indicates whether this Element is capable of being started.
-     */
-    default boolean isEligible(Collection<PodInstanceRequirement> dirtyAssets) {
-        return !isComplete() && !hasErrors();
     }
 
     /**

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/PlanUtils.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/PlanUtils.java
@@ -1,27 +1,24 @@
 package com.mesosphere.sdk.scheduler.plan;
 
 import com.mesosphere.sdk.offer.TaskUtils;
+
 import org.apache.mesos.Protos.Offer;
 import org.apache.mesos.Protos.OfferID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.*;
 import java.util.stream.Collectors;
 
 /**
- * Common utility methods for {@link PlanManager}s.
+ * Common utility methods for {@link Plan} elements.
  */
 public class PlanUtils {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(PlanUtils.class);
+
     private PlanUtils() {
         // do not instantiate
-    }
-
-    public static boolean allHaveStatus(Status status, Collection<? extends Element> elements) {
-        return elements.stream().allMatch(element -> element.getStatus() == status);
-    }
-
-    public static boolean anyHaveStatus(Status status, Collection<? extends Element> elements) {
-        return elements.stream().anyMatch(element -> element.getStatus() == status);
     }
 
     public static List<Offer> filterAcceptedOffers(List<Offer> offers, Collection<OfferID> acceptedOfferIds) {
@@ -34,7 +31,11 @@ public class PlanUtils {
      * elements are not complete, it has operations.
      */
     public static boolean hasOperations(Plan plan) {
-        boolean complete = allHaveStatus(Status.COMPLETE, plan.getChildren());
+        boolean complete = allMatch(
+                Status.COMPLETE,
+                plan.getChildren().stream()
+                        .map(phase -> phase.getStatus())
+                        .collect(Collectors.toList()));
         boolean interrupted = plan.isInterrupted();
         return !complete && !interrupted;
     }
@@ -76,8 +77,114 @@ public class PlanUtils {
 
         return plan.getChildren().stream()
                 .flatMap(phase -> phase.getChildren().stream())
-                .filter(step -> step.isAssetDirty() && step.getPodInstanceRequirement().isPresent())
+                .filter(step -> (step.isPrepared() || step.isStarting())
+                        && step.getPodInstanceRequirement().isPresent())
                 .map(step -> step.getPodInstanceRequirement().get())
                 .collect(Collectors.toSet());
+    }
+
+    /**
+     * Returns whether the provided Plan {@link Element} is eligible for work.
+     *
+     * @param element the element to be checked
+     * @param dirtyAssets list of current dirty assets which are already being worked on
+     * @return whether this element may proceed with work
+     */
+    public static boolean isEligible(Element element, Collection<PodInstanceRequirement> dirtyAssets) {
+        if (element.isComplete() || element.hasErrors()) {
+            return false;
+        }
+        if (element instanceof Interruptible && ((Interruptible) element).isInterrupted()) {
+            return false;
+        }
+        if (element instanceof Step) {
+            Optional<PodInstanceRequirement> podInstanceRequirement = ((Step) element).getPodInstanceRequirement();
+            if (podInstanceRequirement.isPresent()
+                    && PlanUtils.assetConflicts(podInstanceRequirement.get(), dirtyAssets)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Returns the overall status to display by a parent element of the provided children.
+     *
+     * @param parentName the name of the parent element, used for logging
+     * @param childStatuses the statuses of the parent element's children
+     * @param candidateStatuses the statuses of the parent element's candidate children, as selected by the parent
+     *      element's Strategy
+     * @param errors any errors from the parent element
+     * @param isInterrupted whether the parent element is interrupted
+     * @return the Status to display for the parent element
+     */
+    public static <C extends Element> Status getAggregateStatus(
+            String parentName,
+            Collection<Status> childStatuses,
+            Collection<Status> candidateStatuses,
+            Collection<String> errors,
+            boolean isInterrupted) {
+        // Ordering matters throughout this method.  Modify with care.
+        // Also note that this function MUST NOT call parent.getStatus() as that creates a circular call.
+        Status result;
+
+        if (!errors.isEmpty() || anyMatch(Status.ERROR, childStatuses)) {
+            result = Status.ERROR;
+            LOGGER.debug("({} status={}) One or more children contain errors.", parentName, result);
+        } else if (allMatch(Status.COMPLETE, childStatuses)) {
+            result = Status.COMPLETE;
+            LOGGER.debug("({} status={}) All children have status: {}", parentName, result, Status.COMPLETE);
+        } else if (isInterrupted) {
+            result = Status.WAITING;
+            LOGGER.debug("({} status={}) Parent element is interrupted", parentName, result);
+        } else if (anyMatch(Status.PREPARED, childStatuses)) {
+            result = Status.IN_PROGRESS;
+            LOGGER.debug("({} status={}) At least one child has status: {}", parentName, result, Status.PREPARED);
+        } else if (anyMatch(Status.WAITING, candidateStatuses)) {
+            result = Status.WAITING;
+            LOGGER.debug("({} status={}) At least one candidate has status: {}", parentName, result, Status.WAITING);
+        } else if (anyMatch(Status.IN_PROGRESS, candidateStatuses)) {
+            result = Status.IN_PROGRESS;
+            LOGGER.debug("({} status={}) At least one candidate has status: {}",
+                    parentName, result, Status.IN_PROGRESS);
+        } else if (anyMatch(Status.COMPLETE, childStatuses) && anyMatch(Status.PENDING, candidateStatuses)) {
+            result = Status.IN_PROGRESS;
+            LOGGER.debug("({} status={}) At least one child has status '{}' and at least one candidate has status '{}'",
+                    parentName, result, Status.COMPLETE, Status.PENDING);
+        } else if (anyMatch(Status.COMPLETE, childStatuses) && anyMatch(Status.STARTING, candidateStatuses)) {
+            result = Status.IN_PROGRESS;
+            LOGGER.debug("({} status={}) At least one child has status '{}' and at least one candidate has status '{}'",
+                    parentName, result, Status.COMPLETE, Status.STARTING);
+        } else if (anyMatch(Status.COMPLETE, childStatuses) && anyMatch(Status.STARTED, candidateStatuses)) {
+            result = Status.IN_PROGRESS;
+            LOGGER.debug("({} status={}) At least one child has status '{}' and at least one candidate has status '{}'",
+                    parentName, result, Status.COMPLETE, Status.STARTED);
+        } else if (anyMatch(Status.PENDING, candidateStatuses)) {
+            result = Status.PENDING;
+            LOGGER.debug("({} status={}) At least one candidate has status: {}", parentName, result, Status.PENDING);
+        } else if (anyMatch(Status.WAITING, childStatuses)) {
+            result = Status.WAITING;
+            LOGGER.debug("({} status={}) At least one child has status: {}", parentName, result, Status.WAITING);
+        } else if (anyMatch(Status.STARTING, candidateStatuses)) {
+            result = Status.STARTING;
+            LOGGER.debug("({} status={}) At least one candidate has status '{}'", parentName, result, Status.STARTING);
+        } else if (anyMatch(Status.STARTED, candidateStatuses)) {
+            result = Status.STARTED;
+            LOGGER.debug("({} status={}) At least one candidate has status '{}'", parentName, result, Status.STARTED);
+        } else {
+            result = Status.ERROR;
+            LOGGER.warn("({} status={}) Unexpected state. Children: {} Candidates: {}",
+                    parentName, result, childStatuses, candidateStatuses);
+        }
+
+        return result;
+    }
+
+    private static boolean allMatch(Status status, Collection<Status> statuses) {
+        return statuses.stream().allMatch(s -> s == status);
+    }
+
+    private static boolean anyMatch(Status status, Collection<Status> statuses) {
+        return statuses.stream().anyMatch(s -> s == status);
     }
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/Step.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/Step.java
@@ -48,21 +48,6 @@ public interface Step extends Element, Interruptible {
         return getStatus().toString();
     }
 
-    /**
-     * Reports whether the Asset associated with this Step is dirty.
-     */
-    default boolean isAssetDirty() {
-        return isPrepared() || isStarting();
-    }
-
-    @Override
-    default boolean isEligible(Collection<PodInstanceRequirement> dirtyAssets) {
-        return Element.super.isEligible(dirtyAssets) &&
-                !isInterrupted() &&
-                !(getPodInstanceRequirement().isPresent()
-                        && PlanUtils.assetConflicts(getPodInstanceRequirement().get(), dirtyAssets));
-    }
-
     @Override
     default String getMessage() {
         if (!getStatus().toString().equals(getDisplayStatus())) {

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/strategy/CanaryStrategy.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/strategy/CanaryStrategy.java
@@ -1,5 +1,6 @@
 package com.mesosphere.sdk.scheduler.plan.strategy;
 
+import com.mesosphere.sdk.scheduler.plan.PlanUtils;
 import com.mesosphere.sdk.scheduler.plan.PodInstanceRequirement;
 import com.mesosphere.sdk.scheduler.plan.Step;
 
@@ -75,7 +76,7 @@ public class CanaryStrategy implements Strategy<Step> {
         if (getNextCanaryStep() != null) {
             // Still in canary. Only return subset of canary steps which are now eligible due to proceed() calls.
             return canarySteps.stream()
-                    .filter(step -> step.isEligible(dirtyAssets))
+                    .filter(step -> PlanUtils.isEligible(step, dirtyAssets))
                     .collect(Collectors.toList());
         }
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/strategy/DependencyStrategyHelper.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/strategy/DependencyStrategyHelper.java
@@ -1,8 +1,8 @@
 package com.mesosphere.sdk.scheduler.plan.strategy;
 
 import com.mesosphere.sdk.scheduler.plan.Element;
+import com.mesosphere.sdk.scheduler.plan.PlanUtils;
 import com.mesosphere.sdk.scheduler.plan.PodInstanceRequirement;
-
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -17,10 +17,6 @@ public class DependencyStrategyHelper<C extends Element> {
      * Mapping of elements to their prerequisites which must be {@link Element#isComplete()}.
      */
     private final Map<C, Set<C>> dependencies;
-
-    public DependencyStrategyHelper() {
-        this(Collections.emptyList());
-    }
 
     public DependencyStrategyHelper(Collection<C> elements) {
         this.dependencies = new HashMap<>();
@@ -54,7 +50,7 @@ public class DependencyStrategyHelper<C extends Element> {
             return Collections.emptyList();
         }
         return dependencies.entrySet().stream()
-                .filter(entry -> entry.getKey().isEligible(dirtyAssets))
+                .filter(entry -> PlanUtils.isEligible(entry.getKey(), dirtyAssets))
                 .filter(entry -> dependenciesFulfilled(entry.getValue()))
                 .map(entry -> entry.getKey())
                 .collect(Collectors.toList());
@@ -65,11 +61,7 @@ public class DependencyStrategyHelper<C extends Element> {
     }
 
     private static <C extends Element> boolean dependenciesFulfilled(Set<C> deps) {
-        if (deps.isEmpty()) {
-            return true;
-        } else {
-            return deps.stream().allMatch(c -> c.isComplete());
-        }
+        return deps.isEmpty() || deps.stream().allMatch(c -> c.isComplete());
     }
 
     /**

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/plan/DefaultPhaseTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/plan/DefaultPhaseTest.java
@@ -9,8 +9,8 @@ import org.mockito.Mockito;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
-import static org.mockito.Matchers.anyCollectionOf;
 import static org.mockito.Mockito.when;
 
 public class DefaultPhaseTest {
@@ -27,17 +27,16 @@ public class DefaultPhaseTest {
                 new SerialStrategy<>(),
                 Collections.emptyList());
 
+        when(step1.getPodInstanceRequirement()).thenReturn(Optional.empty());
+        when(step2.getPodInstanceRequirement()).thenReturn(Optional.empty());
+
         when(step1.getStatus()).thenReturn(Status.PENDING);
         when(step2.getStatus()).thenReturn(Status.WAITING);
-        when(step1.isEligible(anyCollectionOf(PodInstanceRequirement.class))).thenReturn(true);
-        when(step2.isEligible(anyCollectionOf(PodInstanceRequirement.class))).thenReturn(true);
 
         Assert.assertEquals(Status.PENDING, serialPhase.getStatus());
 
         when(step1.getStatus()).thenReturn(Status.WAITING);
         when(step2.getStatus()).thenReturn(Status.WAITING);
-        when(step1.isEligible(anyCollectionOf(PodInstanceRequirement.class))).thenReturn(true);
-        when(step2.isEligible(anyCollectionOf(PodInstanceRequirement.class))).thenReturn(true);
 
         final DefaultPhase canaryPhase = new DefaultPhase(
                 "canary-phase",

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/plan/DeploymentStepTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/plan/DeploymentStepTest.java
@@ -182,32 +182,6 @@ public class DeploymentStepTest {
     }
 
     @Test
-    public void testIsEligible() {
-        TaskSpec taskSpec0 =
-                TestPodFactory.getTaskSpec(
-                        TASK_NAME_0, TestConstants.RESOURCE_SET_ID + 0, TestConstants.TASK_DNS_PREFIX);
-        TaskSpec taskSpec1 =
-                TestPodFactory.getTaskSpec(
-                        TASK_NAME_1, TestConstants.RESOURCE_SET_ID + 1, TestConstants.TASK_DNS_PREFIX);
-        PodSpec podSpec = DefaultPodSpec.newBuilder("")
-                .type(TestConstants.POD_TYPE)
-                .count(1)
-                .tasks(Arrays.asList(taskSpec0, taskSpec1))
-                .build();
-        PodInstance podInstance = new DefaultPodInstance(podSpec, 0);
-
-        DeploymentStep step = new DeploymentStep(
-                TEST_STEP_NAME,
-                PodInstanceRequirement.newBuilder(podInstance, TaskUtils.getTaskNames(podInstance)).build(),
-                mockStateStore);
-
-        Assert.assertTrue(step.isEligible(Arrays.asList()));
-
-        Collection<PodInstanceRequirement> dirtyAssets = Arrays.asList(step.getPodInstanceRequirement().get());
-        Assert.assertFalse(step.isEligible(dirtyAssets));
-    }
-
-    @Test
     public void testPrepared() {
         TaskSpec taskSpec0 =
                 TestPodFactory.getTaskSpec(

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/plan/PlanUtilsTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/plan/PlanUtilsTest.java
@@ -1,0 +1,134 @@
+package com.mesosphere.sdk.scheduler.plan;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import com.mesosphere.sdk.offer.TaskUtils;
+import com.mesosphere.sdk.specification.DefaultPodSpec;
+import com.mesosphere.sdk.specification.PodInstance;
+import com.mesosphere.sdk.specification.PodSpec;
+import com.mesosphere.sdk.state.StateStore;
+import com.mesosphere.sdk.testutils.TestConstants;
+import com.mesosphere.sdk.testutils.TestPodFactory;
+
+public class PlanUtilsTest {
+    private static final String TEST_STEP_NAME = "test-step";
+    private static final String TASK_NAME_0 = TestConstants.TASK_NAME + 0;
+    private static final String TASK_NAME_1 = TestConstants.TASK_NAME + 1;
+
+    private static final PodSpec POD_SPEC = DefaultPodSpec.newBuilder("")
+            .type(TestConstants.POD_TYPE)
+            .count(1)
+            .tasks(Arrays.asList(
+                    TestPodFactory.getTaskSpec(
+                            TASK_NAME_0, TestConstants.RESOURCE_SET_ID + 0, TestConstants.TASK_DNS_PREFIX),
+                    TestPodFactory.getTaskSpec(
+                            TASK_NAME_1, TestConstants.RESOURCE_SET_ID + 1, TestConstants.TASK_DNS_PREFIX)))
+            .build();
+
+    @Mock private StateStore mockStateStore;
+
+    private DeploymentStep step;
+
+    @Before
+    public void beforeEach() {
+        MockitoAnnotations.initMocks(this);
+        PodInstance podInstance = new DefaultPodInstance(POD_SPEC, 0);
+        step = new DeploymentStep(
+                TEST_STEP_NAME,
+                PodInstanceRequirement.newBuilder(podInstance, TaskUtils.getTaskNames(podInstance)).build(),
+                mockStateStore);
+    }
+
+    @Test
+    public void testAggregateStatusError() {
+        Assert.assertEquals(Status.ERROR, PlanUtils.getAggregateStatus("foo",
+                Collections.emptyList(), Collections.emptyList(), Arrays.asList("err"), false));
+        Assert.assertEquals(Status.ERROR, PlanUtils.getAggregateStatus("foo",
+                Arrays.asList(Status.ERROR), Collections.emptyList(), Collections.emptyList(), false));
+    }
+
+    @Test
+    public void testAggregateStatusComplete() {
+        Assert.assertEquals(Status.COMPLETE, PlanUtils.getAggregateStatus("foo",
+                Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), false));
+        Assert.assertEquals(Status.COMPLETE, PlanUtils.getAggregateStatus("foo",
+                Arrays.asList(Status.COMPLETE, Status.COMPLETE), Collections.emptyList(), Collections.emptyList(), false));
+    }
+
+    @Test
+    public void testAggregateStatusWaiting() {
+        Assert.assertEquals(Status.WAITING, PlanUtils.getAggregateStatus("foo",
+                Arrays.asList(Status.COMPLETE, Status.PENDING), Collections.emptyList(), Collections.emptyList(), true));
+        Assert.assertEquals(Status.WAITING, PlanUtils.getAggregateStatus("foo",
+                Arrays.asList(Status.COMPLETE, Status.WAITING), Collections.emptyList(), Collections.emptyList(), false));
+        Assert.assertEquals(Status.WAITING, PlanUtils.getAggregateStatus("foo",
+                Arrays.asList(Status.COMPLETE, Status.WAITING), Arrays.asList(Status.WAITING), Collections.emptyList(), false));
+    }
+
+    @Test
+    public void testAggregateStatusInProgress() {
+        Assert.assertEquals(Status.IN_PROGRESS, PlanUtils.getAggregateStatus("foo",
+                Arrays.asList(Status.PREPARED, Status.WAITING), Collections.emptyList(), Collections.emptyList(), false));
+        Assert.assertEquals(Status.IN_PROGRESS, PlanUtils.getAggregateStatus("foo",
+                Arrays.asList(Status.COMPLETE, Status.IN_PROGRESS), Arrays.asList(Status.IN_PROGRESS), Collections.emptyList(), false));
+        Assert.assertEquals(Status.IN_PROGRESS, PlanUtils.getAggregateStatus("foo",
+                Arrays.asList(Status.COMPLETE, Status.PENDING), Arrays.asList(Status.PENDING), Collections.emptyList(), false));
+        Assert.assertEquals(Status.IN_PROGRESS, PlanUtils.getAggregateStatus("foo",
+                Arrays.asList(Status.COMPLETE, Status.STARTING), Arrays.asList(Status.STARTING), Collections.emptyList(), false));
+        Assert.assertEquals(Status.IN_PROGRESS, PlanUtils.getAggregateStatus("foo",
+                Arrays.asList(Status.COMPLETE, Status.STARTED), Arrays.asList(Status.STARTED), Collections.emptyList(), false));
+    }
+
+    @Test
+    public void testAggregateStatusPending() {
+        Assert.assertEquals(Status.PENDING, PlanUtils.getAggregateStatus("foo",
+                Arrays.asList(Status.PENDING, Status.PENDING), Arrays.asList(Status.PENDING), Collections.emptyList(), false));
+    }
+
+    @Test
+    public void testAggregateStatusStarting() {
+        Assert.assertEquals(Status.STARTING, PlanUtils.getAggregateStatus("foo",
+                Arrays.asList(Status.STARTING, Status.PENDING), Arrays.asList(Status.STARTING), Collections.emptyList(), false));
+    }
+
+    @Test
+    public void testAggregateStatusStarted() {
+        Assert.assertEquals(Status.STARTED, PlanUtils.getAggregateStatus("foo",
+                Arrays.asList(Status.STARTED, Status.PENDING), Arrays.asList(Status.STARTED), Collections.emptyList(), false));
+    }
+
+    @Test
+    public void testStepNoDirtyAssets() {
+        Assert.assertTrue(PlanUtils.isEligible(step, Collections.emptyList()));
+    }
+
+    @Test
+    public void testStepMatchingDirtyAsset() {
+        Collection<PodInstanceRequirement> dirtyAssets = Arrays.asList(step.getPodInstanceRequirement().get());
+        Assert.assertFalse(PlanUtils.isEligible(step, dirtyAssets));
+    }
+
+    @Test
+    public void testInterruptedStep() {
+        step.interrupt();
+        Assert.assertFalse(PlanUtils.isEligible(step, Collections.emptyList()));
+        step.proceed();
+        Assert.assertTrue(PlanUtils.isEligible(step, Collections.emptyList()));
+    }
+
+    @Test
+    public void testCompletedStep() {
+        step.forceComplete();
+        Assert.assertFalse(PlanUtils.isEligible(step, Collections.emptyList()));
+        step.restart();
+        Assert.assertTrue(PlanUtils.isEligible(step, Collections.emptyList()));
+    }
+}

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/plan/RandomRecoveryStrategyTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/plan/RandomRecoveryStrategyTest.java
@@ -12,7 +12,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Optional;
 
-import static org.mockito.Matchers.anyCollectionOf;
 import static org.mockito.Mockito.when;
 
 /**
@@ -30,13 +29,11 @@ public class RandomRecoveryStrategyTest {
         when(pendingStep.getName()).thenReturn("mock-step");
         when(pendingStep.getPodInstanceRequirement()).thenReturn(Optional.of(podInstancePending));
         when(pendingStep.isPending()).thenReturn(true);
-        when(pendingStep.isEligible(anyCollectionOf(PodInstanceRequirement.class))).thenReturn(true);
 
         when(completeStep.getName()).thenReturn("mock-step");
         when(completeStep.getPodInstanceRequirement()).thenReturn(Optional.of(podInstanceComplete));
         when(completeStep.isPending()).thenReturn(false);
         when(completeStep.isComplete()).thenReturn(true);
-        when(completeStep.isEligible(anyCollectionOf(PodInstanceRequirement.class))).thenReturn(false);
     }
 
 

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/plan/strategy/ParallelStrategyTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/plan/strategy/ParallelStrategyTest.java
@@ -12,7 +12,6 @@ import org.mockito.MockitoAnnotations;
 
 import java.util.*;
 
-import static org.mockito.Matchers.anyCollectionOf;
 import static org.mockito.Mockito.when;
 
 /**
@@ -47,10 +46,6 @@ public class ParallelStrategyTest {
         when(el1.isPending()).thenReturn(true);
         when(el2.isPending()).thenReturn(true);
 
-        when(el0.isEligible(anyCollectionOf(PodInstanceRequirement.class))).thenReturn(true);
-        when(el1.isEligible(anyCollectionOf(PodInstanceRequirement.class))).thenReturn(true);
-        when(el2.isEligible(anyCollectionOf(PodInstanceRequirement.class))).thenReturn(true);
-
         steps = Arrays.asList(el0, el1, el2);
     }
 
@@ -59,16 +54,13 @@ public class ParallelStrategyTest {
         Assert.assertEquals(3, getCandidates().size());
 
         when(el0.isComplete()).thenReturn(true);
-        when(el0.isEligible(anyCollectionOf(PodInstanceRequirement.class))).thenReturn(false);
         Assert.assertEquals(2, getCandidates().size());
 
         when(el1.isComplete()).thenReturn(true);
-        when(el1.isEligible(anyCollectionOf(PodInstanceRequirement.class))).thenReturn(false);
         Assert.assertEquals(1, getCandidates().size());
         Assert.assertEquals(el2, getCandidates().iterator().next());
 
         when(el2.isComplete()).thenReturn(true);
-        when(el2.isEligible(anyCollectionOf(PodInstanceRequirement.class))).thenReturn(false);
         Assert.assertTrue(getCandidates().isEmpty());
     }
 

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/plan/strategy/SerialStrategyTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/plan/strategy/SerialStrategyTest.java
@@ -12,7 +12,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-import static org.mockito.Matchers.anyCollectionOf;
 import static org.mockito.Mockito.when;
 
 /**
@@ -47,10 +46,6 @@ public class SerialStrategyTest {
         when(el1.isPending()).thenReturn(true);
         when(el2.isPending()).thenReturn(true);
 
-        when(el0.isEligible(anyCollectionOf(PodInstanceRequirement.class))).thenReturn(true);
-        when(el1.isEligible(anyCollectionOf(PodInstanceRequirement.class))).thenReturn(true);
-        when(el2.isEligible(anyCollectionOf(PodInstanceRequirement.class))).thenReturn(true);
-
         steps = Arrays.asList(el0, el1, el2);
     }
 
@@ -61,17 +56,14 @@ public class SerialStrategyTest {
         Assert.assertEquals(el0, strategy.getCandidates(steps, Collections.emptyList()).iterator().next());
 
         when(el0.isComplete()).thenReturn(true);
-        when(el0.isEligible(anyCollectionOf(PodInstanceRequirement.class))).thenReturn(false);
         Assert.assertEquals(1, strategy.getCandidates(steps, Collections.emptyList()).size());
         Assert.assertEquals(el1, strategy.getCandidates(steps, Collections.emptyList()).iterator().next());
 
         when(el1.isComplete()).thenReturn(true);
-        when(el1.isEligible(anyCollectionOf(PodInstanceRequirement.class))).thenReturn(false);
         Assert.assertEquals(1, strategy.getCandidates(steps, Collections.emptyList()).size());
         Assert.assertEquals(el2, strategy.getCandidates(steps, Collections.emptyList()).iterator().next());
 
         when(el2.isComplete()).thenReturn(true);
-        when(el2.isEligible(anyCollectionOf(PodInstanceRequirement.class))).thenReturn(false);
         Assert.assertTrue(strategy.getCandidates(steps, Collections.emptyList()).isEmpty());
     }
 


### PR DESCRIPTION
(BACKPORT OF: #2174)

- Fetch plan status after phase/step status. If the steps change in the middle of this, then we end up with e.g. a plan that's still IN_PROGRESS when its steps are all COMPLETE. This is less ugly for users.
- Move some Element-level functions into internal utilities. Started on this in an earlier version of this fix, may as well keep it around.