### PR TITLE
[INFINITY-3214] Nullify default value for HDFS authz mapping

### DIFF
--- a/frameworks/hdfs/universe/config.json
+++ b/frameworks/hdfs/universe/config.json
@@ -1466,7 +1466,7 @@
             "binaryEncoding": "base64",
             "type": "application/x-yaml"
           },
-          "default": "UlVMRTpbMjokMUAkMF0oLiopcy8uKi9ub2JvZHkvClJVTEU6WzE6JDFAJDBdKC4qKXMvLiovbm9ib2R5Lwo="
+          "default": ""
         },
         "io_file_buffer_size": {
           "type": "string",


### PR DESCRIPTION
The docs reflecting this change are in #2216 