### PR TITLE
Fix 404 for developer-guide link on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 
 [__Quick Start__](README.md#quick-start) |
-[__Developer Guide__](https://mesosphere.github.io/dcos-commons/developer-guide.html) |
+[__Developer Guide__](https://mesosphere.github.io/dcos-commons/developer-guide/) |
 [__FAQ__](docs/pages/faq.md) |
 [__Javadocs__](https://mesosphere.github.io/dcos-commons/reference/api/) |
 [__Contributing__](CONTRIBUTING.md) |

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ volume:
 
 ---
 ### References
-* [Developer Guide](https://mesosphere.github.io/dcos-commons/developer-guide.html)
+* [Developer Guide](https://mesosphere.github.io/dcos-commons/developer-guide/)
 * [Javadocs](https://mesosphere.github.io/dcos-commons/reference/api/)
 
 ---


### PR DESCRIPTION
The current developer guide link now results in a 404 not found. I've replaced with the correct link.