### PR TITLE
[INFINITY-3174] Add alternate form of accepted envvars in airgap_linter.

### DIFF
--- a/tools/airgap_linter.py
+++ b/tools/airgap_linter.py
@@ -52,8 +52,10 @@ def is_bad_uri(uri, file_name):
         ".thisdcos",
         ".mesos:",
         "$MESOS_CONTAINER_IP",
+        "${MESOS_CONTAINER_IP}",
         "{{FRAMEWORK_HOST}}",
         "$FRAMEWORK_HOST",
+        "${FRAMEWORK_HOST}",
     ]
 
     # Are any of the exceptions present?


### PR DESCRIPTION
This adds `${FRAMEWORK_HOST}` and `${MESOS_CONTAINER_IP}` alongside `$FRAMEWORK_HOST` and `$MESOS_CONTAINER_IP` as accepted envvars in the airgap linter.

Note: I'm not going to backport this as no downstreams require this change.