### PR TITLE
[INFINITY-2725] fix kdc soak issues (#2212)

### DIFF
--- a/testing/sdk_auth.py
+++ b/testing/sdk_auth.py
@@ -29,7 +29,6 @@ import sdk_security
 log = logging.getLogger(__name__)
 
 KERBEROS_APP_ID = "kdc"
-KERBEROS_KEYTAB_FILE_NAME = "keytab"
 DCOS_BASE64_PREFIX = "__dcos_base64__"
 LINUX_USER = "core"
 KERBEROS_CONF = "krb5.conf"
@@ -167,8 +166,9 @@ class KerberosEnvironment:
 
         # Kerberos-specific information
         self.principals = []
-        self.keytab_file_name = KERBEROS_KEYTAB_FILE_NAME
         self.kdc_realm = REALM
+
+        self.set_keytab_path("_keytab", is_binary=False)
 
     def load_kdc_app_definition(self) -> dict:
         kdc_app_def_path = "{current_file_dir}/../tools/kdc/kdc.json".format(
@@ -189,6 +189,11 @@ class KerberosEnvironment:
             success, _ = sdk_marathon.install_app(app_definition)
             return success
 
+        if sdk_marathon.app_exists(self.app_definition["id"]):
+            log.info("Found installed KDC app")
+            return _get_kdc_task(self.app_definition["id"])
+
+        log.info("Installing KDC Marathon app")
         _install_marathon_app(self.app_definition)
         log.info("KDC app installed successfully")
 
@@ -254,12 +259,11 @@ class KerberosEnvironment:
 
         log.info("Principals successfully added to KDC")
 
-    def create_remote_keytab(self, name: str, principals: list=[]) -> str:
+    def create_remote_keytab(self, keytab_id: str, principals: list=[]) -> str:
         """
         Create a remote keytab for the specified list of principals
         """
-        if not name:
-            name = "{}.keytab".format(str(uuid.uuid4()))
+        name = "{}.{}.keytab".format(keytab_id, str(uuid.uuid4()))
 
         log.info("Creating keytab: %s", name)
 
@@ -288,12 +292,14 @@ class KerberosEnvironment:
         return keytab_absolute_path
 
     @retrying.retry(stop_max_attempt_number=2, wait_fixed=5000)
-    def get_keytab_for_principals(self, principals: list, output_filename: str):
+    def get_keytab_for_principals(self, keytab_id: str, principals: list):
         """
         Download a generated keytab for the specified list of principals
         """
-        remote_keytab_path = self.create_remote_keytab(self.keytab_file_name, principals=principals)
-        _copy_file_to_localhost(self.kdc_host_id, remote_keytab_path, output_filename)
+        remote_keytab_path = self.create_remote_keytab(keytab_id, principals=principals)
+        local_keytab_path = self.get_working_file_path(os.path.basename(remote_keytab_path))
+
+        _copy_file_to_localhost(self.kdc_host_id, remote_keytab_path, local_keytab_path)
 
         # In a fun twist, at least in the HDFS tests, we sometimes wind up with a _bad_ keytab. I know, right?
         # We can validate if it is good or bad by checking it with some internal Java APIs.
@@ -304,7 +310,7 @@ class KerberosEnvironment:
                          "security",
                          "keytab-validator",
                          "keytab-validator.jar"),
-            output_filename)
+            local_keytab_path)
         result = subprocess.run(command,
                                 shell=True,
                                 stdout=subprocess.PIPE,
@@ -318,16 +324,36 @@ class KerberosEnvironment:
                             "We're going to retry generating this keytab with reversed principals. "
                             "What fun.")
 
+        return local_keytab_path
+
     def __create_and_fetch_keytab(self):
         """
         Creates the keytab file that holds the info about all the principals
         that have been added to the KDC. It also fetches it locally so that
         the keytab can be uploaded to the secret store later.
         """
-        local_keytab_filename = self.get_working_file_path(self.keytab_file_name)
-        self.get_keytab_for_principals(self.principals, local_keytab_filename)
+        keytab_id = self.get_keytab_path().replace("/", "_")
+        return self.get_keytab_for_principals(keytab_id, self.principals)
 
-        return local_keytab_filename
+    def __encode_secret(self, keytab_path: str) -> str:
+        if self.get_keytab_path().startswith(DCOS_BASE64_PREFIX):
+            try:
+                base64_encoded_keytab_path = "{}.base64".format(keytab_path)
+                with open(keytab_path, "rb") as f:
+                    keytab = f.read()
+
+                base64_encoding = base64.b64encode(keytab).decode("utf-8")
+                with open(base64_encoded_keytab_path, "w") as f:
+                    f.write(base64_encoding)
+
+                log.info("Finished base64-encoding secret content (%d bytes): %s", len(base64_encoding), base64_encoding)
+
+                return ["--value-file", base64_encoded_keytab_path, ]
+            except Exception as e:
+                raise Exception("Failed to base64-encode the keytab file: {}".format(repr(e)))
+
+        log.info("Creating binary secret from %s", keytab_path)
+        return ["-f", keytab_path]
 
     def __create_and_upload_secret(self, keytab_path: str):
         """
@@ -336,30 +362,22 @@ class KerberosEnvironment:
         """
         log.info("Creating and uploading the keytab file %s to the secret store", keytab_path)
 
