### PR TITLE
[INFINITY-3111] Gracefully handle invalid placement constraints (#2221)

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/config/validate/DefaultConfigValidators.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/config/validate/DefaultConfigValidators.java
@@ -25,6 +25,7 @@ public class DefaultConfigValidators {
                 new PreReservationCannotChange(),
                 new UserCannotChange(),
                 new TLSRequiresServiceAccount(schedulerConfig),
-                new DomainCapabilityValidator());
+                new DomainCapabilityValidator(),
+                new PlacementRuleIsValid());
     }
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/config/validate/PlacementRuleIsValid.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/config/validate/PlacementRuleIsValid.java
@@ -1,0 +1,55 @@
+package com.mesosphere.sdk.config.validate;
+
+import com.mesosphere.sdk.offer.evaluate.placement.AndRule;
+import com.mesosphere.sdk.offer.evaluate.placement.InvalidPlacementRule;
+import com.mesosphere.sdk.offer.evaluate.placement.OrRule;
+import com.mesosphere.sdk.offer.evaluate.placement.PlacementRule;
+import com.mesosphere.sdk.specification.PodSpec;
+import com.mesosphere.sdk.specification.ServiceSpec;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+
+/**
+ * A {@link ConfigValidator} that checks for valid placement constraints.
+ */
+public class PlacementRuleIsValid implements ConfigValidator<ServiceSpec> {
+    @Override
+    public Collection<ConfigValidationError> validate(Optional<ServiceSpec> oldConfig, ServiceSpec newConfig) {
+        List<PodSpec> podSpecs = newConfig.getPods().stream()
+                .filter(podSpec -> podSpec.getPlacementRule().isPresent())
+                .collect(Collectors.toList());
+
+        List<ConfigValidationError> errors = new ArrayList<>();
+        for (final PodSpec podSpec : podSpecs) {
+            PlacementRule placementRule = podSpec.getPlacementRule().get();
+
+            if (!isValid(placementRule)) {
+                String errMsg = String.format(
+                        "The PlacementRule for PodSpec '%s' had invalid constraints",
+                        podSpec.getType());
+                errors.add(ConfigValidationError.valueError("PlacementRule", placementRule.toString(), errMsg));
+            }
+        }
+
+        return errors;
+    }
+
+    /**
+     * A placement rule is valid none of its children are invalid and it is valid.
+     */
+    private boolean isValid(final PlacementRule rule) {
+        if (rule instanceof OrRule) {
+            return ((OrRule) rule).getRules().stream().allMatch(r -> isValid(r));
+        } else if (rule instanceof AndRule) {
+            return ((AndRule) rule).getRules().stream().allMatch(r -> isValid(r));
+        } else {
+            return !(rule instanceof InvalidPlacementRule);
+        }
+    }
+
+}

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/AndRule.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/AndRule.java
@@ -69,7 +69,7 @@ public class AndRule implements PlacementRule {
     }
 
     @JsonProperty("rules")
