### PR TITLE
INFINITY-3167: Add LIBMESOS_URI envvar removed by accident 

### DIFF
--- a/frameworks/cassandra/universe/marathon.json.mustache
+++ b/frameworks/cassandra/universe/marathon.json.mustache
@@ -152,11 +152,12 @@
     "TASKCFG_ALL_CASSANDRA_MAX_VALUE_SIZE_IN_MB": "{{cassandra.max_value_size_in_mb}}",
     "TASKCFG_ALL_CASSANDRA_OTC_COALESCING_STRATEGY": "{{cassandra.otc_coalescing_strategy}}",
     "TASKCFG_ALL_REMOTE_SEEDS": "{{service.remote_seeds}}",
+    "TASKCFG_ALL_CASSANDRA_LOCATION_DATA_CENTER": "{{service.data_center}}",
     "EXECUTOR_URI": "{{resource.assets.uris.executor-zip}}",
     "BOOTSTRAP_URI": "{{resource.assets.uris.bootstrap-zip}}",
     "CASSANDRA_URI": "{{resource.assets.uris.cassandra-tar-gz}}",
     "JAVA_URI": "{{resource.assets.uris.jre-tar-gz}}",
-    "TASKCFG_ALL_CASSANDRA_LOCATION_DATA_CENTER": "{{service.data_center}}",
+    "LIBMESOS_URI": "{{resource.assets.uris.libmesos-bundle-tar-gz}}",
     "BACKUP_RESTORE_STRATEGY": "{{service.backup_restore_strategy}}"
   },
   "fetch": [


### PR DESCRIPTION
This PR re-adds the `LIBMESOS_URI` environment variable that was removed as part of #2233  
d441869ce51bbf4d9211f39ce9c8a9be899a86c0