### PR TITLE
INFINITY-3211 Fix flakes in TaskKiller unit tests

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/TaskKiller.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/TaskKiller.java
@@ -24,36 +24,43 @@ import java.util.stream.Collectors;
 public final class TaskKiller {
     private static final Logger LOGGER = LoggerFactory.getLogger(TaskKiller.class);
 
-    private static final Duration killInterval = Duration.ofSeconds(5);
-    private static final Set<TaskID> tasksToKill = new HashSet<>();
-    private static final Object lock = new Object();
+    private static final Duration KILL_INTERVAL = Duration.ofSeconds(5);
+    private static final Set<TaskID> TASKS_TO_KILL = new HashSet<>();
+    private static final Object LOCK = new Object();
 
+    /**
+     * After the first task kill, this executor will be created and will periodically reissue kill invocations for any
+     * tasks which haven't produced a dead or unknown status. We do this because the Mesos kill command is best-effort.
+     */
     private static ScheduledExecutorService executor;
-    private static TaskKiller taskKiller = new TaskKiller();
+
+    /**
+     * Whether the above executor should be running. Only disabled for tests.
+     */
+    private static boolean executorEnabled = true;
 
     private TaskKiller() {
-        startScheduling();
+        // Do not instantiate
     }
 
+    /**
+     * Resets the {@link TaskKiller}'s internal state for tests.
+     *
+     * @param executorEnabled whether the background kill executor should be enabled, should only be disabled in tests
+     */
     @VisibleForTesting
-    static void shutdownScheduling() throws InterruptedException {
-        executor.shutdownNow();
-        executor.awaitTermination(killInterval.toMillis(), TimeUnit.MILLISECONDS);
-    }
+    public static void reset(boolean executorEnabled) throws InterruptedException {
+        synchronized (LOCK) {
+            if (executor != null) {
+                executor.shutdownNow();
+                executor.awaitTermination(KILL_INTERVAL.toMillis(), TimeUnit.MILLISECONDS);
+            }
+            executor = null;
 
-    @VisibleForTesting
-    static void startScheduling() {
-        executor = Executors.newSingleThreadScheduledExecutor();
-        executor.scheduleAtFixedRate(
-                new Runnable() {
-                    @Override
-                    public void run() {
-                        killAllTasks();
-                    }
-                },
-                killInterval.toMillis(),
-                killInterval.toMillis(),
-                TimeUnit.MILLISECONDS);
+            TASKS_TO_KILL.clear();
+
+            TaskKiller.executorEnabled = executorEnabled;
+        }
     }
 
     /**
@@ -74,25 +81,44 @@ public final class TaskKiller {
             return;
         }
 
-        synchronized (lock) {
-            LOGGER.info("Enqueueing kill of task: {}", taskId.getValue());
-            tasksToKill.add(taskId);
+        synchronized (LOCK) {
+            TASKS_TO_KILL.add(taskId);
+            LOGGER.info("Enqueued kill of task: {}, {} tasks to kill: {}",
+                    taskId.getValue(),
+                    TASKS_TO_KILL.size(),
+                    TASKS_TO_KILL.stream().map(t -> t.getValue()).collect(Collectors.toList()));
+
+            // Initialize the executor if enabled and not already running.
+            if (executor == null && executorEnabled) {
+                LOGGER.info("Initializing scheduled executor with an interval of {}s", KILL_INTERVAL.getSeconds());
+                executor = Executors.newSingleThreadScheduledExecutor();
+                executor.scheduleAtFixedRate(
+                        new Runnable() {
+                            @Override
+                            public void run() {
+                                killAllTasks();
+                            }
+                        },
+                        KILL_INTERVAL.toMillis(),
+                        KILL_INTERVAL.toMillis(),
+                        TimeUnit.MILLISECONDS);
+            }
         }
 
+        // Finally, try invoking the task kill (if driver is set).
         killTaskInternal(taskId);
     }
 
     public static void update(Protos.TaskStatus taskStatus) {
         if (isDead(taskStatus)) {
-            synchronized (lock) {
-                if (tasksToKill.remove(taskStatus.getTaskId())) {
-                    LOGGER.info("Completed killing: {}, remaining tasks to kill: {}",
+            synchronized (LOCK) {
+                if (TASKS_TO_KILL.remove(taskStatus.getTaskId())) {
+                    LOGGER.info("Completed killing: {}, {} remaining tasks to kill: {}",
                             taskStatus.getTaskId().getValue(),
-                            tasksToKill.stream().map(t -> t.getValue()).collect(Collectors.toList()));
+                            TASKS_TO_KILL.size(),
+                            TASKS_TO_KILL.stream().map(t -> t.getValue()).collect(Collectors.toList()));
                 } else {
-                    LOGGER.warn(
-                            "Attempted to complete killing of unexpected task: {}",
-                            taskStatus.getTaskId().getValue());
+                    LOGGER.warn("Task was not scheduled for killing: {}", taskStatus.getTaskId().getValue());
                 }
             }
         }
@@ -101,8 +127,8 @@ public final class TaskKiller {
     @VisibleForTesting
     static void killAllTasks() {
         Set<TaskID> copy;
-        synchronized (lock) {
-            copy = new HashSet<>(tasksToKill);
+        synchronized (LOCK) {
+            copy = new HashSet<>(TASKS_TO_KILL);
         }
 
         for (TaskID taskId : copy) {

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/http/PodResourceTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/http/PodResourceTest.java
@@ -4,6 +4,7 @@ import com.mesosphere.sdk.http.types.TaskInfoAndStatus;
 import com.mesosphere.sdk.offer.CommonIdUtils;
 import com.mesosphere.sdk.offer.taskdata.TaskLabelWriter;
 import com.mesosphere.sdk.scheduler.Driver;
+import com.mesosphere.sdk.scheduler.TaskKiller;
 import com.mesosphere.sdk.scheduler.recovery.TaskFailureListener;
 import com.mesosphere.sdk.state.GoalStateOverride;
 import com.mesosphere.sdk.state.StateStore;
@@ -16,7 +17,9 @@ import org.apache.mesos.Protos.TaskStatus;
 import org.apache.mesos.SchedulerDriver;
 import org.json.JSONArray;
 import org.json.JSONObject;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -115,6 +118,16 @@ public class PodResourceTest {
     @Mock private SchedulerDriver driver;
 
     private PodResource resource;
+
+    @BeforeClass
+    public static void beforeAll() throws InterruptedException {
+        TaskKiller.reset(false); // disable background executor to avoid unexpected calls
+    }
+
+    @AfterClass
+    public static void afterAll() throws InterruptedException {
+        TaskKiller.reset(true); // reenable background executor to return to default behavior
+    }
 
     @Before
     public void beforeEach() {

--- a/sdk/testing/src/main/java/com/mesosphere/sdk/testing/ServiceTestRunner.java
+++ b/sdk/testing/src/main/java/com/mesosphere/sdk/testing/ServiceTestRunner.java
@@ -6,6 +6,7 @@ import com.mesosphere.sdk.offer.evaluate.PodInfoBuilder;
 import com.mesosphere.sdk.scheduler.AbstractScheduler;
 import com.mesosphere.sdk.scheduler.DefaultScheduler;
 import com.mesosphere.sdk.scheduler.SchedulerConfig;
+import com.mesosphere.sdk.scheduler.TaskKiller;
 import com.mesosphere.sdk.scheduler.plan.DefaultPodInstance;
 import com.mesosphere.sdk.scheduler.recovery.RecoveryPlanOverriderFactory;
 import com.mesosphere.sdk.specification.*;
@@ -296,6 +297,9 @@ public class ServiceTestRunner {
         Mockito.when(mockCapabilities.supportsDefaultExecutor()).thenReturn(supportsDefaultExecutor);
         Capabilities.overrideCapabilities(mockCapabilities);
 
+        // Disable background TaskKiller thread, to avoid erroneous kill invocations
+        TaskKiller.reset(false);
+
         Map<String, String> schedulerEnvironment =
                 CosmosRenderer.renderSchedulerEnvironment(cosmosOptions, buildTemplateParams);
         schedulerEnvironment.putAll(customSchedulerEnv);
@@ -351,6 +355,9 @@ public class ServiceTestRunner {
 
         // Reset Capabilities API to default behavior:
         Capabilities.overrideCapabilities(null);
+
+        // Re-enable background TaskKiller thread for other tests
+        TaskKiller.reset(true);
 
         return new ServiceTestResult(
                 serviceSpec, rawServiceSpec, schedulerEnvironment, taskConfigs, persister, clusterState);


### PR DESCRIPTION
Support disabling the background executor in tests, so that it doesn't kill tasks when we don't expect it.