### PR TITLE
INFINITY-3103 Break out template parameters into per-service YAMLs

### DIFF
--- a/docs/pages/_data/services/cassandra.yml
+++ b/docs/pages/_data/services/cassandra.yml
@@ -1,0 +1,20 @@
+# Common values:
+
+packageName: beta-cassandra
+serviceName: cassandra
+techName: Apache Cassandra
+
+# Values specific to certain templates:
+
+install:
+  minNodeCount: three
+  nodeDescription: with three Apache Cassandra nodes
+  serviceAccountInstructionsUrl: https://docs.mesosphere.com/services/cassandra/cass-auth/
+
+managing:
+  podType: node
+  taskType: server
+
+supportedVersions:
+  techExampleVersion: 3.0.13
+  techLink: "[Cassandra](http://cassandra.apache.org/download/)"

--- a/docs/pages/_data/services/elastic.yml
+++ b/docs/pages/_data/services/elastic.yml
@@ -1,0 +1,20 @@
+# Common values:
+
+packageName: beta-elastic
+serviceName: elastic
+techName: Elastic
+
+# Values specific to certain templates:
+
+install:
+  minNodeCount: three
+  nodeDescription: with three master nodes, two data nodes, and one coordinator node
+  serviceAccountInstructionsUrl: https://docs.mesosphere.com/services/elastic/elastic-auth/
+
+managing:
+  podType: data
+  taskType: node
+
+supportedVersions:
+  techExampleVersion: 6.1.3
+  techLink: "the [Elastic Stack](https://www.elastic.co/downloads/elasticsearch) and [X-Pack](https://www.elastic.co/downloads/x-pack)"

--- a/docs/pages/_data/services/hdfs.yml
+++ b/docs/pages/_data/services/hdfs.yml
@@ -1,0 +1,20 @@
+# Common values:
+
+packageName: beta-hdfs
+serviceName: hdfs
+techName: HDFS
+
+# Values specific to certain templates:
+
+install:
+  minNodeCount: five
+  nodeDescription: with three journal nodes, two name nodes, and three data nodes
+  serviceAccountInstructionsUrl: https://docs.mesosphere.com/services/hdfs/hdfs-auth/
+
+managing:
+  podType: data
+  taskType: node
+
+supportedVersions:
+  techExampleVersion: 2.9.0
+  techLink: "[HDFS](http://hadoop.apache.org/releases.html)"

--- a/docs/pages/_data/services/kafka.yml
+++ b/docs/pages/_data/services/kafka.yml
@@ -1,0 +1,26 @@
+# Common values:
+
+packageName: beta-kafka
+serviceName: kafka
+techName: Apache Kafka
+
+# Values specific to certain templates:
+
+install:
+  minNodeCount: three
+  nodeDescription: with three brokers
+  serviceAccountInstructionsUrl: https://docs.mesosphere.com/services/kafka/kafka-auth/
+
+managing:
+  podType: kafka
+  taskType: broker
+
+supportedVersions:
+  techExampleVersion: 0.11.0.2
+  techLink: "[Apache Kafka](https://kafka.apache.org/downloads)"
+
+# Values specific to Kafka's own docs content:
+
+kafka:
+  zookeeperPackageName: beta-kafka-zookeeper
+  zookeeperServiceName: kafka-zookeeper

--- a/docs/pages/_data/services/template.yml
+++ b/docs/pages/_data/services/template.yml
@@ -1,0 +1,20 @@
+# Common values:
+
+packageName: template
+serviceName: template
+techName: TEMPLATE SERVICE
+
+# Values specific to certain templates:
+
+install:
+  minNodeCount: some
+  nodeDescription: with SOME QUANTITY OF NODES
+  serviceAccountInstructionsUrl: https://docs.mesosphere.com/services/TEMPLATE/TEMPLATE-auth/
+
+managing:
+  podType: template
+  taskType: node
+
+supportedVersions:
+  techExampleVersion: 1.2.3.4
+  techLink: "[LINK TO UNDERLYING TECH](http://example.com)"

--- a/docs/pages/_includes/services/api-reference.md
+++ b/docs/pages/_includes/services/api-reference.md
@@ -1,8 +1,8 @@
-The DC/OS {{ include.techName }} Service implements a REST API that may be accessed from outside the cluster. The <dcos_url> parameter referenced below indicates the base URL of the DC/OS cluster on which the {{ include.techName }} Service is deployed.
+The DC/OS {{ include.data.techName }} Service implements a REST API that may be accessed from outside the cluster. The <dcos_url> parameter referenced below indicates the base URL of the DC/OS cluster on which the {{ include.data.techName }} Service is deployed.
 
 # REST API Authentication
 
