### PR TITLE
[INFINITY-3172] Fix sidecar refinement / MOUNT volume reuse (#2207)

### DIFF
--- a/frameworks/helloworld/src/main/dist/examples/pre-reserved-sidecar.yml
+++ b/frameworks/helloworld/src/main/dist/examples/pre-reserved-sidecar.yml
@@ -1,0 +1,47 @@
+name: {{FRAMEWORK_NAME}}
+scheduler:
+  principal: {{SERVICE_PRINCIPAL}}
+  user: {{SERVICE_USER}}
+pods:
+  hello:
+    pre-reserved-role: slave_public
+    count: {{HELLO_COUNT}}
+    placement: '{{{HELLO_PLACEMENT}}}'
+    volume:
+      path: pod-container-path
+      type: ROOT
+      size: {{HELLO_DISK}}
+    tasks:
+      server:
+        goal: RUNNING
+        cmd: echo hello >> hello-container-path/output && echo hello >> pod-container-path/output && sleep $SLEEP_DURATION
+        cpus: {{HELLO_CPUS}}
+        memory: {{HELLO_MEM}}
+        volume:
+          path: hello-container-path
+          type: ROOT
+          size: {{HELLO_DISK}}
+        env:
+          SLEEP_DURATION: {{SLEEP_DURATION}}
+      sidecar:
+        goal: FINISHED
+        cmd: echo sidecar >> pod-container-path/output
+        cpus: 0.1
+        memory: 256
+
+plans:
+  deploy:
+    phases:
+      hello:
+        strategy: serial
+        pod: hello
+        steps:
+          - default: [[server], [sidecar]]
+  sidecar:
+    strategy: serial
+    phases:
+      sidecar-deploy:
+        strategy: parallel
+        pod: hello
+        steps:
+          - default: [[sidecar]]

--- a/frameworks/helloworld/tests/test_pre_reserved_sidecar.py
+++ b/frameworks/helloworld/tests/test_pre_reserved_sidecar.py
@@ -1,0 +1,55 @@
+import logging
+
+import pytest
+import retrying
+
+import sdk_cmd
+import sdk_install
+import sdk_marathon
+import sdk_plan
+import sdk_utils
+from tests import config
+
+log = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope='module', autouse=True)
+def configure_package(configure_security):
+    try:
+        sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
+        options = {
+            "service": {
+                "spec_file": "examples/pre-reserved-sidecar.yml"
+            }
+        }
+
+        # this yml has 1 hello's + 0 world's:
+        sdk_install.install(config.PACKAGE_NAME, config.SERVICE_NAME, 1, additional_options=options)
+
+        yield # let the test session execute
+    finally:
+        sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
+
+
+@pytest.mark.sanity
+@pytest.mark.dcos_min_version('1.10')
+def test_deploy():
+    sdk_plan.wait_for_completed_deployment(config.SERVICE_NAME)
+
+
+@pytest.mark.sanity
+@pytest.mark.dcos_min_version('1.10')
+def test_sidecar():
+    run_plan('sidecar')
+
+
+def run_plan(plan_name, params=None):
+    sdk_plan.start_plan(config.SERVICE_NAME, plan_name, params)
+
+    started_plan = sdk_plan.get_plan(config.SERVICE_NAME, plan_name)
+    log.info("sidecar plan: " + str(started_plan))
+    assert(len(started_plan['phases']) == 1)
+    assert(started_plan['phases'][0]['name'] == plan_name + '-deploy')
+    assert(len(started_plan['phases'][0]['steps']) == 1)
+
+    sdk_plan.wait_for_completed_plan(config.SERVICE_NAME, plan_name)

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/ResourceUtils.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/ResourceUtils.java
@@ -115,10 +115,18 @@ public class ResourceUtils {
     }
 
     public static Optional<String> getSourceRoot(Resource resource) {
-        if (resource.hasDisk() && resource.getDisk().hasSource()) {
-            return Optional.of(resource.getDisk().getSource().getMount().getRoot());
+        if (!isMountVolume(resource)) {
+            return Optional.empty();
         }
 
-        return Optional.empty();
+        return Optional.of(resource.getDisk().getSource().getMount().getRoot());
+    }
+
+    private static boolean isMountVolume(Resource resource) {
+        return resource.hasDisk()
+                && resource.getDisk().hasSource()
+                && resource.getDisk().getSource().hasType()
+                && resource.getDisk().getSource().getType()
+                .equals(Resource.DiskInfo.Source.Type.MOUNT);
     }
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluationUtils.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluationUtils.java
@@ -2,10 +2,7 @@ package com.mesosphere.sdk.offer.evaluate;
 
 import com.google.protobuf.TextFormat;
 import com.mesosphere.sdk.offer.*;
-import com.mesosphere.sdk.specification.DefaultResourceSpec;
-import com.mesosphere.sdk.specification.PodSpec;
-import com.mesosphere.sdk.specification.ResourceSpec;
-import com.mesosphere.sdk.specification.TaskSpec;
+import com.mesosphere.sdk.specification.*;
 import org.apache.mesos.Protos;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -231,5 +228,15 @@ class OfferEvaluationUtils {
         }
 
         return false;
+    }
+
+    public static VolumeSpec updateVolumeSpec(VolumeSpec original, double diskSize) {
+        return new DefaultVolumeSpec(
+                diskSize,
+                original.getType(),
+                original.getContainerPath(),
+                original.getRole(),
+                original.getPreReservedRole(),
+                original.getPrincipal());
     }
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluator.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluator.java
@@ -323,9 +323,7 @@ public class OfferEvaluator {
         }
 
         for (VolumeSpec volumeSpec : podInstanceRequirement.getPodInstance().getPod().getVolumes()) {
-            evaluationStages.add(
-                    new VolumeEvaluationStage(
-                            volumeSpec, null, Optional.empty(), Optional.empty(), useDefaultExecutor));
+            evaluationStages.add(VolumeEvaluationStage.getNew(volumeSpec, null, useDefaultExecutor));
         }
 
         String preReservedRole = null;
