### PR TITLE
[INFINITY-3115] Remove update strategy

### DIFF
--- a/frameworks/hdfs/src/main/dist/svc.yml
+++ b/frameworks/hdfs/src/main/dist/svc.yml
@@ -517,14 +517,14 @@ plans:
     strategy: serial
     phases:
       journal:
-        strategy: {{UPDATE_STRATEGY}}
+        strategy: serial
         pod: journal
         steps:
           - 0: [[node]]
           - 1: [[node]]
           - 2: [[node]]
       name:
-        strategy: {{UPDATE_STRATEGY}}
+        strategy: serial
         pod: name
         steps:
           - 0: [[node, zkfc]]

--- a/frameworks/hdfs/universe/config.json
+++ b/frameworks/hdfs/universe/config.json
@@ -73,15 +73,6 @@
           ],
           "default": "parallel"
         },
-        "update_strategy": {
-          "description": "HDFS update strategy. [parallel, serial]",
-          "type": "string",
-          "enum": [
-            "parallel",
-            "serial"
-          ],
-          "default": "serial"
-        },
         "security": {
           "description": "HDFS security settings.",
           "type": "object",

--- a/frameworks/hdfs/universe/marathon.json.mustache
+++ b/frameworks/hdfs/universe/marathon.json.mustache
@@ -30,7 +30,6 @@
     "FRAMEWORK_LOG_LEVEL": "{{service.log_level}}",
     "TASKCFG_ALL_HDFS_VERSION": "hadoop-2.6.0-cdh5.11.0",
     "DEPLOY_STRATEGY": "{{service.deploy_strategy}}",
-    "UPDATE_STRATEGY": "{{service.update_strategy}}",
     "SERVICE_PRINCIPAL": "{{service.service_account}}",
     "JOURNAL_CPUS": "{{journal_node.cpus}}",
     "JOURNAL_MEM": "{{journal_node.mem}}",


### PR DESCRIPTION
The update strategy for HDFS is currently configurable to `serial, parallel` but a parallel update actually doesn't make sense for any component of HDFS.

Journal Nodes need to be updated serially as a parallel update would crash the name nodes, and thus the service.

Name nodes can't be updated in parallel because the service becomes unavailable to new clients.

Data nodes can't be updated in parallel because data access will be down for the duration of the update.