### PR TITLE
Derive Kafka version from a single source.

### DIFF
--- a/frameworks/kafka/build.sh
+++ b/frameworks/kafka/build.sh
@@ -4,6 +4,9 @@ set -e
 FRAMEWORK_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 REPO_ROOT_DIR=$(dirname $(dirname $FRAMEWORK_DIR))
 
+# grab TEMPLATE_x vars for use in universe template:
+source $FRAMEWORK_DIR/versions.sh
+
 # Build SDK artifacts (executor, bootstrap) to be included in our release, but skip SDK tests
 # since since that's not in our scope. Projects that aren't colocated in dcos-commons should skip
 # this step, and should omit the "REPO_ROOT_DIR" artifacts listed below.

--- a/frameworks/kafka/src/test/java/com/mesosphere/sdk/kafka/scheduler/ServiceTest.java
+++ b/frameworks/kafka/src/test/java/com/mesosphere/sdk/kafka/scheduler/ServiceTest.java
@@ -41,6 +41,7 @@ public class ServiceTest {
         map.put("SETUP_HELPER_SUPER_USERS", "User:fake"); // set by setup-helper
 
         return new ServiceTestRunner()
-                .setPodEnv("kafka", map);
+                .setPodEnv("kafka", map)
+                .setBuildTemplateParams("kafka-version", "2.11-1.0.0"); // set by build.sh/versions.sh
     }
 }

--- a/frameworks/kafka/universe/marathon.json.mustache
+++ b/frameworks/kafka/universe/marathon.json.mustache
@@ -43,6 +43,7 @@
     "SETUP_HELPER_URI": "{{resource.assets.uris.setup-helper-zip}}",
     "ZOOKEEPER_CLIENT_URI": "{{resource.assets.uris.zookeeper-client-jar}}",
     "CUSTOM_KAFKA_PRINCIPAL_URI": "{{resource.assets.uris.custom-kafka-principal-jar}}",
+    "KAFKA_VERSION": "{{kafka-version}}",
 
     "PLACEMENT_CONSTRAINTS": "{{{service.placement_constraint}}}",
     "DEPLOY_STRATEGY":"{{service.deploy_strategy}}",
@@ -108,7 +109,7 @@
     "TASKCFG_ALL_SECURITY_AUTHORIZATION_ALLOW_EVERYONE_IF_NO_ACL_FOUND": "{{service.security.authorization.allow_everyone_if_no_acl_found}}",
     {{/service.security.authorization.enabled}}
 
-    "KAFKA_VERSION_PATH": "kafka_2.11-1.0.0",
+    "KAFKA_VERSION_PATH": "kafka_{{kafka-version}}",
 
     "KAFKA_ZOOKEEPER_URI": "{{kafka.kafka_zookeeper_uri}}",
 

--- a/frameworks/kafka/universe/resource.json
+++ b/frameworks/kafka/universe/resource.json
@@ -4,7 +4,7 @@
       "jre-tar-gz": "{{jre-url}}",
       "libmesos-bundle-tar-gz": "{{libmesos-bundle-url}}",
       "bootstrap-zip": "{{artifact-dir}}/bootstrap.zip",
-      "kafka-tgz": "https://downloads.mesosphere.com/kafka/assets/kafka_2.11-1.0.0.tgz",
+      "kafka-tgz": "https://downloads.mesosphere.com/kafka/assets/kafka_{{kafka-version}}.tgz",
       "kafka-jre-tar-gz": "{{jre-url}}",
       "kafka-scheduler-zip": "{{artifact-dir}}/kafka-scheduler.zip",
       "executor-zip": "{{artifact-dir}}/executor.zip",

--- a/frameworks/kafka/versions.sh
+++ b/frameworks/kafka/versions.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+export TEMPLATE_KAFKA_VERSION="2.11-1.0.0"


### PR DESCRIPTION
This should make upgrading the base tech easier and avoid weird version template value mismatch errors like https://jira.mesosphere.com/browse/DCOS_KAFKA-27