### PR TITLE
[INFINITY-3133] Fix false-positive HDFS readiness check  

### DIFF
--- a/frameworks/hdfs/src/main/dist/svc.yml
+++ b/frameworks/hdfs/src/main/dist/svc.yml
@@ -113,6 +113,8 @@ pods:
               curl -v -X PUT -F "file=@${VERSION_FILE}" $SCHEDULER_API_HOSTNAME/v1/state/files/VERSION
               touch journal-data/uploadedVersionFile
             fi
+            # check for presence of these env vars to ensure equality check isn't false positive
+            [[ ! -z $LAGGING_TX_COUNT ]] && [[ ! -z $WRITTEN_TX_COUNT ]] &&
             [[ $LAGGING_TX_COUNT -eq {{JOURNAL_LAGGING_TX_COUNT}} ]] && [[ $WRITTEN_TX_COUNT -gt 0 ]]
           delay: 30
           interval: 5


### PR DESCRIPTION
The current readiness check sets some env vars based on a fetch of the HDFS jmx endpoint. These env vars are used for an equality check that determines readiness.

If HDFS is kerberized, these env vars aren't set and the equality passes regardless which provides a false-positive result as to journal nodes' true readiness.