### PR TITLE
[INFINITY-3111] Gracefully handle invalid placement constraints

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/config/validate/DefaultConfigValidators.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/config/validate/DefaultConfigValidators.java
@@ -25,6 +25,7 @@ public class DefaultConfigValidators {
                 new PreReservationCannotChange(),
                 new UserCannotChange(),
                 new TLSRequiresServiceAccount(schedulerConfig),
-                new DomainCapabilityValidator());
+                new DomainCapabilityValidator(),
+                new PlacementRuleIsValid());
     }
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/config/validate/PlacementRuleIsValid.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/config/validate/PlacementRuleIsValid.java
@@ -1,0 +1,35 @@
+package com.mesosphere.sdk.config.validate;
+
+import com.mesosphere.sdk.offer.evaluate.placement.PlacementRule;
+import com.mesosphere.sdk.specification.PodSpec;
+import com.mesosphere.sdk.specification.ServiceSpec;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+
+public class PlacementRuleIsValid implements ConfigValidator<ServiceSpec> {
+    @Override
+    public Collection<ConfigValidationError> validate(Optional<ServiceSpec> oldConfig, ServiceSpec newConfig) {
+        List<PodSpec> podSpecs = newConfig.getPods().stream()
+                .filter(podSpec -> podSpec.getPlacementRule().isPresent())
+                .collect(Collectors.toList());
+
+        List<ConfigValidationError> errors = new ArrayList<>();
+        for (final PodSpec podSpec : podSpecs) {
+            PlacementRule placementRule = podSpec.getPlacementRule().get();
+
+            if (!placementRule.isValid()) {
+                String errMsg = String.format(
+                        "The PlacementRule for PodSpec '%s' had invalid constraints",
+                        podSpec.getType());
+                errors.add(ConfigValidationError.valueError("PlacementRule", placementRule.toString(), errMsg));
+            }
+        }
+
+        return errors;
+    }
+}

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/config/validate/PlacementRuleIsValid.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/config/validate/PlacementRuleIsValid.java
@@ -11,6 +11,9 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 
+/**
+ * A {@link ConfigValidator} that checks for valid placement constraints.
+ */
 public class PlacementRuleIsValid implements ConfigValidator<ServiceSpec> {
     @Override
     public Collection<ConfigValidationError> validate(Optional<ServiceSpec> oldConfig, ServiceSpec newConfig) {

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/AndRule.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/AndRule.java
@@ -87,4 +87,14 @@ public class AndRule implements PlacementRule {
     public int hashCode() {
         return HashCodeBuilder.reflectionHashCode(this);
     }
+
+    @Override
+    public boolean isValid() {
+        if (rules.isEmpty()) {
+            return false;
+        }
+
+        return rules.stream().allMatch(PlacementRule::isValid);
+
+    }
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/AndRule.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/AndRule.java
@@ -69,7 +69,7 @@ public class AndRule implements PlacementRule {
     }
 
     @JsonProperty("rules")
-    private Collection<PlacementRule> getRules() {
+    public Collection<PlacementRule> getRules() {
         return rules;
     }
 
@@ -88,13 +88,4 @@ public class AndRule implements PlacementRule {
         return HashCodeBuilder.reflectionHashCode(this);
     }
 
-    @Override
-    public boolean isValid() {
-        if (rules.isEmpty()) {
-            return false;
-        }
-
-        return rules.stream().allMatch(PlacementRule::isValid);
-
-    }
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/InvalidPlacementRule.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/InvalidPlacementRule.java
@@ -13,7 +13,7 @@ import java.util.Collection;
 import java.util.Collections;
 
 /**
- * Wrapper for a placement rule that is ALWAYS invalid
+ * An implementation of a {@PlacementRule} that is ALWAYS invalid.
  */
 public class InvalidPlacementRule implements PlacementRule {
     private final String constraints;

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/InvalidPlacementRule.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/InvalidPlacementRule.java
@@ -1,6 +1,7 @@
 package com.mesosphere.sdk.offer.evaluate.placement;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.mesosphere.sdk.offer.evaluate.EvaluationOutcome;
 import com.mesosphere.sdk.specification.PodInstance;
 import org.apache.commons.lang3.builder.EqualsBuilder;
@@ -15,24 +16,26 @@ import java.util.Collections;
  * Wrapper for a placement rule that is ALWAYS invalid
  */
 public class InvalidPlacementRule implements PlacementRule {
-    private String constraint;
-    private String exception;
+    private final String constraints;
+    private final String exception;
 
     @JsonCreator
-    public InvalidPlacementRule(String constraintString, String exception) {
-        this.constraint = constraintString;
+    public InvalidPlacementRule(
+            @JsonProperty("constraints ") String constraints,
+            @JsonProperty("exception") String exception) {
+        this.constraints = constraints;
         this.exception = exception;
     }
 
     @Override
     public EvaluationOutcome filter(Offer offer, PodInstance podInstance, Collection<TaskInfo> tasks) {
         return EvaluationOutcome.fail(this,
-                String.format("Invalid placement constraint for %s: %s", podInstance.getName(), constraint)).build();
+                String.format("Invalid placement constraints for %s: %s", podInstance.getName(), constraints)).build();
     }
 
     @Override
     public String toString() {
-        return String.format("InvalidPlacementRule{constraint=%s, exception=%s}", constraint, exception);
+        return String.format("InvalidPlacementRule{constraints=%s, exception=%s}", constraints, exception);
     }
 
     @Override
@@ -43,6 +46,16 @@ public class InvalidPlacementRule implements PlacementRule {
     @Override
     public boolean equals(Object o) {
         return EqualsBuilder.reflectionEquals(this, o);
+    }
+
+    @JsonProperty("constraints")
+    public String getConstraints() {
+        return constraints;
+    }
+
+    @JsonProperty("exception")
+    public String getException() {
+        return exception;
     }
 
     @Override

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/InvalidPlacementRule.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/InvalidPlacementRule.java
@@ -1,0 +1,53 @@
+package com.mesosphere.sdk.offer.evaluate.placement;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.mesosphere.sdk.offer.evaluate.EvaluationOutcome;
+import com.mesosphere.sdk.specification.PodInstance;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.mesos.Protos.Offer;
+import org.apache.mesos.Protos.TaskInfo;
+
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * Wrapper for a placement rule that is ALWAYS invalid
+ */
+public class InvalidPlacementRule implements PlacementRule {
+    private String constraint;
+    private String exception;
+
+    @JsonCreator
+    public InvalidPlacementRule(String constraintString, String exception) {
+        this.constraint = constraintString;
+        this.exception = exception;
+    }
+
+    @Override
+    public EvaluationOutcome filter(Offer offer, PodInstance podInstance, Collection<TaskInfo> tasks) {
+        return EvaluationOutcome.fail(this,
+                String.format("Invalid placement constraint for %s: %s", podInstance.getName(), constraint)).build();
+    }
+
+    @Override
+    public String toString() {
+        return String.format("InvalidPlacementRule{constraint=%s, exception=%s}", constraint, exception);
+    }
+
+    @Override
+    public Collection<PlacementField> getPlacementFields() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return EqualsBuilder.reflectionEquals(this, o);
+    }
+
+    @Override
+    public int hashCode() {
+        return HashCodeBuilder.reflectionHashCode(this);
+    }
+
+}

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/InvalidPlacementRule.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/InvalidPlacementRule.java
@@ -50,4 +50,9 @@ public class InvalidPlacementRule implements PlacementRule {
         return HashCodeBuilder.reflectionHashCode(this);
     }
 
+    @Override
+    public boolean isValid() {
+        return false;
+    }
+
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/InvalidPlacementRule.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/InvalidPlacementRule.java
@@ -63,9 +63,4 @@ public class InvalidPlacementRule implements PlacementRule {
         return HashCodeBuilder.reflectionHashCode(this);
     }
 
-    @Override
-    public boolean isValid() {
-        return false;
-    }
-
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/MarathonConstraintParser.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/MarathonConstraintParser.java
@@ -41,11 +41,12 @@ public class MarathonConstraintParser {
      * {@link PlacementRule}, or returns the provided {@link PlacementRule} as-is if the
      * marathon-style constraint is {@code null} or empty.
      *
-     * @param podName             The task type these constraints apply to (e.g. "hello"). Applying a constraint to all tasks
-     *                            in a service is not supported.
+     * @param podName             The task type these constraints apply to (e.g. "hello"). Applying a constraint to all
+     *                            tasks in a service is not supported.
      * @param rule                The hard-coded {@link PlacementRule}
      * @param marathonConstraints the marathon-style constraint string, containing one or more
-     *                            nested json list entries of the form {@code [["multi","list","value"],["hello","hi"]]},
+     *                            nested json list entries of the form
+     *                            {@code [["multi","list","value"],["hello","hi"]]},
      *                            or one or more colon-separated entries of the form {@code multi:list:value,hello:hi},
      *                            or a {@code null} or empty value if no constraint is defined
      * @throws IOException if {@code marathonConstraints} couldn't be parsed, or if the parsed
@@ -65,10 +66,11 @@ public class MarathonConstraintParser {
      * constraint string. Returns a {@link PassthroughRule} if the provided constraint string is
      * {@code null} or empty.
      *
-     * @param podName             The task type these constraints apply to (e.g. "hello"). Applying a constraint to all tasks
-     *                            in a service is not supported.
+     * @param podName             The task type these constraints apply to (e.g. "hello"). Applying a constraint to all
+     *                            tasks in a service is not supported.
      * @param marathonConstraints the marathon-style constraint string, containing one or more
-     *                            nested json list entries of the form {@code [["multi","list","value"],["hello","hi"]]},
+     *                            nested json list entries of the form
+     *                            {@code [["multi","list","value"],["hello","hi"]]},
      *                            or one or more colon-separated entries of the form {@code multi:list:value,hello:hi},
      *                            or a {@code null} or empty value if no constraint is defined
      * @throws IOException if {@code marathonConstraints} couldn't be parsed, or if the parsed
@@ -155,6 +157,8 @@ public class MarathonConstraintParser {
                 LOGGER.debug("Nested list '{}' => {} rows: '{}'", marathonConstraints, rows.size(), rows);
                 return rows;
             } catch (IOException | ClassCastException e2) { // May throw ClassCastException as well as IOException
+
+
                 // Finally try: a:b:c,d:e
                 // Note: We use Guava's Splitter rather than String.split(regex) in order to correctly
                 // handle empty trailing fields like 'a:b:' => ['a', 'b', ''] (shouldn't come up but just in case).

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/MarathonConstraintParser.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/MarathonConstraintParser.java
@@ -155,13 +155,6 @@ public class MarathonConstraintParser {
                 LOGGER.debug("Nested list '{}' => {} rows: '{}'", marathonConstraints, rows.size(), rows);
                 return rows;
             } catch (IOException | ClassCastException e2) { // May throw ClassCastException as well as IOException
-
-                // A common reason for incorrect placement is over-escaping.
-                String strippedConstraints = marathonConstraints.replace("\\\"", "\"");
-                if (!strippedConstraints.equals(marathonConstraints)) {
-                    return splitConstraints(strippedConstraints);
-                }
-
                 // Finally try: a:b:c,d:e
                 // Note: We use Guava's Splitter rather than String.split(regex) in order to correctly
                 // handle empty trailing fields like 'a:b:' => ['a', 'b', ''] (shouldn't come up but just in case).

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/MarathonConstraintParser.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/MarathonConstraintParser.java
@@ -37,31 +37,6 @@ public class MarathonConstraintParser {
     }
 
     /**
-     * ANDs the provided marathon-style constraint string onto the provided hard-coded
-     * {@link PlacementRule}, or returns the provided {@link PlacementRule} as-is if the
-     * marathon-style constraint is {@code null} or empty.
-     *
-     * @param podName             The task type these constraints apply to (e.g. "hello"). Applying a constraint to all
-     *                            tasks in a service is not supported.
-     * @param rule                The hard-coded {@link PlacementRule}
-     * @param marathonConstraints the marathon-style constraint string, containing one or more
-     *                            nested json list entries of the form
-     *                            {@code [["multi","list","value"],["hello","hi"]]},
-     *                            or one or more colon-separated entries of the form {@code multi:list:value,hello:hi},
-     *                            or a {@code null} or empty value if no constraint is defined
-     * @throws IOException if {@code marathonConstraints} couldn't be parsed, or if the parsed
-     *                     content isn't valid or supported
-     */
-    public static PlacementRule parseWith(String podName, PlacementRule rule, String marathonConstraints)
-            throws IOException {
-        PlacementRule marathonRule = parse(podName, marathonConstraints);
-        if (marathonRule instanceof PassthroughRule) {
-            return rule; // pass-through original rule
-        }
-        return new AndRule(rule, marathonRule);
-    }
-
-    /**
      * Creates and returns a new {@link PlacementRule} against the provided marathon-style
      * constraint string. Returns a {@link PassthroughRule} if the provided constraint string is
      * {@code null} or empty.

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/OrRule.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/OrRule.java
@@ -65,7 +65,7 @@ public class OrRule implements PlacementRule {
     }
 
     @JsonProperty("rules")
-    private Collection<PlacementRule> getRules() {
+    public Collection<PlacementRule> getRules() {
         return rules;
     }
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/PlacementRule.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/PlacementRule.java
@@ -1,13 +1,13 @@
 package com.mesosphere.sdk.offer.evaluate.placement;
 
-import java.util.Collection;
-
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.mesosphere.sdk.offer.evaluate.EvaluationOutcome;
 import com.mesosphere.sdk.specification.PodInstance;
 import org.apache.mesos.Protos.Offer;
 import org.apache.mesos.Protos.TaskInfo;
-import com.mesosphere.sdk.offer.evaluate.EvaluationOutcome;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import java.util.Collection;
 
 /**
  * Implements placement constraint logic on an offer, filtering out the Resources which are not
@@ -50,4 +50,12 @@ public interface PlacementRule {
      * com.mesosphere.sdk.specification.TaskSpec)
      */
     boolean equals(Object o);
+
+    /**
+     * All placement rules are valid by default. This can be overridden as
+     * required.
+     */
+    default boolean isValid() {
+        return true;
+    }
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/PlacementRule.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/PlacementRule.java
@@ -51,12 +51,4 @@ public interface PlacementRule {
      */
     boolean equals(Object o);
 
-    /**
-     * All placement rules are valid by default. This can be overridden as
-     * required.
-     */
-    @JsonIgnore
-    default boolean isValid() {
-        return true;
-    }
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/PlacementRule.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/PlacementRule.java
@@ -12,11 +12,11 @@ import java.util.Collection;
 /**
  * Implements placement constraint logic on an offer, filtering out the Resources which are not
  * to be used according to the filter logic.
- *
+ * <p>
  * Accepts an Offer and returns a copy of that Offer with any disallowed Resources filtered out, or
  * may return the original Offer without copying if everything passes the filter. If the entire
  * Offer is rejected, the return value will be a non-{@code null} Offer with zero Resources.
- *
+ * <p>
  * PlacementRules may contain multiple internal checks, and may even be a composition of other
  * PlacementRules.
  */
@@ -46,7 +46,7 @@ public interface PlacementRule {
      * Must be explicitly implemented by all PlacementRules.
      *
      * @see com.mesosphere.sdk.offer.TaskUtils#areDifferent(
-     * com.mesosphere.sdk.specification.TaskSpec,
+     *com.mesosphere.sdk.specification.TaskSpec,
      * com.mesosphere.sdk.specification.TaskSpec)
      */
     boolean equals(Object o);
@@ -55,6 +55,7 @@ public interface PlacementRule {
      * All placement rules are valid by default. This can be overridden as
      * required.
      */
+    @JsonIgnore
     default boolean isValid() {
         return true;
     }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultServiceSpec.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultServiceSpec.java
@@ -24,7 +24,6 @@ import com.mesosphere.sdk.specification.yaml.RawServiceSpec;
 import com.mesosphere.sdk.specification.yaml.YAMLToInternalMappers;
 import com.mesosphere.sdk.state.ConfigStoreException;
 import com.mesosphere.sdk.storage.StorageError.Reason;
-
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -34,7 +33,6 @@ import org.slf4j.LoggerFactory;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -126,10 +124,10 @@ public class DefaultServiceSpec implements ServiceSpec {
     /**
      * Returns a new generator with the provided configuration.
      *
-     * @param rawServiceSpec The object model representation of a Service Specification YAML file
-     * @param schedulerConfig Scheduler configuration containing operator-facing knobs
+     * @param rawServiceSpec    The object model representation of a Service Specification YAML file
+     * @param schedulerConfig   Scheduler configuration containing operator-facing knobs
      * @param configTemplateDir Path to the directory containing any config templates for the service, often the same
-     *     directory as the Service Specification YAML file
+     *                          directory as the Service Specification YAML file
      */
     public static Generator newGenerator(
             RawServiceSpec rawServiceSpec, SchedulerConfig schedulerConfig, File configTemplateDir) {
@@ -157,7 +155,7 @@ public class DefaultServiceSpec implements ServiceSpec {
             SchedulerConfig schedulerConfig,
             Map<String, String> schedulerEnvironment,
             File configTemplateDir)
-                    throws Exception {
+            throws Exception {
         return new Generator(
                 rawServiceSpec, schedulerConfig, new TaskEnvRouter(schedulerEnvironment), configTemplateDir);
     }
@@ -325,6 +323,7 @@ public class DefaultServiceSpec implements ServiceSpec {
                 DefaultVolumeSpec.class,
                 ExactMatcher.class,
                 HostnameRule.class,
+                InvalidPlacementRule.class,
                 IsLocalRegionRule.class,
                 MaxPerAttributeRule.class,
                 MaxPerHostnameRule.class,

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/config/validate/PlacementRuleIsValidTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/config/validate/PlacementRuleIsValidTest.java
@@ -1,0 +1,56 @@
+package com.mesosphere.sdk.config.validate;
+
+import com.mesosphere.sdk.offer.evaluate.placement.PlacementRule;
+import com.mesosphere.sdk.specification.PodSpec;
+import com.mesosphere.sdk.specification.ServiceSpec;
+import com.mesosphere.sdk.testutils.TestConstants;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Optional;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+
+public class PlacementRuleIsValidTest {
+    @Mock
+    private ServiceSpec serviceSpec;
+    @Mock
+    private PodSpec podSpec;
+    @Mock
+    private PlacementRule placementRule;
+
+    private static final PlacementRuleIsValid validator = new PlacementRuleIsValid();
+
+    @Before
+    public void beforeEach() {
+        MockitoAnnotations.initMocks(this);
+        when(serviceSpec.getPods()).thenReturn(Arrays.asList(podSpec));
+        when(podSpec.getType()).thenReturn(TestConstants.POD_TYPE);
+    }
+
+    @Test
+    public void emptyPlacementRuleIsValid() throws IOException {
+        when(podSpec.getPlacementRule()).thenReturn(Optional.empty());
+        assertThat(validator.validate(Optional.empty(), serviceSpec), hasSize(0));
+    }
+
+    @Test
+    public void invalidPlacementRuleFailsValidation() throws IOException {
+        when(placementRule.isValid()).thenReturn(false);
+        when(podSpec.getPlacementRule()).thenReturn(Optional.of(placementRule));
+        assertThat(validator.validate(Optional.empty(), serviceSpec), hasSize(1));
+    }
+
+    @Test
+    public void validPlacementRulePassesValidation() throws IOException {
+        when(placementRule.isValid()).thenReturn(true);
+        when(podSpec.getPlacementRule()).thenReturn(Optional.of(placementRule));
+        assertThat(validator.validate(Optional.empty(), serviceSpec), hasSize(0));
+    }
+}

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/placement/AndRuleTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/placement/AndRuleTest.java
@@ -76,6 +76,36 @@ public class AndRuleTest {
                 SerializationUtils.toJsonString(rule), PlacementRule.class, TestPlacementUtils.OBJECT_MAPPER));
     }
 
+    @Test
+    public void testEmptyAndRuleIsNotValid() {
+        PlacementRule rule = new AndRule(Collections.emptyList());
+        assertFalse(rule.isValid());
+    }
+
+    @Test
+    public void testSingleAndRuleIsValid() {
+        PlacementRule rule = new AndRule(TestPlacementUtils.PASS);
+        assertTrue(rule.isValid());
+    }
+
+    @Test
+    public void testMultipleAndRuleIsValid() {
+        PlacementRule rule = new AndRule(TestPlacementUtils.PASS, TestPlacementUtils.FAIL);
+        assertTrue(rule.isValid());
+    }
+
+    @Test
+    public void testSingleInvalidRuleIsNotValid() {
+        PlacementRule rule = new AndRule(TestPlacementUtils.INVALID);
+        assertFalse(rule.isValid());
+    }
+
+    @Test
+    public void testAnyInvalidRuleIsNotValid() {
+        PlacementRule rule = new AndRule(TestPlacementUtils.PASS, TestPlacementUtils.INVALID);
+        assertFalse(rule.isValid());
+    }
+
     private static Offer offerWith(Collection<Resource> resources) {
         Offer.Builder o = OfferTestUtils.getEmptyOfferBuilder();
         for (Resource r : resources) {

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/placement/AndRuleTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/placement/AndRuleTest.java
@@ -76,36 +76,6 @@ public class AndRuleTest {
                 SerializationUtils.toJsonString(rule), PlacementRule.class, TestPlacementUtils.OBJECT_MAPPER));
     }
 
-    @Test
-    public void testEmptyAndRuleIsNotValid() {
-        PlacementRule rule = new AndRule(Collections.emptyList());
-        assertFalse(rule.isValid());
-    }
-
-    @Test
-    public void testSingleAndRuleIsValid() {
-        PlacementRule rule = new AndRule(TestPlacementUtils.PASS);
-        assertTrue(rule.isValid());
-    }
-
-    @Test
-    public void testMultipleAndRuleIsValid() {
-        PlacementRule rule = new AndRule(TestPlacementUtils.PASS, TestPlacementUtils.FAIL);
-        assertTrue(rule.isValid());
-    }
-
-    @Test
-    public void testSingleInvalidRuleIsNotValid() {
-        PlacementRule rule = new AndRule(TestPlacementUtils.INVALID);
-        assertFalse(rule.isValid());
-    }
-
-    @Test
-    public void testAnyInvalidRuleIsNotValid() {
-        PlacementRule rule = new AndRule(TestPlacementUtils.PASS, TestPlacementUtils.INVALID);
-        assertFalse(rule.isValid());
-    }
-
     private static Offer offerWith(Collection<Resource> resources) {
         Offer.Builder o = OfferTestUtils.getEmptyOfferBuilder();
         for (Resource r : resources) {

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/placement/InvalidPlacementRuleTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/placement/InvalidPlacementRuleTest.java
@@ -1,8 +1,12 @@
 package com.mesosphere.sdk.offer.evaluate.placement;
 
+import com.mesosphere.sdk.config.SerializationUtils;
 import org.junit.Test;
 
+import java.io.IOException;
+
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 public class InvalidPlacementRuleTest {
@@ -11,4 +15,12 @@ public class InvalidPlacementRuleTest {
     public void invalidPlacementRuleIsAlwaysInvalid() {
         assertThat(new InvalidPlacementRule("", "").isValid(), is(false));
     }
+
+    @Test
+    public void testSerializeDeserialize() throws IOException {
+        PlacementRule rule = new InvalidPlacementRule("constraint", "exception");
+        assertEquals(rule, SerializationUtils.fromString(
+                SerializationUtils.toJsonString(rule), PlacementRule.class, TestPlacementUtils.OBJECT_MAPPER));
+    }
+
 }

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/placement/InvalidPlacementRuleTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/placement/InvalidPlacementRuleTest.java
@@ -5,16 +5,9 @@ import org.junit.Test;
 
 import java.io.IOException;
 
-import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 
 public class InvalidPlacementRuleTest {
-
-    @Test
-    public void invalidPlacementRuleIsAlwaysInvalid() {
-        assertThat(new InvalidPlacementRule("", "").isValid(), is(false));
-    }
 
     @Test
     public void testSerializeDeserialize() throws IOException {

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/placement/InvalidPlacementRuleTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/placement/InvalidPlacementRuleTest.java
@@ -1,0 +1,14 @@
+package com.mesosphere.sdk.offer.evaluate.placement;
+
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class InvalidPlacementRuleTest {
+
+    @Test
+    public void invalidPlacementRuleIsAlwaysInvalid() {
+        assertThat(new InvalidPlacementRule("", "").isValid(), is(false));
+    }
+}

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/placement/MarathonConstraintParserTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/placement/MarathonConstraintParserTest.java
@@ -41,12 +41,6 @@ public class MarathonConstraintParserTest {
     }
 
     @Test
-    public void testSplitOverEscapedConstraint() throws IOException {
-        assertEquals(MarathonConstraintParser.splitConstraints("[[\"a\"]]"),
-                MarathonConstraintParser.splitConstraints("[[\\\"a\\\"]]"));
-    }
-
-    @Test
     public void testUniqueOperator() throws IOException {
         // example from marathon documentation:
         String constraintStr = MarathonConstraintParser.parse(POD_NAME, unescape("[['hostname', 'UNIQUE']]")).toString();
@@ -105,22 +99,6 @@ public class MarathonConstraintParserTest {
         assertEquals(constraintStr, MarathonConstraintParser.parse(POD_NAME, unescape("['hostname', 'GROUP_BY', '3']")).toString());
         assertEquals(constraintStr, MarathonConstraintParser.parse(POD_NAME, "hostname:GROUP_BY:3").toString());
     }
-
-    @Test
-    public void testValidOverEscapedRule() throws IOException {
-        String expectedString = MarathonConstraintParser.parse(POD_NAME, "[[\"hostname\",\"MAX_PER\",\"1\"]]").toString();
-        String overEscapedString = MarathonConstraintParser.parse(POD_NAME, "[[\\\"hostname\\\",\\\"MAX_PER\\\",\\\"1\\\"]]").toString();
-
-        assertEquals(expectedString, overEscapedString);
-    }
-
-    @Test
-    public void testInvalidRule() throws IOException {
-        String invalidPlacementRuleString = MarathonConstraintParser.parse(POD_NAME, "[[\"hostname\",]]").toString();
-
-        assertEquals("InvalidPlacementRule{constraint=[[\"hostname\",]], exception=Invalid number of entries in rule. Expected 2 or 3, got 1: [[[\"hostname\"]}", invalidPlacementRuleString);
-    }
-
 
     @Test
     public void testLikeOperator() throws IOException {
@@ -235,6 +213,11 @@ public class MarathonConstraintParserTest {
     @Test
     public void testEmptyArrayConstraint() throws IOException {
         assertEquals("PassthroughRule{}", MarathonConstraintParser.parse(POD_NAME, "[]").toString());
+    }
+
+    @Test
+    public void testOverEscapedConstraintIsInvalid() throws IOException {
+        assertTrue("too many \\'s", isInvalidConstraints("[[\\\"hostname\\\",\\\"MAX_PER\\\",\\\"1\\\"]]"));
     }
 
     @Test

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/placement/MarathonConstraintParserTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/placement/MarathonConstraintParserTest.java
@@ -7,6 +7,7 @@ import java.util.Arrays;
 import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests for {@link MarathonConstraintParser}.
@@ -238,55 +239,52 @@ public class MarathonConstraintParserTest {
 
     @Test
     public void testBadListConstraint() throws IOException {
-        String ruleString = MarathonConstraintParser.parse(POD_NAME, unescape("[['rack-id', 'MAX_PER', '2'")).toString(); // missing ']]'
-
-        assertEquals("InvalidPlacementRule{constraint=[[\"rack-id\", \"MAX_PER\", \"2\", exception=Invalid number of entries in rule. Expected 2 or 3, got 1: [[[\"rack-id\"]}",
-                ruleString);
+        assertTrue("missing ']]'", isInvalidConstraints(unescape("[['rack-id', 'MAX_PER', '2'")));
     }
 
-    @Test(expected = IOException.class)
+    @Test
     public void testBadFlatConstraint() throws IOException {
-        MarathonConstraintParser.parse(POD_NAME, "rack-id:MAX_PER:,"); // missing last elem
+        assertTrue("Missing last element", isInvalidConstraints("rack-id:MAX_PER:,"));
     }
 
-    @Test(expected = IOException.class)
+    @Test
     public void testBadParamGroupBy() throws IOException {
-        MarathonConstraintParser.parse(POD_NAME, "rack-id:GROUP_BY:foo"); // expected int
+        assertTrue("Expected integer", isInvalidConstraints("rack-id:GROUP_BY:foo"));
     }
 
-    @Test(expected = IOException.class)
+    @Test
     public void testBadParamMaxPer() throws IOException {
-        MarathonConstraintParser.parse(POD_NAME, "rack-id:MAX_PER:foo"); // expected int
+        assertTrue("Expected integer", isInvalidConstraints("rack-id:MAX_PER:foo"));
     }
 
-    @Test(expected = IOException.class)
+    @Test
     public void testMissingParamCluster() throws IOException {
-        MarathonConstraintParser.parse(POD_NAME, "rack-id:CLUSTER"); // expected param
+        assertTrue("Expected parameter", isInvalidConstraints("rack-id:CLUSTER"));
     }
 
-    @Test(expected = IOException.class)
+    @Test
     public void testMissingParamLike() throws IOException {
-        MarathonConstraintParser.parse(POD_NAME, "rack-id:LIKE"); // expected param
+        assertTrue("Expected parameter", isInvalidConstraints("rack-id:LIKE"));
     }
 
-    @Test(expected = IOException.class)
+    @Test
     public void testMissingParamUnlike() throws IOException {
-        MarathonConstraintParser.parse(POD_NAME, "rack-id:UNLIKE"); // expected param
+        assertTrue("Expected parameter", isInvalidConstraints("rack-id:UNLIKE"));
     }
 
-    @Test(expected = IOException.class)
+    @Test
     public void testMissingParamMaxPer() throws IOException {
-        MarathonConstraintParser.parse(POD_NAME, "rack-id:MAX_PER"); // expected param
+        assertTrue("Expected parameter", isInvalidConstraints("rack-id:MAX_PER"));
     }
 
-    @Test(expected = IOException.class)
+    @Test
     public void testUnknownCommand() throws IOException {
-        MarathonConstraintParser.parse(POD_NAME, "rack-id:FOO:foo");
+        assertTrue(isInvalidConstraints("rack-id:FOO:foo"));
     }
 
-    @Test(expected = IOException.class)
+    @Test
     public void testTooManyElemenents() throws IOException {
-        MarathonConstraintParser.parse(POD_NAME, "rack-id:LIKE:foo:bar");
+        assertTrue(isInvalidConstraints("rack-id:LIKE:foo:bar"));
     }
 
     @Test
@@ -327,5 +325,9 @@ public class MarathonConstraintParserTest {
     // Avoid needing \"'s throughout json strings:
     private static String unescape(String s) {
         return s.replace('\'', '"');
+    }
+
+    private boolean isInvalidConstraints(String constraints) throws IOException {
+        return MarathonConstraintParser.parse(POD_NAME, constraints) instanceof InvalidPlacementRule;
     }
 }

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/placement/MarathonConstraintParserTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/placement/MarathonConstraintParserTest.java
@@ -246,10 +246,7 @@ public class MarathonConstraintParserTest {
 
     @Test(expected = IOException.class)
     public void testBadFlatConstraint() throws IOException {
-        String ruleString = MarathonConstraintParser.parse(POD_NAME, "rack-id:MAX_PER:,").toString(); // missing last elem
-
-        new InvalidPlacementRule("rack-id:MAX_PER")
-        assertEquals(ex);
+        MarathonConstraintParser.parse(POD_NAME, "rack-id:MAX_PER:,"); // missing last elem
     }
 
     @Test(expected = IOException.class)

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/placement/TestPlacementUtils.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/placement/TestPlacementUtils.java
@@ -119,34 +119,15 @@ public class TestPlacementUtils {
         }
     }
 
-    private static class InvalidTestRule implements PlacementRule {
+    private static class InvalidTestRule extends InvalidPlacementRule {
         @JsonCreator
         public InvalidTestRule() {
+            super("constaints", "exception");
         }
 
         @Override
         public EvaluationOutcome filter(Offer offer, PodInstance podInstance, Collection<TaskInfo> tasks) {
             return EvaluationOutcome.fail(this, "invalid rule").build();
-        }
-
-        @Override
-        public Collection<PlacementField> getPlacementFields() {
-            return Collections.emptyList();
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            return EqualsBuilder.reflectionEquals(this, o);
-        }
-
-        @Override
-        public int hashCode() {
-            return HashCodeBuilder.reflectionHashCode(this);
-        }
-
-        @Override
-        public boolean isValid() {
-            return false;
         }
 
     }

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/placement/TestPlacementUtils.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/placement/TestPlacementUtils.java
@@ -4,6 +4,9 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableList;
+import com.mesosphere.sdk.config.SerializationUtils;
+import com.mesosphere.sdk.offer.evaluate.EvaluationOutcome;
+import com.mesosphere.sdk.specification.DefaultServiceSpec;
 import com.mesosphere.sdk.specification.PodInstance;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -11,9 +14,6 @@ import org.apache.mesos.Protos.Offer;
 import org.apache.mesos.Protos.Resource;
 import org.apache.mesos.Protos.TaskInfo;
 import org.apache.mesos.Protos.Value;
-import com.mesosphere.sdk.config.SerializationUtils;
-import com.mesosphere.sdk.offer.evaluate.EvaluationOutcome;
-import com.mesosphere.sdk.specification.DefaultServiceSpec;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -54,8 +54,10 @@ public class TestPlacementUtils {
 
     public static final PlacementRule PASS = new PassTestRule();
     public static final PlacementRule FAIL = new FailTestRule();
+    public static final PlacementRule INVALID = new InvalidTestRule();
 
     public static final ObjectMapper OBJECT_MAPPER;
+
     static {
         OBJECT_MAPPER = SerializationUtils.registerDefaultModules(new ObjectMapper());
         for (Class<?> c : DefaultServiceSpec.ConfigFactory.getDefaultRegisteredSubtypes()) {
@@ -67,7 +69,8 @@ public class TestPlacementUtils {
 
     private static class PassTestRule implements PlacementRule {
         @JsonCreator
-        public PassTestRule() { }
+        public PassTestRule() {
+        }
 
         @Override
         public EvaluationOutcome filter(Offer offer, PodInstance podInstance, Collection<TaskInfo> tasks) {
@@ -80,15 +83,20 @@ public class TestPlacementUtils {
         }
 
         @Override
-        public boolean equals(Object o) { return EqualsBuilder.reflectionEquals(this, o); }
+        public boolean equals(Object o) {
+            return EqualsBuilder.reflectionEquals(this, o);
+        }
 
         @Override
-        public int hashCode() { return HashCodeBuilder.reflectionHashCode(this); }
+        public int hashCode() {
+            return HashCodeBuilder.reflectionHashCode(this);
+        }
     }
 
     private static class FailTestRule implements PlacementRule {
         @JsonCreator
-        public FailTestRule() { }
+        public FailTestRule() {
+        }
 
         @Override
         public EvaluationOutcome filter(Offer offer, PodInstance podInstance, Collection<TaskInfo> tasks) {
@@ -101,11 +109,47 @@ public class TestPlacementUtils {
         }
 
         @Override
-        public boolean equals(Object o) { return EqualsBuilder.reflectionEquals(this, o); }
+        public boolean equals(Object o) {
+            return EqualsBuilder.reflectionEquals(this, o);
+        }
 
         @Override
-        public int hashCode() { return HashCodeBuilder.reflectionHashCode(this); }
-    };
+        public int hashCode() {
+            return HashCodeBuilder.reflectionHashCode(this);
+        }
+    }
+
+    private static class InvalidTestRule implements PlacementRule {
+        @JsonCreator
+        public InvalidTestRule() {
+        }
+
+        @Override
+        public EvaluationOutcome filter(Offer offer, PodInstance podInstance, Collection<TaskInfo> tasks) {
+            return EvaluationOutcome.fail(this, "invalid rule").build();
+        }
+
+        @Override
+        public Collection<PlacementField> getPlacementFields() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            return EqualsBuilder.reflectionEquals(this, o);
+        }
+
+        @Override
+        public int hashCode() {
+            return HashCodeBuilder.reflectionHashCode(this);
+        }
+
+        @Override
+        public boolean isValid() {
+            return false;
+        }
+
+    }
 
     private TestPlacementUtils() {
         // do not instantiate


### PR DESCRIPTION
This PR adds better validation support for placement constraints. Invalid constraints are wrapped in a placement rule and a validator is added to check for this.

This means that:
* If the initial deployment has an invalid placement constraint, the scheduler does not crash and one can successfully uninstall it.
* If a config update introduces an invalid constraint, deployment plan has an error as with any other invalid config change.

One question:
* I have only added an overloaded `isValid()` method to the `AndRule` and `InvalidPlacementRule`, but it would make sense to add this to all rules.

Example output of a failed update:
```
deploy (serial strategy) (ERROR)
├─ hello (serial strategy) (COMPLETE)
│  └─ hello-0:[server] (COMPLETE)
└─ world (serial strategy) (COMPLETE)
   ├─ world-0:[server] (COMPLETE)
   └─ world-1:[server] (COMPLETE)

Errors:
- Field: 'PlacementRule'; Value: 'AndRule{rules=[IsLocalRegionRule, InvalidPlacementRule{constraints=[[\"hostname\", "UNIQUE"]], exception=Invalid number of entries in rule. Expected 2 or 3, got 1: [[[\"hostname\"]}]}'; Message: 'The PlacementRule for PodSpec 'hello' had invalid constraints'
```