### PR TITLE
INFINITY-3107 Trim 'beta-' prefix for default service name in CLI (#2217)

### DIFF
--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -15,7 +15,7 @@ var (
 	// ModuleName represents the name of this CLI module (e.g. "hello-world") and is read in from the $1 argument.
 	ModuleName string
 	// ServiceName represents the name of this instantiation of the service.
-	// This defaults to the value of ModuleName unless overridden by the user.
+	// This defaults to a sanitized version of ModuleName unless overridden by the user.
 	ServiceName string
 
 	// Verbose will print additional messages to aid with debugging if set to true.


### PR DESCRIPTION
(BACKPORT of #2217)

If `--name` (or the `<modname>.service_name` option) isn't specified, the CLI currently defaults to using the package name. However, this doesn't work for `beta-foo` packages, where the default service name is `foo`.

With this change, the CLI will align with the service name convention used by beta packages. Users interacting with default installs of beta packages will no longer be required to provide the `--name` argument. If they provide a custom name then they will need to specify the `--name` argument, as they would with a GA package.