@@ -354,9 +352,7 @@ public class OfferEvaluator {
             }
 
             for (VolumeSpec volumeSpec : entry.getValue().getVolumes()) {
-                evaluationStages.add(
-                        new VolumeEvaluationStage(
-                                volumeSpec, taskName, Optional.empty(), Optional.empty(), useDefaultExecutor));
+                evaluationStages.add(VolumeEvaluationStage.getNew(volumeSpec, taskName, useDefaultExecutor));
             }
 
             if (shouldAddExecutorResources) {

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/ResourceLabels.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/ResourceLabels.java
@@ -1,0 +1,76 @@
+package com.mesosphere.sdk.offer.evaluate;
+
+import com.mesosphere.sdk.specification.ResourceSpec;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+import java.util.Optional;
+
+/**
+ * Pairs a {@link ResourceSpec} definition with an existing task's labels associated with that resource.
+ */
+class ResourceLabels {
+    private final ResourceSpec original;
+    private final ResourceSpec updated;
+
+    private final String resourceId;
+    private final Optional<String> persistenceId;
+    private final Optional<String> sourceRoot;
+
+    public ResourceLabels(ResourceSpec resourceSpec, String resourceId) {
+        this(resourceSpec, resourceSpec, resourceId);
+    }
+
+    public ResourceLabels(ResourceSpec original, ResourceSpec updated, String resourceId) {
+        this(original, updated, resourceId, Optional.empty(), Optional.empty());
+    }
+
+    /**
+     * ResourceLabels are used to map {@link com.mesosphere.sdk.specification.ServiceSpec} entities to resources which
+     * have actually been consumed.  Generally speaking there should be no difference between the resources from a Mesos
+     * perspective and the resources from a {@link com.mesosphere.sdk.specification.ServiceSpec} perspective.
+     *
+     * There is one special case in which they differ, MOUNT volume resources.  In this case the {@link ResourceSpec}
+     * and actually consumed resources differ in value.  Because MOUNT volumes are atomic if the {@link ResourceSpec}
+     * indicates a need for 25 GB of disk and 50 GB of disk are actually offered, then 50 GB must be consumed.
+     *
+     * To capture this change the concept of an "updated" ResourceSpec is needed.  We modify the ResourceSpec in this
+     * scenario to match the actually consumed resources to facilitate consistent protobuf construction.
+     */
+    public ResourceLabels(
+            ResourceSpec original,
+            ResourceSpec updated,
+            String resourceId,
+            Optional<String> persistenceId,
+            Optional<String> sourceRoot) {
+        this.original = original;
+        this.updated = updated;
+        this.resourceId = resourceId;
+        this.persistenceId = persistenceId;
+        this.sourceRoot = sourceRoot;
+    }
+
+    public ResourceSpec getOriginal() {
+        return original;
+    }
+
+    public ResourceSpec getUpdated() {
+        return updated;
+    }
+
+    public String getResourceId() {
+        return resourceId;
+    }
+
+    public Optional<String> getPersistenceId() {
+        return persistenceId;
+    }
+
+    public Optional<String> getSourceRoot() {
+        return sourceRoot;
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
+    }
+}

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/TaskResourceMapper.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/TaskResourceMapper.java
@@ -5,7 +5,6 @@ import com.mesosphere.sdk.offer.Constants;
 import com.mesosphere.sdk.offer.RangeUtils;
 import com.mesosphere.sdk.offer.ResourceUtils;
 import com.mesosphere.sdk.specification.*;
-import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.mesos.Protos;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,30 +25,6 @@ class TaskResourceMapper {
     private final TaskPortLookup taskPortFinder;
     private final Collection<Protos.Resource> resources;
     private final boolean useDefaultExecutor;
-
-    /**
-     * Pairs a {@link ResourceSpec} definition with an existing task's labels associated with that resource.
-     */
-    static class ResourceLabels {
-        private final ResourceSpec resourceSpec;
-        private final String resourceId;
-        private final Optional<String> persistenceId;
-
-        private ResourceLabels(ResourceSpec resourceSpec, String resourceId) {
-            this(resourceSpec, resourceId, Optional.empty());
-        }
-
-        private ResourceLabels(ResourceSpec resourceSpec, String resourceId, Optional<String> persistenceId) {
-            this.resourceSpec = resourceSpec;
-            this.resourceId = resourceId;
-            this.persistenceId = persistenceId;
-        }
-
-        @Override
-        public String toString() {
-            return ToStringBuilder.reflectionToString(this);
-        }
-    }
 
     public TaskResourceMapper(TaskSpec taskSpec, Protos.TaskInfo taskInfo, boolean useDefaultExecutor) {
         this.taskSpecName = taskSpec.getName();
@@ -91,9 +66,9 @@ class TaskResourceMapper {
                     break;
             }
             if (matchingResource.isPresent()) {
-                if (!remainingResourceSpecs.remove(matchingResource.get().resourceSpec)) {
+                if (!remainingResourceSpecs.remove(matchingResource.get().getOriginal())) {
                     throw new IllegalStateException(String.format("Didn't find %s in %s",
-                            matchingResource.get().resourceSpec, remainingResourceSpecs));
+                            matchingResource.get().getOriginal(), remainingResourceSpecs));
                 }
                 matchingResources.add(matchingResource.get());
             } else {
@@ -126,7 +101,8 @@ class TaskResourceMapper {
     }
 
     private Optional<ResourceLabels> findMatchingDiskSpec(
-            Protos.Resource taskResource, Collection<ResourceSpec> resourceSpecs) {
+            Protos.Resource taskResource,
+            Collection<ResourceSpec> resourceSpecs) {
         for (ResourceSpec resourceSpec : resourceSpecs) {
             if (!(resourceSpec instanceof VolumeSpec)) {
                 continue;
@@ -140,10 +116,15 @@ class TaskResourceMapper {
                     continue;
                 }
 
+                double diskSize = taskResource.getScalar().getValue();
+                VolumeSpec updatedSpec = OfferEvaluationUtils.updateVolumeSpec((VolumeSpec) resourceSpec, diskSize);
+
                 return Optional.of(new ResourceLabels(
                         resourceSpec,
+                        updatedSpec,
                         resourceId.get(),
-                        Optional.of(taskResource.getDisk().getPersistence().getId())));
+                        Optional.of(taskResource.getDisk().getPersistence().getId()),
+                        ResourceUtils.getSourceRoot(taskResource)));
             }
         }
 
@@ -213,26 +194,31 @@ class TaskResourceMapper {
     }
 
     private OfferEvaluationStage newUpdateEvaluationStage(String taskSpecName, ResourceLabels resourceLabels) {
-        return toEvaluationStage(taskSpecName, resourceLabels.resourceSpec, Optional.of(resourceLabels.resourceId),
-                resourceLabels.persistenceId);
+        return toEvaluationStage(
+                taskSpecName,
+                resourceLabels.getUpdated(),
+                Optional.of(resourceLabels.getResourceId()),
+                resourceLabels.getPersistenceId(),
+                resourceLabels.getSourceRoot());
     }
 
     private OfferEvaluationStage newCreateEvaluationStage(String taskSpecName, ResourceSpec resourceSpec) {
-        return toEvaluationStage(taskSpecName, resourceSpec, Optional.empty(), Optional.empty());
+        return toEvaluationStage(taskSpecName, resourceSpec, Optional.empty(), Optional.empty(), Optional.empty());
     }
 
     private OfferEvaluationStage toEvaluationStage(
             String taskSpecName,
             ResourceSpec resourceSpec,
             Optional<String> resourceId,
-            Optional<String> persistenceId) {
+            Optional<String> persistenceId,
+            Optional<String> sourceRoot) {
         if (resourceSpec instanceof NamedVIPSpec) {
             return new NamedVIPEvaluationStage((NamedVIPSpec) resourceSpec, taskSpecName, resourceId);
         } else if (resourceSpec instanceof PortSpec) {
             return new PortEvaluationStage((PortSpec) resourceSpec, taskSpecName, resourceId);
         } else if (resourceSpec instanceof VolumeSpec) {
-            return new VolumeEvaluationStage(
-                    (VolumeSpec) resourceSpec, taskSpecName, resourceId, persistenceId, useDefaultExecutor);
+            return VolumeEvaluationStage.getExisting(
+                    (VolumeSpec) resourceSpec, taskSpecName, resourceId, persistenceId, sourceRoot, useDefaultExecutor);
         } else {
             return new ResourceEvaluationStage(resourceSpec, resourceId, taskSpecName);
         }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/VolumeEvaluationStage.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/VolumeEvaluationStage.java
@@ -25,17 +25,46 @@ public class VolumeEvaluationStage implements OfferEvaluationStage {
     private final String taskName;
     private final Optional<String> resourceId;
     private final boolean useDefaultExecutor;
+    private final Optional<String> sourceRoot;
 
-    public VolumeEvaluationStage(
+    public static VolumeEvaluationStage getNew(VolumeSpec volumeSpec, String taskName, boolean useDefaultExecutor) {
+        return new VolumeEvaluationStage(
+                volumeSpec,
+                taskName,
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                useDefaultExecutor);
+    }
+
+    public static VolumeEvaluationStage getExisting(
             VolumeSpec volumeSpec,
             String taskName,
             Optional<String> resourceId,
             Optional<String> persistenceId,
+            Optional<String> sourceRoot,
+            boolean useDefaultExecutor) {
+        return new VolumeEvaluationStage(
+                volumeSpec,
+                taskName,
+                resourceId,
+                persistenceId,
+                sourceRoot,
+                useDefaultExecutor);
+    }
+
+    private VolumeEvaluationStage(
+            VolumeSpec volumeSpec,
+            String taskName,
+            Optional<String> resourceId,
+            Optional<String> persistenceId,
+            Optional<String> sourceRoot,
             boolean useDefaultExecutor) {
         this.volumeSpec = volumeSpec;
         this.taskName = taskName;
         this.resourceId = resourceId;
         this.persistenceId = persistenceId;
+        this.sourceRoot = sourceRoot;
         this.useDefaultExecutor = useDefaultExecutor;
     }
 
@@ -60,8 +89,9 @@ public class VolumeEvaluationStage implements OfferEvaluationStage {
 
             Resource volume = PodInfoBuilder.getExistingExecutorVolume(
                     volumeSpec,
-                    resourceId.get(),
-                    persistenceId.get(),
+                    resourceId,
+                    persistenceId,
+                    sourceRoot,
                     useDefaultExecutor);
             podInfoBuilder.getExecutorBuilder().get().addResources(volume);
 

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/VolumeEvaluationStageTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/VolumeEvaluationStageTest.java
@@ -26,11 +26,9 @@ public class VolumeEvaluationStageTest extends DefaultCapabilitiesTestSuite {
         PodInstanceRequirement podInstanceRequirement =
                 PodInstanceRequirementTestUtils.getMountVolumeRequirement(1.0, 1000);
 
-        VolumeEvaluationStage volumeEvaluationStage = new VolumeEvaluationStage(
+        VolumeEvaluationStage volumeEvaluationStage = VolumeEvaluationStage.getNew(
                 getVolumeSpec(podInstanceRequirement.getPodInstance()),
                 getTaskName(podInstanceRequirement.getPodInstance()),
-                Optional.empty(),
-                Optional.empty(),
                 true);
         EvaluationOutcome outcome =
                 volumeEvaluationStage.evaluate(
@@ -81,11 +79,9 @@ public class VolumeEvaluationStageTest extends DefaultCapabilitiesTestSuite {
         PodInstanceRequirement podInstanceRequirement =
                 PodInstanceRequirementTestUtils.getMountVolumeRequirement(1.0, 2000);
 
-        VolumeEvaluationStage volumeEvaluationStage = new VolumeEvaluationStage(
+        VolumeEvaluationStage volumeEvaluationStage = VolumeEvaluationStage.getNew(
                 getVolumeSpec(podInstanceRequirement.getPodInstance()),
                 getTaskName(podInstanceRequirement.getPodInstance()),
-                Optional.empty(),
-                Optional.empty(),
                 true);
         EvaluationOutcome outcome =
                 volumeEvaluationStage.evaluate(


### PR DESCRIPTION
* Add hello-world example for sidecars on pre-reserved resources

* Fix executor construction for shared volumes on refined reservations

* Add pre-reserved sidecar integration test

* Fix MOUNT volume reuse