### PR TITLE
[INFINITY-3280] Regression in advertised listeners behavior

### DIFF
--- a/frameworks/kafka/setup-helper/setup_helper.go
+++ b/frameworks/kafka/setup-helper/setup_helper.go
@@ -175,12 +175,11 @@ func setListeners() error {
 	// NOTE: To be consistent with the legacy behavior of the 2.0.X Kafka series,
 	// when there is no security enabled, we must honor the kafka.kafka_advertise_host_ip
 	// configuration parameter
-	if !kerberosEnabled && !tlsEncryptionEnabled && !getBooleanEnvvar(advertiseHostIPEnvvar) {
-		// Write an empty file.
-		err = writeToWorkingDirectory(advertisedListenersProperty, "")
-	} else {
+	if kerberosEnabled || tlsEncryptionEnabled || getBooleanEnvvar(advertiseHostIPEnvvar) {
 		err = writeToWorkingDirectory(advertisedListenersProperty,
 			"advertised.listeners="+strings.Join(advertisedListeners, ","))
+	} else {
+		err = writeToWorkingDirectory(advertisedListenersProperty, "")
 	}
 
 	return err

--- a/frameworks/kafka/setup-helper/setup_helper_test.go
+++ b/frameworks/kafka/setup-helper/setup_helper_test.go
@@ -41,6 +41,7 @@ func TestCalculateSettingsListenersError(t *testing.T) {
 }
 
 var listenerTests = []struct {
+	advertiseHostIPEnvvarValue  string
 	kerberosEnvvarValue         string
 	tlsEncryptionEnvvarValue    string
 	tlsAllowPlainEnvvarValue    string
@@ -48,15 +49,24 @@ var listenerTests = []struct {
 	expectedAdvertisedListeners string
 }{
 	{ // Everything false
+		advertiseHostIPEnvvarValue:  "false",
 		kerberosEnvvarValue:         "false",
 		tlsEncryptionEnvvarValue:    "false",
 		tlsAllowPlainEnvvarValue:    "false",
 		expectedListeners:           "listeners=PLAINTEXT://127.0.0.1:1000",
-		expectedAdvertisedListeners: "advertised.listeners=PLAINTEXT://a-task.a-framework:1000",
+		expectedAdvertisedListeners: "",
+	},
+	{ // Everything false except advertise host ip
+		advertiseHostIPEnvvarValue:  "true",
+		kerberosEnvvarValue:         "false",
+		tlsEncryptionEnvvarValue:    "false",
+		tlsAllowPlainEnvvarValue:    "false",
+		expectedListeners:           "listeners=PLAINTEXT://127.0.0.1:1000",
+		expectedAdvertisedListeners: "advertised.listeners=PLAINTEXT://127.0.0.1:1000",
 	},
 	{ // None of the booleans set.
 		expectedListeners:           "listeners=PLAINTEXT://127.0.0.1:1000",
-		expectedAdvertisedListeners: "advertised.listeners=PLAINTEXT://a-task.a-framework:1000",
+		expectedAdvertisedListeners: "",
 	},
 	{ // Kerberos enabled, no TLS
 		kerberosEnvvarValue:         "true",
@@ -87,6 +97,7 @@ var listenerTests = []struct {
 		expectedAdvertisedListeners: "advertised.listeners=SSL://a-task.a-framework:1001",
 	},
 	{ // Kerberos disabled, TLS enabled, Plaintext allowed
+		advertiseHostIPEnvvarValue:  "false",
 		kerberosEnvvarValue:         "false",
 		tlsEncryptionEnvvarValue:    "true",
 		tlsAllowPlainEnvvarValue:    "true",
@@ -105,6 +116,7 @@ func TestSetListeners(t *testing.T) {
 
 		// Set the envvars
 		os.Clearenv()
+		setEnv(advertiseHostIPEnvvar, test.advertiseHostIPEnvvarValue)
 		setEnv(kerberosEnvvar, test.kerberosEnvvarValue)
 		setEnv(tlsEncryptionEnvvar, test.tlsEncryptionEnvvarValue)
 		setEnv(tlsAllowPlainEnvvar, test.tlsAllowPlainEnvvarValue)

--- a/frameworks/kafka/universe/config.json
+++ b/frameworks/kafka/universe/config.json
@@ -306,7 +306,7 @@
           "default": true
         },
         "kafka_advertise_host_ip": {
-          "description": "DEPRECATED: This configuration parameter has been deprecated and will be removed in a future release. When set to true, and no security settings are enabled, kafka's advertised.listeners property is set to PLAINTEXT://<broker-ip>:<broker-port>. When the setting is false and no security is enabled, then advertised.listeners is NOT set. When security is enabled, the advertised.listeners property will be set to broker hostnames.",
+          "description": "[DEPRECATED] This configuration parameter has been deprecated and will be removed in a future release. When set to true, and no security settings are enabled, kafka's advertised.listeners property is set to PLAINTEXT://<broker-ip>:<broker-port>. When the setting is false and no security is enabled, then advertised.listeners is NOT set. When security is enabled, the advertised.listeners property will be set to broker hostnames.",
           "type": "boolean",
           "default": true
         },

--- a/frameworks/kafka/universe/config.json
+++ b/frameworks/kafka/universe/config.json
@@ -306,7 +306,7 @@
           "default": true
         },
         "kafka_advertise_host_ip": {
-          "description": "Automatically configure advertised.host.name with the tasks' IP address",
+          "description": "DEPRECATED: This configuration parameter has been deprecated and will be removed in a future release. When set to true, and no security settings are enabled, kafka's advertised.listeners property is set to PLAINTEXT://<broker-ip>:<broker-port>. When the setting is false and no security is enabled, then advertised.listeners is NOT set. When security is enabled, the advertised.listeners property will be set to broker hostnames.",
           "type": "boolean",
           "default": true
         },


### PR DESCRIPTION
Only advertise IPs when security is not enabled.

This is consistent with the current behavior in 2.0.X.