### PR TITLE
[INFINITY-3080] Use fine-grained permissions for DC/OS 1.11.

### DIFF
--- a/frameworks/cassandra/tests/test_tls.py
+++ b/frameworks/cassandra/tests/test_tls.py
@@ -45,7 +45,7 @@ def cassandra_service_tls(service_account):
     sdk_install.uninstall(package_name=config.PACKAGE_NAME, service_name=config.SERVICE_NAME)
     sdk_install.install(
         config.PACKAGE_NAME,
-        service_account,
+        config.SERVICE_NAME,
         config.DEFAULT_TASK_COUNT,
         additional_options={
             "service": {

--- a/frameworks/cassandra/tests/test_tls.py
+++ b/frameworks/cassandra/tests/test_tls.py
@@ -29,7 +29,7 @@ def dcos_ca_bundle():
 @pytest.fixture(scope='module')
 def service_account(configure_security):
     """
-    Creates service account for TLS.
+    Sets up a service account for use with TLS.
     """
     try:
         name = config.SERVICE_NAME

--- a/frameworks/cassandra/tests/test_tls.py
+++ b/frameworks/cassandra/tests/test_tls.py
@@ -49,8 +49,8 @@ def cassandra_service_tls(service_account):
         config.DEFAULT_TASK_COUNT,
         additional_options={
             "service": {
-                "service_account_secret": service_account["name"],
-                "service_account": service_account["secret"],
+                "service_account": service_account["name"],
+                "service_account_secret": service_account["secret"],
                 "security": {
                     "transport_encryption": {
                         "enabled": True

--- a/frameworks/cassandra/tests/test_tls.py
+++ b/frameworks/cassandra/tests/test_tls.py
@@ -37,7 +37,8 @@ def service_account(configure_security):
 
         yield service_account_info
     finally:
-        transport_encryption.cleanup_service_account(service_account_info)
+        transport_encryption.cleanup_service_account(config.SERVICE_NAME,
+                                                     service_account_info)
 
 
 @pytest.fixture(scope='module')

--- a/frameworks/cassandra/tests/test_tls.py
+++ b/frameworks/cassandra/tests/test_tls.py
@@ -8,8 +8,10 @@ import sdk_cmd
 import sdk_install
 import sdk_jobs
 import sdk_plan
-import sdk_security
 import sdk_utils
+
+from security import transport_encryption
+
 from tests import config
 
 
@@ -25,20 +27,17 @@ def dcos_ca_bundle():
 
 
 @pytest.fixture(scope='module')
-def service_account():
+def service_account(configure_security):
     """
-    Creates service account with `hello-world` name and yields the name.
+    Creates service account for TLS.
     """
-    # This name should be same as SERVICE_NAME as it determines scheduler DCOS_LABEL value.
-    name = config.SERVICE_NAME
-    sdk_security.create_service_account(
-        service_account_name=name, service_account_secret=name)
-    # TODO(mh): Fine grained permissions needs to be addressed in DCOS-16475
-    sdk_cmd.run_cli(
-        "security org groups add_user superusers {name}".format(name=name))
-    yield name
-    sdk_security.delete_service_account(
-        service_account_name=name, service_account_secret=name)
+    try:
+        name = config.SERVICE_NAME
+        service_account_info = transport_encryption.setup_service_account(name)
+
+        yield service_account_info
+    finally:
+        transport_encryption.cleanup_service_account(service_account_info)
 
 
 @pytest.fixture(scope='module')
@@ -50,8 +49,8 @@ def cassandra_service_tls(service_account):
         config.DEFAULT_TASK_COUNT,
         additional_options={
             "service": {
-                "service_account_secret": service_account,
-                "service_account": service_account,
+                "service_account_secret": service_account["name"],
+                "service_account": service_account["secret"],
                 "security": {
                     "transport_encryption": {
                         "enabled": True
@@ -90,7 +89,8 @@ def test_tls_connection(cassandra_service_tls, dcos_ca_bundle):
 
         key_id = os.getenv('AWS_ACCESS_KEY_ID')
         if not key_id:
-            assert False, 'AWS credentials are required for this test. Disable test with e.g. TEST_TYPES="sanity and not aws"'
+            assert False, 'AWS credentials are required for this test. ' \
+                          'Disable test with e.g. TEST_TYPES="sanity and not aws"'
         plan_parameters = {
             'AWS_ACCESS_KEY_ID': key_id,
             'AWS_SECRET_ACCESS_KEY': os.getenv('AWS_SECRET_ACCESS_KEY'),

--- a/frameworks/cassandra/tests/test_toggle_tls.py
+++ b/frameworks/cassandra/tests/test_toggle_tls.py
@@ -20,7 +20,7 @@ log = logging.getLogger(__name__)
 @pytest.fixture(scope='module')
 def service_account(configure_security):
     """
-    Creates service account for TLS.
+    Sets up a service account for use with TLS.
     """
     try:
         name = config.SERVICE_NAME

--- a/frameworks/cassandra/tests/test_toggle_tls.py
+++ b/frameworks/cassandra/tests/test_toggle_tls.py
@@ -8,7 +8,6 @@ import sdk_cmd
 import sdk_install
 import sdk_jobs
 import sdk_plan
-import sdk_security
 import sdk_utils
 
 from security import transport_encryption
@@ -21,20 +20,15 @@ log = logging.getLogger(__name__)
 @pytest.fixture(scope='module')
 def service_account(configure_security):
     """
-    Creates service account and secret and yields dict containing both.
+    Creates service account for TLS.
     """
     try:
         name = config.SERVICE_NAME
-        secret = "{}-secret".format(name)
-        sdk_security.create_service_account(
-            service_account_name=name, service_account_secret=secret)
-        # TODO(mh): Fine grained permissions needs to be addressed in DCOS-16475
-        sdk_cmd.run_cli(
-            "security org groups add_user superusers {name}".format(name=name))
-        yield {"name": name, "secret": secret}
+        service_account_info = transport_encryption.setup_service_account(name)
+
+        yield service_account_info
     finally:
-        sdk_security.delete_service_account(
-            service_account_name=name, service_account_secret=secret)
+        transport_encryption.cleanup_service_account(service_account_info)
 
 
 @pytest.fixture(scope='module')

--- a/frameworks/cassandra/tests/test_toggle_tls.py
+++ b/frameworks/cassandra/tests/test_toggle_tls.py
@@ -28,7 +28,8 @@ def service_account(configure_security):
 
         yield service_account_info
     finally:
-        transport_encryption.cleanup_service_account(service_account_info)
+        transport_encryption.cleanup_service_account(config.SERVICE_NAME,
+                                                     service_account_info)
 
 
 @pytest.fixture(scope='module')

--- a/frameworks/elastic/tests/test_tls.py
+++ b/frameworks/elastic/tests/test_tls.py
@@ -1,11 +1,12 @@
 import pytest
 import shakedown
 
-import sdk_cmd
 import sdk_install
 import sdk_plan
-import sdk_security
 import sdk_utils
+
+from security import transport_encryption
+
 from tests import config
 
 pytestmark = pytest.mark.skipif(sdk_utils.is_open_dcos(),
@@ -13,19 +14,17 @@ pytestmark = pytest.mark.skipif(sdk_utils.is_open_dcos(),
 
 
 @pytest.fixture(scope='module')
-def service_account():
+def service_account(configure_security):
     """
-    Creates service account with `elastic` name and yields the name.
+    Creates service account for TLS.
     """
-    name = config.SERVICE_NAME
-    sdk_security.create_service_account(
-        service_account_name=name, service_account_secret=name)
-    # TODO(mh): Fine grained permissions needs to be addressed in DCOS-16475
-    sdk_cmd.run_cli(
-        "security org groups add_user superusers {name}".format(name=name))
-    yield name
-    sdk_security.delete_service_account(
-        service_account_name=name, service_account_secret=name)
+    try:
+        name = config.SERVICE_NAME
+        service_account_info = transport_encryption.setup_service_account(name)
+
+        yield service_account_info
+    finally:
+        transport_encryption.cleanup_service_account(service_account_info)
 
 
 @pytest.fixture(scope='module')
@@ -36,8 +35,8 @@ def elastic_service_tls(service_account):
         expected_running_tasks=config.DEFAULT_TASK_COUNT,
         additional_options={
             "service": {
-                "service_account_secret": service_account,
-                "service_account": service_account,
+                "service_account_secret": service_account["name"],
+                "service_account": service_account["secret"],
                 "security": {
                     "transport_encryption": {
                         "enabled": True

--- a/frameworks/elastic/tests/test_tls.py
+++ b/frameworks/elastic/tests/test_tls.py
@@ -16,7 +16,7 @@ pytestmark = pytest.mark.skipif(sdk_utils.is_open_dcos(),
 @pytest.fixture(scope='module')
 def service_account(configure_security):
     """
-    Creates service account for TLS.
+    Sets up a service account for use with TLS.
     """
     try:
         name = config.SERVICE_NAME

--- a/frameworks/elastic/tests/test_tls.py
+++ b/frameworks/elastic/tests/test_tls.py
@@ -24,7 +24,8 @@ def service_account(configure_security):
 
         yield service_account_info
     finally:
-        transport_encryption.cleanup_service_account(service_account_info)
+        transport_encryption.cleanup_service_account(config.SERVICE_NAME,
+                                                     service_account_info)
 
 
 @pytest.fixture(scope='module')

--- a/frameworks/hdfs/tests/test_kerberos_auth.py
+++ b/frameworks/hdfs/tests/test_kerberos_auth.py
@@ -7,10 +7,10 @@ import sdk_cmd
 import sdk_hosts
 import sdk_install
 import sdk_marathon
-import sdk_security
 import sdk_utils
 
 from security import kerberos as krb5
+from security import transport_encryption
 
 from tests import auth
 from tests import config
@@ -26,19 +26,15 @@ pytestmark = pytest.mark.skipif(sdk_utils.is_open_dcos(),
 @pytest.fixture(scope='module', autouse=True)
 def service_account(configure_security):
     """
-    Creates service account and yields the name.
+    Creates service account for TLS.
     """
     try:
         name = config.SERVICE_NAME
-        sdk_security.create_service_account(
-            service_account_name=name, service_account_secret=name)
-        # TODO(mh): Fine grained permissions needs to be addressed in DCOS-16475
-        sdk_cmd.run_cli(
-            "security org groups add_user superusers {name}".format(name=name))
-        yield name
+        service_account_info = transport_encryption.setup_service_account(name)
+
+        yield service_account_info
     finally:
-        sdk_security.delete_service_account(
-            service_account_name=name, service_account_secret=name)
+        transport_encryption.cleanup_service_account(service_account_info)
 
 
 @pytest.fixture(scope='module', autouse=True)
@@ -66,8 +62,8 @@ def hdfs_server(kerberos, service_account):
     service_kerberos_options = {
         "service": {
             "name": config.FOLDERED_SERVICE_NAME,
-            "service_account": service_account,
-            "service_account_secret": service_account,
+            "service_account": service_account["name"],
+            "service_account_secret": service_account["secret"],
             "security": {
                 "kerberos": {
                     "enabled": True,

--- a/frameworks/hdfs/tests/test_kerberos_auth.py
+++ b/frameworks/hdfs/tests/test_kerberos_auth.py
@@ -34,7 +34,8 @@ def service_account(configure_security):
 
         yield service_account_info
     finally:
-        transport_encryption.cleanup_service_account(service_account_info)
+        transport_encryption.cleanup_service_account(config.SERVICE_NAME,
+                                                     service_account_info)
 
 
 @pytest.fixture(scope='module', autouse=True)

--- a/frameworks/hdfs/tests/test_kerberos_auth.py
+++ b/frameworks/hdfs/tests/test_kerberos_auth.py
@@ -26,7 +26,7 @@ pytestmark = pytest.mark.skipif(sdk_utils.is_open_dcos(),
 @pytest.fixture(scope='module', autouse=True)
 def service_account(configure_security):
     """
-    Creates service account for TLS.
+    Sets up a service account for use with TLS.
     """
     try:
         name = config.SERVICE_NAME

--- a/frameworks/hdfs/tests/test_ssl_kerberos_auth.py
+++ b/frameworks/hdfs/tests/test_ssl_kerberos_auth.py
@@ -34,7 +34,8 @@ def service_account(configure_security):
 
         yield service_account_info
     finally:
-        transport_encryption.cleanup_service_account(service_account_info)
+        transport_encryption.cleanup_service_account(config.SERVICE_NAME,
+                                                     service_account_info)
 
 
 @pytest.fixture(scope='module', autouse=True)

--- a/frameworks/hdfs/tests/test_ssl_kerberos_auth.py
+++ b/frameworks/hdfs/tests/test_ssl_kerberos_auth.py
@@ -7,7 +7,6 @@ import sdk_cmd
 import sdk_hosts
 import sdk_install
 import sdk_marathon
-import sdk_security
 import sdk_utils
 
 from security import kerberos as krb5
@@ -27,19 +26,15 @@ pytestmark = pytest.mark.skipif(sdk_utils.is_open_dcos(),
 @pytest.fixture(scope='module', autouse=True)
 def service_account(configure_security):
     """
-    Creates service account and yields the name.
+    Creates service account for TLS.
     """
     try:
         name = config.SERVICE_NAME
-        sdk_security.create_service_account(
-            service_account_name=name, service_account_secret=name)
-        # TODO(mh): Fine grained permissions needs to be addressed in DCOS-16475
-        sdk_cmd.run_cli(
-            "security org groups add_user superusers {name}".format(name=name))
-        yield name
+        service_account_info = transport_encryption.setup_service_account(name)
+
+        yield service_account_info
     finally:
-        sdk_security.delete_service_account(
-            service_account_name=name, service_account_secret=name)
+        transport_encryption.cleanup_service_account(service_account_info)
 
 
 @pytest.fixture(scope='module', autouse=True)
@@ -67,8 +62,8 @@ def hdfs_server(kerberos, service_account):
     service_kerberos_options = {
         "service": {
             "name": config.SERVICE_NAME,
-            "service_account": service_account,
-            "service_account_secret": service_account,
+            "service_account": service_account["name"],
+            "service_account_secret": service_account["secret"],
             "security": {
                 "kerberos": {
                     "enabled": True,

--- a/frameworks/hdfs/tests/test_ssl_kerberos_auth.py
+++ b/frameworks/hdfs/tests/test_ssl_kerberos_auth.py
@@ -26,7 +26,7 @@ pytestmark = pytest.mark.skipif(sdk_utils.is_open_dcos(),
 @pytest.fixture(scope='module', autouse=True)
 def service_account(configure_security):
     """
-    Creates service account for TLS.
+    Sets up a service account for use with TLS.
     """
     try:
         name = config.SERVICE_NAME

--- a/frameworks/hdfs/tests/test_tls.py
+++ b/frameworks/hdfs/tests/test_tls.py
@@ -28,7 +28,8 @@ def service_account(configure_security):
 
         yield service_account_info
     finally:
-        transport_encryption.cleanup_service_account(service_account_info)
+        transport_encryption.cleanup_service_account(config.SERVICE_NAME,
+                                                     service_account_info)
 
 
 @pytest.fixture(scope='module')

--- a/frameworks/hdfs/tests/test_tls.py
+++ b/frameworks/hdfs/tests/test_tls.py
@@ -20,7 +20,7 @@ DEFAULT_DATA_NODE_TLS_PORT = 9006
 @pytest.fixture(scope='module')
 def service_account(configure_security):
     """
-    Creates service account for TLS.
+    Sets up a service account for use with TLS.
     """
     try:
         name = config.SERVICE_NAME

--- a/frameworks/kafka/tests/test_ssl_auth.py
+++ b/frameworks/kafka/tests/test_ssl_auth.py
@@ -110,8 +110,8 @@ def test_authn_client_can_read_and_write(kafka_client, service_account, setup_pr
                     "port_tls": 1030
                 },
                 "service": {
-                    "service_account": service_account,
-                    "service_account_secret": service_account,
+                    "service_account": service_account["name"],
+                    "service_account_secret": service_account["secret"],
                     "security": {
                         "transport_encryption": {
                             "enabled": True
@@ -162,8 +162,8 @@ def test_authz_acls_required(kafka_client, service_account, setup_principals):
                     "port_tls": 1030
                 },
                 "service": {
-                    "service_account": service_account,
-                    "service_account_secret": service_account,
+                    "service_account": service_account["name"],
+                    "service_account_secret": service_account["secret"],
                     "security": {
                         "transport_encryption": {
                             "enabled": True
@@ -235,8 +235,8 @@ def test_authz_acls_not_required(kafka_client, service_account, setup_principals
                     "port_tls": 1030
                 },
                 "service": {
-                    "service_account": service_account,
-                    "service_account_secret": service_account,
+                    "service_account": service_account["name"],
+                    "service_account_secret": service_account["secret"],
                     "security": {
                         "transport_encryption": {
                             "enabled": True

--- a/frameworks/kafka/tests/test_ssl_auth.py
+++ b/frameworks/kafka/tests/test_ssl_auth.py
@@ -34,7 +34,8 @@ def service_account(configure_security):
 
         yield service_account_info
     finally:
-        transport_encryption.cleanup_service_account(service_account_info)
+        transport_encryption.cleanup_service_account(config.SERVICE_NAME,
+                                                     service_account_info)
 
 
 @pytest.fixture(scope='module', autouse=True)

--- a/frameworks/kafka/tests/test_ssl_auth.py
+++ b/frameworks/kafka/tests/test_ssl_auth.py
@@ -26,7 +26,7 @@ pytestmark = pytest.mark.skipif(sdk_utils.is_open_dcos(),
 @pytest.fixture(scope='module', autouse=True)
 def service_account(configure_security):
     """
-    Creates service account for TLS.
+    Sets up a service account for use with TLS.
     """
     try:
         name = config.SERVICE_NAME

--- a/frameworks/kafka/tests/test_ssl_kerberos_auth.py
+++ b/frameworks/kafka/tests/test_ssl_kerberos_auth.py
@@ -4,10 +4,8 @@ import pytest
 
 import sdk_auth
 import sdk_cmd
-import sdk_hosts
 import sdk_install
 import sdk_marathon
-import sdk_security
 import sdk_utils
 
 
@@ -29,17 +27,15 @@ pytestmark = pytest.mark.skipif(sdk_utils.is_open_dcos(),
 @pytest.fixture(scope='module', autouse=True)
 def service_account(configure_security):
     """
-    Creates service account and yields the name.
+    Creates service account for TLS.
     """
-    name = config.SERVICE_NAME
-    sdk_security.create_service_account(
-        service_account_name=name, service_account_secret=name)
-    # TODO(mh): Fine grained permissions needs to be addressed in DCOS-16475
-    sdk_cmd.run_cli(
-        "security org groups add_user superusers {name}".format(name=name))
-    yield name
-    sdk_security.delete_service_account(
-        service_account_name=name, service_account_secret=name)
+    try:
+        name = config.SERVICE_NAME
+        service_account_info = transport_encryption.setup_service_account(name)
+
+        yield service_account_info
+    finally:
+        transport_encryption.cleanup_service_account(service_account_info)
 
 
 @pytest.fixture(scope='module', autouse=True)

--- a/frameworks/kafka/tests/test_ssl_kerberos_auth.py
+++ b/frameworks/kafka/tests/test_ssl_kerberos_auth.py
@@ -35,7 +35,8 @@ def service_account(configure_security):
 
         yield service_account_info
     finally:
-        transport_encryption.cleanup_service_account(service_account_info)
+        transport_encryption.cleanup_service_account(config.SERVICE_NAME,
+                                                     service_account_info)
 
 
 @pytest.fixture(scope='module', autouse=True)

--- a/frameworks/kafka/tests/test_ssl_kerberos_auth.py
+++ b/frameworks/kafka/tests/test_ssl_kerberos_auth.py
@@ -27,7 +27,7 @@ pytestmark = pytest.mark.skipif(sdk_utils.is_open_dcos(),
 @pytest.fixture(scope='module', autouse=True)
 def service_account(configure_security):
     """
-    Creates service account for TLS.
+    Sets up a service account for use with TLS.
     """
     try:
         name = config.SERVICE_NAME

--- a/frameworks/kafka/tests/test_ssl_kerberos_auth.py
+++ b/frameworks/kafka/tests/test_ssl_kerberos_auth.py
@@ -64,8 +64,8 @@ def kafka_server(kerberos, service_account):
     service_kerberos_options = {
         "service": {
             "name": config.SERVICE_NAME,
-            "service_account": service_account,
-            "service_account_secret": service_account,
+            "service_account": service_account["name"],
+            "service_account_secret": service_account["secret"],
             "security": {
                 "kerberos": {
                     "enabled": True,

--- a/frameworks/kafka/tests/test_tls.py
+++ b/frameworks/kafka/tests/test_tls.py
@@ -1,12 +1,12 @@
 import pytest
-import shakedown
 
 import sdk_cmd
 import sdk_install
 import sdk_networks
 import sdk_plan
-import sdk_security
 import sdk_utils
+
+from security import transport_encryption
 
 from tests import config
 
@@ -17,19 +17,15 @@ BROKER_TLS_ENDPOINT = 'broker-tls'
 @pytest.fixture(scope='module')
 def service_account(configure_security):
     """
-    Creates service account and yields the name.
+    Creates service account for TLS.
     """
     try:
         name = config.SERVICE_NAME
-        sdk_security.create_service_account(
-            service_account_name=name, service_account_secret=name)
-        # TODO(mh): Fine grained permissions needs to be addressed in DCOS-16475
-        sdk_cmd.run_cli(
-            "security org groups add_user superusers {name}".format(name=name))
-        yield name
+        service_account_info = transport_encryption.setup_service_account(name)
+
+        yield service_account_info
     finally:
-        sdk_security.delete_service_account(
-            service_account_name=name, service_account_secret=name)
+        transport_encryption.cleanup_service_account(service_account_info)
 
 
 @pytest.fixture(scope='module')
@@ -42,8 +38,8 @@ def kafka_service_tls(service_account):
             config.DEFAULT_BROKER_COUNT,
             additional_options={
                 "service": {
-                    "service_account": service_account,
-                    "service_account_secret": service_account,
+                    "service_account": service_account["name"],
+                    "service_account_secret": service_account["secret"],
                     "security": {
                         "transport_encryption": {
                             "enabled": True
@@ -70,7 +66,8 @@ def test_tls_endpoints(kafka_service_tls):
     assert BROKER_TLS_ENDPOINT in endpoints
 
     # Test that broker-tls endpoint is available
-    endpoint_tls = sdk_cmd.svc_cli(config.PACKAGE_NAME, config.SERVICE_NAME, 'endpoints {name}'.format(name=BROKER_TLS_ENDPOINT), json=True)
+    endpoint_tls = sdk_cmd.svc_cli(config.PACKAGE_NAME, config.SERVICE_NAME,
+                                   'endpoints {name}'.format(name=BROKER_TLS_ENDPOINT), json=True)
     assert len(endpoint_tls['dns']) == config.DEFAULT_BROKER_COUNT
 
 
@@ -82,13 +79,19 @@ def test_tls_endpoints(kafka_service_tls):
 def test_producer_over_tls(kafka_service_tls):
     sdk_cmd.svc_cli(config.PACKAGE_NAME, config.SERVICE_NAME, 'topic create {}'.format(config.DEFAULT_TOPIC_NAME))
 
-    topic_info = sdk_cmd.svc_cli(config.PACKAGE_NAME, config.SERVICE_NAME, 'topic describe {}'.format(config.DEFAULT_TOPIC_NAME), json=True)
+    topic_info = sdk_cmd.svc_cli(config.PACKAGE_NAME, config.SERVICE_NAME,
+                                 'topic describe {}'.format(config.DEFAULT_TOPIC_NAME),
+                                 json=True)
     assert len(topic_info['partitions']) == config.DEFAULT_PARTITION_COUNT
 
     # Write twice: Warm up TLS connections
     num_messages = 10
-    write_info = sdk_cmd.svc_cli(config.PACKAGE_NAME, config.SERVICE_NAME, 'topic producer_test_tls {} {}'.format(config.DEFAULT_TOPIC_NAME, num_messages), json=True)
+    write_info = sdk_cmd.svc_cli(config.PACKAGE_NAME, config.SERVICE_NAME,
+                                 'topic producer_test_tls {} {}'.format(config.DEFAULT_TOPIC_NAME, num_messages),
+                                 json=True)
 
-    write_info = sdk_cmd.svc_cli(config.PACKAGE_NAME, config.SERVICE_NAME, 'topic producer_test_tls {} {}'.format(config.DEFAULT_TOPIC_NAME, num_messages), json=True)
+    write_info = sdk_cmd.svc_cli(config.PACKAGE_NAME, config.SERVICE_NAME,
+                                 'topic producer_test_tls {} {}'.format(config.DEFAULT_TOPIC_NAME, num_messages),
+                                 json=True)
     assert len(write_info) == 1
     assert write_info['message'].startswith('Output: {} records sent'.format(num_messages))

--- a/frameworks/kafka/tests/test_tls.py
+++ b/frameworks/kafka/tests/test_tls.py
@@ -25,7 +25,8 @@ def service_account(configure_security):
 
         yield service_account_info
     finally:
-        transport_encryption.cleanup_service_account(service_account_info)
+        transport_encryption.cleanup_service_account(config.SERVICE_NAME,
+                                                     service_account_info)
 
 
 @pytest.fixture(scope='module')

--- a/frameworks/kafka/tests/test_tls.py
+++ b/frameworks/kafka/tests/test_tls.py
@@ -17,7 +17,7 @@ BROKER_TLS_ENDPOINT = 'broker-tls'
 @pytest.fixture(scope='module')
 def service_account(configure_security):
     """
-    Creates service account for TLS.
+    Sets up a service account for use with TLS.
     """
     try:
         name = config.SERVICE_NAME

--- a/frameworks/kafka/tests/test_toggle_security.py
+++ b/frameworks/kafka/tests/test_toggle_security.py
@@ -9,7 +9,6 @@ import sdk_cmd
 import sdk_install
 import sdk_marathon
 import sdk_plan
-import sdk_security
 import sdk_utils
 
 from security import transport_encryption
@@ -36,20 +35,15 @@ MESSAGES = []
 @pytest.fixture(scope='module', autouse=True)
 def service_account(configure_security):
     """
-    Creates service account and yields the name and corresponding secret name.
+    Creates service account for TLS.
     """
     try:
         name = config.SERVICE_NAME
-        secret = "{}-secret".format(name)
-        sdk_security.create_service_account(
-            service_account_name=name, service_account_secret=secret)
-        # TODO(mh): Fine grained permissions needs to be addressed in DCOS-16475
-        sdk_cmd.run_cli(
-            "security org groups add_user superusers {name}".format(name=name))
-        yield {"name": name, "secret": secret}
+        service_account_info = transport_encryption.setup_service_account(name)
+
+        yield service_account_info
     finally:
-        sdk_security.delete_service_account(
-            service_account_name=name, service_account_secret=secret)
+        transport_encryption.cleanup_service_account(service_account_info)
 
 
 @pytest.fixture(scope='module', autouse=True)
@@ -239,7 +233,8 @@ def test_forward_kerberos_on_tls_on_plaintext_on(kafka_client, kafka_server, ker
 
     tls_brokers = service_get_brokers(kafka_server, "broker-tls")
 
-    assert set(_get_hostnames(brokers)) == set(_get_hostnames(tls_brokers)), "TLS and non-TLS broker hostnames should match"
+    assert set(_get_hostnames(brokers)) == set(_get_hostnames(tls_brokers)), "TLS and non-TLS broker " \
+                                                                             "hostnames should match"
 
     write_success, read_successes = client_can_read_and_write("client", kafka_client, kafka_server,
                                                               "broker", kerberos)
@@ -334,7 +329,8 @@ def test_forward_kerberos_off_tls_on_plaintext_on(kafka_client, kafka_server):
 
     non_tls_brokers = service_get_brokers(kafka_server, "broker")
 
-    assert set(_get_hostnames(brokers)) == set(_get_hostnames(non_tls_brokers)), "TLS and non-TLS broker hostnames should match"
+    assert set(_get_hostnames(brokers)) == set(_get_hostnames(non_tls_brokers)), "TLS and non-TLS broker " \
+                                                                                 "hostnames should match"
 
     write_success, read_successes = client_can_read_and_write("client", kafka_client, kafka_server,
                                                               "broker", None)
@@ -446,7 +442,8 @@ def test_reverse_kerberos_on_tls_on_plaintext_on(kafka_client, kafka_server, ker
 
     non_tls_brokers = service_get_brokers(kafka_server, "broker")
 
-    assert set(_get_hostnames(brokers)) == set(_get_hostnames(non_tls_brokers)), "TLS and non-TLS broker hostnames should match"
+    assert set(_get_hostnames(brokers)) == set(_get_hostnames(non_tls_brokers)), "TLS and non-TLS broker " \
+                                                                                 "hostnames should match"
 
     write_success, read_successes = client_can_read_and_write("client", kafka_client, kafka_server,
                                                               "broker", kerberos)

--- a/frameworks/kafka/tests/test_toggle_security.py
+++ b/frameworks/kafka/tests/test_toggle_security.py
@@ -43,7 +43,8 @@ def service_account(configure_security):
 
         yield service_account_info
     finally:
-        transport_encryption.cleanup_service_account(service_account_info)
+        transport_encryption.cleanup_service_account(config.SERVICE_NAME,
+                                                     service_account_info)
 
 
 @pytest.fixture(scope='module', autouse=True)

--- a/frameworks/kafka/tests/test_toggle_security.py
+++ b/frameworks/kafka/tests/test_toggle_security.py
@@ -35,7 +35,7 @@ MESSAGES = []
 @pytest.fixture(scope='module', autouse=True)
 def service_account(configure_security):
     """
-    Creates service account for TLS.
+    Sets up a service account for use with TLS.
     """
     try:
         name = config.SERVICE_NAME

--- a/testing/security/transport_encryption.py
+++ b/testing/security/transport_encryption.py
@@ -15,12 +15,13 @@ log = logging.getLogger(__name__)
 def setup_service_account(service_name: str,
                           service_account_secret: str=None) -> dict:
     """
-    Setup the service account for TLS
+    Setup the service account for TLS. If the account or secret of the specified
+    name already exists, these are deleted.
     """
 
     if sdk_utils.is_open_dcos():
-        log.warn("The setup of a service account requires DC/OS EE")
-        return {}
+        log.error("The setup of a service account requires DC/OS EE. service_name=%s", service_name)
+        raise Exception("The setup of a service account requires DC/OS EE")
 
     name = service_name
     secret = name if service_account_secret is None else service_account_secret
@@ -51,7 +52,9 @@ def setup_service_account(service_name: str,
 
 def cleanup_service_account(service_account_info: dict):
     """
-    Clean up the service account
+    Clean up the specified service account.
+
+    Ideally, this service account was created using the setup_service_account function.
     """
     if isinstance(service_account_info, str):
         service_account_info = {"name": service_account_info}

--- a/testing/security/transport_encryption.py
+++ b/testing/security/transport_encryption.py
@@ -6,9 +6,61 @@ import logging
 
 
 import sdk_cmd
-
+import sdk_security
+import sdk_utils
 
 log = logging.getLogger(__name__)
+
+
+def setup_service_account(service_name: str,
+                          service_account_secret: str=None) -> dict:
+    """
+    Setup the service account for TLS
+    """
+
+    if sdk_utils.is_open_dcos():
+        log.warn("The setup of a service account requires DC/OS EE")
+        return {}
+
+    name = service_name
+    secret = name if service_account_secret is None else service_account_secret
+    sdk_security.create_service_account(service_account_name=name,
+                                        service_account_secret=secret)
+
+    if sdk_utils.dcos_version_less_than("1.11"):
+        sdk_cmd.run_cli("security org groups add_user superusers {name}".format(name=name))
+    else:
+        acls = [
+                {"rid": "dcos:secrets:default:/{}/*".format(service_name), "action": "full"},
+                {"rid": "dcos:secrets:list:default:/{}".format(service_name), "action": "read"},
+                {"rid": "dcos:adminrouter:ops:ca:rw", "action": "full"},
+                {"rid": "dcos:adminrouter:ops:ca:ro", "action": "full"},
+                ]
+
+        for acl in acls:
+            cmd_list = ["security", "org", "users", "grant",
+                        "--description", "\"Permissing required to provision TLS certificates\"",
+                        name, acl["rid"], acl["action"]
+                        ]
+
+            output = sdk_cmd.run_cli(" ".join(cmd_list))
+            log.info("output=%s", output)
+
+    return {"name": name, "secret": secret}
+
+
+def cleanup_service_account(service_account_info: dict):
+    """
+    Clean up the service account
+    """
+    if isinstance(service_account_info, str):
+        service_account_info = {"name": service_account_info}
+
+    name = service_account_info["name"]
+    secret = service_account_info["secret"] if "secret" in service_account_info else name
+
+    sdk_security.delete_service_account(service_account_name=name,
+                                        service_account_secret=secret)
 
 
 def fetch_dcos_ca_bundle(task: str) -> str:

--- a/testing/security/transport_encryption.py
+++ b/testing/security/transport_encryption.py
@@ -25,9 +25,12 @@ def setup_service_account(service_name: str,
 
     name = service_name
     secret = name if service_account_secret is None else service_account_secret
-    sdk_security.create_service_account(service_account_name=name,
-                                        service_account_secret=secret)
 
+    service_account_info = sdk_security.setup_security(service_name,
+                                                       service_account=name,
+                                                       service_account_secret=secret)
+
+    log.info("Adding permissions required for TLS.")
     if sdk_utils.dcos_version_less_than("1.11"):
         sdk_cmd.run_cli("security org groups add_user superusers {name}".format(name=name))
     else:
@@ -47,10 +50,10 @@ def setup_service_account(service_name: str,
             output = sdk_cmd.run_cli(" ".join(cmd_list))
             log.info("output=%s", output)
 
-    return {"name": name, "secret": secret}
+    return service_account_info
 
 
-def cleanup_service_account(service_account_info: dict):
+def cleanup_service_account(service_name: str, service_account_info: dict):
     """
     Clean up the specified service account.
 
@@ -62,8 +65,9 @@ def cleanup_service_account(service_account_info: dict):
     name = service_account_info["name"]
     secret = service_account_info["secret"] if "secret" in service_account_info else name
 
-    sdk_security.delete_service_account(service_account_name=name,
-                                        service_account_secret=secret)
+    sdk_security.cleanup_security(service_name,
+                                  service_account=name,
+                                  service_account_secret=secret)
 
 
 def fetch_dcos_ca_bundle(task: str) -> str:


### PR DESCRIPTION
This PR restructures how service accounts are created in the setup process, and adds fine-grained settings for DC/OS 1.11.

For clarity the effective changes are as follows:
* Use the same service account fixture for *all* TLS tests requiring a service account.
* On 1.11 clusters use fine-grained permissions instead of `superuser` for this service account.
* Use return a dict from the fixture instead of a string so as to allow for latter setting different secrets and service account names.

What has not changes:
* The logic in calling `create_service_account` and `delete_service_account`
* The names of the service account and secrets created (with the exception of one Kafka test where service account name and service account secret are now the same for uniformity).
* The setup of service accounts and secrets in strict mode.