-REST API requests must be authenticated. This authentication is only applicable for interacting with the {{ include.techName }} REST API directly. You do not need the token to access the {{ include.techName }} nodes themselves.
+REST API requests must be authenticated. This authentication is only applicable for interacting with the {{ include.data.techName }} REST API directly. You do not need the token to access the {{ include.data.techName }} nodes themselves.
 
 If you are using Enterprise DC/OS, follow these instructions to [create a service account and an authentication token](https://docs.mesosphere.com/latest/security/service-auth/custom-service-auth/). You can then configure your service to automatically refresh the authentication token when it expires. To get started more quickly, you can also [get the authentication token without a service account](https://docs.mesosphere.com/latest/security/iam-api/), but you will need to manually refresh the token.
 
@@ -27,11 +27,11 @@ The Plan API provides endpoints for monitoring and controlling service installat
 You may list the configured plans for the service. By default, all services at least have a `deploy` plan and a `recovery` plan. Some services may have additional custom plans defined.
 
 ```bash
-$ curl -H "Authorization:token=$auth_token" <dcos_url>/service/{{ include.serviceName }}/v1/plans
+$ curl -H "Authorization:token=$auth_token" <dcos_url>/service/{{ include.data.serviceName }}/v1/plans
 ```
 
 ```bash
-$ dcos {{ include.packageName }} --name={{ include.serviceName }} plan list
+$ dcos {{ include.data.packageName }} --name={{ include.data.serviceName }} plan list
 ```
 
 ## View plan
@@ -39,17 +39,17 @@ $ dcos {{ include.packageName }} --name={{ include.serviceName }} plan list
 You may view the current state of a listed plan:
 
 ```bash
-$ curl -H "Authorization:token=$auth_token" <dcos_url>/service/{{ include.serviceName }}/v1/plans/<plan>
+$ curl -H "Authorization:token=$auth_token" <dcos_url>/service/{{ include.data.serviceName }}/v1/plans/<plan>
 ```
 
 The CLI may be used to show a formatted tree of the plan (default), or the underlying JSON data as retrieved from the above HTTP endpoint:
 
 ```bash
-$ dcos {{ include.packageName }} --name={{ include.serviceName }} plan show <plan>
+$ dcos {{ include.data.packageName }} --name={{ include.data.serviceName }} plan show <plan>
 ```
 
 ```bash
-$ dcos {{ include.packageName }} --name={{ include.serviceName }} plan show <plan> --json
+$ dcos {{ include.data.packageName }} --name={{ include.data.serviceName }} plan show <plan> --json
 ```
 
 ## Pause plan
@@ -57,11 +57,11 @@ $ dcos {{ include.packageName }} --name={{ include.serviceName }} plan show <pla
 The installation will pause after completing the operation of the current node and wait for user input before proceeding further.
 
 ```bash
-$ curl -X POST -H "Authorization:token=$auth_token" <dcos_url>/service/{{ include.serviceName }}/v1/plans/deploy/interrupt
+$ curl -X POST -H "Authorization:token=$auth_token" <dcos_url>/service/{{ include.data.serviceName }}/v1/plans/deploy/interrupt
 ```
 
 ```bash
-$ dcos {{ include.packageName }} --name={{ include.serviceName }} plan pause deploy
+$ dcos {{ include.data.packageName }} --name={{ include.data.serviceName }} plan pause deploy
 ```
 
 ## Resume plan
@@ -69,11 +69,11 @@ $ dcos {{ include.packageName }} --name={{ include.serviceName }} plan pause dep
 The REST API request below will resume the operation at the next pending node.
 
 ```bash
-$ curl -X PUT -H "Authorization:token=$auth_token" <dcos_surl>/service/{{ include.serviceName }}/v1/plans/deploy/continue
+$ curl -X PUT -H "Authorization:token=$auth_token" <dcos_surl>/service/{{ include.data.serviceName }}/v1/plans/deploy/continue
 ```
 
 ```bash
-$ dcos {{ include.packageName }} --name={{ include.serviceName }} plan continue deploy
+$ dcos {{ include.data.packageName }} --name={{ include.data.serviceName }} plan continue deploy
 ```
 
 # Nodes API
@@ -86,12 +86,12 @@ A list of available node ids can be retrieved by sending a GET request to `/v1/p
 
 CLI Example
 ```bash
-$ dcos {{ include.packageName }} --name={{ include.serviceName }} pod list
+$ dcos {{ include.data.packageName }} --name={{ include.data.serviceName }} pod list
 ```
 
 HTTP Example
 ```bash
-$ curl -H "Authorization:token=$auth_token" <dcos_url>/service/{{ include.serviceName }}/v1/pod
+$ curl -H "Authorization:token=$auth_token" <dcos_url>/service/{{ include.data.serviceName }}/v1/pod
 ```
 
 ## Node Info
@@ -99,17 +99,17 @@ $ curl -H "Authorization:token=$auth_token" <dcos_url>/service/{{ include.servic
 You can retrieve node information by sending a GET request to `/v1/pod/<node-id>/info`:
 
 ```bash
-$ curl  -H "Authorization:token=$auth_token" <dcos_url>/service/{{ include.serviceName }}/v1/pod/<node-id>/info
+$ curl  -H "Authorization:token=$auth_token" <dcos_url>/service/{{ include.data.serviceName }}/v1/pod/<node-id>/info
 ```
 
 CLI Example
 ```bash
-$ dcos {{ include.packageName }} --name={{ include.serviceName }} pod info journalnode-0
+$ dcos {{ include.data.packageName }} --name={{ include.data.serviceName }} pod info journalnode-0
 ```
 
 HTTP Example
 ```bash
-$ curl  -H "Authorization:token=$auth_token" <dcos_url>/service/{{ include.serviceName }}/v1/pod/journalnode-0/info
+$ curl  -H "Authorization:token=$auth_token" <dcos_url>/service/{{ include.data.serviceName }}/v1/pod/journalnode-0/info
 ```
 
 ## Replace a Node
@@ -118,12 +118,12 @@ The replace endpoint can be used to replace a node with an instance running on a
 
 CLI Example
 ```bash
-$ dcos {{ include.packageName }} --name={{ include.serviceName }} pod replace <node-id>
+$ dcos {{ include.data.packageName }} --name={{ include.data.serviceName }} pod replace <node-id>
 ```
 
 HTTP Example
 ```bash
-$ curl -X POST -H "Authorization:token=$auth_token" <dcos_url>/service/{{ include.serviceName }}/v1/pod/<node-id>/replace
+$ curl -X POST -H "Authorization:token=$auth_token" <dcos_url>/service/{{ include.data.serviceName }}/v1/pod/<node-id>/replace
 ```
 
 If the operation succeeds, a `200 OK` is returned.
@@ -134,12 +134,12 @@ The restart endpoint can be used to restart a node in place on the same agent no
 
 CLI Example
 ```bash
-$ dcos {{ include.packageName }} --name={{ include.serviceName }} pod restart <node-id>
+$ dcos {{ include.data.packageName }} --name={{ include.data.serviceName }} pod restart <node-id>
 ```
 
 HTTP Example
 ```bash
-$ curl -X POST -H "Authorization:token=$auth_token" <dcos_url>/service/{{ include.serviceName }}/v1/pod/<node-id>/restart
+$ curl -X POST -H "Authorization:token=$auth_token" <dcos_url>/service/{{ include.data.serviceName }}/v1/pod/<node-id>/restart
 ```
 
 If the operation succeeds a `200 OK` is returned.
@@ -150,12 +150,12 @@ The pause endpoint can be used to relaunch a node in an idle command state for d
 
 CLI example
 ```bash
-dcos {{ include.packageName }} --name={{ include.serviceName }} debug pod pause <node-id>
+dcos {{ include.data.packageName }} --name={{ include.data.serviceName }} debug pod pause <node-id>
 ```
 
 HTTP Example
 ```bash
-$ curl -X POST -H "Authorization:token=$auth_token" <dcos_url>/service/{{ include.serviceName }}/v1/pod/<node-id>/pause
+$ curl -X POST -H "Authorization:token=$auth_token" <dcos_url>/service/{{ include.data.serviceName }}/v1/pod/<node-id>/pause
 ```
 
 # Configuration API
@@ -168,12 +168,12 @@ You can view the current target configuration by sending a GET request to `/v1/c
 
 CLI Example
 ```bash
-$ dcos {{ include.packageName }} --name={{ include.serviceName }} config target
+$ dcos {{ include.data.packageName }} --name={{ include.data.serviceName }} config target
 ```
 
 HTTP Example
 ```bash
-$ curl -H "Authorization:token=$auth_token" <dcos_url>/service/{{ include.serviceName }}/v1/configurations/target
+$ curl -H "Authorization:token=$auth_token" <dcos_url>/service/{{ include.data.serviceName }}/v1/configurations/target
 ```
 
 ## List Configs
@@ -182,7 +182,7 @@ You can list all configuration IDs by sending a GET request to `/v1/configuratio
 
 CLI Example
 ```bash
-$ dcos {{ include.packageName }} --name={{ include.serviceName }} config list
+$ dcos {{ include.data.packageName }} --name={{ include.data.serviceName }} config list
 [
   "319ebe89-42e2-40e2-9169-8568e2421023",
   "294235f2-8504-4194-b43d-664443f2132b"
@@ -191,7 +191,7 @@ $ dcos {{ include.packageName }} --name={{ include.serviceName }} config list
 
 HTTP Example
 ```bash
-$ curl -H "Authorization:token=$auth_token" <dcos_url>/service/{{ include.serviceName }}/v1/configurations
+$ curl -H "Authorization:token=$auth_token" <dcos_url>/service/{{ include.data.serviceName }}/v1/configurations
 [
   "319ebe89-42e2-40e2-9169-8568e2421023",
   "294235f2-8504-4194-b43d-664443f2132b"
@@ -204,10 +204,10 @@ You can view a specific configuration by sending a GET request to `/v1/configura
 
 CLI Example
 ```bash
-$ dcos {{ include.packageName }} --name={{ include.serviceName }} config show 9a8d4308-ab9d-4121-b460-696ec3368ad6
+$ dcos {{ include.data.packageName }} --name={{ include.data.serviceName }} config show 9a8d4308-ab9d-4121-b460-696ec3368ad6
 ```
 
 HTTP Example
 ```bash
-$ curl -H "Authorization:token=$auth_token" <dcos_url>/service/{{ include.serviceName }}/v1/configurations/9a8d4308-ab9d-4121-b460-696ec3368ad6
+$ curl -H "Authorization:token=$auth_token" <dcos_url>/service/{{ include.data.serviceName }}/v1/configurations/9a8d4308-ab9d-4121-b460-696ec3368ad6
 ```

--- a/docs/pages/_includes/services/install.md
+++ b/docs/pages/_includes/services/install.md
@@ -1,69 +1,69 @@
-The default DC/OS {{ include.techName }} installation provides reasonable defaults for trying out the service, but may not be sufficient for production use. You may require a different configuration depending on the context of the deployment.
+The default DC/OS {{ include.data.techName }} installation provides reasonable defaults for trying out the service, but may not be sufficient for production use. You may require a different configuration depending on the context of the deployment.
 
 ## Prerequisites
 
-- Depending on your security mode in Enterprise DC/OS, you may [need to provision a service account]({{ include.serviceAccountInstructionsUrl }}) before installing. Only someone with `superuser` permission can create the service account.
+- Depending on your security mode in Enterprise DC/OS, you may [need to provision a service account]({{ include.data.install.serviceAccountInstructionsUrl }}) before installing. Only someone with `superuser` permission can create the service account.
 	- `strict` [security mode](https://docs.mesosphere.com/latest/installing/custom/configuration-parameters/#security) requires a service account.
 	- `permissive` security mode a service account is optional.
 	- `disabled` security mode does not require a service account.
-- Your cluster must have at least {{ include.minNodeCount }} private nodes.
+- Your cluster must have at least {{ include.data.install.minNodeCount }} private nodes.
 {{ include.customInstallRequirements }}
 
 ## Default Installation
 
-To start a basic test cluster {{ include.defaultInstallDescription }}, run the following command on the DC/OS CLI. Enterprise DC/OS users may need to follow [additional instructions]({{ include.serviceAccountInstructionsUrl }}), depending on the security mode of the Enterprise DC/OS cluster.
+To start a basic test cluster {{ include.data.install.nodeDescription }}, run the following command on the DC/OS CLI. Enterprise DC/OS users may need to follow [additional instructions]({{ include.data.install.serviceAccountInstructionsUrl }}), depending on the security mode of the Enterprise DC/OS cluster.
 
 ```bash
-$ dcos package install {{ include.packageName }}
+$ dcos package install {{ include.data.packageName }}
 ```
 
-This command creates a new instance with the default name `{{ include.serviceName }}`. Two instances cannot share the same name, so installing additional instances beyond the default instance requires [customizing the `name` at install time](#custom-installation) for each additional instance.
+This command creates a new instance with the default name `{{ include.data.serviceName }}`. Two instances cannot share the same name, so installing additional instances beyond the default instance requires [customizing the `name` at install time](#custom-installation) for each additional instance.
 
-All `dcos {{ include.packageName }}` CLI commands have a `--name` argument allowing the user to specify which instance to query. If you do not specify a service name, the CLI assumes a default value matching the package name, i.e. `{{ include.packageName }}`. The default value for `--name` can be customized via the DC/OS CLI configuration:
+All `dcos {{ include.data.packageName }}` CLI commands have a `--name` argument allowing the user to specify which instance to query. If you do not specify a service name, the CLI assumes a default value matching the package name, i.e. `{{ include.data.packageName }}`. The default value for `--name` can be customized via the DC/OS CLI configuration:
 
 ```bash
-$ dcos {{ include.packageName }} --name={{ include.serviceName }} <cmd>
+$ dcos {{ include.data.packageName }} --name={{ include.data.serviceName }} <cmd>
 ```
 
-**Note:** Alternatively, you can [install from the DC/OS web interface](https://docs.mesosphere.com/latest/deploying-services/install/). If you install {{ include.techName }} from the DC/OS web interface, the `dcos {{ include.packageName }}` CLI commands are not automatically installed to your workstation. They may be manually installed using the DC/OS CLI:
+**Note:** Alternatively, you can [install from the DC/OS web interface](https://docs.mesosphere.com/latest/deploying-services/install/). If you install {{ include.data.techName }} from the DC/OS web interface, the `dcos {{ include.data.packageName }}` CLI commands are not automatically installed to your workstation. They may be manually installed using the DC/OS CLI:
 
 ```bash
-dcos package install {{ include.packageName }} --cli
+dcos package install {{ include.data.packageName }} --cli
 ```
 
 ## Alternate install configurations
 
-The following are some examples of how to customize the installation of your {{ include.techName }} instance.
+The following are some examples of how to customize the installation of your {{ include.data.techName }} instance.
 
-In each case, you would create a new {{ instance.techName }} instance using the custom configuration as follows:
+In each case, you would create a new {{ include.data.techName }} instance using the custom configuration as follows:
 
 ```bash
-$ dcos package install {{ include.packageName }} --options=sample-{{ include.serviceName }}.json
+$ dcos package install {{ include.data.packageName }} --options=sample-{{ include.data.serviceName }}.json
 ```
 
 **Recommendation:** Store your custom configuration in source control.
 
 ### Installing multiple instances
 
-By default, the {{ include.techName }} service is installed with a service name of `{{ include.serviceName }}`. You may specify a different name using a custom service configuration as follows:
+By default, the {{ include.data.techName }} service is installed with a service name of `{{ include.data.serviceName }}`. You may specify a different name using a custom service configuration as follows:
 
 ```json
 {
   "service": {
-    "name": "{{ include.serviceName }}-other"
+    "name": "{{ include.data.serviceName }}-other"
   }
 }
 ```
 
-When the above JSON configuration is passed to the `package install {{ include.packageName }}` command via the `--options` argument, the new service will use the name specified in that JSON configuration:
+When the above JSON configuration is passed to the `package install {{ include.data.packageName }}` command via the `--options` argument, the new service will use the name specified in that JSON configuration:
 
 ```bash
-$ dcos package install {{ include.packageName }} --options={{ include.serviceName }}-other.json
+$ dcos package install {{ include.data.packageName }} --options={{ include.data.serviceName }}-other.json
 ```
 
-Multiple instances of {{ install.techName }} may be installed into your DC/OS cluster by customizing the name of each instance. For example, you might have one instance of {{ install.techName }} named `{{ include.serviceName }}-staging` and another named `{{ include.serviceName }}-prod`, each with its own custom configuration.
+Multiple instances of {{ include.data.techName }} may be installed into your DC/OS cluster by customizing the name of each instance. For example, you might have one instance of {{ include.data.techName }} named `{{ include.data.serviceName }}-staging` and another named `{{ include.data.serviceName }}-prod`, each with its own custom configuration.
 
-After specifying a custom name for your instance, it can be reached using `dcos {{ include.packageName }}` CLI commands or directly over HTTP as described [below](#addressing-named-instances).
+After specifying a custom name for your instance, it can be reached using `dcos {{ include.data.packageName }}` CLI commands or directly over HTTP as described [below](#addressing-named-instances).
 
 **Note:** The service name _cannot_ be changed after initial install. Changing the service name would require installing a new instance of the service against the new name, then copying over any data as necessary to the new instance.
 
@@ -74,48 +74,48 @@ In DC/OS 1.10 and above, services may be installed into _folders_ by specifying 
 ```json
 {
   "service": {
-    "name": "/foldered/path/to/{{ include.serviceName }}"
+    "name": "/foldered/path/to/{{ include.data.serviceName }}"
   }
 }
 ```
 
-The above example will install the service under a path of `foldered` => `path` => `to` => `{{ include.serviceName }}`. It can then be reached using `dcos {{ include.packageName }}` CLI commands or directly over HTTP as described [below](#addressing-named-instances).
+The above example will install the service under a path of `foldered` => `path` => `to` => `{{ include.data.serviceName }}`. It can then be reached using `dcos {{ include.data.packageName }}` CLI commands or directly over HTTP as described [below](#addressing-named-instances).
 
 **Note:** The service folder location _cannot_ be changed after initial install. Changing the service location would require installing a new instance of the service against the new location, then copying over any data as necessary to the new instance.
 
 ### Addressing named instances
 
-After you've installed the service under a custom name or under a folder, it may be accessed from all `dcos {{ package.packageName }}` CLI commands using the `--name` argument. By default, the `--name` value defaults to the name of the package, or `{{ include.packageName }}`.
+After you've installed the service under a custom name or under a folder, it may be accessed from all `dcos {{ include.data.packageName }}` CLI commands using the `--name` argument. By default, the `--name` value defaults to the name of the package, or `{{ include.data.packageName }}`.
 
-For example, if you had an instance named `{{ include.serviceName }}-dev`, the following command would invoke a `pod list` command against it:
+For example, if you had an instance named `{{ include.data.serviceName }}-dev`, the following command would invoke a `pod list` command against it:
 
 ```bash
-$ dcos {{ include.packageName }} --name={{ include.serviceName }}-dev pod list
+$ dcos {{ include.data.packageName }} --name={{ include.data.serviceName }}-dev pod list
 ```
 
 The same query would be over HTTP as follows:
 
 ```bash
-$ curl -H "Authorization:token=$auth_token" <dcos_url>/service/{{ include.serviceName }}-dev/v1/pod
+$ curl -H "Authorization:token=$auth_token" <dcos_url>/service/{{ include.data.serviceName }}-dev/v1/pod
 ```
 
-Likewise, if you had an instance in a folder like `/foldered/path/to/{{ include.serviceName }}`, the following command would invoke a `pod list` command against it:
+Likewise, if you had an instance in a folder like `/foldered/path/to/{{ include.data.serviceName }}`, the following command would invoke a `pod list` command against it:
 
 ```bash
-$ dcos {{ include.packageName }} --name=/foldered/path/to/{{ include.serviceName }} pod list
+$ dcos {{ include.data.packageName }} --name=/foldered/path/to/{{ include.data.serviceName }} pod list
 ```
 
 Similarly, it could be queried directly over HTTP as follows:
 
 ```bash
-$ curl -H "Authorization:token=$auth_token" <dcos_url>/service/foldered/path/to/{{ include.serviceName }}-dev/v1/pod
+$ curl -H "Authorization:token=$auth_token" <dcos_url>/service/foldered/path/to/{{ include.data.serviceName }}-dev/v1/pod
 ```
 
-**Note:** You may add a `-v` (verbose) argument to any `dcos {{ include.packageName }}` command to see the underlying HTTP queries that are being made. This can be a useful tool to see where the CLI is getting its information. In practice, `dcos {{ include.packageName }}` commands are a thin wrapper around an HTTP interface provided by the DC/OS {{ include.techName }} Service itself.
+**Note:** You may add a `-v` (verbose) argument to any `dcos {{ include.data.packageName }}` command to see the underlying HTTP queries that are being made. This can be a useful tool to see where the CLI is getting its information. In practice, `dcos {{ include.data.packageName }}` commands are a thin wrapper around an HTTP interface provided by the DC/OS {{ include.data.techName }} Service itself.
 
 ### Virtual networks
 
-DC/OS {{ include.techName }} supports deployment on virtual networks on DC/OS (including the `dcos` overlay network), allowing each container (task) to have its own IP address and not use port resources on the agent machines. This can be specified by passing the following configuration during installation:
+DC/OS {{ include.data.techName }} supports deployment on virtual networks on DC/OS (including the `dcos` overlay network), allowing each container (task) to have its own IP address and not use port resources on the agent machines. This can be specified by passing the following configuration during installation:
 
 ```json
 {
@@ -131,7 +131,7 @@ DC/OS {{ include.techName }} supports deployment on virtual networks on DC/OS (i
 
 ## Integration with DC/OS access controls
 
-In Enterprise DC/OS 1.10 and above, you can integrate your SDK-based service with DC/OS ACLs to grant users and groups access to only certain services. You do this by installing your service into a folder, and then restricting access to some number of folders. Folders also allow you to namespace services. For instance, `staging/{{ include.serviceName }}` and `production/{{ include.serviceName }}`.
+In Enterprise DC/OS 1.10 and above, you can integrate your SDK-based service with DC/OS ACLs to grant users and groups access to only certain services. You do this by installing your service into a folder, and then restricting access to some number of folders. Folders also allow you to namespace services. For instance, `staging/{{ include.data.serviceName }}` and `production/{{ include.data.serviceName }}`.
 
 Steps:
 
@@ -147,10 +147,10 @@ Steps:
      dcos:adminrouter:ops:slave full
      ```
 
-1. Install your service into a folder called `test`. Go to **Catalog**, then search for **{{ include.packageName }}**.
-1. Click **CONFIGURE** and change the service name to `/testing/{{ include.serviceName }}`, then deploy.
+1. Install your service into a folder called `test`. Go to **Catalog**, then search for **{{ include.data.packageName }}**.
+1. Click **CONFIGURE** and change the service name to `/testing/{{ include.data.serviceName }}`, then deploy.
 
-     The slashes in your service name are interpreted as folders. You are deploying `{{ include.serviceName }}` in the `/testing` folder. Any user with access to the `/testing` folder will have access to the service.
+     The slashes in your service name are interpreted as folders. You are deploying `{{ include.data.serviceName }}` in the `/testing` folder. Any user with access to the `/testing` folder will have access to the service.
 
 **Important:**
 - Services cannot be renamed. Because the location of the service is specified in the name, you cannot move services between folders.
@@ -159,7 +159,7 @@ Steps:
 ## Interacting with your foldered service
 
 - Interact with your foldered service via the DC/OS CLI with this flag: `--name=/path/to/myservice`.
-- To interact with your foldered service over the web directly, use `http://<dcos-url>/service/path/to/myservice`. E.g., `http://<dcos-url>/service/testing/{{ include.serviceName }}/v1/endpoints`.
+- To interact with your foldered service over the web directly, use `http://<dcos-url>/service/path/to/myservice`. E.g., `http://<dcos-url>/service/testing/{{ include.data.serviceName }}/v1/endpoints`.
 
 ## Placement Constraints
 

--- a/docs/pages/_includes/services/limitations.md
+++ b/docs/pages/_includes/services/limitations.md
@@ -4,8 +4,6 @@ Out-of-band configuration modifications are not supported. The service's core re
 - If a task crashes, it will be restarted with the configuration known to the scheduler, not one modified out-of-band.
 - If a configuration update is initiated, all out-of-band modifications will be overwritten during the rolling update.
 
-{{ include.configBlurb }}
-
 ## Scaling in
 
 To prevent accidental data loss, the service does not support reducing the number of pods.

--- a/docs/pages/_includes/services/managing.md
+++ b/docs/pages/_includes/services/managing.md
@@ -1,8 +1,8 @@
 # Updating Configuration
 
-You can make changes to the service after it has been launched. Configuration management is handled by the scheduler process, which in turn handles deploying {{ include.techName }} itself.
+You can make changes to the service after it has been launched. Configuration management is handled by the scheduler process, which in turn handles deploying {{ include.data.techName }} itself.
 
-After making a change, the scheduler will be restarted and will automatically deploy any detected changes to the service, one node at a time. For example, a given change will first be applied to `{{ include.podType }}-0`, then `{{ include.podType }}-1`, and so on.
+After making a change, the scheduler will be restarted and will automatically deploy any detected changes to the service, one node at a time. For example, a given change will first be applied to `{{ include.data.managing.podType }}-0`, then `{{ include.data.managing.podType }}-1`, and so on.
 
 Nodes are configured with a "readiness check" to ensure that the underlying service appears to be in a healthy state before continuing with applying a given change to the next node in the sequence. However, this basic check is not foolproof and reasonable care should be taken to ensure that a given configuration change will not negatively affect the behavior of the service.
 
@@ -22,11 +22,11 @@ Enterprise DC/OS 1.10 introduces a convenient command line option that allows fo
 + Service with a version greater than 2.0.0-x.
 + [The DC/OS CLI](https://docs.mesosphere.com/latest/cli/install/) installed and available.
 + The service's subcommand available and installed on your local machine.
-  + You can install just the subcommand CLI by running `dcos package install --cli {{ include.packageName }}`.
+  + You can install just the subcommand CLI by running `dcos package install --cli {{ include.data.packageName }}`.
   + If you are running an older version of the subcommand CLI that doesn't have the `update` command, uninstall and reinstall your CLI.
     ```bash
-    $ dcos package uninstall --cli {{ include.packageName }}
-    $ dcos package install --cli {{ include.packageName }}
+    $ dcos package uninstall --cli {{ include.data.packageName }}
+    $ dcos package install --cli {{ include.data.packageName }}
     ```
 
 ### Preparing configuration
@@ -34,7 +34,7 @@ Enterprise DC/OS 1.10 introduces a convenient command line option that allows fo
 If you installed this service with Enterprise DC/OS 1.10, you can fetch the full configuration of a service, including any default values that were applied during installation. For example:
 
 ```bash
-$ dcos {{ include.packageName }} --name={{ include.serviceName }} describe > options.json
+$ dcos {{ include.data.packageName }} --name={{ include.data.serviceName }} describe > options.json
 ```
 
 Make any configuration changes to this `options.json` file.
@@ -52,19 +52,19 @@ First, we'll fetch the default application's environment, current application's 
 1. Ensure you have [jq](https://stedolan.github.io/jq/) installed.
 1. Get the version of the package that is currently installed:
 ```bash
-$ PACKAGE_VERSION=$(dcos package list | grep {{ include.packageName }} | awk '{print $2}')
+$ PACKAGE_VERSION=$(dcos package list | grep {{ include.data.packageName }} | awk '{print $2}')
 ```
 1. Then fetch and save the environment variables that have been set for the service:
 ```bash
-$ dcos marathon app show {{ include.serviceName }} | jq .env > current_env.json
+$ dcos marathon app show {{ include.data.serviceName }} | jq .env > current_env.json
 ```
 1. To identify those values that are custom, we'll get the default environment variables for this version of the service:
 ```bash
-$ dcos package describe --package-version=$PACKAGE_VERSION --render --app {{ include.serviceName }} | jq .env > default_env.json
+$ dcos package describe --package-version=$PACKAGE_VERSION --render --app {{ include.data.serviceName }} | jq .env > default_env.json
 ```
 1. We'll also get the entire application template:
 ```bash
-$ dcos package describe {{ include.serviceName }} --app > marathon.json.mustache
+$ dcos package describe {{ include.data.serviceName }} --app > marathon.json.mustache
 ```
 
 With these files, `options.json` can be recreated.
@@ -85,7 +85,7 @@ $ less marathon.json.mustache
 Once you are ready to begin, initiate an update using the DC/OS CLI, passing in the updated `options.json` file:
 
 ```bash
-$ dcos {{ include.packageName }} --name={{ include.serviceName }} update start --options=options.json
+$ dcos {{ include.data.packageName }} --name={{ include.data.serviceName }} update start --options=options.json
 ```
 
 You will receive an acknowledgement message and the DC/OS package manager will restart the Scheduler in Marathon.
@@ -100,18 +100,18 @@ If you do not have Enterprise DC/OS 1.10 or later, the CLI commands above are no
 
 To make configuration changes via scheduler environment updates, perform the following steps:
 1. Visit `<dcos-url>` to access the DC/OS web interface.
-1. Navigate to `Services` and click on the service to be configured (default `{{ include.serviceName }}`).
+1. Navigate to `Services` and click on the service to be configured (default `{{ include.data.serviceName }}`).
 1. Click `Edit` in the upper right. On DC/OS 1.9.x, the `Edit` button is in a menu made up of three dots.
 1. Navigate to `Environment` (or `Environment variables`) and search for the option to be updated.
 1. Update the option value and click `Review and run` (or `Deploy changes`).
 1. The Scheduler process will be restarted with the new configuration and will validate any detected changes.
 1. If the detected changes pass validation, the relaunched Scheduler will deploy the changes by sequentially relaunching affected tasks as described above.
 
-To see a full listing of available options, run `dcos package describe --config {{ include.packageName }}` in the CLI, or browse the {{ include.packageName }} package install dialog in the DC/OS web interface.
+To see a full listing of available options, run `dcos package describe --config {{ include.data.packageName }}` in the CLI, or browse the {{ include.data.packageName }} package install dialog in the DC/OS web interface.
 
 # Upgrade Software
 
-1.  In the DC/OS web interface, destroy the `{{ include.serviceName }}` scheduler to be updated.
+1.  In the DC/OS web interface, destroy the `{{ include.data.serviceName }}` scheduler to be updated.
 
 1.  Verify that you no longer see it in the DC/OS web interface.
 
@@ -126,10 +126,10 @@ To see a full listing of available options, run `dcos package describe --config 
 ```
 
 
-1.  Install the latest version of the {{ include.packageName }} package with the specified options:
+1.  Install the latest version of the {{ include.data.packageName }} package with the specified options:
 
 ```bash
-$ dcos package install {{ include.packageName }} -—options=options.json
+$ dcos package install {{ include.data.packageName }} -—options=options.json
 ```
 
 # Pod Info
@@ -137,22 +137,22 @@ $ dcos package install {{ include.packageName }} -—options=options.json
 Comprehensive information is available about every pod.  To list all pods:
 
 ```bash
-dcos {{ include.packageName }} --name={{ include.serviceName }} pod list
+dcos {{ include.data.packageName }} --name={{ include.data.serviceName }} pod list
 [
-  "{{ include.podType }}-0",
-  "{{ include.podType }}-1",
+  "{{ include.data.managing.podType }}-0",
+  "{{ include.data.managing.podType }}-1",
   ...
 ]
 ```
 
 To view information about a pod, run the following command from the CLI.
 ```bash
-$ dcos {{ include.packageName }} --name={{ include.serviceName }} pod info <{{ include.podType }}-id>
+$ dcos {{ include.data.packageName }} --name={{ include.data.serviceName }} pod info <{{ include.data.managing.podType }}-id>
 ```
 
 For example:
 ```bash
-$ dcos {{ include.packageName }} --name={{ include.serviceName }} pod info {{ include.podType }}-0
+$ dcos {{ include.data.packageName }} --name={{ include.data.serviceName }} pod info {{ include.data.managing.podType }}-0
 {
   ... lots of JSON ...
 }
@@ -162,17 +162,17 @@ $ dcos {{ include.packageName }} --name={{ include.serviceName }} pod info {{ in
 Similarly, the status for any pod may also be queried.
 
 ```bash
-$ dcos {{ include.packageName }} --name={{ include.serviceName }} pod status <{{ include.podType }}-id>
+$ dcos {{ include.data.packageName }} --name={{ include.data.serviceName }} pod status <{{ include.data.managing.podType }}-id>
 ```
 
 For example:
 
 ```bash
-$ dcos {{ include.packageName }} --name={{ include.serviceName }} pod status {{ include.podType }}-1
+$ dcos {{ include.data.packageName }} --name={{ include.data.serviceName }} pod status {{ include.data.managing.podType }}-1
 [
   {
-    "name": "{{ include.podType }}-1-{{ include.taskType}}",
-    "id": "{{ include.podType }}-1-{{ include.taskType}}__b31a70f4-73c5-4065-990c-76c0c704b8e4",
+    "name": "{{ include.data.managing.podType }}-1-{{ include.data.managing.taskType }}",
+    "id": "{{ include.data.managing.podType }}-1-{{ include.data.managing.taskType }}__b31a70f4-73c5-4065-990c-76c0c704b8e4",
     "state": "TASK_RUNNING"
   }
 ]
@@ -189,56 +189,56 @@ Being able to put the pod in an offline but accessible state makes it easier to 
 
 After the pod has been paused, it may be started again, at which point it will be restarted and will resume running task(s) where it left off.
 
-Here is an example session where a `{{ include.podType }}-1` pod is crash looping due to some corrupted data in a persistent volume. The operator pauses the `{{ include.podType }}-1` pod, then uses `task exec` to repair the pod. Following this, the operator starts the pod and it resumes normal operation:
+Here is an example session where a `{{ include.data.managing.podType }}-1` pod is crash looping due to some corrupted data in a persistent volume. The operator pauses the `{{ include.data.managing.podType }}-1` pod, then uses `task exec` to repair the pod. Following this, the operator starts the pod and it resumes normal operation:
 
 ```bash
-$ dcos {{ include.packageName }} --name={{ include.serviceName }} debug pod pause {{ include.podType }}-1
+$ dcos {{ include.data.packageName }} --name={{ include.data.serviceName }} debug pod pause {{ include.data.managing.podType }}-1
 {
-  "pod": "{{ include.podType }}-1",
+  "pod": "{{ include.data.managing.podType }}-1",
   "tasks": [
-    "{{ include.podType }}-1-{{ include.taskType }}"
+    "{{ include.data.managing.podType }}-1-{{ include.data.managing.taskType }}"
   ]
 }
 
-$ dcos {{ include.packageName }} --name={{ include.serviceName }} pod status
-{{ include.serviceName }}
-└─ {{ include.podType }}
-   ├─ {{ include.podType }}-0
-   │  └─ {{ include.podType }}-0-{{ include.taskType }} (RUNNING)
-   └─ {{ include.podType }}-1
-      └─ {{ include.podType }}-1-{{ include.taskType }} (PAUSING)
+$ dcos {{ include.data.packageName }} --name={{ include.data.serviceName }} pod status
+{{ include.data.serviceName }}
+└─ {{ include.data.managing.podType }}
+   ├─ {{ include.data.managing.podType }}-0
+   │  └─ {{ include.data.managing.podType }}-0-{{ include.data.managing.taskType }} (RUNNING)
+   └─ {{ include.data.managing.podType }}-1
+      └─ {{ include.data.managing.podType }}-1-{{ include.data.managing.taskType }} (PAUSING)
 
-... repeat "pod status" until {{ include.podType }}-1 is PAUSED ...
+... repeat "pod status" until {{ include.data.managing.podType }}-1 is PAUSED ...
 
-$ dcos task exec --interactive --tty {{ include.podType }}-1-{{ include.taskType }} /bin/bash
-{{ include.podType }}-1-node$ ./repair-{{ include.podType }} && exit
+$ dcos task exec --interactive --tty {{ include.data.managing.podType }}-1-{{ include.data.managing.taskType }} /bin/bash
+{{ include.data.managing.podType }}-1-node$ ./repair-{{ include.data.managing.podType }} && exit
 
-$ dcos {{ include.packageName }} --name={{ include.serviceName }} debug pod resume {{ include.podType }}-1
+$ dcos {{ include.data.packageName }} --name={{ include.data.serviceName }} debug pod resume {{ include.data.managing.podType }}-1
 {
-  "pod": "{{ include.podType }}-1",
+  "pod": "{{ include.data.managing.podType }}-1",
   "tasks": [
-    "{{ include.podType }}-1-{{ include.taskType }}"
+    "{{ include.data.managing.podType }}-1-{{ include.data.managing.taskType }}"
   ]
 }
 
-$ dcos {{ include.packageName }} --name={{ include.serviceName }} pod status
-{{ include.serviceName }}
-└─ {{ include.podType }}
-   ├─ {{ include.podType }}-0
-   │  └─ {{ include.podType }}-0-{{ include.taskType }} (RUNNING)
-   └─ {{ include.podType }}-1
-      └─ {{ include.podType }}-1-{{ include.taskType }} (STARTING)
+$ dcos {{ include.data.packageName }} --name={{ include.data.serviceName }} pod status
+{{ include.data.serviceName }}
+└─ {{ include.data.managing.podType }}
+   ├─ {{ include.data.managing.podType }}-0
+   │  └─ {{ include.data.managing.podType }}-0-{{ include.data.managing.taskType }} (RUNNING)
+   └─ {{ include.data.managing.podType }}-1
+      └─ {{ include.data.managing.podType }}-1-{{ include.data.managing.taskType }} (STARTING)
 
-... repeat "pod status" until {{ include.podType }}-1 is RUNNING ...
+... repeat "pod status" until {{ include.data.managing.podType }}-1 is RUNNING ...
 ```
 
-In the above example, all tasks in the pod were being paused and started, but it's worth noting that the commands also support pausing and starting individual tasks within a pod. For example, `dcos {{ include.packageName }} --name={{ include.serviceName }} debug pod pause {{ include.podType }}-1 -t {{ include.taskType }}` will pause only the `{{ include.taskType }}` task within the `{{ include.podType }}-1` pod.
+In the above example, all tasks in the pod were being paused and started, but it's worth noting that the commands also support pausing and starting individual tasks within a pod. For example, `dcos {{ include.data.packageName }} --name={{ include.data.serviceName }} debug pod pause {{ include.data.managing.podType }}-1 -t {{ include.data.managing.taskType }}` will pause only the `{{ include.data.managing.taskType }}` task within the `{{ include.data.managing.podType }}-1` pod.
 
 # Upgrading Service Version
 
 <!-- THIS CONTENT DUPLICATES THE DC/OS OPERATION GUIDE -->
 
-The instructions below show how to safely update one version of DC/OS {{ include.techName }} Service to the next.
+The instructions below show how to safely update one version of DC/OS {{ include.data.techName }} Service to the next.
 
 ## Viewing available versions
 
@@ -246,25 +246,25 @@ The `update package-versions` command allows you to view the versions of a servi
 
 For example, run:
 ```bash
-$ dcos {{ include.packageName }} --name={{ include.serviceName }} update package-versions
+$ dcos {{ include.data.packageName }} --name={{ include.data.serviceName }} update package-versions
 ```
 
 ## Upgrading or downgrading a service
 
 1. Before updating the service itself, update its CLI subcommand to the new version:
    ```bash
-   $ dcos package uninstall --cli {{ include.packageName }}
-   $ dcos package install --cli {{ include.packageName }} --package-version="1.1.6-5.0.7"
+   $ dcos package uninstall --cli {{ include.data.packageName }}
+   $ dcos package install --cli {{ include.data.packageName }} --package-version="1.1.6-5.0.7"
    ```
-1. Once the CLI subcommand has been updated, call the update start command, passing in the version. For example, to update DC/OS {{ include.techName }} Service to version `1.1.6-5.0.7`:
+1. Once the CLI subcommand has been updated, call the update start command, passing in the version. For example, to update DC/OS {{ include.data.techName }} Service to version `1.1.6-5.0.7`:
    ```bash
-   $ dcos {{ include.packageName }} --name={{ include.serviceName }} update start --package-version="1.1.6-5.0.7"
+   $ dcos {{ include.data.packageName }} --name={{ include.data.serviceName }} update start --package-version="1.1.6-5.0.7"
    ```
 
 If you are missing mandatory configuration parameters, the `update` command will return an error. To supply missing values, you can also provide an `options.json` file (see [Updating configuration](#updating-configuration)):
 
 ```bash
-$ dcos {{ include.packageName }} --name={{ include.serviceName }} update start --options=options.json --package-version="1.1.6-5.0.7"
+$ dcos {{ include.data.packageName }} --name={{ include.data.serviceName }} update start --options=options.json --package-version="1.1.6-5.0.7"
 ```
 
 See [Advanced update actions](#advanced-update-actions) for commands you can use to inspect and manipulate an update after it has started.
@@ -284,7 +284,7 @@ Once the Scheduler has been restarted, it will begin a new deployment plan as in
 You can query the status of the update as follows:
 
 ```bash
-$ dcos {{ include.packageName }} --name={{ include.serviceName }} update status
+$ dcos {{ include.data.packageName }} --name={{ include.data.serviceName }} update status
 ```
 
 If the Scheduler is still restarting, DC/OS will not be able to route to it and this command will return an error message. Wait a short while and try again. You can also go to the Services tab of the DC/OS GUI to check the status of the restart.
@@ -294,7 +294,7 @@ If the Scheduler is still restarting, DC/OS will not be able to route to it and 
 To pause an ongoing update, issue a pause command:
 
 ```bash
-$ dcos {{ include.packageName }} --name={{ include.serviceName }} update pause
+$ dcos {{ include.data.packageName }} --name={{ include.data.serviceName }} update pause
 ```
 
 You will receive an error message if the plan has already completed or has been paused. Once completed, the plan will enter the `WAITING` state.
@@ -304,7 +304,7 @@ You will receive an error message if the plan has already completed or has been 
 If a plan is in a `WAITING` state, as a result of being paused or reaching a breakpoint that requires manual operator verification, you can use the `resume` command to continue the plan:
 
 ```bash
-$ dcos {{ include.packageName }} --name={{ include.serviceName }} update resume
+$ dcos {{ include.data.packageName }} --name={{ include.data.serviceName }} update resume
 ```
 
 You will receive an error message if you attempt to `resume` a plan that is already in progress or has already completed.
@@ -314,7 +314,7 @@ You will receive an error message if you attempt to `resume` a plan that is alre
 In order to manually "complete" a step (such that the Scheduler stops attempting to launch a task), you can issue a `force-complete` command. This will instruct to Scheduler to mark a specific step within a phase as complete. You need to specify both the phase and the step, for example:
 
 ```bash
-$ dcos {{ include.packageName }} --name={{ include.serviceName }} update force-complete service-phase {{ include.podType }}-0:[task]
+$ dcos {{ include.data.packageName }} --name={{ include.data.serviceName }} update force-complete service-phase {{ include.data.managing.podType }}-0:[task]
 ```
 
 ## Force Restart
@@ -323,17 +323,17 @@ Similar to force complete, you can also force a restart. This can either be done
 
 To restart the entire plan:
 ```bash
-$ dcos {{ include.packageName }} --name={{ include.serviceName }} update force-restart
+$ dcos {{ include.data.packageName }} --name={{ include.data.serviceName }} update force-restart
 ```
 
 Or for all steps in a single phase:
 ```bash
-$ dcos {{ include.packageName }} --name={{ include.serviceName }} update force-restart service-phase
+$ dcos {{ include.data.packageName }} --name={{ include.data.serviceName }} update force-restart service-phase
 ```
 
 Or for a specific step within a specific phase:
 ```bash
-$ dcos {{ include.packageName }} --name={{ include.serviceName }} update force-restart service-phase {{ include.podType }}-0:[task]
+$ dcos {{ include.data.packageName }} --name={{ include.data.serviceName }} update force-restart service-phase {{ include.data.managing.podType }}-0:[task]
 ```
 
 <!-- END DUPLICATE BLOCK -->

--- a/docs/pages/_includes/services/supported-versions.md
+++ b/docs/pages/_includes/services/supported-versions.md
@@ -1,17 +1,16 @@
-<a name="package-versioning-scheme"></a>
 ## Package Versioning Scheme
 
-- {{ include.techName }}: latest stable at the time of the release, refer to the package version.
+- {{ include.data.techName }}: latest stable at the time of the release, refer to the package version.
 - DC/OS: 1.10 or higher.
 
-Packages are versioned with an `a.b.c-x.y.z` format, where `a.b.c` is the version of the DC/OS integration and `x.y.z` indicates the version of {{ include.techName }}. For example, `2.1.1-{{ include.techVersion }}` indicates version `2.1.1` of the DC/OS integration and version `{{ include.techVersion }}` of {{ include.techName }}.
+Packages are versioned with an `a.b.c-x.y.z` format, where `a.b.c` is the version of the DC/OS integration and `x.y.z` indicates the version of {{ include.data.techName }}. For example, `2.1.1-{{ include.data.supportedVersions.techExampleVersion }}` indicates version `2.1.1` of the DC/OS integration and version `{{ include.data.supportedVersions.techExampleVersion }}` of {{ include.data.techName }}.
 
-<a name="version-policy"></a>
 ## Version Policy
-The DC/OS {{ include.techName }} Service is engineered and tested to work with a specific release of {{ include.techPolicyDesc }}. We select stable versions of the base technology in order to promote customer success. We have selected the latest stable version of {{ include.techName }} for new releases.
 
-<a name="contacting-technical-support"></a>
+The DC/OS {{ include.data.techName }} Service is engineered and tested to work with a specific release of {{ include.data.supportedVersions.techLink }}. We select stable versions of the base technology in order to promote customer success. We have selected the latest stable version of {{ include.data.techName }} for new releases.
+
 ## Contacting Technical Support
 
 ### Mesosphere DC/OS
+
 [Submit a request](https://support.mesosphere.com/hc/en-us/requests/new).

--- a/docs/pages/_includes/services/troubleshooting.md
+++ b/docs/pages/_includes/services/troubleshooting.md
@@ -3,7 +3,7 @@
 After a configuration change, the service may enter an unhealthy state. This commonly occurs when an invalid configuration change was made by the user. Certain configuration values may not be changed, or may not be decreased. To verify whether this is the case, check the service's `deploy` plan for any errors.
 
 ```bash
-$ dcos {{ include.packageName }} --name={{ include.serviceName }}-dev plan show deploy
+$ dcos {{ include.data.packageName }} --name={{ include.data.serviceName }}-dev plan show deploy
 ```
 
 ## Accessing Logs
@@ -17,14 +17,14 @@ In all cases, logs are generally piped to files named `stdout` and/or `stderr`.
 
 To view logs for a given node, perform the following steps:
 1. Visit <dcos-url> to access the DC/OS web interface.
-1. Navigate to `Services` and click on the service to be examined (default `{{ include.serviceName }}`).
+1. Navigate to `Services` and click on the service to be examined (default `{{ include.data.serviceName }}`).
 1. In the list of tasks for the service, click on the task to be examined (scheduler is named after the service, nodes are each named e.g. `node-<#>-server` depending on their type).
 1. In the task details, click on the `Logs` tab to go into the log viewer. By default, you will see `stdout`, but `stderr` is also useful. Use the pull-down in the upper right to select the file to be examined.
 
 You can also access the logs via the Mesos UI:
 1. Visit `<dcos-url>/mesos` to view the Mesos UI.
 1. Click the `Frameworks` tab in the upper left to get a list of services running in the cluster.
-1. Navigate into the correct framework for your needs. The scheduler runs under `marathon` with a task name matching the service name (default {{ include.serviceName }}). Service nodes run under a framework whose name matches the service name (default {{ include.serviceName }}).
+1. Navigate into the correct framework for your needs. The scheduler runs under `marathon` with a task name matching the service name (default {{ include.data.serviceName }}). Service nodes run under a framework whose name matches the service name (default {{ include.data.serviceName }}).
 1. You should now see two lists of tasks. `Active Tasks` are tasks currently running, and `Completed Tasks` are tasks that have exited. Click the `Sandbox` link for the task you wish to examine.
 1. The `Sandbox` view will list files named `stdout` and `stderr`. Click the file names to view the files in the browser, or click `Download` to download them to your system for local examination. Note that very old tasks will have their Sandbox automatically deleted to limit disk space usage.
 
@@ -32,42 +32,42 @@ You can also access the logs via the Mesos UI:
 
 The DC/OS Elastic Service is resilient to temporary pod failures, automatically relaunching them in-place if they stop running. However, if a machine hosting a pod is permanently lost, manual intervention is required to discard the downed pod and reconstruct it on a new machine.
 
-The following command should be used to get a list of available pods. In this example we are querying a service named `{{ include.serviceName }}-dev`.
+The following command should be used to get a list of available pods. In this example we are querying a service named `{{ include.data.serviceName }}-dev`.
 
 ```bash
-$ dcos {{ include.packageName }} --name={{ include.serviceName }}-dev pod list
+$ dcos {{ include.data.packageName }} --name={{ include.data.serviceName }}-dev pod list
 ```
 
 The following command should then be used to replace the pod residing on the failed machine, using the appropriate `pod_name` provided in the above list.
 
 ```bash
-$ dcos {{ include.packageName }} --name={{ include.serviceName }}-dev pod replace <pod_name>
+$ dcos {{ include.data.packageName }} --name={{ include.data.serviceName }}-dev pod replace <pod_name>
 ```
 
 The pod recovery may then be monitored via the `recovery` plan.
 
 ```bash
-$ dcos {{ include.packageName }} --name={{ include.serviceName }}-dev plan show recovery
+$ dcos {{ include.data.packageName }} --name={{ include.data.serviceName }}-dev plan show recovery
 ```
 
 ## Restarting a Node
 
 If you must forcibly restart a pod's processes but do not wish to clear that pod's data, use the following command to restart the pod on the same agent machine where it currently resides. This will not result in an outage or loss of data.
 
-The following command should be used to get a list of available pods. In this example we are querying a service named `{{ include.serviceName }}-dev`.
+The following command should be used to get a list of available pods. In this example we are querying a service named `{{ include.data.serviceName }}-dev`.
 
 ```bash
-$ dcos {{ include.packageName }} --name={{ include.serviceName }}-dev pod list
+$ dcos {{ include.data.packageName }} --name={{ include.data.serviceName }}-dev pod list
 ```
 
 The following command should then be used to restart the pod, using the appropriate `pod_name` provided in the above list.
 
 ```bash
-$ dcos {{ include.packageName }} --name={{ include.serviceName }}-dev pod restart <pod_name>
+$ dcos {{ include.data.packageName }} --name={{ include.data.serviceName }}-dev pod restart <pod_name>
 ```
 
 The pod recovery may then be monitored via the `recovery` plan.
 
 ```bash
-$ dcos {{ include.packageName }} --name={{ include.serviceName }}-dev plan show recovery
+$ dcos {{ include.data.packageName }} --name={{ include.data.serviceName }}-dev plan show recovery
 ```

--- a/docs/pages/_includes/services/uninstall.md
+++ b/docs/pages/_includes/services/uninstall.md
@@ -1,30 +1,32 @@
 <!-- THIS CONTENT DUPLICATES THE DC/OS OPERATION GUIDE -->
 
-### DC/OS 1.10
+Support for an improved uninstall process was introduced in DC/OS 1.10. In order to take advantage of this new support, changes were required to the `{{ include.data.packageName }}` package, which were included as of versions 2.0.0-x and greater.
 
-If you are using DC/OS 1.10 and the installed service has a version greater than 2.0.0-x:
+### DC/OS 1.10 and newer, and package 2.0.0-x and newer
 
-1. Uninstall the service. From the DC/OS CLI, enter `dcos package uninstall --app-id=<instancename> {{ include.packageName }}`.
+If you are using DC/OS 1.10 or newer and the installed service has a version greater than 2.0.0-x:
 
-For example, to uninstall {{ include.techName }} instance named `{{ include.serviceName }}-dev`, run:
+1. Uninstall the service. From the DC/OS CLI, enter `dcos package uninstall --app-id=<instancename> {{ include.data.packageName }}`.
+
+For example, to uninstall the {{ include.data.techName }} instance named `{{ include.data.serviceName }}-dev`, run:
 
 ```bash
-dcos package uninstall --app-id={{ include.serviceName }}-dev {{ include.packageName }}
+dcos package uninstall --app-id={{ include.data.serviceName }}-dev {{ include.data.packageName }}
 ```
 
-### Older versions
+### DC/OS 1.9 and older, or package older than 2.0.0-x
 
 If you are running DC/OS 1.9 or older, or a version of the service that is older than 2.0.0-x, follow these steps:
 
 1. Stop the service. From the DC/OS CLI, enter `dcos package uninstall --app-id=<instancename> <packagename>`.
-   For example, `dcos package uninstall --app-id={{ include.serviceName }}-dev {{ include.packageName }}`.
+   For example, `dcos package uninstall --app-id={{ include.data.serviceName }}-dev {{ include.data.packageName }}`.
 1. Clean up remaining reserved resources with the framework cleaner script, `janitor.py`. See [DC/OS documentation](https://docs.mesosphere.com/1.9/deploying-services/uninstall/#framework-cleaner) for more information about the framework cleaner script.
 
-For example, to uninstall {{ include.techName }} instance named `{{ include.serviceName }}-dev`, run:
+For example, to uninstall {{ include.data.techName }} instance named `{{ include.data.serviceName }}-dev`, run:
 
 ```bash
-$ MY_SERVICE_NAME={{ include.serviceName }}-dev
-$ dcos package uninstall --app-id=$MY_SERVICE_NAME {{ include.packageName }}`.
+$ MY_SERVICE_NAME={{ include.data.serviceName }}-dev
+$ dcos package uninstall --app-id=$MY_SERVICE_NAME {{ include.data.packageName }}`.
 $ dcos node ssh --master-proxy --leader "docker run mesosphere/janitor /janitor.py \
     -r $MY_SERVICE_NAME-role \
     -p $MY_SERVICE_NAME-principal \

--- a/frameworks/cassandra/docs/api-reference.md
+++ b/frameworks/cassandra/docs/api-reference.md
@@ -4,12 +4,7 @@ navigationTitle:
 excerpt:
 title: API Reference
 menuWeight: 70
-
-packageName: beta-cassandra
-serviceName: cassandra
 ---
+{% assign data = site.data.services.cassandra %}
 
-{% include services/api-reference.md
-    techName="Apache Cassandra"
-    packageName=page.packageName
-    serviceName=page.serviceName %}
+{% include services/api-reference.md data=data %}

--- a/frameworks/cassandra/docs/connecting-clients.md
+++ b/frameworks/cassandra/docs/connecting-clients.md
@@ -4,10 +4,8 @@ navigationTitle:
 excerpt:
 title: Connecting Clients
 menuWeight: 50
-
-packageName: beta-cassandra
-serviceName: cassandra
 ---
+{% assign data = site.data.services.cassandra %}
 
 Clients communicating with Apache Cassandra use the Cassandra Query Language (CQL) to issue queries and write data to the cluster. CQL client libraries exist in many languages, and Apache Cassandra ships with a utility called `cqlsh` that enables you to issue queries against an Apache Cassandra cluster from the command line.
 
@@ -15,13 +13,13 @@ Clients communicating with Apache Cassandra use the Cassandra Query Language (CQ
 
 Once the service is running, you may view information about its endpoints via either of the following methods:
 - CLI:
-  - List endpoint types: `dcos {{ page.packageName }} --name={{ page.serviceName }} endpoints`
-  - View endpoints for an endpoint type: `dcos {{ page.packageName }} --name={{ page.serviceName }} endpoints <endpoint>`
+  - List endpoint types: `dcos {{ data.packageName }} --name={{ data.serviceName }} endpoints`
+  - View endpoints for an endpoint type: `dcos {{ data.packageName }} --name={{ data.serviceName }} endpoints <endpoint>`
 - Web:
-  - List endpoint types: `<dcos-url>/service/{{ page.serviceName }}/v1/endpoints`
-  - View endpoints for an endpoint type: `<dcos-url>/service/{{ page.serviceName }}/v1/endpoints/<endpoint>`
+  - List endpoint types: `<dcos-url>/service/{{ data.serviceName }}/v1/endpoints`
+  - View endpoints for an endpoint type: `<dcos-url>/service/{{ data.serviceName }}/v1/endpoints/<endpoint>`
 
-By default, the DC/OS Apache Cassandra Service exposes only the `native-client` endpoint type, which shows the locations for all Cassandra nodes in the cluster. If you have enabled the Thrift protocol in your service configuration, a `thrift-client` endpoint will also be listed. To see node addresses for use by native clients, such as `cqlsh`, run `dcos {{ page.packageName }} --name={{ page.serviceName }} endpoints native-client`. A typical response will look like the following:
+By default, the DC/OS Apache Cassandra Service exposes only the `native-client` endpoint type, which shows the locations for all Cassandra nodes in the cluster. If you have enabled the Thrift protocol in your service configuration, a `thrift-client` endpoint will also be listed. To see node addresses for use by native clients, such as `cqlsh`, run `dcos {{ data.packageName }} --name={{ data.serviceName }} endpoints native-client`. A typical response will look like the following:
 
 ```json
 {
@@ -31,9 +29,9 @@ By default, the DC/OS Apache Cassandra Service exposes only the `native-client` 
     "10.0.1.27:9042"
   ],
   "dns": [
-    "node-2-server.{{ page.serviceName }}.autoip.dcos.thisdcos.directory:9042",
-    "node-0-server.{{ page.serviceName }}.autoip.dcos.thisdcos.directory:9042",
-    "node-1-server.{{ page.serviceName }}.autoip.dcos.thisdcos.directory:9042"
+    "node-2-server.{{ data.serviceName }}.autoip.dcos.thisdcos.directory:9042",
+    "node-0-server.{{ data.serviceName }}.autoip.dcos.thisdcos.directory:9042",
+    "node-1-server.{{ data.serviceName }}.autoip.dcos.thisdcos.directory:9042"
   ]
 }
 ```
@@ -49,7 +47,7 @@ dcos node ssh --leader --master-proxy
 
 Then, use the `cassandra` Docker image to run `cqlsh`, passing as an argument the address of one of the Apache Cassandra nodes in the cluster:
 ```
-docker run cassandra:3.0.13 cqlsh node-0-server.{{ page.serviceName }}.autoip.dcos.thisdcos.directory
+docker run cassandra:3.0.13 cqlsh node-0-server.{{ data.serviceName }}.autoip.dcos.thisdcos.directory
 ```
 
 This will open an interactive shell from which you can issue queries and write to the cluster. To ensure that the `cqlsh` client and your cluster are using the same CQL version, be sure to use the version of the `cassandra` Docker image that corresponds to the version of Apache Cassandra being run in your cluster. The version installed by the DC/OS Apache Cassandra Service is 3.0.13.

--- a/frameworks/cassandra/docs/disaster-recovery.md
+++ b/frameworks/cassandra/docs/disaster-recovery.md
@@ -4,10 +4,8 @@ navigationTitle:
 excerpt:
 title: Disaster Recovery
 menuWeight: 80
-
-packageName: beta-cassandra
-serviceName: cassandra
 ---
+{% assign data = site.data.services.cassandra %}
 
 # Backup
 
@@ -35,7 +33,7 @@ AWS_ACCESS_KEY_ID=<my_access_key_id>
 AWS_SECRET_ACCESS_KEY=<my_secret_access_key>
 AWS_REGION=us-west-2
 S3_BUCKET_NAME=backups
-dcos {{ page.packageName }} --name={{ page.serviceName }} plan start backup-s3 \
+dcos {{ data.packageName }} --name={{ data.serviceName }} plan start backup-s3 \
     -p SNAPSHOT_NAME=$SNAPSHOT_NAME \
     -p "CASSANDRA_KEYSPACES=$CASSANDRA_KEYSPACES" \
     -p AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \
@@ -50,7 +48,7 @@ If you're backing up multiple keyspaces, they must be separated by spaces and wr
 
 To view the status of this plan from the command line:
 ```
-dcos {{ page.packageName }} --name={{ page.serviceName }} plan status backup-s3
+dcos {{ data.packageName }} --name={{ data.serviceName }} plan status backup-s3
 backup-s3 (IN_PROGRESS)
 ├─ backup-schema (COMPLETE)
 │  ├─ node-0:[backup-schema] (COMPLETE)
@@ -87,7 +85,7 @@ You can also back up to Microsoft Azure using the `backup-azure` plan. This plan
 
 You can initiate this plan from the command line in the same way as the Amazon S3 backup plan:
 ```
-dcos {{ page.packageName }} --name={{ page.serviceName }} plan start backup-azure \
+dcos {{ data.packageName }} --name={{ data.serviceName }} plan start backup-azure \
     -p SNAPSHOT_NAME=$SNAPSHOT_NAME \
     -p "CASSANDRA_KEYSPACES=$CASSANDRA_KEYSPACES" \
     -p CLIENT_ID=$CLIENT_ID \
@@ -100,7 +98,7 @@ dcos {{ page.packageName }} --name={{ page.serviceName }} plan start backup-azur
 
 To view the status of this plan from the command line:
 ```
-dcos {{ page.packageName }} --name={{ page.serviceName }} plan status backup-azure
+dcos {{ data.packageName }} --name={{ data.serviceName }} plan status backup-azure
 backup-azure (IN_PROGRESS)
 ├─ backup-schema (COMPLETE)
 │  ├─ node-0:[backup-schema] (COMPLETE)
@@ -143,7 +141,7 @@ AWS_ACCESS_KEY_ID=<my_access_key_id>
 AWS_SECRET_ACCESS_KEY=<my_secret_access_key>
 AWS_REGION=us-west-2
 S3_BUCKET_NAME=backups
-dcos {{ page.packageName }} --name={{ page.serviceName }} plan start restore-s3 \
+dcos {{ data.packageName }} --name={{ data.serviceName }} plan start restore-s3 \
     -p SNAPSHOT_NAME=$SNAPSHOT_NAME \
     -p "CASSANDRA_KEYSPACES=$CASSANDRA_KEYSPACES" \
     -p AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \
@@ -154,7 +152,7 @@ dcos {{ page.packageName }} --name={{ page.serviceName }} plan start restore-s3 
 
 To view the status of this plan from the command line:
 ```
-dcos {{ page.packageName }} --name={{ page.serviceName }} plan status restore-s3
+dcos {{ data.packageName }} --name={{ data.serviceName }} plan status restore-s3
 restore-s3 (IN_PROGRESS)
 ├─ fetch-s3 (COMPLETE)
 │  ├─ node-0:[fetch-s3] (COMPLETE)
@@ -186,7 +184,7 @@ You can restore from Microsoft Azure using the `restore-azure` plan. This plan r
 
 You can initiate this plan from the command line in the same way as the Amazon S3 restore plan:
 ```
-dcos {{ page.packageName }} --name={{ page.serviceName }} plan start restore-azure \
+dcos {{ data.packageName }} --name={{ data.serviceName }} plan start restore-azure \
     -p SNAPSHOT_NAME=$SNAPSHOT_NAME \
     -p CLIENT_ID=$CLIENT_ID \
     -p TENANT_ID=$TENANT_ID \
@@ -198,7 +196,7 @@ dcos {{ page.packageName }} --name={{ page.serviceName }} plan start restore-azu
 
 To view the status of this plan from the command line:
 ```
-dcos {{ page.packageName }} --name={{ page.serviceName }} plan status restore-azure
+dcos {{ data.packageName }} --name={{ data.serviceName }} plan status restore-azure
 restore-azure (IN_PROGRESS)
 ├─ fetch-azure (COMPLETE)
 │  ├─ node-0:[fetch-azure] (COMPLETE)

--- a/frameworks/cassandra/docs/install.md
+++ b/frameworks/cassandra/docs/install.md
@@ -4,30 +4,21 @@ navigationTitle:
 excerpt:
 title: Install and Customize
 menuWeight: 20
-
-techName: Apache Cassandra
-packageName: beta-cassandra
-serviceName: cassandra
 ---
+{% assign data = site.data.services.cassandra %}
 
-{% include services/install.md
-    techName=page.techName
-    packageName=page.packageName
-    serviceName=page.serviceName
-    minNodeCount="three"
-    defaultInstallDescription="with three Apache Cassandra nodes"
-    serviceAccountInstructionsUrl="https://docs.mesosphere.com/services/cassandra/cass-auth/" %}
+{% include services/install.md data=data %}
 
 # Multi-datacenter deployment
 
-To replicate data across data centers, {{ page.techName }} requires that you configure each cluster with the addresses of the seed nodes from every remote cluster. Here's what starting a multi-data-center {{ page.techName }} deployment would look like, running inside of a single DC/OS cluster.
+To replicate data across data centers, {{ data.techName }} requires that you configure each cluster with the addresses of the seed nodes from every remote cluster. Here's what starting a multi-data-center {{ data.techName }} deployment would look like, running inside of a single DC/OS cluster.
 
 ## Launch two Cassandra clusters
 
 Launch the first cluster with the default configuration:
 
 ```shell
-dcos package install {{ page.packageName }}
+dcos package install {{ data.packageName }}
 ```
 
 Create an `options.json` file for the second cluster that specifies a different service name and data center name:
@@ -35,7 +26,7 @@ Create an `options.json` file for the second cluster that specifies a different 
 ```json
 {
   "service": {
-    "name": "{{ page.serviceName }}2",
+    "name": "{{ data.serviceName }}2",
     "data_center": "dc2"
   }
 }
@@ -43,7 +34,7 @@ Create an `options.json` file for the second cluster that specifies a different 
 
 Launch the second cluster with these custom options:
 ```
-dcos package install {{ page.packageName }} --options=<options.json>
+dcos package install {{ data.packageName }} --options=<options.json>
 ```
 
 ## Get the seed node IP addresses
@@ -53,7 +44,7 @@ dcos package install {{ page.packageName }} --options=<options.json>
 Get the list of seed node addresses for the first cluster:
 
 ```shell
-dcos {{ page.packageName }} --name={{ page.serviceName }} endpoints node
+dcos {{ data.packageName }} --name={{ data.serviceName }} endpoints node
 ```
 
 Alternatively, you can get this information from the scheduler HTTP API:
@@ -61,7 +52,7 @@ Alternatively, you can get this information from the scheduler HTTP API:
 ```json
 DCOS_AUTH_TOKEN=$(dcos config show core.dcos_acs_token)
 DCOS_URL=$(dcos config show core.dcos_url)
-curl -H "authorization:token=$DCOS_AUTH_TOKEN" $DCOS_URL/service/{{ page.serviceName }}/v1/endpoints/node
+curl -H "authorization:token=$DCOS_AUTH_TOKEN" $DCOS_URL/service/{{ data.serviceName }}/v1/endpoints/node
 ```
 
 Your output will resemble:
@@ -73,10 +64,10 @@ Your output will resemble:
     "10.0.0.119:9042"
   ],
   "dns": [
-    "node-0-server.{{ page.serviceName }}.autoip.dcos.thisdcos.directory:9042",
-    "node-1-server.{{ page.serviceName }}.autoip.dcos.thisdcos.directory:9042"
+    "node-0-server.{{ data.serviceName }}.autoip.dcos.thisdcos.directory:9042",
+    "node-1-server.{{ data.serviceName }}.autoip.dcos.thisdcos.directory:9042"
   ],
-  "vip": "node.{{ page.serviceName }}.l4lb.thisdcos.directory:9042"
+  "vip": "node.{{ data.serviceName }}.l4lb.thisdcos.directory:9042"
 }
 ```
 
@@ -85,12 +76,12 @@ Note the IPs in the `address` field.
 Run the same command for your second Cassandra cluster and note the IPs in the `address` field:
 
 ```
-dcos {{ page.packageName }} --name={{ page.serviceName }}2 endpoints node
+dcos {{ data.packageName }} --name={{ data.serviceName }}2 endpoints node
 ```
 
 ## Update configuration for both clusters
 
-Create an `options2.json` file with the IP addresses of the first cluster (`{{ page.serviceName }}`):
+Create an `options2.json` file with the IP addresses of the first cluster (`{{ data.serviceName }}`):
 
 ```json
 {
@@ -103,23 +94,23 @@ Create an `options2.json` file with the IP addresses of the first cluster (`{{ p
 Update the configuration of the second cluster:
 
 ```
-dcos {{ page.packageName }} --name={{ page.serviceName}}2 update start --options=options2.json
+dcos {{ data.packageName }} --name={{ data.serviceName}}2 update start --options=options2.json
 ```
 
-Perform the same operation on the first cluster, creating an `options.json` which contains the IP addresses of the second cluster (`{{ page.serviceName }}2`)'s seed nodes in the `service.remote_seeds` field. Then, update the first cluster's configuration: `dcos {{ page.packageName }} --name={{ page.serviceName }} update start --options=options.json`.
+Perform the same operation on the first cluster, creating an `options.json` which contains the IP addresses of the second cluster (`{{ data.serviceName }}2`)'s seed nodes in the `service.remote_seeds` field. Then, update the first cluster's configuration: `dcos {{ data.packageName }} --name={{ data.serviceName }} update start --options=options.json`.
 
 Both schedulers will restart after each receives the configuration update, and each cluster will communicate with the seed nodes from the other cluster to establish a multi-data-center topology. Repeat this process for each new cluster you add.
 
 You can monitor the progress of the update for the first cluster:
 
 ```shell
-dcos {{ page.packageName }} --name={{ page.serviceName }} update status
+dcos {{ data.packageName }} --name={{ data.serviceName }} update status
 ```
 
 Or for the second cluster:
 
 ```shell
-dcos {{ page.packageName }} --name={{ page.serviceName }}2 update status
+dcos {{ data.packageName }} --name={{ data.serviceName }}2 update status
 ```
 
 Your output will resemble:

--- a/frameworks/cassandra/docs/limitations.md
+++ b/frameworks/cassandra/docs/limitations.md
@@ -5,8 +5,9 @@ excerpt:
 title: Limitations
 menuWeight: 100
 ---
+{% assign data = site.data.services.cassandra %}
 
-{% include services/limitations.md %}
+{% include services/limitations.md data=data %}
 
 ## Backup/Restore
 
@@ -14,15 +15,15 @@ The service does not support performing backup and restore with authentication/a
 
 ## Node Count
 
-The DC/OS Cassandra Service must be deployed with at least 3 nodes.
+The DC/OS {{ data.techName }} Service must be deployed with at least 3 nodes.
 
 ## Security
 
-Apache Cassandra's native TLS, authentication, and authorization features are not supported at this time.
+{{ data.techName }}'s native TLS, authentication, and authorization features are not supported at this time.
 
 ## Data Center Name
 
-The name of the data center cannot be changed after installation. `service.data_center` and `service.rack` options are not allowed to be modified once Cassandra is installed.
+The name of the data center cannot be changed after installation. `service.data_center` and `service.rack` options are not allowed to be modified once {{ data.techName }} is installed.
 
 ```
 "service": {

--- a/frameworks/cassandra/docs/managing.md
+++ b/frameworks/cassandra/docs/managing.md
@@ -4,17 +4,10 @@ navigationTitle:
 excerpt:
 title: Managing
 menuWeight: 60
-
-packageName: beta-cassandra
-serviceName: cassandra
 ---
+{% assign data = site.data.services.cassandra %}
 
-{% include services/managing.md
-    podType="node"
-    taskType="server"
-    techName="Apache Cassandra"
-    packageName=page.packageName
-    serviceName=page.serviceName %}
+{% include services/managing.md data=data %}
 
 ## Performing Cassandra Cleanup and Repair Operations
 
@@ -27,12 +20,12 @@ You may trigger a `nodetool cleanup` operation across your Cassandra nodes using
 
 To initiate this plan from the command line:
 ```
-dcos {{ page.packageName }} --name={{ page.serviceName }} plan start cleanup -p CASSANDRA_KEYSPACE=space1
+dcos {{ data.packageName }} --name={{ data.serviceName }} plan start cleanup -p CASSANDRA_KEYSPACE=space1
 ```
 
 To view the status of this plan from the command line:
 ```
-dcos {{ page.packageName }} --name={{ page.serviceName }} plan status cleanup
+dcos {{ data.packageName }} --name={{ data.serviceName }} plan status cleanup
 cleanup (IN_PROGRESS)
 └─ cleanup-deploy (IN_PROGRESS)
    ├─ node-0:[cleanup] (COMPLETE)
@@ -53,12 +46,12 @@ You may trigger a `nodetool repair` operation across your Cassandra nodes using 
 
 To initiate this command from the command line:
 ```
-dcos {{ page.packageName }} --name={{ page.serviceName }} plan start repair -p CASSANDRA_KEYSPACE=space1
+dcos {{ data.packageName }} --name={{ data.serviceName }} plan start repair -p CASSANDRA_KEYSPACE=space1
 ```
 
 To view the status of this plan from the command line:
 ```
-dcos {{ page.packageName }} --name={{ page.serviceName }} plan status repair
+dcos {{ data.packageName }} --name={{ data.serviceName }} plan status repair
 repair (STARTING)
 └─ repair-deploy (STARTING)
    ├─ node-0:[repair] (STARTING)
@@ -82,13 +75,13 @@ operation is performed automatically.
 For example if `node-0` needed to be replaced we would execute:
 
 ```bash
-dcos {{ page.packageName }} --name={{ page.serviceName }} pod replace node-0
+dcos {{ data.packageName }} --name={{ data.serviceName }} pod replace node-0
 ```
 
 which would result in a recovery plan like the following:
 
 ```bash
-$ dcos {{ page.packageName }} --name={{ page.serviceName }} plan show recovery
+$ dcos {{ data.packageName }} --name={{ data.serviceName }} plan show recovery
 recovery (IN_PROGRESS)
 └─ permanent-node-failure-recovery (IN_PROGRESS)
    ├─ node-0:[server] (COMPLETE)

--- a/frameworks/cassandra/docs/quick-start.md
+++ b/frameworks/cassandra/docs/quick-start.md
@@ -4,10 +4,8 @@ navigationTitle:
 excerpt:
 title: Quick Start
 menuWeight: 40
-
-packageName: beta-cassandra
-serviceName: cassandra
 ---
+{% assign data = site.data.services.cassandra %}
 
 ## Prerequisites
 
@@ -15,7 +13,7 @@ serviceName: cassandra
 1. If you are using open source DC/OS, install DC/OS Apache Cassandra with the following command from the DC/OS CLI. If you are using Enterprise DC/OS, you may need to follow additional instructions. See the Install and Customize section for more information.
 
     ```bash
-    $ dcos package install {{ page.packageName }}
+    $ dcos package install {{ data.packageName }}
     ```
 
 You can also install DC/OS Apache Cassandra from [the DC/OS web interface](https://docs.mesosphere.com/latest/usage/webinterface/).
@@ -27,12 +25,12 @@ You can also install DC/OS Apache Cassandra from [the DC/OS web interface](https
 1. Connect a client to the DC/OS Apache Cassandra service.
 
     ```bash
-    $ dcos {{ page.packageName }} --name={{ page.serviceName }} endpoints
+    $ dcos {{ data.packageName }} --name={{ data.serviceName }} endpoints
     [
       "native-client"
     ]
 
-    $ dcos {{ page.packageName }} --name={{ page.serviceName }} endpoints native-client
+    $ dcos {{ data.packageName }} --name={{ data.serviceName }} endpoints native-client
     {
       "address": [
         "10.0.1.125:9042",
@@ -40,9 +38,9 @@ You can also install DC/OS Apache Cassandra from [the DC/OS web interface](https
         "10.0.1.22:9042"
       ],
       "dns": [
-        "node-1-server.{{ page.serviceName }}.autoip.dcos.thisdcos.directory:9042",
-        "node-0-server.{{ page.serviceName }}.autoip.dcos.thisdcos.directory:9042",
-        "node-2-server.{{ page.serviceName }}.autoip.dcos.thisdcos.directory:9042"
+        "node-1-server.{{ data.serviceName }}.autoip.dcos.thisdcos.directory:9042",
+        "node-0-server.{{ data.serviceName }}.autoip.dcos.thisdcos.directory:9042",
+        "node-2-server.{{ data.serviceName }}.autoip.dcos.thisdcos.directory:9042"
       ]
     }
     ```
@@ -53,8 +51,8 @@ You can also install DC/OS Apache Cassandra from [the DC/OS web interface](https
 
     ```bash
     $ dcos node ssh --master-proxy --leader
-    $ docker run -it cassandra:3.0.14 cqlsh node-0-server.{{ page.serviceName }}.autoip.dcos.thisdcos.directory
-    node-0-server.{{ page.serviceName }}.autoip.dcos.thisdcos.directory:9042
+    $ docker run -it cassandra:3.0.14 cqlsh node-0-server.{{ data.serviceName }}.autoip.dcos.thisdcos.directory
+    node-0-server.{{ data.serviceName }}.autoip.dcos.thisdcos.directory:9042
     > CREATE KEYSPACE space1 WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : 3 };
     > USE space1;
     > CREATE TABLE testtable1 (key varchar, value varchar, PRIMARY KEY(key));

--- a/frameworks/cassandra/docs/supported-versions.md
+++ b/frameworks/cassandra/docs/supported-versions.md
@@ -5,8 +5,6 @@ title: Supported Versions
 menuWeight: 110
 excerpt:
 ---
+{% assign data = site.data.services.cassandra %}
 
-{% include services/supported-versions.md
-    techName="Apache Cassandra"
-    techPolicyDesc="[Cassandra](http://cassandra.apache.org/download/)"
-    techVersion="3.0.13" %}
+{% include services/supported-versions.md data=data %}

--- a/frameworks/cassandra/docs/troubleshooting.md
+++ b/frameworks/cassandra/docs/troubleshooting.md
@@ -4,11 +4,7 @@ navigationTitle:
 excerpt:
 title: Troubleshooting
 menuWeight: 90
-
-packageName: beta-cassandra
-serviceName: cassandra
 ---
+{% assign data = site.data.services.cassandra %}
 
-{% include services/troubleshooting.md
-    packageName=page.packageName
-    serviceName=page.serviceName %}
+{% include services/troubleshooting.md data=data %}

--- a/frameworks/cassandra/docs/uninstall.md
+++ b/frameworks/cassandra/docs/uninstall.md
@@ -4,12 +4,7 @@ navigationTitle:
 excerpt:
 title: Uninstall
 menuWeight: 30
-
-packageName: beta-cassandra
-serviceName: cassandra
 ---
+{% assign data = site.data.services.cassandra %}
 
-{% include services/uninstall.md
-    techName="an Apache Cassandra"
-    packageName=page.packageName
-    serviceName=page.serviceName %}
+{% include services/uninstall.md data=data %}

--- a/frameworks/cassandra/docs/upgrade.md
+++ b/frameworks/cassandra/docs/upgrade.md
@@ -5,5 +5,6 @@ excerpt:
 title: Upgrade
 menuWeight: 130
 ---
+{% assign data = site.data.services.cassandra %}
 
-{% include services/upgrade.md %}
+{% include services/upgrade.md data=data %}

--- a/frameworks/elastic/docs/api-reference.md
+++ b/frameworks/elastic/docs/api-reference.md
@@ -4,12 +4,7 @@ navigationTitle:
 excerpt:
 title: API Reference
 menuWeight: 70
-
-packageName: beta-elastic
-serviceName: elastic
 ---
+{% assign data = site.data.services.elastic %}
 
-{% include services/api-reference.md
-    techName="Elastic"
-    packageName=page.packageName
-    serviceName=page.serviceName %}
+{% include services/api-reference.md data=data %}

--- a/frameworks/elastic/docs/connecting-clients.md
+++ b/frameworks/elastic/docs/connecting-clients.md
@@ -4,10 +4,8 @@ navigationTitle:
 excerpt:
 title: Connecting Clients
 menuWeight: 50
-
-packageName: beta-elastic
-serviceName: elastic
 ---
+{% assign data = site.data.services.elastic %}
 
 # Connecting Clients
 
@@ -16,23 +14,23 @@ The Elasticsearch REST APIs are exposed using JSON over HTTP. You simply send HT
 1. Create an index.
 
   ```bash
-  curl -s -u elastic:changeme -XPUT 'coordinator.{{ page.serviceName }}.l4lb.thisdcos.directory:9200/customer?pretty'
+  curl -s -u elastic:changeme -XPUT 'coordinator.{{ data.serviceName }}.l4lb.thisdcos.directory:9200/customer?pretty'
   ```
 
 1. Store and retrieve data.
 
   ```bash
-  curl -s -u elastic:changeme -XPUT 'coordinator.{{ page.serviceName }}.l4lb.thisdcos.directory:9200/customer/external/1?pretty' -d '
+  curl -s -u elastic:changeme -XPUT 'coordinator.{{ data.serviceName }}.l4lb.thisdcos.directory:9200/customer/external/1?pretty' -d '
   {
     "name": "John Doe"
   }'
-  curl -s -u elastic:changeme -XGET 'coordinator.{{ page.serviceName }}.l4lb.thisdcos.directory:9200/customer/external/1?pretty'
+  curl -s -u elastic:changeme -XGET 'coordinator.{{ data.serviceName }}.l4lb.thisdcos.directory:9200/customer/external/1?pretty'
   ```
 
 **Note:** If you did not install any coordinator nodes, you should direct all queries to your data nodes instead:
 
   ```bash
-  curl -s -u elastic:changeme 'data.{{ page.serviceName }}.l4lb.thisdcos.directory:9200/_cat/nodes?v'
+  curl -s -u elastic:changeme 'data.{{ data.serviceName }}.l4lb.thisdcos.directory:9200/_cat/nodes?v'
   ```
 
 The service address varies based on the name you assigned the framework when you installed it.
@@ -40,7 +38,7 @@ The service address varies based on the name you assigned the framework when you
 <node type>.<framework name>.l4lb.thisdcos.directory:9200
 ```
 
-The default framework name is `{{ page.serviceName }}`. If you customized the name your framework, you need to adjust the service address accordingly.
+The default framework name is `{{ data.serviceName }}`. If you customized the name your framework, you need to adjust the service address accordingly.
 
 ## Kibana
 
@@ -50,7 +48,7 @@ The default framework name is `{{ page.serviceName }}`. If you customized the na
 $ dcos package install kibana
 ```
 
-This command launches a new Kibana application with the default name `kibana` and the default Elasticsearch URL `http://coordinator.{{ page.serviceName }}.l4lb.thisdcos.directory:9200`. Two Kibana application instances cannot share the same name, so installing additional Kibana applications beyond the default one requires customizing the `name` at install time for each additional instance.
+This command launches a new Kibana application with the default name `kibana` and the default Elasticsearch URL `http://coordinator.{{ data.serviceName }}.l4lb.thisdcos.directory:9200`. Two Kibana application instances cannot share the same name, so installing additional Kibana applications beyond the default one requires customizing the `name` at install time for each additional instance.
 
 ### Access Kibana
 
@@ -85,7 +83,7 @@ This command launches a new Kibana application with the default name `kibana` an
 - Service user: This must be a non-root user that already exists on each agent. The default user is `nobody`.
 - The Kibana X-Pack plugin is not installed by default, but you can enable it. See the [X-Pack documentation](../elastic-x-pack/) to learn more about X-Pack in the Elastic package. This setting must match the corresponding setting in the Elastic package (i.e., if you have X-Pack enabled in Kibana, you must also have it enabled in Elastic).
 - Elasticsearch credentials: If you have X-Pack enabled, Kibana will use these credentials for authorization. The default user is  `kibana`.
-- Elasticsearch URL: This is a required configuration parameter. The default value `http://coordinator.{{ page.serviceName }}.l4lb.thisdcos.directory:9200` corresponds to the named VIP that exists when the Elastic package is launched with its own default configuration.
+- Elasticsearch URL: This is a required configuration parameter. The default value `http://coordinator.{{ data.serviceName }}.l4lb.thisdcos.directory:9200` corresponds to the named VIP that exists when the Elastic package is launched with its own default configuration.
 
 ### Custom Installation
 

--- a/frameworks/elastic/docs/install.md
+++ b/frameworks/elastic/docs/install.md
@@ -4,10 +4,8 @@ navigationTitle:
 excerpt:
 title: Install and Customize
 menuWeight: 20
-
-packageName: beta-elastic
-serviceName: elastic
 ---
+{% assign data = site.data.services.elastic %}
 
 {% capture customInstallConfigurations %}
 ### Example custom installation
@@ -31,19 +29,14 @@ You can customize the Elastic cluster in a variety of ways by specifying a JSON 
 The command below creates a cluster using a `options.json` file:
 
 ```bash
-$ dcos package install {{ page.packageName }} --options=options.json
+$ dcos package install {{ data.packageName }} --options=options.json
 ```
 
 **Recommendation:** Store your custom configuration in source control.
 {% endcapture %}
 
 {% include services/install.md
-    techName="Elastic"
-    packageName=page.packageName
-    serviceName=page.serviceName
-    minNodeCount="three"
-    defaultInstallDescription="with three master nodes, two data nodes, and one coordinator node"
-    serviceAccountInstructionsUrl="https://docs.mesosphere.com/services/elastic/elastic-auth/"
+    data=data
     customInstallConfigurations=customInstallConfigurations %}
 
 ## TLS
@@ -87,7 +80,7 @@ Sample JSON options file named `kibana-tls.json`:
 {
     "kibana": {
         "xpack_enabled": true,
-        "elasticsearch_url": "https://coordinator.{{ page.serviceName }}.l4lb.thisdcos.directory:9200",
+        "elasticsearch_url": "https://coordinator.{{ data.serviceName }}.l4lb.thisdcos.directory:9200",
         "elasticsearch_tls": true,
         "...": "..."
     }
@@ -159,7 +152,7 @@ You can set up a minimal development/staging cluster without ingest nodes, or co
 Note that with X-Pack installed, the default monitoring behavior is to try to write to an ingest node every few seconds. Without an ingest node, you will see frequent warnings in your master node error logs. While they can be ignored, you can turn them off by disabling X-Pack monitoring in your cluster, like this:
 
 ```bash
-$ curl -XPUT -u elastic:changeme master.{{ page.serviceName }}.l4lb.thisdcos.directory:9200/_cluster/settings -d '{
+$ curl -XPUT -u elastic:changeme master.{{ data.serviceName }}.l4lb.thisdcos.directory:9200/_cluster/settings -d '{
     "persistent" : {
         "xpack.monitoring.collection.interval" : -1
     }

--- a/frameworks/elastic/docs/managing.md
+++ b/frameworks/elastic/docs/managing.md
@@ -4,17 +4,10 @@ navigationTitle:
 excerpt:
 title: Managing
 menuWeight: 60
-
-packageName: beta-elastic
-serviceName: elastic
 ---
+{% assign data = site.data.services.elastic %}
 
-{% include services/managing.md
-    podType="data"
-    taskType="node"
-    techName="Elastic"
-    packageName=page.packageName
-    serviceName=page.serviceName %}
+{% include services/managing.md data=data %}
 
 # Add a Data/Ingest/Coordinator Node
 

--- a/frameworks/elastic/docs/quick-start.md
+++ b/frameworks/elastic/docs/quick-start.md
@@ -4,10 +4,8 @@ navigationTitle:
 excerpt:
 title: Quick Start
 menuWeight: 40
-
-packageName: beta-elastic
-serviceName: elastic
 ---
+{% assign data = site.data.services.elastic %}
 
 ## Steps
 
@@ -17,22 +15,22 @@ serviceName: elastic
 1. Wait until the cluster is deployed and the nodes are all running. This may take 5-10 minutes. You can monitor the deployment via the CLI:
 
     ```bash
-    $ dcos {{ page.packageName }} --name={{ page.serviceName }} plan show deploy
+    $ dcos {{ data.packageName }} --name={{ data.serviceName }} plan show deploy
     ```
 
 1. Retrieve client endpoint information by running the `endpoints` command:
 
     ```bash
-    $ dcos {{ page.packageName }} --name={{ page.serviceName }} endpoints coordinator-http
+    $ dcos {{ data.packageName }} --name={{ data.serviceName }} endpoints coordinator-http
     {
-        "vip": "coordinator.{{ page.serviceName }}.l4lb.thisdcos.directory:9200",
+        "vip": "coordinator.{{ data.serviceName }}.l4lb.thisdcos.directory:9200",
         "address": [
             "10.0.2.88:1026",
             "10.0.2.88:1027"
         ],
         "dns": [
-            "coordinator-0-node.{{ page.serviceName }}.autoip.dcos.thisdcos.directory:1026",
-            "coordinator-0-node.{{ page.serviceName }}.autoip.dcos.thisdcos.directory:1027"
+            "coordinator-0-node.{{ data.serviceName }}.autoip.dcos.thisdcos.directory:1026",
+            "coordinator-0-node.{{ data.serviceName }}.autoip.dcos.thisdcos.directory:1027"
         ],
     }
     ```
@@ -48,14 +46,14 @@ serviceName: elastic
 1. Create an index:
 
     ```bash
-    $ curl -s -u elastic:changeme -XPUT 'coordinator.{{ page.serviceName }}.l4lb.thisdcos.directory:9200/customer?pretty'
+    $ curl -s -u elastic:changeme -XPUT 'coordinator.{{ data.serviceName }}.l4lb.thisdcos.directory:9200/customer?pretty'
     ```
 
 1. Store data in your index:
 
     ```bash
     $ curl -s -u elastic:changeme -XPUT \
-        'coordinator.{{ page.serviceName }}.l4lb.thisdcos.directory:9200/customer/external/1?pretty' \
+        'coordinator.{{ data.serviceName }}.l4lb.thisdcos.directory:9200/customer/external/1?pretty' \
         -d '{ "name": "John Doe" }'
     ```
 
@@ -63,5 +61,5 @@ serviceName: elastic
 
     ```bash
     $ curl -s -u elastic:changeme -XGET \
-        'coordinator.{{ page.serviceName }}.l4lb.thisdcos.directory:9200/customer/external/1?pretty'
+        'coordinator.{{ data.serviceName }}.l4lb.thisdcos.directory:9200/customer/external/1?pretty'
     ```

--- a/frameworks/elastic/docs/supported-versions.md
+++ b/frameworks/elastic/docs/supported-versions.md
@@ -5,8 +5,6 @@ title: Supported Versions
 menuWeight: 110
 excerpt:
 ---
+{% assign data = site.data.services.elastic %}
 
-{% include services/supported-versions.md
-    techName="Elastic"
-    techPolicyDesc="the [Elastic Stack](https://www.elastic.co/downloads/elasticsearch) and [X-Pack](https://www.elastic.co/downloads/x-pack)"
-    techVersion="6.1.3" %}
+{% include services/supported-versions.md data=data %}

--- a/frameworks/elastic/docs/troubleshooting.md
+++ b/frameworks/elastic/docs/troubleshooting.md
@@ -4,11 +4,7 @@ navigationTitle:
 excerpt:
 title: Troubleshooting
 menuWeight: 90
-
-packageName: beta-elastic
-serviceName: elastic
 ---
+{% assign data = site.data.services.elastic %}
 
-{% include services/troubleshooting.md
-    packageName=page.packageName
-    serviceName=page.serviceName %}
+{% include services/troubleshooting.md data=data %}

--- a/frameworks/elastic/docs/uninstall.md
+++ b/frameworks/elastic/docs/uninstall.md
@@ -4,12 +4,7 @@ navigationTitle:
 excerpt:
 title: Uninstall
 menuWeight: 30
-
-packageName: beta-elastic
-serviceName: elastic
 ---
+{% assign data = site.data.services.elastic %}
 
-{% include services/uninstall.md
-    techName="an Elastic"
-    packageName=page.packageName
-    serviceName=page.serviceName %}
+{% include services/uninstall.md data=data %}

--- a/frameworks/elastic/docs/upgrade.md
+++ b/frameworks/elastic/docs/upgrade.md
@@ -5,5 +5,6 @@ excerpt:
 title: Upgrade
 menuWeight: 130
 ---
+{% assign data = site.data.services.elastic %}
 
-{% include services/upgrade.md %}
+{% include services/upgrade.md data=data %}

--- a/frameworks/hdfs/docs/api-reference.md
+++ b/frameworks/hdfs/docs/api-reference.md
@@ -4,26 +4,21 @@ navigationTitle:
 excerpt:
 title: API Reference
 menuWeight: 70
-
-packageName: beta-hdfs
-serviceName: hdfs
 ---
+{% assign data = site.data.services.hdfs %}
 
-{% include services/api-reference.md
-    techName="HDFS"
-    packageName=page.packageName
-    serviceName=page.serviceName %}
+{% include services/api-reference.md data=data %}
 
 # Connection Information
 
-The HDFS service exposes contents of `hdfs-site.xml` and `core-site.xml` for use by clients. Those contents may be requested as follows (assuming your service is named "{{ page.serviceName }}"):
+The HDFS service exposes contents of `hdfs-site.xml` and `core-site.xml` for use by clients. Those contents may be requested as follows (assuming your service is named "{{ data.serviceName }}"):
 
 ```bash
-$ curl -H "Authorization:token=$auth_token" dcos_url/service/{{ page.serviceName }}/v1/endpoints/hdfs-site.xml
+$ curl -H "Authorization:token=$auth_token" dcos_url/service/{{ data.serviceName }}/v1/endpoints/hdfs-site.xml
 ```
 
 ```bash
-$ curl -H "Authorization:token=$auth_token" <dcos_url>/service/{{ page.serviceName }}/v1/endpoints/core-site.xml
+$ curl -H "Authorization:token=$auth_token" <dcos_url>/service/{{ data.serviceName }}/v1/endpoints/core-site.xml
 ```
 
 The contents of the responses represent valid `hdfs-site.xml` and `core-site.xml` that can be used by clients to connect to the service.

--- a/frameworks/hdfs/docs/connecting-clients.md
+++ b/frameworks/hdfs/docs/connecting-clients.md
@@ -4,10 +4,8 @@ navigationTitle:
 excerpt:
 title: Connecting Clients
 menuWeight: 50
-
-packageName: beta-hdfs
-serviceName: hdfs
 ---
+{% assign data = site.data.services.hdfs %}
 
 # Connecting Clients
 
@@ -20,9 +18,9 @@ Applications interface with HDFS like they would any POSIX file system. However,
 Execute the following command from the DC/OS CLI to retrieve the `hdfs-site.xml` file that client applications can use to connect to the HDFS instance, in this case named "hdfs".
 
 ```bash
-$ dcos {{ page.packageName }} --name={{ page.serviceName }} endpoints hdfs-site.xml
+$ dcos {{ data.packageName }} --name={{ data.serviceName }} endpoints hdfs-site.xml
 ...
-$ dcos {{ page.packageName }} --name={{ page.serviceName }} endpoints core-site.xml
+$ dcos {{ data.packageName }} --name={{ data.serviceName }} endpoints core-site.xml
 ...
 ```
 

--- a/frameworks/hdfs/docs/install.md
+++ b/frameworks/hdfs/docs/install.md
@@ -4,10 +4,8 @@ navigationTitle:
 excerpt:
 title: Install and Customize
 menuWeight: 20
-
-packageName: beta-hdfs
-serviceName: hdfs
 ---
+{% assign data = site.data.services.hdfs %}
 
 {% capture customInstallRequirements %}
 - Each agent node must have eight GiB of memory and ten GiB of disk, and each must have these ports available: 8480, 8485, 9000, 9001, 9002, 9005, and 9006, and 9007.
@@ -18,7 +16,7 @@ serviceName: hdfs
 
 If you are ready to ship into production, you will likely need to customize the deployment to suit the workload requirements of your application(s). Customize the default deployment by creating a JSON file, then pass it to `dcos package install` using the `--options` parameter.
 
-Sample JSON options file named `sample-{{ page.serviceName }}.json`:
+Sample JSON options file named `sample-{{ data.serviceName }}.json`:
 
 ```json
 {
@@ -37,13 +35,8 @@ Many of the other Infinity services currently support deployment in DC/OS Vagran
 {% endcapture %}
 
 {% include services/install.md
-    techName="Apache HDFS"
-    packageName=page.packageName
-    serviceName=page.serviceName
-    minNodeCount="five"
-    defaultInstallDescription="with three journal nodes, two name nodes, and three data nodes"
+    data=data
     customInstallRequirements=customInstallRequirements
-    serviceAccountInstructionsUrl="https://docs.mesosphere.com/services/hdfs/hdfs-auth/"
     customInstallConfigurations=customInstallConfigurations %}
 
 ## Topology
@@ -93,8 +86,8 @@ The service configuration object contains properties that MUST be specified duri
 ```json
 {
   "service": {
-    "name": "{{ page.serviceName }}",
-    "service_account": "{{ page.serviceName }}-principal",
+    "name": "{{ data.serviceName }}",
+    "service_account": "{{ data.serviceName }}-principal",
   }
 }
 ```

--- a/frameworks/hdfs/docs/kerberos.md
+++ b/frameworks/hdfs/docs/kerberos.md
@@ -4,10 +4,8 @@ navigationTitle:
 excerpt:
 title: Kerberos
 menuWeight: 22
-
-packageName: beta-kafka
-serviceName: kafka
 ---
+{% assign data = site.data.services.hdfs %}
 
 ## Setting up Apache Hadoop Distributed File System (HDFS) with Kerberos
 
@@ -17,44 +15,44 @@ The utility tool `kinit` needs to be installed on the agents and be accessible f
 
 In order to run Apache HDFS with Kerberos security enabled, a principal needs to be added for every service component in the cluster. The following principals are required (although the realm can be modified):
 ```
-hdfs/name-0-node.{{ page.serviceName }}.autoip.dcos.thisdcos.directory@LOCAL
-HTTP/name-0-node.{{ page.serviceName }}.autoip.dcos.thisdcos.directory@LOCAL
-hdfs/name-0-zkfc.{{ page.serviceName }}.autoip.dcos.thisdcos.directory@LOCAL
-HTTP/name-0-zkfc.{{ page.serviceName }}.autoip.dcos.thisdcos.directory@LOCAL
-hdfs/name-1-node.{{ page.serviceName }}.autoip.dcos.thisdcos.directory@LOCAL
-HTTP/name-1-node.{{ page.serviceName }}.autoip.dcos.thisdcos.directory@LOCAL
-hdfs/name-1-zkfc.{{ page.serviceName }}.autoip.dcos.thisdcos.directory@LOCAL
-HTTP/name-1-zkfc.{{ page.serviceName }}.autoip.dcos.thisdcos.directory@LOCAL
-hdfs/journal-0-node.{{ page.serviceName }}.autoip.dcos.thisdcos.directory@LOCAL
-HTTP/journal-0-node.{{ page.serviceName }}.autoip.dcos.thisdcos.directory@LOCAL
-hdfs/journal-1-node.{{ page.serviceName }}.autoip.dcos.thisdcos.directory@LOCAL
-HTTP/journal-1-node.{{ page.serviceName }}.autoip.dcos.thisdcos.directory@LOCAL
-hdfs/journal-2-node.{{ page.serviceName }}.autoip.dcos.thisdcos.directory@LOCAL
-HTTP/journal-2-node.{{ page.serviceName }}.autoip.dcos.thisdcos.directory@LOCAL
-hdfs/data-0-node.{{ page.serviceName }}.autoip.dcos.thisdcos.directory@LOCAL
-HTTP/data-0-node.{{ page.serviceName }}.autoip.dcos.thisdcos.directory@LOCAL
-hdfs/data-1-node.{{ page.serviceName }}.autoip.dcos.thisdcos.directory@LOCAL
-HTTP/data-1-node.{{ page.serviceName }}.autoip.dcos.thisdcos.directory@LOCAL
-hdfs/data-2-node.{{ page.serviceName }}.autoip.dcos.thisdcos.directory@LOCAL
-HTTP/data-2-node.{{ page.serviceName }}.autoip.dcos.thisdcos.directory@LOCAL
-HTTP/api.{{ page.serviceName }}.marathon.l4lb.thisdcos.directory@LOCAL
+hdfs/name-0-node.{{ data.serviceName }}.autoip.dcos.thisdcos.directory@LOCAL
+HTTP/name-0-node.{{ data.serviceName }}.autoip.dcos.thisdcos.directory@LOCAL
+hdfs/name-0-zkfc.{{ data.serviceName }}.autoip.dcos.thisdcos.directory@LOCAL
+HTTP/name-0-zkfc.{{ data.serviceName }}.autoip.dcos.thisdcos.directory@LOCAL
+hdfs/name-1-node.{{ data.serviceName }}.autoip.dcos.thisdcos.directory@LOCAL
+HTTP/name-1-node.{{ data.serviceName }}.autoip.dcos.thisdcos.directory@LOCAL
+hdfs/name-1-zkfc.{{ data.serviceName }}.autoip.dcos.thisdcos.directory@LOCAL
+HTTP/name-1-zkfc.{{ data.serviceName }}.autoip.dcos.thisdcos.directory@LOCAL
+hdfs/journal-0-node.{{ data.serviceName }}.autoip.dcos.thisdcos.directory@LOCAL
+HTTP/journal-0-node.{{ data.serviceName }}.autoip.dcos.thisdcos.directory@LOCAL
+hdfs/journal-1-node.{{ data.serviceName }}.autoip.dcos.thisdcos.directory@LOCAL
+HTTP/journal-1-node.{{ data.serviceName }}.autoip.dcos.thisdcos.directory@LOCAL
+hdfs/journal-2-node.{{ data.serviceName }}.autoip.dcos.thisdcos.directory@LOCAL
+HTTP/journal-2-node.{{ data.serviceName }}.autoip.dcos.thisdcos.directory@LOCAL
+hdfs/data-0-node.{{ data.serviceName }}.autoip.dcos.thisdcos.directory@LOCAL
+HTTP/data-0-node.{{ data.serviceName }}.autoip.dcos.thisdcos.directory@LOCAL
+hdfs/data-1-node.{{ data.serviceName }}.autoip.dcos.thisdcos.directory@LOCAL
+HTTP/data-1-node.{{ data.serviceName }}.autoip.dcos.thisdcos.directory@LOCAL
+hdfs/data-2-node.{{ data.serviceName }}.autoip.dcos.thisdcos.directory@LOCAL
+HTTP/data-2-node.{{ data.serviceName }}.autoip.dcos.thisdcos.directory@LOCAL
+HTTP/api.{{ data.serviceName }}.marathon.l4lb.thisdcos.directory@LOCAL
 ```
 This cluster has 3 data nodes, though the correct number of principals should be added up to N data nodes.
-(assuming a default service name of `{{ page.serviceName }}`)
+(assuming a default service name of `{{ data.serviceName }}`)
 
 Note that the service name is part of the instance in the principal. The template of a principal with `hdfs` primary is:
 ```
 hdfs/<pod-type>-<pod-index>-<task-type>.<service-name>.autoip.dcos.thisdcos.directory@<REALM>
 ```
-Given a service name of `{{ page.serviceName }}-demo`, the principal for a name node becomes:
+Given a service name of `{{ data.serviceName }}-demo`, the principal for a name node becomes:
 ```
-hdfs/name-0-node.{{ page.serviceName }}-demo.autoip.dcos.thisdcos.directory@LOCAL
+hdfs/name-0-node.{{ data.serviceName }}-demo.autoip.dcos.thisdcos.directory@LOCAL
 ```
 
-Also note that if the service name is foldered, such as `myfolder/{{ page.serviceName }}`, then the FQDN in the instance of the principal
-becomes `myfolder{{ page.serviceName }}`. For example:
+Also note that if the service name is foldered, such as `myfolder/{{ data.serviceName }}`, then the FQDN in the instance of the principal
+becomes `myfolder{{ data.serviceName }}`. For example:
 ```
-hdfs/name-0-node.myfolder{{ page.serviceName }}.autoip.dcos.thisdcos.directory@LOCAL
+hdfs/name-0-node.myfolder{{ data.serviceName }}.autoip.dcos.thisdcos.directory@LOCAL
 ```
 
 ## Create the keytab secret
@@ -73,7 +71,7 @@ Create the following `kerberos-options.json` file:
 ```json
 {
     "service": {
-        "name": "{{ page.serviceName }}",
+        "name": "{{ data.serviceName }}",
         "security": {
             "kerberos": {
                 "enabled": true,
@@ -93,7 +91,7 @@ Note the specification of the secret name as created in the previous step.
 
 The kerberized Apache HDFS service is then deployed by running:
 ```bash
-$ dcos package install {{ page.packageName }} --options=kerberos-options.json
+$ dcos package install {{ data.packageName }} --options=kerberos-options.json
 ```
 
 ## Active Directory
@@ -102,27 +100,27 @@ Kerberized Apache HDFS also supports Active Directory as a KDC. Here the generat
 
 As an example, the `ktpass` utility can be used to generate the keytab for the Apache HDFS principals as follows:
 ```bash
-ktpass.exe                    /princ hdfs/name-0-node.{{ page.serviceName }}.autoip.dcos.thisdcos.directory@EXAMPLE.COM /mapuser name-0-node@example.com /ptype KRB5_NT_PRINCIPAL +rndPass            /out hdfs-00.keytab
-ktpass.exe /in hdfs-00.keytab /princ HTTP/name-0-node.{{ page.serviceName }}.autoip.dcos.thisdcos.directory@EXAMPLE.COM /mapuser http-name-0-node@example.com /ptype KRB5_NT_PRINCIPAL +rndPass       /out hdfs-01.keytab
-ktpass.exe /in hdfs-01.keytab /princ hdfs/name-0-zkfc.{{ page.serviceName }}.autoip.dcos.thisdcos.directory@EXAMPLE.COM /mapuser name-0-zkfc@example.com /ptype KRB5_NT_PRINCIPAL +rndPass            /out hdfs-02.keytab
-ktpass.exe /in hdfs-02.keytab /princ HTTP/name-0-zkfc.{{ page.serviceName }}.autoip.dcos.thisdcos.directory@EXAMPLE.COM /mapuser http-name-0-zkfc@example.com /ptype KRB5_NT_PRINCIPAL +rndPass       /out hdfs-03.keytab
-ktpass.exe /in hdfs-03.keytab /princ hdfs/name-1-node.{{ page.serviceName }}.autoip.dcos.thisdcos.directory@EXAMPLE.COM /mapuser name-1-node@example.com /ptype KRB5_NT_PRINCIPAL +rndPass            /out hdfs-04.keytab
-ktpass.exe /in hdfs-04.keytab /princ HTTP/name-1-node.{{ page.serviceName }}.autoip.dcos.thisdcos.directory@EXAMPLE.COM /mapuser http-name-1-node@example.com /ptype KRB5_NT_PRINCIPAL +rndPass       /out hdfs-05.keytab
-ktpass.exe /in hdfs-05.keytab /princ hdfs/name-1-zkfc.{{ page.serviceName }}.autoip.dcos.thisdcos.directory@EXAMPLE.COM /mapuser name-1-zkfc@example.com /ptype KRB5_NT_PRINCIPAL +rndPass            /out hdfs-06.keytab
-ktpass.exe /in hdfs-06.keytab /princ HTTP/name-1-zkfc.{{ page.serviceName }}.autoip.dcos.thisdcos.directory@EXAMPLE.COM /mapuser http-name-1-zkfc@example.com /ptype KRB5_NT_PRINCIPAL +rndPass       /out hdfs-07.keytab
-ktpass.exe /in hdfs-07.keytab /princ hdfs/journal-0-node.{{ page.serviceName }}.autoip.dcos.thisdcos.directory@EXAMPLE.COM /mapuser journal-0-node@example.com /ptype KRB5_NT_PRINCIPAL +rndPass      /out hdfs-08.keytab
-ktpass.exe /in hdfs-08.keytab /princ HTTP/journal-0-node.{{ page.serviceName }}.autoip.dcos.thisdcos.directory@EXAMPLE.COM /mapuser http-journal-0-node@example.com /ptype KRB5_NT_PRINCIPAL +rndPass /out hdfs-09.keytab
-ktpass.exe /in hdfs-09.keytab /princ hdfs/journal-1-node.{{ page.serviceName }}.autoip.dcos.thisdcos.directory@EXAMPLE.COM /mapuser journal-1-node@example.com /ptype KRB5_NT_PRINCIPAL +rndPass      /out hdfs-10.keytab
-ktpass.exe /in hdfs-10.keytab /princ HTTP/journal-1-node.{{ page.serviceName }}.autoip.dcos.thisdcos.directory@EXAMPLE.COM /mapuser http-journal-1-node@example.com /ptype KRB5_NT_PRINCIPAL +rndPass /out hdfs-11.keytab
-ktpass.exe /in hdfs-11.keytab /princ hdfs/journal-2-node.{{ page.serviceName }}.autoip.dcos.thisdcos.directory@EXAMPLE.COM /mapuser journal-2-node@example.com /ptype KRB5_NT_PRINCIPAL +rndPass      /out hdfs-12.keytab
-ktpass.exe /in hdfs-12.keytab /princ HTTP/journal-2-node.{{ page.serviceName }}.autoip.dcos.thisdcos.directory@EXAMPLE.COM /mapuser http-journal-2-node@example.com /ptype KRB5_NT_PRINCIPAL +rndPass /out hdfs-13.keytab
-ktpass.exe /in hdfs-13.keytab /princ hdfs/data-0-node.{{ page.serviceName }}.autoip.dcos.thisdcos.directory@EXAMPLE.COM /mapuser data-0-node@example.com /ptype KRB5_NT_PRINCIPAL +rndPass            /out hdfs-14.keytab
-ktpass.exe /in hdfs-14.keytab /princ HTTP/data-0-node.{{ page.serviceName }}.autoip.dcos.thisdcos.directory@EXAMPLE.COM /mapuser http-data-0-node@example.com /ptype KRB5_NT_PRINCIPAL +rndPass       /out hdfs-15.keytab
-ktpass.exe /in hdfs-15.keytab /princ hdfs/data-1-node.{{ page.serviceName }}.autoip.dcos.thisdcos.directory@EXAMPLE.COM /mapuser data-1-node@example.com /ptype KRB5_NT_PRINCIPAL +rndPass            /out hdfs-16.keytab
-ktpass.exe /in hdfs-16.keytab /princ HTTP/data-1-node.{{ page.serviceName }}.autoip.dcos.thisdcos.directory@EXAMPLE.COM /mapuser http-data-1-node@example.com /ptype KRB5_NT_PRINCIPAL +rndPass       /out hdfs-17.keytab
-ktpass.exe /in hdfs-17.keytab /princ hdfs/data-2-node.{{ page.serviceName }}.autoip.dcos.thisdcos.directory@EXAMPLE.COM /mapuser data-2-node@example.com /ptype KRB5_NT_PRINCIPAL +rndPass            /out hdfs-18.keytab
-ktpass.exe /in hdfs-18.keytab /princ HTTP/data-2-node.{{ page.serviceName }}.autoip.dcos.thisdcos.directory@EXAMPLE.COM /mapuser http-data-2-node@example.com /ptype KRB5_NT_PRINCIPAL +rndPass       /out hdfs-19.keytab
-ktpass.exe /in hdfs-19.keytab /princ HTTP/api.{{ page.serviceName }}.l4lb.thisdcos.directory@EXAMPLE.COM /mapuser http-api@example.com /ptype KRB5_NT_PRINCIPAL +rndPass                              /out hdfs.keytab
+ktpass.exe                    /princ hdfs/name-0-node.{{ data.serviceName }}.autoip.dcos.thisdcos.directory@EXAMPLE.COM /mapuser name-0-node@example.com /ptype KRB5_NT_PRINCIPAL +rndPass            /out hdfs-00.keytab
+ktpass.exe /in hdfs-00.keytab /princ HTTP/name-0-node.{{ data.serviceName }}.autoip.dcos.thisdcos.directory@EXAMPLE.COM /mapuser http-name-0-node@example.com /ptype KRB5_NT_PRINCIPAL +rndPass       /out hdfs-01.keytab
+ktpass.exe /in hdfs-01.keytab /princ hdfs/name-0-zkfc.{{ data.serviceName }}.autoip.dcos.thisdcos.directory@EXAMPLE.COM /mapuser name-0-zkfc@example.com /ptype KRB5_NT_PRINCIPAL +rndPass            /out hdfs-02.keytab
+ktpass.exe /in hdfs-02.keytab /princ HTTP/name-0-zkfc.{{ data.serviceName }}.autoip.dcos.thisdcos.directory@EXAMPLE.COM /mapuser http-name-0-zkfc@example.com /ptype KRB5_NT_PRINCIPAL +rndPass       /out hdfs-03.keytab
+ktpass.exe /in hdfs-03.keytab /princ hdfs/name-1-node.{{ data.serviceName }}.autoip.dcos.thisdcos.directory@EXAMPLE.COM /mapuser name-1-node@example.com /ptype KRB5_NT_PRINCIPAL +rndPass            /out hdfs-04.keytab
+ktpass.exe /in hdfs-04.keytab /princ HTTP/name-1-node.{{ data.serviceName }}.autoip.dcos.thisdcos.directory@EXAMPLE.COM /mapuser http-name-1-node@example.com /ptype KRB5_NT_PRINCIPAL +rndPass       /out hdfs-05.keytab
+ktpass.exe /in hdfs-05.keytab /princ hdfs/name-1-zkfc.{{ data.serviceName }}.autoip.dcos.thisdcos.directory@EXAMPLE.COM /mapuser name-1-zkfc@example.com /ptype KRB5_NT_PRINCIPAL +rndPass            /out hdfs-06.keytab
+ktpass.exe /in hdfs-06.keytab /princ HTTP/name-1-zkfc.{{ data.serviceName }}.autoip.dcos.thisdcos.directory@EXAMPLE.COM /mapuser http-name-1-zkfc@example.com /ptype KRB5_NT_PRINCIPAL +rndPass       /out hdfs-07.keytab
+ktpass.exe /in hdfs-07.keytab /princ hdfs/journal-0-node.{{ data.serviceName }}.autoip.dcos.thisdcos.directory@EXAMPLE.COM /mapuser journal-0-node@example.com /ptype KRB5_NT_PRINCIPAL +rndPass      /out hdfs-08.keytab
+ktpass.exe /in hdfs-08.keytab /princ HTTP/journal-0-node.{{ data.serviceName }}.autoip.dcos.thisdcos.directory@EXAMPLE.COM /mapuser http-journal-0-node@example.com /ptype KRB5_NT_PRINCIPAL +rndPass /out hdfs-09.keytab
+ktpass.exe /in hdfs-09.keytab /princ hdfs/journal-1-node.{{ data.serviceName }}.autoip.dcos.thisdcos.directory@EXAMPLE.COM /mapuser journal-1-node@example.com /ptype KRB5_NT_PRINCIPAL +rndPass      /out hdfs-10.keytab
+ktpass.exe /in hdfs-10.keytab /princ HTTP/journal-1-node.{{ data.serviceName }}.autoip.dcos.thisdcos.directory@EXAMPLE.COM /mapuser http-journal-1-node@example.com /ptype KRB5_NT_PRINCIPAL +rndPass /out hdfs-11.keytab
+ktpass.exe /in hdfs-11.keytab /princ hdfs/journal-2-node.{{ data.serviceName }}.autoip.dcos.thisdcos.directory@EXAMPLE.COM /mapuser journal-2-node@example.com /ptype KRB5_NT_PRINCIPAL +rndPass      /out hdfs-12.keytab
+ktpass.exe /in hdfs-12.keytab /princ HTTP/journal-2-node.{{ data.serviceName }}.autoip.dcos.thisdcos.directory@EXAMPLE.COM /mapuser http-journal-2-node@example.com /ptype KRB5_NT_PRINCIPAL +rndPass /out hdfs-13.keytab
+ktpass.exe /in hdfs-13.keytab /princ hdfs/data-0-node.{{ data.serviceName }}.autoip.dcos.thisdcos.directory@EXAMPLE.COM /mapuser data-0-node@example.com /ptype KRB5_NT_PRINCIPAL +rndPass            /out hdfs-14.keytab
+ktpass.exe /in hdfs-14.keytab /princ HTTP/data-0-node.{{ data.serviceName }}.autoip.dcos.thisdcos.directory@EXAMPLE.COM /mapuser http-data-0-node@example.com /ptype KRB5_NT_PRINCIPAL +rndPass       /out hdfs-15.keytab
+ktpass.exe /in hdfs-15.keytab /princ hdfs/data-1-node.{{ data.serviceName }}.autoip.dcos.thisdcos.directory@EXAMPLE.COM /mapuser data-1-node@example.com /ptype KRB5_NT_PRINCIPAL +rndPass            /out hdfs-16.keytab
+ktpass.exe /in hdfs-16.keytab /princ HTTP/data-1-node.{{ data.serviceName }}.autoip.dcos.thisdcos.directory@EXAMPLE.COM /mapuser http-data-1-node@example.com /ptype KRB5_NT_PRINCIPAL +rndPass       /out hdfs-17.keytab
+ktpass.exe /in hdfs-17.keytab /princ hdfs/data-2-node.{{ data.serviceName }}.autoip.dcos.thisdcos.directory@EXAMPLE.COM /mapuser data-2-node@example.com /ptype KRB5_NT_PRINCIPAL +rndPass            /out hdfs-18.keytab
+ktpass.exe /in hdfs-18.keytab /princ HTTP/data-2-node.{{ data.serviceName }}.autoip.dcos.thisdcos.directory@EXAMPLE.COM /mapuser http-data-2-node@example.com /ptype KRB5_NT_PRINCIPAL +rndPass       /out hdfs-19.keytab
+ktpass.exe /in hdfs-19.keytab /princ HTTP/api.{{ data.serviceName }}.l4lb.thisdcos.directory@EXAMPLE.COM /mapuser http-api@example.com /ptype KRB5_NT_PRINCIPAL +rndPass                              /out hdfs.keytab
 ```
 Here it is assumed that the domain `example.com` exists and that the domain users (`name-0-node`, `http-name-0-node` etc.) have been created (using the `net user` command, for example).
 
@@ -136,7 +134,7 @@ Kerberized Apache HDFS can then be deployed using the following configuration op
 ```json
 {
     "service": {
-        "name": "{{ page.serviceName }}",
+        "name": "{{ data.serviceName }}",
         "security": {
             "kerberos": {
                 "enabled": true,

--- a/frameworks/hdfs/docs/limitations.md
+++ b/frameworks/hdfs/docs/limitations.md
@@ -5,8 +5,9 @@ excerpt:
 title: Limitations
 menuWeight: 100
 ---
+{% assign data = site.data.services.hdfs %}
 
-{% include services/limitations.md %}
+{% include services/limitations.md data=data %}
 
 ## Zones
 

--- a/frameworks/hdfs/docs/managing.md
+++ b/frameworks/hdfs/docs/managing.md
@@ -4,17 +4,10 @@ navigationTitle:
 excerpt:
 title: Managing
 menuWeight: 60
-
-packageName: beta-hdfs
-serviceName: hdfs
 ---
+{% assign data = site.data.services.hdfs %}
 
-{% include services/managing.md
-    podType="data"
-    taskType="node"
-    techName="HDFS"
-    packageName=page.packageName
-    serviceName=page.serviceName %}
+{% include services/managing.md data=data %}
 
 # Replacing Journal Nodes
 
@@ -25,7 +18,7 @@ refer to the unhealthy Journal Node as it's the replaced Journal Node.
 
 Replace the Journal Node via:
 ```bash
-$ dcos {{ page.packageName }} --name={{ page.serviceName }} pod replace journal-0
+$ dcos {{ data.packageName }} --name={{ data.serviceName }} pod replace journal-0
 ```
 
 ## Detecting an unhealthy Journal Node after `replace`
@@ -66,7 +59,7 @@ $ mkdir -p journal-data/hdfs/current
 
 5. Restart the unhealthy Journal Node via:
 ```bash
-$ dcos {{ page.packageName }} --name={{ page.serviceName }} pod restart journal-0
+$ dcos {{ data.packageName }} --name={{ data.serviceName }} pod restart journal-0
 ```
 
 6. Once the restarted Journal Node is up and running, confirm that it is now healthy again by inspecting the `stderr` log. You should see:

--- a/frameworks/hdfs/docs/quick-start.md
+++ b/frameworks/hdfs/docs/quick-start.md
@@ -4,10 +4,8 @@ navigationTitle:
 excerpt:
 title: Quick Start
 menuWeight: 40
-
-packageName: beta-hdfs
-serviceName: hdfs
 ---
+{% assign data = site.data.services.hdfs %}
 
 This tutorial will get you up and running in minutes with HDFS. You will install and configure the DC/OS HDFS package and retrieve the core-site.xml and hdfs-site.xml files. These XML files are used to configure client nodes of the HDFS cluster.
 
@@ -27,16 +25,16 @@ This tutorial will get you up and running in minutes with HDFS. You will install
 1.  Install the HDFS package.
 
     ```bash
-    $ dcos package install {{ page.packageName }}
+    $ dcos package install {{ data.packageName }}
     ```
 
-    **Tip:** Type `dcos {{ page.packageName }}` to view the HDFS CLI options.
+    **Tip:** Type `dcos {{ data.packageName }}` to view the HDFS CLI options.
 
 
 1.  Show the currently configured HDFS nodes.
 
     ```bash
-    $ dcos {{ page.packageName }} --name={{ page.serviceName }} config list
+    $ dcos {{ data.packageName }} --name={{ data.serviceName }} config list
     ```
 
     The output should resemble:
@@ -79,7 +77,7 @@ This tutorial will get you up and running in minutes with HDFS. You will install
     Status: Downloaded newer image for mesosphere/hdfs-client:2.6.4
     ```
 
-    By default, the client is configured to be configured to connect to an HDFS service named `{{ page.serviceName }}` and no further client configuration is required. If you want to configure with a different name, run this command with name (`<hdfs-name>`) specified:
+    By default, the client is configured to be configured to connect to an HDFS service named `{{ data.serviceName }}` and no further client configuration is required. If you want to configure with a different name, run this command with name (`<hdfs-name>`) specified:
 
     ```bash
     $ HDFS_SERVICE_NAME=<hdfs-name> ./configure-hdfs.sh
@@ -129,7 +127,7 @@ This tutorial will get you up and running in minutes with HDFS. You will install
     1.  Run this command to retrieve the `hdfs-site.xml` file.
 
         ```bash
-        $ dcos {{ page.packageName }} --name={{ page.serviceName }} endpoints hdfs-site.xml
+        $ dcos {{ data.packageName }} --name={{ data.serviceName }} endpoints hdfs-site.xml
         ```
 
         The output should resemble:
@@ -149,7 +147,7 @@ This tutorial will get you up and running in minutes with HDFS. You will install
     1.  Run this command to retrieve the `core-site.xml` file.
 
         ```bash
-        $ dcos {{ page.packageName }} --name={{ page.serviceName }} endpoints core-site.xml
+        $ dcos {{ data.packageName }} --name={{ data.serviceName }} endpoints core-site.xml
         ```
 
         The output should resemble:

--- a/frameworks/hdfs/docs/supported-versions.md
+++ b/frameworks/hdfs/docs/supported-versions.md
@@ -5,8 +5,6 @@ title: Supported Versions
 menuWeight: 110
 excerpt:
 ---
+{% assign data = site.data.services.hdfs %}
 
-{% include services/supported-versions.md
-    techName="HDFS"
-    techPolicyDesc="[HDFS](http://hadoop.apache.org/releases.html)"
-    techVersion="2.9.0" %}
+{% include services/supported-versions.md data=data %}

--- a/frameworks/hdfs/docs/troubleshooting.md
+++ b/frameworks/hdfs/docs/troubleshooting.md
@@ -4,11 +4,7 @@ navigationTitle:
 excerpt:
 title: Troubleshooting
 menuWeight: 90
-
-packageName: beta-hdfs
-serviceName: hdfs
 ---
+{% assign data = site.data.services.hdfs %}
 
-{% include services/troubleshooting.md
-    packageName=page.packageName
-    serviceName=page.serviceName %}
+{% include services/troubleshooting.md data=data %}

--- a/frameworks/hdfs/docs/uninstall.md
+++ b/frameworks/hdfs/docs/uninstall.md
@@ -4,12 +4,7 @@ navigationTitle:
 excerpt:
 title: Uninstall
 menuWeight: 30
-
-packageName: beta-hdfs
-serviceName: hdfs
 ---
+{% assign data = site.data.services.hdfs %}
 
-{% include services/uninstall.md
-    techName="an HDFS"
-    packageName=page.packageName
-    serviceName=page.serviceName %}
+{% include services/uninstall.md data=data %}

--- a/frameworks/hdfs/docs/upgrade.md
+++ b/frameworks/hdfs/docs/upgrade.md
@@ -5,5 +5,6 @@ excerpt:
 title: Upgrade
 menuWeight: 130
 ---
+{% assign data = site.data.services.hdfs %}
 
-{% include services/upgrade.md %}
+{% include services/upgrade.md data=data %}

--- a/frameworks/kafka/docs/api-reference.md
+++ b/frameworks/kafka/docs/api-reference.md
@@ -4,31 +4,26 @@ navigationTitle:
 excerpt:
 title: API Reference
 menuWeight: 70
-
-packageName: beta-kafka
-serviceName: kafka
 ---
+{% assign data = site.data.services.kafka %}
 
-{% include services/api-reference.md
-    techName="Apache Kafka"
-    packageName=page.packageName
-    serviceName=page.serviceName %}
+{% include services/api-reference.md data=data %}
 
 # Connection Information
 
-Kafka comes with many useful tools of its own that often require either Zookeeper connection information or the list of broker endpoints. This information can be retrieved in an easily consumable format from the `/endpoints` endpoint (assuming your service is named "{{ page.serviceName }}"):
+Kafka comes with many useful tools of its own that often require either Zookeeper connection information or the list of broker endpoints. This information can be retrieved in an easily consumable format from the `/endpoints` endpoint (assuming your service is named "{{ data.serviceName }}"):
 
 ```bssh
-$ curl -H "Authorization: token=$auth_token" "<dcos_url>/service/{{ page.serviceName }}/v1/endpoints/broker"
+$ curl -H "Authorization: token=$auth_token" "<dcos_url>/service/{{ data.serviceName }}/v1/endpoints/broker"
 {
-  "vip": "broker.{{ page.serviceName }}.l4lb.thisdcos.directory:9092",
+  "vip": "broker.{{ data.serviceName }}.l4lb.thisdcos.directory:9092",
   "address": [
     "10.0.0.35:1028",
     "10.0.1.249:1030"
   ],
   "dns": [
-    "kafka-0-broker.{{ page.serviceName }}.autoip.dcos.thisdcos.directory:1028",
-    "kafka-1-broker.{{ page.serviceName }}.autoip.dcos.thisdcos.directory:1030"
+    "kafka-0-broker.{{ data.serviceName }}.autoip.dcos.thisdcos.directory:1028",
+    "kafka-1-broker.{{ data.serviceName }}.autoip.dcos.thisdcos.directory:1030"
   ],
 }
 ```
@@ -36,16 +31,16 @@ $ curl -H "Authorization: token=$auth_token" "<dcos_url>/service/{{ page.service
 The same information can be retrieved through the DC/OS CLI:
 
 ```bash
-$ dcos {{ page.packageName }} --name={{ page.serviceName }} endpoints broker
+$ dcos {{ data.packageName }} --name={{ data.serviceName }} endpoints broker
 {
-  "vip": "broker.{{ page.serviceName }}.l4lb.thisdcos.directory:9092",
+  "vip": "broker.{{ data.serviceName }}.l4lb.thisdcos.directory:9092",
   "address": [
     "10.0.0.35:1028",
     "10.0.1.249:1030"
   ],
   "dns": [
-    "kafka-0-broker.{{ page.serviceName }}.autoip.dcos.thisdcos.directory:1028",
-    "kafka-1-broker.{{ page.serviceName }}.autoip.dcos.thisdcos.directory:1030"
+    "kafka-0-broker.{{ data.serviceName }}.autoip.dcos.thisdcos.directory:1028",
+    "kafka-1-broker.{{ data.serviceName }}.autoip.dcos.thisdcos.directory:1030"
   ],
 }
 ```
@@ -57,7 +52,7 @@ These operations mirror what is available with `bin/kafka-topics.sh`.
 ## List Topics
 
 ```bash
-$ dcos {{ page.packageName }} --name={{ page.serviceName }} topic list
+$ dcos {{ data.packageName }} --name={{ data.serviceName }} topic list
 [
   "topic1",
   "topic0"
@@ -65,7 +60,7 @@ $ dcos {{ page.packageName }} --name={{ page.serviceName }} topic list
 ```
 
 ```bash
-$ curl -H "Authorization: token=$auth_token" "<dcos_url>/service/{{ page.serviceName }}/v1/topics"
+$ curl -H "Authorization: token=$auth_token" "<dcos_url>/service/{{ data.serviceName }}/v1/topics"
 [
   "topic1",
   "topic0"
@@ -75,7 +70,7 @@ $ curl -H "Authorization: token=$auth_token" "<dcos_url>/service/{{ page.service
 ## Describe Topic
 
 ```bash
-$ dcos {{ page.packageName }} --name={{ page.serviceName }} topic describe topic1
+$ dcos {{ data.packageName }} --name={{ data.serviceName }} topic describe topic1
 {
   "partitions": [
   {
@@ -122,7 +117,7 @@ $ dcos {{ page.packageName }} --name={{ page.serviceName }} topic describe topic
 ```
 
 ```bash
-$ curl -X POST -H "Authorization: token=$auth_token" "<dcos_url>/service/{{ page.serviceName }}/v1/topics/topic1"
+$ curl -X POST -H "Authorization: token=$auth_token" "<dcos_url>/service/{{ data.serviceName }}/v1/topics/topic1"
 {
   "partitions": [
   {
@@ -172,14 +167,14 @@ $ curl -X POST -H "Authorization: token=$auth_token" "<dcos_url>/service/{{ page
 ## Create Topic
 
 ```bash
-$ dcos {{ page.packageName }} --name={{ page.serviceName }} topic create topic1 --partitions=3 --replication=3
+$ dcos {{ data.packageName }} --name={{ data.serviceName }} topic create topic1 --partitions=3 --replication=3
 {
   "message": "Output: Created topic \"topic1\"\n"
 }
 ```
 
 ```bash
-$ curl -X POST -H "Authorization: token=$auth_token" "<dcos_url>/service/{{ page.serviceName }}/v1/topics/topic1?partitions=3&replication=3"
+$ curl -X POST -H "Authorization: token=$auth_token" "<dcos_url>/service/{{ data.serviceName }}/v1/topics/topic1?partitions=3&replication=3"
 {
   "message": "Output: Created topic \"topic1\"\n"
 }
@@ -190,7 +185,7 @@ $ curl -X POST -H "Authorization: token=$auth_token" "<dcos_url>/service/{{ page
 There is an optional `--time` parameter which may be set to either "first", "last", or a timestamp in milliseconds as [described in the Kafka documentation][15].
 
 ```bash
-$ dcos {{ page.packageName }} --name={{ page.serviceName }} topic offsets topic1 --time=last
+$ dcos {{ data.packageName }} --name={{ data.serviceName }} topic offsets topic1 --time=last
 [
   {
     "2": "334"
@@ -205,7 +200,7 @@ $ dcos {{ page.packageName }} --name={{ page.serviceName }} topic offsets topic1
 ```
 
 ```bash
-$ curl -H "Authorization: token=$auth_token" "<dcos_url>/service/{{ page.serviceName }}/v1/topics/topic1/offsets?time=-1"
+$ curl -H "Authorization: token=$auth_token" "<dcos_url>/service/{{ data.serviceName }}/v1/topics/topic1/offsets?time=-1"
 [
   {
     "2": "334"
@@ -222,14 +217,14 @@ $ curl -H "Authorization: token=$auth_token" "<dcos_url>/service/{{ page.service
 ## Alter Topic Partition Count
 
 ```
-$ dcos {{ page.packageName }} --name={{ page.serviceName }} topic partitions topic1 2
+$ dcos {{ data.packageName }} --name={{ data.serviceName }} topic partitions topic1 2
 {
   "message": "Output: WARNING: If partitions are increased for a topic that has a key, the partition logic or ordering of the messages will be affectednAdding partitions succeeded!n"
 }
 ```
 
 ```bash
-$ curl -X PUT -H "Authorization: token=$auth_token" "<dcos_url>/service/{{ page.serviceName }}/v1/topics/topic1?operation=partitions&partitions=2"
+$ curl -X PUT -H "Authorization: token=$auth_token" "<dcos_url>/service/{{ data.serviceName }}/v1/topics/topic1?operation=partitions&partitions=2"
 {
   "message": "Output: WARNING: If partitions are increased for a topic that has a key, the partition logic or ordering of the messages will be affectednAdding partitions succeeded!n"
 }
@@ -238,13 +233,13 @@ $ curl -X PUT -H "Authorization: token=$auth_token" "<dcos_url>/service/{{ page.
 ## Run Producer Test on Topic
 
 ```
-$ dcos {{ page.packageName }} --name={{ page.serviceName }} topic producer_test topic1 10
+$ dcos {{ data.packageName }} --name={{ data.serviceName }} topic producer_test topic1 10
 {
   "message": "10 records sent, 70.422535 records/sec (0.07 MB/sec), 24.20 ms avg latency, 133.00 ms max latency, 13 ms 50th, 133 ms 95th, 133 ms 99th, 133 ms 99.9th.n"
 }
 
 ```bash
-$ curl -X PUT -H "Authorization: token=$auth_token" "<dcos_url>/service/{{ page.serviceName }}/v1/topics/topic1?operation=producer-test&messages=10"
+$ curl -X PUT -H "Authorization: token=$auth_token" "<dcos_url>/service/{{ data.serviceName }}/v1/topics/topic1?operation=producer-test&messages=10"
 {
   "message": "10 records sent, 70.422535 records/sec (0.07 MB/sec), 24.20 ms avg latency, 133.00 ms max latency, 13 ms 50th, 133 ms 95th, 133 ms 99th, 133 ms 99.9th.n"
 }
@@ -263,14 +258,14 @@ $ kafka-producer-perf-test.sh \
 ## Delete Topic
 
 ```bash
-$ dcos {{ page.packageName }} --name={{ page.serviceName }} topic delete topic1
+$ dcos {{ data.packageName }} --name={{ data.serviceName }} topic delete topic1
 {
   "message": "Topic topic1 is marked for deletion.nNote: This will have no impact if delete.topic.enable is not set to true.n"
 }
 ```
 
 ```bash
-$ curl -X DELETE -H "Authorization: token=$auth_token" "<dcos_url>/service/{{ page.serviceName }}/v1/topics/topic1"
+$ curl -X DELETE -H "Authorization: token=$auth_token" "<dcos_url>/service/{{ data.serviceName }}/v1/topics/topic1"
 {
   "message": "Topic topic1 is marked for deletion.nNote: This will have no impact if delete.topic.enable is not set to true.n"
 }
@@ -281,14 +276,14 @@ Note the warning in the output from the commands above. You can change the indic
 ## List Under Replicated Partitions
 
 ```bash
-$ dcos {{ page.packageName }} --name={{ page.serviceName }} topic under_replicated_partitions
+$ dcos {{ data.packageName }} --name={{ data.serviceName }} topic under_replicated_partitions
 {
   "message": ""
 }
 ```
 
 ```bash
-$ curl -H "Authorization: token=$auth_token" "<dcos_url>/service/{{ page.serviceName }}/v1/topics/under_replicated_partitions"
+$ curl -H "Authorization: token=$auth_token" "<dcos_url>/service/{{ data.serviceName }}/v1/topics/under_replicated_partitions"
 {
   "message": ""
 }
@@ -297,14 +292,14 @@ $ curl -H "Authorization: token=$auth_token" "<dcos_url>/service/{{ page.service
 ## List Unavailable Partitions
 
 ```bash
-$ dcos {{ page.packageName }} --name={{ page.serviceName }} topic unavailable_partitions
+$ dcos {{ data.packageName }} --name={{ data.serviceName }} topic unavailable_partitions
 {
   "message": ""
 }
 ```
 
 ```bash
-$ curl -H "Authorization: token=$auth_token" "<dcos_url>/service/{{ page.serviceName }}/v1/topics/unavailable_partitions"
+$ curl -H "Authorization: token=$auth_token" "<dcos_url>/service/{{ data.serviceName }}/v1/topics/unavailable_partitions"
 {
   "message": ""
 }

--- a/frameworks/kafka/docs/connecting-clients.md
+++ b/frameworks/kafka/docs/connecting-clients.md
@@ -4,10 +4,8 @@ navigationTitle:
 excerpt:
 title: Connecting Clients
 menuWeight: 50
-
-packageName: beta-kafka
-serviceName: kafka
 ---
+{% assign data = site.data.services.kafka %}
 
 # Supported Client Libraries
 
@@ -30,7 +28,7 @@ Through Confluent:
 The following command can be executed from the cli in order to retrieve a set of brokers to connect to.
 
 ```bash
-$ dcos {{ page.packageName }} --name={{ page.serviceName }} endpoints broker
+$ dcos {{ data.packageName }} --name={{ data.serviceName }} endpoints broker
 ```
 
 <a name="using-the-rest-api"></a>
@@ -41,7 +39,7 @@ REST API requests must be authenticated. See the REST API Authentication part of
 The following `curl` example demonstrates how to retrive connection a set of brokers to connect to using the REST API.
 
 ```bash
-$ curl -H "Authorization: token=$auth_token" "<dcos_url>/service/{{ page.serviceName }}/v1/endpoints/broker"
+$ curl -H "Authorization: token=$auth_token" "<dcos_url>/service/{{ data.serviceName }}/v1/endpoints/broker"
 ```
 
 ## User token authentication
@@ -61,7 +59,7 @@ $ export auth_token=uSeR_t0k3n
 Then, use this token to authenticate requests to the Kafka Service:
 
 ```bash
-$ curl -H "Authorization: token=$auth_token" "<dcos_url>/service/{{ page.serviceName }}/v1/endpoints/broker"
+$ curl -H "Authorization: token=$auth_token" "<dcos_url>/service/{{ data.serviceName }}/v1/endpoints/broker"
 ```
 
 You do not need the token to access the Kafka brokers themselves.
@@ -78,11 +76,11 @@ The response, for both the CLI and the REST API is as below.
     "10.0.1.27:1025"
   ],
   "dns": [
-    "kafka-2-broker.{{ page.serviceName }}.autoip.dcos.thisdcos.directory:1025",
-    "kafka-0-broker.{{ page.serviceName }}.autoip.dcos.thisdcos.directory:1025",
-    "kafka-1-broker.{{ page.serviceName }}.autoip.dcos.thisdcos.directory:1025"
+    "kafka-2-broker.{{ data.serviceName }}.autoip.dcos.thisdcos.directory:1025",
+    "kafka-0-broker.{{ data.serviceName }}.autoip.dcos.thisdcos.directory:1025",
+    "kafka-1-broker.{{ data.serviceName }}.autoip.dcos.thisdcos.directory:1025"
   ],
-  "vip": "broker.{{ page.serviceName }}.l4lb.thisdcos.directory:9092"
+  "vip": "broker.{{ data.serviceName }}.l4lb.thisdcos.directory:9092"
 }
 ```
 
@@ -175,7 +173,7 @@ The code snippet below demonstrates how to connect a Kafka Consumer to the clust
 The following code connects to a DC/OS-hosted Kafka instance using `bin/kafka-console-producer.sh` and `bin/kafka-console-consumer.sh` as an example:
 
 ```bvash
-$ dcos {{ page.packageName }} --name={{ page.serviceName }} endpoints broker
+$ dcos {{ data.packageName }} --name={{ data.serviceName }} endpoints broker
 {
   "address": [
     "10.0.0.49:1025",
@@ -183,11 +181,11 @@ $ dcos {{ page.packageName }} --name={{ page.serviceName }} endpoints broker
     "10.0.1.27:1025"
   ],
   "dns": [
-    "kafka-2-broker.{{ page.serviceName }}.autoip.dcos.thisdcos.directory:1025",
-    "kafka-0-broker.{{ page.serviceName }}.autoip.dcos.thisdcos.directory:1025",
-    "kafka-1-broker.{{ page.serviceName }}.autoip.dcos.thisdcos.directory:1025"
+    "kafka-2-broker.{{ data.serviceName }}.autoip.dcos.thisdcos.directory:1025",
+    "kafka-0-broker.{{ data.serviceName }}.autoip.dcos.thisdcos.directory:1025",
+    "kafka-1-broker.{{ data.serviceName }}.autoip.dcos.thisdcos.directory:1025"
   ],
-  "vip": "broker.{{ page.serviceName }}.l4lb.thisdcos.directory:9092"
+  "vip": "broker.{{ data.serviceName }}.l4lb.thisdcos.directory:9092"
 }
 
 $ dcos node ssh --master-proxy --leader
@@ -196,6 +194,6 @@ core@ip-10-0-6-153 ~ $ docker run -it mesosphere/kafka-client
 
 root@7d0aed75e582:/bin# echo "Hello, World." | ./kafka-console-producer.sh --broker-list 10.0.0.49:1025, 10.0.2.253:1025, 10.0.1.27:1025 --topic topic1
 
-root@7d0aed75e582:/bin# ./kafka-console-consumer.sh --zookeeper master.mesos:2181/dcos-service-{{ page.serviceName }} --topic topic1 --from-beginning
+root@7d0aed75e582:/bin# ./kafka-console-consumer.sh --zookeeper master.mesos:2181/dcos-service-{{ data.serviceName }} --topic topic1 --from-beginning
     Hello, World.
 ```

--- a/frameworks/kafka/docs/install.md
+++ b/frameworks/kafka/docs/install.md
@@ -4,18 +4,13 @@ navigationTitle:
 excerpt:
 title: Install and Customize
 menuWeight: 20
-
-techName: Apache Kafka
-packageName: beta-kafka
-serviceName: kafka
-zookeeperPackageName: beta-kafka-zookeeper
-zookeeperServiceName: kafka-zookeeper
 ---
+{% assign data = site.data.services.kafka %}
 
 {% capture customInstallConfigurations %}
 ### Minimal installation
 
-For development purposes, you may wish to install {{ page.techName }} on a local DC/OS cluster. For this, you can use [dcos-docker](https://github.com/dcos/dcos-docker) or [dcos-vagrant](https://github.com/dcos/dcos-vagrant).
+For development purposes, you may wish to install {{ data.techName }} on a local DC/OS cluster. For this, you can use [dcos-docker](https://github.com/dcos/dcos-docker) or [dcos-vagrant](https://github.com/dcos/dcos-vagrant).
 
 To start a minimal cluster with a single broker, create a JSON options file named `sample-kafka-minimal.json`:
 
@@ -32,7 +27,7 @@ To start a minimal cluster with a single broker, create a JSON options file name
 The command below creates a cluster using `sample-kafka-minimal.json`:
 
 ```bash
-$ dcos package install {{ page.packageName }} --options=sample-kafka-minimal.json
+$ dcos package install {{ data.packageName }} --options=sample-kafka-minimal.json
 ```
 
 ### Example custom installation
@@ -61,7 +56,7 @@ Sample JSON options file named `sample-kafka-custom.json`:
 The command below creates a cluster using `sample-kafka.json`:
 
 ```bash
-$ dcos package install {{ page.packageName }} --options=sample-kafka-custom.json
+$ dcos package install {{ data.packageName }} --options=sample-kafka-custom.json
 ```
 
 **Recommendation:** Store your custom configuration in source control.
@@ -70,42 +65,37 @@ Alternatively, you can perform a custom installation from the DC/OS web interfac
 
 ### Alternate ZooKeeper
 
-{{ page.techName }} requires a running ZooKeeper ensemble to perform its own internal accounting. By default, the DC/OS {{ page.techName }} Service uses the ZooKeeper ensemble made available on the Mesos masters of a DC/OS cluster at `master.mesos:2181/dcos-service-<servicename>`. At install time, you can configure an alternate ZooKeeper for {{ page.techName }} to use. This enables you to increase {{ page.techName }}'s capacity and removes the DC/OS System ZooKeeper ensemble's involvement in running it.
+{{ data.techName }} requires a running ZooKeeper ensemble to perform its own internal accounting. By default, the DC/OS {{ data.techName }} Service uses the ZooKeeper ensemble made available on the Mesos masters of a DC/OS cluster at `master.mesos:2181/dcos-service-<servicename>`. At install time, you can configure an alternate ZooKeeper for {{ data.techName }} to use. This enables you to increase {{ data.techName }}'s capacity and removes the DC/OS System ZooKeeper ensemble's involvement in running it.
 
 To configure an alternate Zookeeper instance:
 
 1. Create a file named `options.json` with the following contents.
 
-**Note:** If you are using the [DC/OS Apache ZooKeeper service](https://docs.mesosphere.com/services/{{ page.zookeeperPackageName }}), use the DNS addresses provided by the `dcos {{ page.zookeeperPackageName }} endpoints clientport` command as the value of `kafka_zookeeper_uri`. Here is an example `options.json` which points to a `{{ page.zookeeperPackageName }}` instance named `{{ page.zookeeperServiceName }}`:
+**Note:** If you are using the [DC/OS Apache ZooKeeper service](https://docs.mesosphere.com/services/{{ data.kafka.zookeeperPackageName }}), use the DNS addresses provided by the `dcos {{ data.kafka.zookeeperPackageName }} endpoints clientport` command as the value of `kafka_zookeeper_uri`. Here is an example `options.json` which points to a `{{ data.kafka.zookeeperPackageName }}` instance named `{{ data.kafka.zookeeperServiceName }}`:
 
 ```json
 {
   "kafka": {
-    "kafka_zookeeper_uri": "zookeeper-0-server.{{ page.zookeeperServiceName }}.autoip.dcos.thisdcos.directory:1140,zookeeper-1-server.{{ page.zookeeperServiceName }}.autoip.dcos.thisdcos.directory:1140,zookeeper-2-server.{{ page.zookeeperServiceName }}.autoip.dcos.thisdcos.directory:1140"
+    "kafka_zookeeper_uri": "zookeeper-0-server.{{ data.kafka.zookeeperServiceName }}.autoip.dcos.thisdcos.directory:1140,zookeeper-1-server.{{ data.kafka.zookeeperServiceName }}.autoip.dcos.thisdcos.directory:1140,zookeeper-2-server.{{ data.kafka.zookeeperServiceName }}.autoip.dcos.thisdcos.directory:1140"
   }
 }
 ```
 
-1. Install {{ page.techName }} with the options file you created.
+1. Install {{ data.techName }} with the options file you created.
 
 ```bash
-$ dcos package install {{ page.packageName }} --options="options.json"
+$ dcos package install {{ data.packageName }} --options="options.json"
 ```
 
-You can also update an already-running {{ page.techName }} instance from the DC/OS CLI, in case you need to migrate your ZooKeeper data elsewhere.
+You can also update an already-running {{ data.techName }} instance from the DC/OS CLI, in case you need to migrate your ZooKeeper data elsewhere.
 
 **Note:** Before performing this configuration change, you must first copy the data from your current ZooKeeper ensemble to the new ZooKeeper ensemble. The new location must have the same data as the previous location during the migration.
 
 ```bash
-$ dcos {{ page.packageName }} --name={{ page.serviceName }} update start --options=options.json
+$ dcos {{ data.packageName }} --name={{ data.serviceName }} update start --options=options.json
 ```
 {% endcapture %}
 
 {% include services/install.md
-    techName=page.techName
-    packageName=page.packageName
-    serviceName=page.serviceName
-    minNodeCount="three"
-    defaultInstallDescription="with three brokers"
-    serviceAccountInstructionsUrl="https://docs.mesosphere.com/services/kafka/kafka-auth/"
+    data=data
     customInstallConfigurations=customInstallConfigurations %}

--- a/frameworks/kafka/docs/limitations.md
+++ b/frameworks/kafka/docs/limitations.md
@@ -5,8 +5,9 @@ excerpt:
 title: Limitations
 menuWeight: 100
 ---
+{% assign data = site.data.services.kafka %}
 
-{% include services/limitations.md %}
+{% include services/limitations.md data=data %}
 
 ## Configurations
 

--- a/frameworks/kafka/docs/managing.md
+++ b/frameworks/kafka/docs/managing.md
@@ -4,23 +4,16 @@ navigationTitle:
 excerpt:
 title: Managing
 menuWeight: 60
-
-packageName: beta-kafka
-serviceName: kafka
 ---
+{% assign data = site.data.services.kafka %}
 
-{% include services/managing.md
-    podType="kafka"
-    taskType="broker"
-    techName="Apache Kafka"
-    packageName=page.packageName
-    serviceName=page.serviceName %}
+{% include services/managing.md data=data %}
 
 # Graceful Shutdown
 
 ## Extend the Kill Grace Period
 
-When performing a requested restart or replace of a running broker, the Kafka service will wait a default of `30` seconds for a broker to exit, before killing the process. This grace period may be customized via the `brokers.kill_grace_period` setting. In this example we will use the DC/OS CLI to increase the grace period delay to `60` seconds. This example assumes that the Kafka service instance is named `{{ page.serviceName }}`.
+When performing a requested restart or replace of a running broker, the Kafka service will wait a default of `30` seconds for a broker to exit, before killing the process. This grace period may be customized via the `brokers.kill_grace_period` setting. In this example we will use the DC/OS CLI to increase the grace period delay to `60` seconds. This example assumes that the Kafka service instance is named `{{ data.serviceName }}`.
 
 During the configuration update, each of the Kafka broker tasks are restarted. During the shutdown portion of the task restart, the previous configuration value for `brokers.kill_grace_period` is in effect. Following the shutdown, each broker task is launched with the new effective configuration value. Take care to monitor the amount of time Kafka brokers take to cleanly shut down by observing their logs.
 
@@ -37,7 +30,7 @@ Create an options file `kafka-options.json` with the following content. If you h
 Issue the following command:
 
 ```bash
-$ dcos {{ page.packageName }} --name={{ page.serviceName }} update --options=kafka-options.json
+$ dcos {{ data.packageName }} --name={{ data.serviceName }} update --options=kafka-options.json
 ```
 
 ## Restart a Broker with Grace

--- a/frameworks/kafka/docs/quick-start.md
+++ b/frameworks/kafka/docs/quick-start.md
@@ -4,10 +4,8 @@ navigationTitle:
 excerpt:
 title: Quick Start
 menuWeight: 40
-
-packageName: beta-kafka
-serviceName: kafka
 ---
+{% assign data = site.data.services.kafka %}
 
 ## Prerequisites
 
@@ -18,7 +16,7 @@ serviceName: kafka
 1. Install a Kafka cluster. If you are using open source DC/OS, install a Kafka cluster with the following command from the DC/OS CLI. If you are using Enterprise DC/OS, you may need to follow additional instructions. See the Install and Customize section for more information.
 
    ```bash
-   dcos package install {{ page.packageName }}
+   dcos package install {{ data.packageName }}
    ```
 
    Alternatively, you can install Kafka from [the DC/OS web interface](https://docs.mesosphere.com/latest/usage/webinterface/).
@@ -28,17 +26,17 @@ serviceName: kafka
 1. Create a new topic.
 
     ```bash
-    $ dcos {{ page.packageName }} --name={{ page.serviceName }} topic create topic1
+    $ dcos {{ data.packageName }} --name={{ data.serviceName }} topic create topic1
     ```
 
 
 1. Find Zookeeper and broker endpoint information.
 
     ```bash
-    $ dcos {{ page.packageName }} --name={{ page.serviceName }} endpoints zookeeper
-    master.mesos:2181/dcos-service-{{ page.serviceName }}
+    $ dcos {{ data.packageName }} --name={{ data.serviceName }} endpoints zookeeper
+    master.mesos:2181/dcos-service-{{ data.serviceName }}
 
-    $ dcos {{ page.packageName }} --name={{ page.serviceName }} endpoints broker
+    $ dcos {{ data.packageName }} --name={{ data.serviceName }} endpoints broker
     {
       "address": [
         "10.0.3.226:1000",
@@ -46,11 +44,11 @@ serviceName: kafka
         "10.0.0.120:1000"
       ],
       "dns": [
-        "kafka-2-broker.{{ page.serviceName }}.autoip.dcos.thisdcos.directory:1000",
-        "kafka-0-broker.{{ page.serviceName }}.autoip.dcos.thisdcos.directory:1000",
-        "kafka-1-broker.{{ page.serviceName }}.autoip.dcos.thisdcos.directory:1000"
+        "kafka-2-broker.{{ data.serviceName }}.autoip.dcos.thisdcos.directory:1000",
+        "kafka-0-broker.{{ data.serviceName }}.autoip.dcos.thisdcos.directory:1000",
+        "kafka-1-broker.{{ data.serviceName }}.autoip.dcos.thisdcos.directory:1000"
       ],
-      "vip": "broker.{{ page.serviceName }}.l4lb.thisdcos.directory:9092"
+      "vip": "broker.{{ data.serviceName }}.l4lb.thisdcos.directory:9092"
     }
     ```
 
@@ -78,10 +76,10 @@ serviceName: kafka
     $ dcos marathon app add kafkaclient.json
 
     # Produce single `Hello world` event
-    $ dcos task exec kafka-client bash -c "export JAVA_HOME=/opt/jdk1.8.0_144/jre/; echo 'Hello, World.' | /opt/kafka_2.12-0.11.0.0/bin/kafka-console-producer.sh --broker-list broker.{{ page.serviceName }}.l4lb.thisdcos.directory:9092 --topic topic1"
+    $ dcos task exec kafka-client bash -c "export JAVA_HOME=/opt/jdk1.8.0_144/jre/; echo 'Hello, World.' | /opt/kafka_2.12-0.11.0.0/bin/kafka-console-producer.sh --broker-list broker.{{ data.serviceName }}.l4lb.thisdcos.directory:9092 --topic topic1"
 
     # Consume events from topic1
-    $ dcos task exec kafka-client bash -c "export JAVA_HOME=/opt/jdk1.8.0_144/jre/; /opt/kafka_2.12-0.11.0.0/bin/kafka-console-consumer.sh --zookeeper master.mesos:2181/dcos-service-{{ page.serviceName }} --topic topic1 --from-beginning"
+    $ dcos task exec kafka-client bash -c "export JAVA_HOME=/opt/jdk1.8.0_144/jre/; /opt/kafka_2.12-0.11.0.0/bin/kafka-console-consumer.sh --zookeeper master.mesos:2181/dcos-service-{{ data.serviceName }} --topic topic1 --from-beginning"
     Hello, World.
     ```
 

--- a/frameworks/kafka/docs/supported-versions.md
+++ b/frameworks/kafka/docs/supported-versions.md
@@ -5,9 +5,6 @@ title: Supported Versions
 menuWeight: 110
 excerpt:
 ---
+{% assign data = site.data.services.kafka %}
 
-{% include services/supported-versions.md
-    techName="Apache Kafka"
-    techPolicyDesc="[Apache Kafka](https://kafka.apache.org/downloads)"
-    techVersion="0.11.0.2" %}
-
+{% include services/supported-versions.md data=data %}

--- a/frameworks/kafka/docs/troubleshooting.md
+++ b/frameworks/kafka/docs/troubleshooting.md
@@ -4,18 +4,14 @@ navigationTitle:
 excerpt:
 title: Troubleshooting
 menuWeight: 90
-
-packageName: beta-kafka
-serviceName: kafka
 ---
+{% assign data = site.data.services.kafka %}
 
-{% include services/troubleshooting.md
-    packageName=page.packageName
-    serviceName=page.serviceName %}
+{% include services/troubleshooting.md data=data %}
 
 ## Partition replication
 
-Kafka may become unhealthy when it detects any underreplicated partitions. This error condition usually indicates a malfunctioning broker. Use the `dcos {{ page.packageName }} --name={{ page.serviceName }} topic under_replicated_partitions` and `dcos {{ page.packageName }} --name={{ page.serviceName }} topic describe <topic-name>` commands to find the problem broker and determine what actions are required.
+Kafka may become unhealthy when it detects any underreplicated partitions. This error condition usually indicates a malfunctioning broker. Use the `dcos {{ data.packageName }} --name={{ data.serviceName }} topic under_replicated_partitions` and `dcos {{ data.packageName }} --name={{ data.serviceName }} topic describe <topic-name>` commands to find the problem broker and determine what actions are required.
 
 Possible repair actions include [restarting the affected broker](#restarting-a-node) and [destructively replacing the affected broker](#replacing-a-permanently-failed-node). The replace operation is destructive and will irrevocably lose all data associated with the broker. The restart operation is not destructive and indicates an attempt to restart a broker process.
 

--- a/frameworks/kafka/docs/uninstall.md
+++ b/frameworks/kafka/docs/uninstall.md
@@ -4,12 +4,7 @@ navigationTitle:
 excerpt:
 title: Uninstall
 menuWeight: 30
-
-packageName: beta-kafka
-serviceName: kafka
 ---
+{% assign data = site.data.services.kafka %}
 
-{% include services/uninstall.md
-    techName="an Apache Kafka"
-    packageName=page.packageName
-    serviceName=page.serviceName %}
+{% include services/uninstall.md data=data %}

--- a/frameworks/kafka/docs/upgrade.md
+++ b/frameworks/kafka/docs/upgrade.md
@@ -5,5 +5,6 @@ excerpt:
 title: Upgrade
 menuWeight: 130
 ---
+{% assign data = site.data.services.kafka %}
 
-{% include services/upgrade.md %}
+{% include services/upgrade.md data=data %}

--- a/frameworks/template/docs/api-reference.md
+++ b/frameworks/template/docs/api-reference.md
@@ -4,12 +4,7 @@ navigationTitle:
 excerpt:
 title: API Reference
 menuWeight: 70
-
-packageName: template
-serviceName: template
 ---
+{% assign data = site.data.services.template %}
 
-{% include services/api-reference.md
-    techName="TEMPLATE SERVICE"
-    packageName=page.packageName
-    serviceName=page.serviceName %}
+{% include services/api-reference.md data=data %}

--- a/frameworks/template/docs/connecting-clients.md
+++ b/frameworks/template/docs/connecting-clients.md
@@ -4,10 +4,8 @@ navigationTitle:
 excerpt:
 title: Connecting Clients
 menuWeight: 50
-
-packageName: template
-serviceName: template
 ---
+{% assign data = site.data.services.template %}
 
 # Connecting Clients
 One of the benefits of running containerized services is that they can be placed anywhere in the cluster. Because they can be deployed anywhere on the cluster, clients need a way to find the service. This is where service discovery comes in.
@@ -16,11 +14,11 @@ One of the benefits of running containerized services is that they can be placed
 
 Once the service is running, you may view information about its endpoints via either of the following methods:
 - CLI:
-  - List endpoint types: `dcos {{ page.packageName }} --name={{ page.serviceName }}endpoints`
-  - View endpoints for an endpoint type: `dcos {{ page.packageName }} --name={{ page.serviceName }} endpoints <endpoint>`
+  - List endpoint types: `dcos {{ data.packageName }} --name={{ data.serviceName }}endpoints`
+  - View endpoints for an endpoint type: `dcos {{ data.packageName }} --name={{ data.serviceName }} endpoints <endpoint>`
 - API:
-  - List endpoint types: `<dcos-url>/service/{{ page.serviceName }}/v1/endpoints`
-  - View endpoints for an endpoint type: `<dcos-url>/service/{{ page.serviceName }}/v1/endpoints/<endpoint>`
+  - List endpoint types: `<dcos-url>/service/{{ data.serviceName }}/v1/endpoints`
+  - View endpoints for an endpoint type: `<dcos-url>/service/{{ data.serviceName }}/v1/endpoints/<endpoint>`
 
 Returned endpoints will include the following:
 - `.autoip.dcos.thisdcos.directory` hostnames for each instance that will follow them if they're moved within the DC/OS cluster.

--- a/frameworks/template/docs/install.md
+++ b/frameworks/template/docs/install.md
@@ -4,10 +4,8 @@ navigationTitle:
 excerpt:
 title: Install and Customize
 menuWeight: 20
-
-packageName: template
-serviceName: template
 ---
+{% assign data = site.data.services.template %}
 
 {% capture customInstallRequirements %}
 - Each agent node must have some quantity of cpu, memory, disk, and ports.
@@ -24,11 +22,6 @@ A COMMON WAY OF CUSTOMIZING YOUR SERVICE'S CONFIG THAT YOU'D LIKE TO POINT OUT I
 {% endcapture %}
 
 {% include services/install.md
-    techName="TEMPLATE SERVICE"
-    packageName=page.packageName
-    serviceName=page.serviceName
-    minNodeCount="some"
-    defaultInstallDescription="with SOME QUANTITY OF NODES"
+    data=data
     customInstallRequirements=customInstallRequirements
-    serviceAccountInstructionsUrl="https://docs.mesosphere.com/services/TEMPLATE/TEMPLATE-auth/"
-    customInstallConfigurations=customInstallConfigurations%}
+    customInstallConfigurations=customInstallConfigurations %}

--- a/frameworks/template/docs/limitations.md
+++ b/frameworks/template/docs/limitations.md
@@ -5,7 +5,8 @@ excerpt:
 title: Limitations
 menuWeight: 100
 ---
+{% assign data = site.data.services.template %}
 
-{% include services/limitations.md %}
+{% include services/limitations.md data=data %}
 
 _MANAGE CUSTOMER EXPECTIONS BY DISCLOSING ANY FEATURES OF YOUR PRODUCT THAT ARE NOT SUPPORTED WITH DC/OS, FEATURES MISSING FROM THE DC/OS INTEGRATION, ETC._

--- a/frameworks/template/docs/managing.md
+++ b/frameworks/template/docs/managing.md
@@ -4,14 +4,7 @@ navigationTitle:
 excerpt:
 title: Managing
 menuWeight: 60
-
-packageName: template
-serviceName: template
 ---
+{% assign data = site.data.services.template %}
 
-{% include services/managing.md
-    podType="template"
-    taskType="node"
-    techName="TEMPLATE_SERVICE"
-    packageName=page.packageName
-    serviceName=page.serviceName %}
+{% include services/managing.md data=data %}

--- a/frameworks/template/docs/quick-start.md
+++ b/frameworks/template/docs/quick-start.md
@@ -4,11 +4,8 @@ navigationTitle:
 excerpt:
 title: Quick Start
 menuWeight: 40
-
-packageNamePretty: YOUR_SERVICE
-packageName: template
-serviceName: template
 ---
+{% assign data = site.data.services.template %}
 
 ## Prerequisites
 
@@ -16,29 +13,29 @@ serviceName: template
 
 ## Steps
 
-1. If you are using open source DC/OS, install {{ page.packageNamePretty }} cluster with the following command from the DC/OS CLI. If you are using Enterprise DC/OS, you may need to follow additional instructions. See the Install and Customize section for information.
+1. If you are using open source DC/OS, install {{ data.techName }} cluster with the following command from the DC/OS CLI. If you are using Enterprise DC/OS, you may need to follow additional instructions. See the Install and Customize section for information.
 
     ```bash
-    dcos package install {{ page.packageName }}
+    dcos package install {{ data.packageName }}
     ```
 
-    Alternatively, you can install {{ page.packageNamePretty }} from [the DC/OS web interface](https://docs.mesosphere.com/latest/usage/webinterface/).
+    Alternatively, you can install {{ data.techName }} from [the DC/OS web interface](https://docs.mesosphere.com/latest/usage/webinterface/).
 
 1. The service will now deploy with a default configuration. You can monitor its deployment via the Services tab of the DC/OS web interface.
 
-1. Connect a client to {{ page.packageNamePretty }}.
+1. Connect a client to {{ data.techName }}.
     ```bash
-    dcos {{ page.packageName }} --name={{ page.serviceName }} endpoints
+    dcos {{ data.packageName }} --name={{ data.serviceName }} endpoints
     [
         "_LIST_",
         "_OF_",
         "_ENDPOINTS_"
     ]
 
-    dcos {{ page.packageName }} --name={{ page.serviceName }} endpoints _ENDPOINT_
+    dcos {{ data.packageName }} --name={{ data.serviceName }} endpoints _ENDPOINT_
     {
         "address": ["10.0.3.156:_PORT_", "10.0.3.84:_PORT_"],
-        "dns": ["_POD_-0.{{ page.serviceName }}.mesos:_PORT_", "_POD_-1.{{ page.serviceName }}.mesos:_PORT_"]
+        "dns": ["_POD_-0.{{ data.serviceName }}.mesos:_PORT_", "_POD_-1.{{ data.serviceName }}.mesos:_PORT_"]
     }
     ```
 
@@ -46,4 +43,4 @@ serviceName: template
 
 ## See Also
 
-- [Connecting clients](https://docs.mesosphere.com/service-docs/{{ page.packageName }}/connecting-clients/)
+- [Connecting clients](https://docs.mesosphere.com/service-docs/{{ data.packageName }}/connecting-clients/)

--- a/frameworks/template/docs/supported-versions.md
+++ b/frameworks/template/docs/supported-versions.md
@@ -5,8 +5,6 @@ title: Supported Versions
 menuWeight: 110
 excerpt:
 ---
+{% assign data = site.data.services.template %}
 
-{% include services/supported-versions.md
-    techName="YOUR_SERVICE_NAME"
-    techPolicyDesc="[YOUR_SERVICE_NAME](http://example.com)"
-    techVersion="2.3.4" %}
+{% include services/supported-versions.md data=data %}

--- a/frameworks/template/docs/troubleshooting.md
+++ b/frameworks/template/docs/troubleshooting.md
@@ -4,12 +4,8 @@ navigationTitle:
 excerpt:
 title: Troubleshooting
 menuWeight: 90
-
-packageName: template
-serviceName: template
 ---
+{% assign data = site.data.services.template %}
 
-{% include services/troubleshooting.md
-    packageName=page.packageName
-    serviceName=page.serviceName %}
+{% include services/troubleshooting.md data=data %}
 

--- a/frameworks/template/docs/uninstall.md
+++ b/frameworks/template/docs/uninstall.md
@@ -4,12 +4,7 @@ navigationTitle:
 excerpt:
 title: Uninstall
 menuWeight: 30
-
-packageName: template
-serviceName: template
 ---
+{% assign data = site.data.services.template %}
 
-{% include services/uninstall.md
-    techName="a TECH_NAME"
-    packageName=page.packageName
-    serviceName=page.serviceName %}
+{% include services/uninstall.md data=data %}

--- a/frameworks/template/docs/upgrade.md
+++ b/frameworks/template/docs/upgrade.md
@@ -5,5 +5,6 @@ excerpt:
 title: Upgrade
 menuWeight: 130
 ---
+{% assign data = site.data.services.template %}
 
-{% include services/upgrade.md %}
+{% include services/upgrade.md data=data %}


### PR DESCRIPTION
- Cleans up duplicated template values that were being specified across each service's respective docs sections.
- When docs are being built for docs.mesosphere.com, the respective service's YAML file may be edited in-place before rendering to customize the output. For example, `packageName: beta-kafka` => `packageName: confluent-kafka`.

More info on the data file mechanism: https://jekyllrb.com/docs/datafiles/