-        try:
-            base64_encoded_keytab_path = "{}.base64".format(keytab_path)
-            with open(keytab_path, "rb") as f:
-                keytab = f.read()
-
-            base64_encoding = base64.b64encode(keytab).decode("utf-8")
-            with open(base64_encoded_keytab_path, "w") as f:
-                f.write(base64_encoding)
-
-            log.info("Finished base64-encoding secret content (%d bytes): %s", len(base64_encoding), base64_encoding)
-
-        except Exception as e:
-            raise Exception("Failed to base64-encode the keytab file: {}".format(repr(e)))
-
-        self.keytab_secret_path = "{}_keytab".format(DCOS_BASE64_PREFIX)
+        encoding_options = self.__encode_secret(keytab_path)
 
         sdk_security.install_enterprise_cli()
         # try to delete any preexisting secret data:
         sdk_security.delete_secret(self.keytab_secret_path)
         # create new secret:
-        create_secret_cmd = "security secrets create {keytab_secret_path} --value-file {encoded_keytab_path}".format(
-            keytab_secret_path=self.keytab_secret_path,
-            encoded_keytab_path=base64_encoded_keytab_path)
-        log.info("Creating secret named %s from file %s: %s", self.keytab_secret_path, base64_encoded_keytab_path, create_secret_cmd)
+
+        cmd_list = ["security",
+                    "secrets",
+                    "create",
+                    self.get_keytab_path(),
+                    ]
+        cmd_list.extend(encoding_options)
+
+        create_secret_cmd = " ".join(cmd_list)
+        log.info("Creating secret %s: %s", self.get_keytab_path(), create_secret_cmd)
         rc, stdout, stderr = sdk_cmd.run_raw_cli(create_secret_cmd)
         if rc != 0:
             raise RuntimeError("Failed ({}) to create secret: {}\nstdout: {}\nstderr: {}".format(rc, create_secret_cmd, stdout, stderr))
@@ -389,10 +407,18 @@ class KerberosEnvironment:
     def get_port(self):
         return str(self.app_definition["portDefinitions"][0]["port"])
 
-    def get_keytab_path(self):
+    def get_keytab_path(self) -> str:
         return self.keytab_secret_path
 
-    def get_realm(self):
+    def set_keytab_path(self, secret_path: str, is_binary: bool):
+        if is_binary:
+            prefix = ""
+        else:
+            prefix = DCOS_BASE64_PREFIX
+
+        self.keytab_secret_path = "{}{}".format(prefix, secret_path)
+
+    def get_realm(self) -> str:
         return self.kdc_realm
 
     def get_kdc_address(self):

--- a/tools/kdc/kdc.py
+++ b/tools/kdc/kdc.py
@@ -86,12 +86,25 @@ def parse_principals(principals_file: str) -> list:
 def deploy(args: dict):
     log.info("Deploying KDC")
 
-    principals = parse_principals(args.principals_file)
-
     kerberos = sdk_auth.KerberosEnvironment()
-    kerberos.keytab_secret_name = args.secret_name
 
+    if args.principals_file:
+        create_keytab_secret(args, kerberos)
+
+    log.info("KDC cluster successfully deployed")
+
+
+def create_keytab_secret(args: dict, kerberos=None):
+
+    if not kerberos:
+        kerberos = sdk_auth.KerberosEnvironment()
+
+    principals = parse_principals(args.principals_file)
     kerberos.add_principals(principals)
+
+    if args.secret_name:
+        kerberos.set_keytab_path(args.secret_name, args.binary_secret)
+
     kerberos.finalize()
 
     log.info("KDC cluster successfully deployed")
@@ -101,8 +114,12 @@ def teardown(args: dict):
     log.info("Tearing down KDC")
 
     sdk_cmd.run_cli(" ".join(["marathon", "app", "remove", "kdc"]))
-    sdk_cmd.run_cli(" ".join(["package", "install", "--yes", "--cli", "dcos-enterprise-cli"]))
-    sdk_security.delete_secret('__dcos_base64__{}'.format(args.secret_name))
+
+    sdk_security.install_enterprise_cli()
+    if args.binary_secret:
+        sdk_security.delete_secret(args.secret_name)
+    else:
+        sdk_security.delete_secret('__dcos_base64__{}'.format(args.secret_name))
 
     log.info("KDC cluster successfully torn down")
 
@@ -111,13 +128,14 @@ def parse_args():
     parser = argparse.ArgumentParser(description='Manage a KDC instance')
 
     parser.add_argument('--secret-name', type=str, required=False,
-                        default='_keytab',
+                        default=None,
                         help='The secret name to use for the generated keytab')
-
+    parser.add_argument('--binary-secret', action='store_true',
+                        help='The secret should be stored as a binary secret')
     subparsers = parser.add_subparsers(help='deploy help')
 
     deploy_parser = subparsers.add_parser('deploy', help='deploy help')
-    deploy_parser.add_argument('principals_file', type=str,
+    deploy_parser.add_argument('principals_file', type=str, default=None,
                                help='Path to a file listing the principals as newline-separated strings')
     deploy_parser.set_defaults(func=deploy)
 


### PR DESCRIPTION
This is the backport to sdk-0.40 for #2212 

- Support operations on Soak:
  - Reuse the KDC app if it is installed
  - Support for setting the secret name
- Support binary secrets
  - base64-encoding is only done if name requires it

Properly handle secret name and binary secrets

Use a unique keytab name on the KDC to allow for better logging