### PR TITLE
[INFINITY-3269] Fix serial strategy

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/strategy/SerialStrategy.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/strategy/SerialStrategy.java
@@ -41,8 +41,11 @@ public class SerialStrategy<C extends Element> extends InterruptibleStrategy<C> 
 
             for (int i = 1; i < planElements.size(); i++) {
                 C previous = planElements.get(i - 1);
-                C current = planElements.get(i);
-                dependencyStrategyHelper.addDependency(previous, current);
+
+                for (int currIndex = i; currIndex < planElements.size(); currIndex++) {
+                    C current = planElements.get(currIndex);
+                    dependencyStrategyHelper.addDependency(previous, current);
+                }
             }
         }
 

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/plan/strategy/SerialStrategyTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/plan/strategy/SerialStrategyTest.java
@@ -98,4 +98,18 @@ public class SerialStrategyTest {
         step1.setStatus(Status.COMPLETE);
         Assert.assertTrue(strategy.getCandidates(phase.getChildren(), Collections.emptyList()).isEmpty());
     }
+
+    @Test
+    public void testMiddleComplete() {
+        Assert.assertEquals(1, strategy.getCandidates(steps, Collections.emptyList()).size());
+        Assert.assertEquals(el0, strategy.getCandidates(steps, Collections.emptyList()).iterator().next());
+
+        when(el1.isComplete()).thenReturn(true);
+        Assert.assertEquals(1, strategy.getCandidates(steps, Collections.emptyList()).size());
+        Assert.assertEquals(el0, strategy.getCandidates(steps, Collections.emptyList()).iterator().next());
+
+        when(el0.isComplete()).thenReturn(true);
+        Assert.assertEquals(1, strategy.getCandidates(steps, Collections.emptyList()).size());
+        Assert.assertEquals(el2, strategy.getCandidates(steps, Collections.emptyList()).iterator().next());
+    }
 }


### PR DESCRIPTION
Each element in a serial strategy should have a dependency on ALL previous elements, not just the immediately previous element.

In particular this fixes the `decommission` plan which executes elements out of order when executing a `serial` strategy.