### PR TITLE
[INFINITY-3285] Fix HDFS tests using client docker container

### DIFF
--- a/frameworks/hdfs/tests/test_active_directory_auth.py
+++ b/frameworks/hdfs/tests/test_active_directory_auth.py
@@ -120,7 +120,7 @@ def hdfs_client(kerberos, hdfs_server):
             "container": {
                 "type": "MESOS",
                 "docker": {
-                    "image": "nvaziri/hdfs-client:dev",
+                    "image": "elezar/hdfs-client:dev",
                     "forcePullImage": True
                 },
                 "volumes": [

--- a/frameworks/hdfs/tools/hdfsclient.json
+++ b/frameworks/hdfs/tools/hdfsclient.json
@@ -5,7 +5,7 @@
     "container": {
         "type": "MESOS",
         "docker": {
-            "image": "nvaziri/hdfs-client:dev",
+            "image": "elezar/hdfs-client:dev",
             "forcePullImage": true
         },
         "volumes": [


### PR DESCRIPTION
The PR switches to `elezar/hdfs-client:dev` (originally based off `nvaziri/hdfs-client:dev`) but without the regression pushed yesterday.