### PR TITLE
Use retrying instead of sleep to wait on goal states in larger clusters

### DIFF
--- a/frameworks/helloworld/tests/test_soak.py
+++ b/frameworks/helloworld/tests/test_soak.py
@@ -38,7 +38,7 @@ def get_task_info(pod_info, task_name):
 @retrying.retry(wait_fixed=1000, stop_max_delay=30 * 1000)
 def wait_for_state(state, pod_name, task_names):
     pod_status = sdk_cmd.svc_cli(
-        config.PACKAGE_NAME, config.SERVICE_NAME, 'pod status {} --json'.format(pod_name), json=True
+        config.PACKAGE_NAME, FRAMEWORK_NAME, 'pod status {} --json'.format(pod_name), json=True
     )
 
     for task_name in task_names:

--- a/frameworks/helloworld/tests/test_soak.py
+++ b/frameworks/helloworld/tests/test_soak.py
@@ -41,9 +41,11 @@ def wait_for_state(state, pod_name, task_names):
         config.PACKAGE_NAME, FRAMEWORK_NAME, 'pod status {} --json'.format(pod_name), json=True
     )
 
-    for task_name in task_names:
-        task_status = get_task_status(pod_status, '{}-{}'.format(pod_name, task_name))
-        assert task_status['status'] == state
+    task_statuses = [
+        get_task_status(pod_status, '{}-{}'.format(pod_name, task_name))
+        for task_name in task_names
+    ]
+    assert all([task_status['status'] == state for task_status in task_statuses])
 
 
 @pytest.mark.soak_pod_pause


### PR DESCRIPTION
The pod pause soak tests fail occasionally when waiting for a task to reach `PAUSED` or `RUNNING`, since the offer cycle is longer on account of the cluster's size. This moves to a smarter way of dealing with that.