-    private Collection<PlacementRule> getRules() {
+    public Collection<PlacementRule> getRules() {
         return rules;
     }
 
@@ -87,4 +87,5 @@ public class AndRule implements PlacementRule {
     public int hashCode() {
         return HashCodeBuilder.reflectionHashCode(this);
     }
+
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/InvalidPlacementRule.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/InvalidPlacementRule.java
@@ -1,0 +1,66 @@
+package com.mesosphere.sdk.offer.evaluate.placement;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.mesosphere.sdk.offer.evaluate.EvaluationOutcome;
+import com.mesosphere.sdk.specification.PodInstance;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.mesos.Protos.Offer;
+import org.apache.mesos.Protos.TaskInfo;
+
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * An implementation of a {@PlacementRule} that is ALWAYS invalid.
+ */
+public class InvalidPlacementRule implements PlacementRule {
+    private final String constraints;
+    private final String exception;
+
+    @JsonCreator
+    public InvalidPlacementRule(
+            @JsonProperty("constraints ") String constraints,
+            @JsonProperty("exception") String exception) {
+        this.constraints = constraints;
+        this.exception = exception;
+    }
+
+    @Override
+    public EvaluationOutcome filter(Offer offer, PodInstance podInstance, Collection<TaskInfo> tasks) {
+        return EvaluationOutcome.fail(this,
+                String.format("Invalid placement constraints for %s: %s", podInstance.getName(), constraints)).build();
+    }
+
+    @Override
+    public String toString() {
+        return String.format("InvalidPlacementRule{constraints=%s, exception=%s}", constraints, exception);
+    }
+
+    @Override
+    public Collection<PlacementField> getPlacementFields() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return EqualsBuilder.reflectionEquals(this, o);
+    }
+
+    @JsonProperty("constraints")
+    public String getConstraints() {
+        return constraints;
+    }
+
+    @JsonProperty("exception")
+    public String getException() {
+        return exception;
+    }
+
+    @Override
+    public int hashCode() {
+        return HashCodeBuilder.reflectionHashCode(this);
+    }
+
+}

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/MarathonConstraintParser.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/MarathonConstraintParser.java
@@ -21,6 +21,7 @@ public class MarathonConstraintParser {
     private static final char ESCAPE_CHAR = '\\';
 
     private static final Map<String, Operator> SUPPORTED_OPERATORS = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+
     static {
         SUPPORTED_OPERATORS.put("UNIQUE", new UniqueOperator());
         SUPPORTED_OPERATORS.put("CLUSTER", new ClusterOperator());
@@ -36,69 +37,52 @@ public class MarathonConstraintParser {
     }
 
     /**
-     * ANDs the provided marathon-style constraint string onto the provided hard-coded
-     * {@link PlacementRule}, or returns the provided {@link PlacementRule} as-is if the
-     * marathon-style constraint is {@code null} or empty.
-     *
-     * @param podName The task type these constraints apply to (e.g. "hello"). Applying a constraint to all tasks
-     * in a service is not supported.
-     * @param rule The hard-coded {@link PlacementRule}
-     * @param marathonConstraints the marathon-style constraint string, containing one or more
-     * nested json list entries of the form {@code [["multi","list","value"],["hello","hi"]]},
-     * or one or more colon-separated entries of the form {@code multi:list:value,hello:hi},
-     * or a {@code null} or empty value if no constraint is defined
-     * @throws IOException if {@code marathonConstraints} couldn't be parsed, or if the parsed
-     * content isn't valid or supported
-     */
-    public static PlacementRule parseWith(String podName, PlacementRule rule, String marathonConstraints)
-            throws IOException {
-        PlacementRule marathonRule = parse(podName, marathonConstraints);
-        if (marathonRule instanceof PassthroughRule) {
-            return rule; // pass-through original rule
-        }
-        return new AndRule(rule, marathonRule);
-    }
-
-    /**
      * Creates and returns a new {@link PlacementRule} against the provided marathon-style
      * constraint string. Returns a {@link PassthroughRule} if the provided constraint string is
      * {@code null} or empty.
      *
-     *
-     * @param podName The task type these constraints apply to (e.g. "hello"). Applying a constraint to all tasks
-     *     in a service is not supported.
+     * @param podName             The task type these constraints apply to (e.g. "hello"). Applying a constraint to all
+     *                            tasks in a service is not supported.
      * @param marathonConstraints the marathon-style constraint string, containing one or more
-     *     nested json list entries of the form {@code [["multi","list","value"],["hello","hi"]]},
-     *     or one or more colon-separated entries of the form {@code multi:list:value,hello:hi},
-     *     or a {@code null} or empty value if no constraint is defined
+     *                            nested json list entries of the form
+     *                            {@code [["multi","list","value"],["hello","hi"]]},
+     *                            or one or more colon-separated entries of the form {@code multi:list:value,hello:hi},
+     *                            or a {@code null} or empty value if no constraint is defined
      * @throws IOException if {@code marathonConstraints} couldn't be parsed, or if the parsed
-     *     content isn't valid or supported
+     *                     content isn't valid or supported
      */
     public static PlacementRule parse(String podName, String marathonConstraints) throws IOException {
         if (marathonConstraints == null || marathonConstraints.isEmpty() || marathonConstraints.equals("[]")) {
             // nothing to enforce
             return new PassthroughRule();
         }
-        List<List<String>> rows = splitConstraints(marathonConstraints);
-        StringMatcher taskFilter = RegexMatcher.create(podName + "-.*");
-        if (rows.size() == 1) {
-            // skip AndRule:
-            return parseRow(taskFilter, rows.get(0));
+
+        try {
+            List<List<String>> rows = splitConstraints(marathonConstraints);
+            StringMatcher taskFilter = RegexMatcher.create(podName + "-.*");
+            if (rows.size() == 1) {
+                // skip AndRule:
+                return parseRow(taskFilter, rows.get(0));
+            }
+            List<PlacementRule> rowRules = new ArrayList<>();
+            for (List<String> row : rows) {
+                rowRules.add(parseRow(taskFilter, row));
+            }
+            return new AndRule(rowRules);
+
+        } catch (Exception e) {
+            LOGGER.error("Failed to parse marathon constraints", podName, marathonConstraints);
+            return new InvalidPlacementRule(marathonConstraints, e.getMessage());
         }
-        List<PlacementRule> rowRules = new ArrayList<>();
-        for (List<String> row : rows) {
-            rowRules.add(parseRow(taskFilter, row));
-        }
-        return new AndRule(rowRules);
+
     }
 
     /**
      * Converts the provided marathon constraint entry to a PlacementRule.
      *
-     *
      * @param taskFilter The filter to apply across all tasks to limit the scope of the constraints
-     * (e.g. to a particular task type)
-     * @param row a list with size 2 or 3
+     *                   (e.g. to a particular task type)
+     * @param row        a list with size 2 or 3
      * @throws IOException if the provided constraint entry is invalid
      */
     private static PlacementRule parseRow(StringMatcher taskFilter, List<String> row) throws IOException {
@@ -115,7 +99,7 @@ public class MarathonConstraintParser {
         if (operator == null) {
             throw new IOException(String.format(
                     "Unsupported operator: '%s' in constraint: %s " +
-                    "(expected one of: UNIQUE, CLUSTER, GROUP_BY, LIKE, UNLIKE, or MAX_PER)",
+                            "(expected one of: UNIQUE, CLUSTER, GROUP_BY, LIKE, UNLIKE, or MAX_PER)",
                     operatorName, row));
         }
         PlacementRule rule = operator.run(taskFilter, fieldName, operatorName, parameter);
@@ -135,17 +119,21 @@ public class MarathonConstraintParser {
         try {
             // First try: ["a", "b", "c"]
             // This format technically isn't present in the Marathon docs, but we're being lenient here.
-            List<String> row = mapper.readValue(marathonConstraints, new TypeReference<List<String>>(){});
+            List<String> row = mapper.readValue(marathonConstraints, new TypeReference<List<String>>() {
+            });
             LOGGER.debug("Flat list '{}' => single row: '{}'", marathonConstraints, row);
             return Arrays.asList(row);
         } catch (IOException | ClassCastException e1) {
             try {
                 // Then try: [["a", "b", "c"], ["d", "e"]]
                 List<List<String>> rows =
-                        mapper.readValue(marathonConstraints, new TypeReference<List<List<String>>>(){});
+                        mapper.readValue(marathonConstraints, new TypeReference<List<List<String>>>() {
+                        });
                 LOGGER.debug("Nested list '{}' => {} rows: '{}'", marathonConstraints, rows.size(), rows);
                 return rows;
             } catch (IOException | ClassCastException e2) { // May throw ClassCastException as well as IOException
+
+
                 // Finally try: a:b:c,d:e
                 // Note: We use Guava's Splitter rather than String.split(regex) in order to correctly
                 // handle empty trailing fields like 'a:b:' => ['a', 'b', ''] (shouldn't come up but just in case).
@@ -163,7 +151,7 @@ public class MarathonConstraintParser {
     /**
      * Tokenizes the provided string using the provided split character. Honors any backslash
      * escaping within the provided string. Tokens in the returned list are automatically trimmed.
-     *
+     * <p>
      * This is equivalent to calling {@code Splitter.on(split).trimResults().split(str)}, except
      * with the addition of support for escaping the 'split' value with backslashes.
      */
@@ -280,7 +268,7 @@ public class MarathonConstraintParser {
      * {@code CLUSTER} allows you to run all tasks of a given task type on agent nodes that share a certain
      * attribute. This is useful for example if you have apps with special hardware needs, or if you
      * want to run them on the same rack for low latency: {@code [["rack_id", "CLUSTER", "rack-1"]]}
-     *
+     * <p>
      * You can also use this attribute to tie a task type to a specific node by using the
      * hostname property: {@code [["hostname", "CLUSTER", "a.specific.node.com"]]}
      */
@@ -313,16 +301,16 @@ public class MarathonConstraintParser {
     /**
      * {@code GROUP_BY} can be used to distribute tasks of a given task type evenly across racks or datacenters for high
      * availability: {@code [["rack_id", "GROUP_BY"]]}
-     *
+     * <p>
      * Marathon only knows about different values of the attribute (e.g. "rack_id") by analyzing
      * incoming offers from Mesos. If tasks are not already spread across all possible values,
      * specify the number of values in constraints. If you don't specify the number of values, you
      * might find that the tasks are only distributed in one value, even though you are using the
      * {@code GROUP_BY} constraint. For example, if you are spreading across 3 racks, use:
      * {@code [["rack_id", "GROUP_BY", "3"]]}
-     *
+     * <p>
      * ---
-     *
+     * <p>
      * TLDR: The idea is to round-robin tasks during rollout across N distinct values (with N
      * provided by the user). For example, avoid placing 2 instances against a given rack value
      * until *all* racks have 1 instance. If N is unspecified, we will just make a best-effort
@@ -365,7 +353,7 @@ public class MarathonConstraintParser {
      * {@code LIKE} accepts a regular expression as parameter, and allows you to run your tasks only
      * on the agent nodes whose field values match the regular expression:
      * {@code [["rack_id", "LIKE", "rack-[1-3]"]]}
-     *
+     * <p>
      * Note, the parameter is required, or you'll get a warning.
      */
     private static class LikeOperator implements Operator {
@@ -396,7 +384,7 @@ public class MarathonConstraintParser {
     /**
      * Just like {@code LIKE} operator, but only run tasks on agent nodes whose field values don't
      * match the regular expression: {@code [["rack_id", "UNLIKE", "rack-[7-9]"]]}
-     *
+     * <p>
      * Note, the parameter is required, or you'll get a warning.
      */
     private static class UnlikeOperator implements Operator {
@@ -427,7 +415,7 @@ public class MarathonConstraintParser {
      * {@code MAX_PER} accepts a number as parameter which specifies the maximum size of each group.
      * It can be used to limit tasks of a given task type across racks or
      * datacenters: {@code [["rack_id", "MAX_PER", "2"]]}
-     *
+     * <p>
      * Note, the parameter is required, or you'll get a warning.
      */
     private static class MaxPerOperator implements Operator {

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/OrRule.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/OrRule.java
@@ -65,7 +65,7 @@ public class OrRule implements PlacementRule {
     }
 
     @JsonProperty("rules")
-    private Collection<PlacementRule> getRules() {
+    public Collection<PlacementRule> getRules() {
         return rules;
     }
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/PlacementRule.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/PlacementRule.java
@@ -1,22 +1,22 @@
 package com.mesosphere.sdk.offer.evaluate.placement;
 
-import java.util.Collection;
-
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.mesosphere.sdk.offer.evaluate.EvaluationOutcome;
 import com.mesosphere.sdk.specification.PodInstance;
 import org.apache.mesos.Protos.Offer;
 import org.apache.mesos.Protos.TaskInfo;
-import com.mesosphere.sdk.offer.evaluate.EvaluationOutcome;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import java.util.Collection;
 
 /**
  * Implements placement constraint logic on an offer, filtering out the Resources which are not
  * to be used according to the filter logic.
- *
+ * <p>
  * Accepts an Offer and returns a copy of that Offer with any disallowed Resources filtered out, or
  * may return the original Offer without copying if everything passes the filter. If the entire
  * Offer is rejected, the return value will be a non-{@code null} Offer with zero Resources.
- *
+ * <p>
  * PlacementRules may contain multiple internal checks, and may even be a composition of other
  * PlacementRules.
  */
@@ -46,8 +46,9 @@ public interface PlacementRule {
      * Must be explicitly implemented by all PlacementRules.
      *
      * @see com.mesosphere.sdk.offer.TaskUtils#areDifferent(
-     * com.mesosphere.sdk.specification.TaskSpec,
+     *com.mesosphere.sdk.specification.TaskSpec,
      * com.mesosphere.sdk.specification.TaskSpec)
      */
     boolean equals(Object o);
+
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultServiceSpec.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultServiceSpec.java
@@ -24,7 +24,6 @@ import com.mesosphere.sdk.specification.yaml.RawServiceSpec;
 import com.mesosphere.sdk.specification.yaml.YAMLToInternalMappers;
 import com.mesosphere.sdk.state.ConfigStoreException;
 import com.mesosphere.sdk.storage.StorageError.Reason;
-
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -34,7 +33,6 @@ import org.slf4j.LoggerFactory;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -126,10 +124,10 @@ public class DefaultServiceSpec implements ServiceSpec {
     /**
      * Returns a new generator with the provided configuration.
      *
-     * @param rawServiceSpec The object model representation of a Service Specification YAML file
-     * @param schedulerConfig Scheduler configuration containing operator-facing knobs
+     * @param rawServiceSpec    The object model representation of a Service Specification YAML file
+     * @param schedulerConfig   Scheduler configuration containing operator-facing knobs
      * @param configTemplateDir Path to the directory containing any config templates for the service, often the same
-     *     directory as the Service Specification YAML file
+     *                          directory as the Service Specification YAML file
      */
     public static Generator newGenerator(
             RawServiceSpec rawServiceSpec, SchedulerConfig schedulerConfig, File configTemplateDir) {
@@ -157,7 +155,7 @@ public class DefaultServiceSpec implements ServiceSpec {
             SchedulerConfig schedulerConfig,
             Map<String, String> schedulerEnvironment,
             File configTemplateDir)
-                    throws Exception {
+            throws Exception {
         return new Generator(
                 rawServiceSpec, schedulerConfig, new TaskEnvRouter(schedulerEnvironment), configTemplateDir);
     }
@@ -325,6 +323,7 @@ public class DefaultServiceSpec implements ServiceSpec {
                 DefaultVolumeSpec.class,
                 ExactMatcher.class,
                 HostnameRule.class,
+                InvalidPlacementRule.class,
                 IsLocalRegionRule.class,
                 MaxPerAttributeRule.class,
                 MaxPerHostnameRule.class,

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/config/validate/PlacementRuleIsValidTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/config/validate/PlacementRuleIsValidTest.java
@@ -1,0 +1,72 @@
+package com.mesosphere.sdk.config.validate;
+
+import com.mesosphere.sdk.offer.evaluate.placement.AndRule;
+import com.mesosphere.sdk.offer.evaluate.placement.OrRule;
+import com.mesosphere.sdk.offer.evaluate.placement.TestPlacementUtils;
+import com.mesosphere.sdk.specification.PodSpec;
+import com.mesosphere.sdk.specification.ServiceSpec;
+import com.mesosphere.sdk.testutils.TestConstants;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Optional;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+
+public class PlacementRuleIsValidTest {
+    @Mock
+    private ServiceSpec serviceSpec;
+    @Mock
+    private PodSpec podSpec;
+
+    private static final PlacementRuleIsValid validator = new PlacementRuleIsValid();
+
+    @Before
+    public void beforeEach() {
+        MockitoAnnotations.initMocks(this);
+        when(serviceSpec.getPods()).thenReturn(Arrays.asList(podSpec));
+        when(podSpec.getType()).thenReturn(TestConstants.POD_TYPE);
+    }
+
+    @Test
+    public void emptyPlacementRuleIsValid() throws IOException {
+        when(podSpec.getPlacementRule()).thenReturn(Optional.empty());
+        assertThat(validator.validate(Optional.empty(), serviceSpec), hasSize(0));
+    }
+
+    @Test
+    public void andRuleWithoutInvalidPlacementRuleIsValid() throws IOException {
+        when(podSpec.getPlacementRule()).thenReturn(Optional.of(new AndRule(TestPlacementUtils.PASS, TestPlacementUtils.FAIL)));
+        assertThat(validator.validate(Optional.empty(), serviceSpec), hasSize(0));
+    }
+
+    @Test
+    public void andRuleWithInvalidPlacementRuleIsInvalid() throws IOException {
+        when(podSpec.getPlacementRule()).thenReturn(Optional.of(new AndRule(TestPlacementUtils.INVALID, TestPlacementUtils.FAIL)));
+        assertThat(validator.validate(Optional.empty(), serviceSpec), hasSize(1));
+    }
+
+    @Test
+    public void orRuleWithoutInvalidPlacementRuleIsValid() throws IOException {
+        when(podSpec.getPlacementRule()).thenReturn(Optional.of(new OrRule(TestPlacementUtils.PASS, TestPlacementUtils.FAIL)));
+        assertThat(validator.validate(Optional.empty(), serviceSpec), hasSize(0));
+    }
+
+    @Test
+    public void orRuleWithInvalidPlacementRuleIsInvalid() throws IOException {
+        when(podSpec.getPlacementRule()).thenReturn(Optional.of(new OrRule(TestPlacementUtils.INVALID, TestPlacementUtils.FAIL)));
+        assertThat(validator.validate(Optional.empty(), serviceSpec), hasSize(1));
+    }
+
+    @Test
+    public void invalidPlacementRuleIsInvalid() throws IOException {
+        when(podSpec.getPlacementRule()).thenReturn(Optional.of(TestPlacementUtils.INVALID));
+        assertThat(validator.validate(Optional.empty(), serviceSpec), hasSize(1));
+    }
+}

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/placement/InvalidPlacementRuleTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/placement/InvalidPlacementRuleTest.java
@@ -1,0 +1,19 @@
+package com.mesosphere.sdk.offer.evaluate.placement;
+
+import com.mesosphere.sdk.config.SerializationUtils;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+
+public class InvalidPlacementRuleTest {
+
+    @Test
+    public void testSerializeDeserialize() throws IOException {
+        PlacementRule rule = new InvalidPlacementRule("constraint", "exception");
+        assertEquals(rule, SerializationUtils.fromString(
+                SerializationUtils.toJsonString(rule), PlacementRule.class, TestPlacementUtils.OBJECT_MAPPER));
+    }
+
+}

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/placement/TestPlacementUtils.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/placement/TestPlacementUtils.java
@@ -4,6 +4,9 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableList;
+import com.mesosphere.sdk.config.SerializationUtils;
+import com.mesosphere.sdk.offer.evaluate.EvaluationOutcome;
+import com.mesosphere.sdk.specification.DefaultServiceSpec;
 import com.mesosphere.sdk.specification.PodInstance;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -11,9 +14,6 @@ import org.apache.mesos.Protos.Offer;
 import org.apache.mesos.Protos.Resource;
 import org.apache.mesos.Protos.TaskInfo;
 import org.apache.mesos.Protos.Value;
-import com.mesosphere.sdk.config.SerializationUtils;
-import com.mesosphere.sdk.offer.evaluate.EvaluationOutcome;
-import com.mesosphere.sdk.specification.DefaultServiceSpec;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -54,8 +54,10 @@ public class TestPlacementUtils {
 
     public static final PlacementRule PASS = new PassTestRule();
     public static final PlacementRule FAIL = new FailTestRule();
+    public static final PlacementRule INVALID = new InvalidTestRule();
 
     public static final ObjectMapper OBJECT_MAPPER;
+
     static {
         OBJECT_MAPPER = SerializationUtils.registerDefaultModules(new ObjectMapper());
         for (Class<?> c : DefaultServiceSpec.ConfigFactory.getDefaultRegisteredSubtypes()) {
@@ -67,7 +69,8 @@ public class TestPlacementUtils {
 
     private static class PassTestRule implements PlacementRule {
         @JsonCreator
-        public PassTestRule() { }
+        public PassTestRule() {
+        }
 
         @Override
         public EvaluationOutcome filter(Offer offer, PodInstance podInstance, Collection<TaskInfo> tasks) {
@@ -80,15 +83,20 @@ public class TestPlacementUtils {
         }
 
         @Override
-        public boolean equals(Object o) { return EqualsBuilder.reflectionEquals(this, o); }
+        public boolean equals(Object o) {
+            return EqualsBuilder.reflectionEquals(this, o);
+        }
 
         @Override
-        public int hashCode() { return HashCodeBuilder.reflectionHashCode(this); }
+        public int hashCode() {
+            return HashCodeBuilder.reflectionHashCode(this);
+        }
     }
 
     private static class FailTestRule implements PlacementRule {
         @JsonCreator
-        public FailTestRule() { }
+        public FailTestRule() {
+        }
 
         @Override
         public EvaluationOutcome filter(Offer offer, PodInstance podInstance, Collection<TaskInfo> tasks) {
@@ -101,11 +109,28 @@ public class TestPlacementUtils {
         }
 
         @Override
-        public boolean equals(Object o) { return EqualsBuilder.reflectionEquals(this, o); }
+        public boolean equals(Object o) {
+            return EqualsBuilder.reflectionEquals(this, o);
+        }
 
         @Override
-        public int hashCode() { return HashCodeBuilder.reflectionHashCode(this); }
-    };
+        public int hashCode() {
+            return HashCodeBuilder.reflectionHashCode(this);
+        }
+    }
+
+    private static class InvalidTestRule extends InvalidPlacementRule {
+        @JsonCreator
+        public InvalidTestRule() {
+            super("constaints", "exception");
+        }
+
+        @Override
+        public EvaluationOutcome filter(Offer offer, PodInstance podInstance, Collection<TaskInfo> tasks) {
+            return EvaluationOutcome.fail(this, "invalid rule").build();
+        }
+
+    }
 
     private TestPlacementUtils() {
         // do not instantiate


### PR DESCRIPTION
Backporting for @elezar:

This PR adds better validation support for placement constraints. Invalid constraints are wrapped in a placement rule and a validator is added to check for this.

This means that:
* If the initial deployment has an invalid placement constraint, the scheduler does not crash and one can successfully uninstall it.
* If a config update introduces an invalid constraint, deployment plan has an error as with any other invalid config change.

Example output of a failed update:
```
deploy (serial strategy) (ERROR)
├─ hello (serial strategy) (COMPLETE)
│  └─ hello-0:[server] (COMPLETE)
└─ world (serial strategy) (COMPLETE)
   ├─ world-0:[server] (COMPLETE)
   └─ world-1:[server] (COMPLETE)

Errors:
- Field: 'PlacementRule'; Value: 'AndRule{rules=[IsLocalRegionRule, InvalidPlacementRule{constraints=[[\"hostname\", "UNIQUE"]], exception=Invalid number of entries in rule. Expected 2 or 3, got 1: [[[\"hostname\"]}]}'; Message: 'The PlacementRule for PodSpec 'hello' had invalid constraints'
```