### PR TITLE
[KAF-409] Add all the missing properties to the plumbing (#2323)

### DIFF
--- a/frameworks/kafka/src/main/dist/server.properties.mustache
+++ b/frameworks/kafka/src/main/dist/server.properties.mustache
@@ -125,8 +125,9 @@ num.recovery.threads.per.data.dir={{KAFKA_NUM_RECOVERY_THREADS_PER_DATA_DIR}}
 # The number of messages to accept before forcing a flush of data to disk
 log.flush.interval.messages={{KAFKA_LOG_FLUSH_INTERVAL_MESSAGES}}
 
-# The maximum amount of time a message can sit in a log before we force a flush
-#log.flush.interval.ms=1000
+{{#KAFKA_LOG_FLUSH_INTERVAL_MS}}
+log.flush.interval.ms={{KAFKA_LOG_FLUSH_INTERVAL_MS}}
+{{/KAFKA_LOG_FLUSH_INTERVAL_MS}}
 
 ############################# Log Retention Policy #############################
 
@@ -136,6 +137,12 @@ log.flush.interval.messages={{KAFKA_LOG_FLUSH_INTERVAL_MESSAGES}}
 # from the end of the log.
 
 # The minimum age of a log file to be eligible for deletion
+{{#KAFKA_LOG_RETENTION_MS}}
+log.retention.ms={{KAFKA_LOG_RETENTION_MS}}
+{{/KAFKA_LOG_RETENTION_MS}}
+{{#KAFKA_LOG_RETENTION_MINUTES}}
+log.retention.minutes={{KAFKA_LOG_RETENTION_MINUTES}}
+{{/KAFKA_LOG_RETENTION_MINUTES}}
 log.retention.hours={{KAFKA_LOG_RETENTION_HOURS}}
 
 # A size-based retention policy for logs. Segments are pruned from the log as long as the remaining
@@ -188,10 +195,13 @@ default.replication.factor={{KAFKA_DEFAULT_REPLICATION_FACTOR}}
 
 delete.topic.enable={{KAFKA_DELETE_TOPIC_ENABLE}}
 
+delete.records.purgatory.purge.interval.requests={{KAFKA_DELETE_RECORDS_PURGATORY_PURGE_INTERVAL_REQUESTS}}
+
 fetch.purgatory.purge.interval.requests={{KAFKA_FETCH_PURGATORY_PURGE_INTERVAL_REQUESTS}}
 
 group.max.session.timeout.ms={{KAFKA_GROUP_MAX_SESSION_TIMEOUT_MS}}
 group.min.session.timeout.ms={{KAFKA_GROUP_MIN_SESSION_TIMEOUT_MS}}
+group.initial.rebalance.delay.ms={{KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS}}
 
 inter.broker.protocol.version={{KAFKA_INTER_BROKER_PROTOCOL_VERSION}}
 
@@ -206,11 +216,13 @@ log.cleaner.io.buffer.load.factor={{KAFKA_LOG_CLEANER_IO_BUFFER_LOAD_FACTOR}}
 log.cleaner.io.buffer.size={{KAFKA_LOG_CLEANER_IO_BUFFER_SIZE}}
 log.cleaner.io.max.bytes.per.second={{KAFKA_LOG_CLEANER_IO_MAX_BYTES_PER_SECOND}}
 log.cleaner.min.cleanable.ratio={{KAFKA_LOG_CLEANER_MIN_CLEANABLE_RATIO}}
+log.cleaner.min.compaction.lag.ms={{KAFKA_LOG_CLEANER_MIN_COMPACTION_LAG_MS}}
 log.cleaner.threads={{KAFKA_LOG_CLEANER_THREADS}}
 log.cleanup.policy={{KAFKA_LOG_CLEANUP_POLICY}}
 
 log.flush.offset.checkpoint.interval.ms={{KAFKA_LOG_FLUSH_OFFSET_CHECKPOINT_INTERVAL_MS}}
 log.flush.scheduler.interval.ms={{KAFKA_LOG_FLUSH_SCHEDULER_INTERVAL_MS}}
+log.flush.start.offset.checkpoint.interval.ms={{KAFKA_LOG_FLUSH_START_OFFSET_CHECKPOINT_INTERVAL_MS}}
 
 log.index.interval.bytes={{KAFKA_LOG_INDEX_INTERVAL_BYTES}}
 log.index.size.max.bytes={{KAFKA_LOG_INDEX_SIZE_MAX_BYTES}}
@@ -219,7 +231,13 @@ log.message.format.version={{KAFKA_LOG_MESSAGE_FORMAT_VERSION}}
 
 log.preallocate={{KAFKA_LOG_PREALLOCATE}}
 
+{{#KAFKA_LOG_ROLL_MS}}
+log.roll.ms={{KAFKA_LOG_ROLL_MS}}
+{{/KAFKA_LOG_ROLL_MS}}
 log.roll.hours={{KAFKA_LOG_ROLL_HOURS}}
+{{#KAFKA_LOG_ROLL_JITTER_MS}}
+log.roll.jitter.ms={{KAFKA_LOG_ROLL_JITTER_MS}}
+{{/KAFKA_LOG_ROLL_JITTER_MS}}
 log.roll.jitter.hours={{KAFKA_LOG_ROLL_JITTER_HOURS}}
 
 log.segment.delete.delay.ms={{KAFKA_LOG_SEGMENT_DELETE_DELAY_MS}}
@@ -252,6 +270,7 @@ offsets.topic.segment.bytes={{KAFKA_OFFSETS_TOPIC_SEGMENT_BYTES}}
 producer.purgatory.purge.interval.requests={{KAFKA_PRODUCER_PURGATORY_PURGE_INTERVAL_REQUESTS}}
 
 queued.max.requests={{KAFKA_QUEUED_MAX_REQUESTS}}
+queued.max.request.bytes={{KAFKA_QUEUED_MAX_REQUEST_BYTES}}
 quota.consumer.default={{KAFKA_QUOTA_CONSUMER_DEFAULT}}
 quota.producer.default={{KAFKA_QUOTA_PRODUCER_DEFAULT}}
 quota.window.num={{KAFKA_QUOTA_WINDOW_NUM}}
@@ -260,15 +279,29 @@ quota.window.size.seconds={{KAFKA_QUOTA_WINDOW_SIZE_SECONDS}}
 replica.fetch.backoff.ms={{KAFKA_REPLICA_FETCH_BACKOFF_MS}}
 replica.fetch.max.bytes={{KAFKA_REPLICA_FETCH_MAX_BYTES}}
 replica.fetch.min.bytes={{KAFKA_REPLICA_FETCH_MIN_BYTES}}
+replica.fetch.response.max.bytes={{KAFKA_REPLICA_FETCH_RESPONSE_MAX_BYTES}}
 replica.fetch.wait.max.ms={{KAFKA_REPLICA_FETCH_WAIT_MAX_MS}}
 replica.high.watermark.checkpoint.interval.ms={{KAFKA_REPLICA_HIGH_WATERMARK_CHECKPOINT_INTERVAL_MS}}
 replica.lag.time.max.ms={{KAFKA_REPLICA_LAG_TIME_MAX_MS}}
 replica.socket.receive.buffer.bytes={{KAFKA_REPLICA_SOCKET_RECEIVE_BUFFER_BYTES}}
 replica.socket.timeout.ms={{KAFKA_REPLICA_SOCKET_TIMEOUT_MS}}
 
+replication.quota.window.num={{KAFKA_REPLICATION_QUOTA_WINDOW_NUM}}
+replication.quota.window.size.seconds={{KAFKA_REPLICATION_QUOTA_WINDOW_SIZE_SECONDS}}
+
 request.timeout.ms={{KAFKA_REQUEST_TIMEOUT_MS}}
 
 reserved.broker.max.id={{KAFKA_RESERVED_BROKER_MAX_ID}}
+
+transaction.state.log.segment.bytes={{KAFKA_TRANSACTION_STATE_LOG_SEGMENT_BYTES}}
+transaction.remove.expired.transaction.cleanup.interval.ms={{KAFKA_TRANSACTION_REMOVE_EXPIRED_TRANSACTION_CLEANUP_INTERVAL_MS}}
+transaction.max.timeout.ms={{KAFKA_TRANSACTION_MAX_TIMEOUT_MS}}
+transaction.state.log.num.partitions={{KAFKA_TRANSACTION_STATE_LOG_NUM_PARTITIONS}}
+transaction.abort.timed.out.transaction.cleanup.interval.ms={{KAFKA_TRANSACTION_ABORT_TIMED_OUT_TRANSACTION_CLEANUP_INTERVAL_MS}}
+transaction.state.log.load.buffer.size={{KAFKA_TRANSACTION_STATE_LOG_LOAD_BUFFER_SIZE}}
+transactional.id.expiration.ms={{KAFKA_TRANSACTIONAL_ID_EXPIRATION_MS}}
+transaction.state.log.replication.factor={{KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR}}
+transaction.state.log.min.isr={{KAFKA_TRANSACTION_STATE_LOG_MIN_ISR}}
 
 unclean.leader.election.enable={{KAFKA_UNCLEAN_LEADER_ELECTION_ENABLE}}
 

--- a/frameworks/kafka/universe/config.json
+++ b/frameworks/kafka/universe/config.json
@@ -301,7 +301,7 @@
         },
         "auto_create_topics_enable": {
           "title": "auto.create.topics.enable",
-          "description": "Enables auto creation of topic on the server",
+          "description": "Enable auto creation of topic on the server",
           "type": "boolean",
           "default": true
         },
@@ -320,11 +320,12 @@
           "title": "background.threads",
           "description": "The number of threads to use for various background processing tasks",
           "type": "integer",
-          "default": 10
+          "default": 10,
+          "minimum": 1
         },
         "compression_type": {
           "title": "compression.type",
-          "description": "Specify the final compression type for a given topic. This configuration accepts the standard compression codecs ('gzip', 'snappy', lz4). It additionally accepts 'uncompressed' which is equivalent to no compression; and 'producer' which means retain the original compression codec set by the producer.",
+          "description": "Specify the final compression type for a given topic. This configuration accepts the standard compression codecs ('gzip', 'snappy', 'lz4'). It additionally accepts 'uncompressed' which is equivalent to no compression; and 'producer' which means retain the original compression codec set by the producer.",
           "type": "string",
           "default": "producer"
         },
@@ -333,6 +334,12 @@
           "description": "Enables delete topic. Delete topic through the admin tool will have no effect if this config is turned off",
           "type": "boolean",
           "default": false
+        },
+        "delete_records_purgatory_purge_interval_requests": {
+          "title": "delete.records.purgatory.purge.interval.requests",
+          "description": "The purge interval (in number of requests) of the delete records request purgatory",
+          "type": "integer",
+          "default": 1
         },
         "leader_imbalance_check_interval_seconds": {
           "title": "leader.imbalance.check.interval.seconds",
@@ -352,11 +359,17 @@
           "type": "string",
           "default": "9223372036854775807"
         },
+        "log_flush_interval_ms": {
+          "title": "log.flush.interval.ms",
+          "description": "The maximum time in ms that a message in any topic is kept in memory before flushed to disk. If not set, the value in log.flush.scheduler.interval.ms is used",
+          "type": "integer"
+        },
         "log_flush_offset_checkpoint_interval_ms": {
           "title": "log.flush.offset.checkpoint.interval.ms",
           "description": "The frequency with which we update the persistent record of the last flush which acts as the log recovery point",
           "type": "integer",
-          "default": 60000
+          "default": 60000,
+          "minimum": 0
         },
         "log_flush_scheduler_interval_ms": {
           "title": "log.flush.scheduler.interval.ms",
@@ -364,11 +377,28 @@
           "type": "string",
           "default": "9223372036854775807"
         },
+        "log_flush_start_offset_checkpoint_interval_ms": {
+          "title": "log.flush.start.offset.checkpoint.interval.ms",
+          "description": "The frequency with which we update the persistent record of log start offset",
+          "type": "integer",
+          "default": 60000,
+          "minimum": 0
+        },
         "log_retention_bytes": {
           "title": "log.retention.bytes",
           "description": "The maximum size of the log before deleting it",
           "type": "string",
           "default": "-1"
+        },
+        "log_retention_ms": {
+          "title": "log.retention.ms",
+          "description": "The number of milliseconds to keep a log file before deleting it (in milliseconds), If not set, the value in log.retention.minutes is used",
+          "type": "integer"
+        },
+        "log_retention_minutes": {
+          "title": "log.retention.minutes",
+          "description": "The number of minutes to keep a log file before deleting it (in minutes), secondary to log.retention.ms property. If not set, the value in log.retention.hours is used",
+          "type": "integer"
         },
         "log_retention_hours": {
           "title": "log.retention.hours",
@@ -376,59 +406,78 @@
           "type": "integer",
           "default": 168
         },
+        "log_roll_ms": {
+          "title": "log.roll.ms",
+          "description": "The maximum time before a new log segment is rolled out (in milliseconds). If not set, the value in log.roll.hours is used",
+          "type": "integer"
+        },
+        "log_roll_jitter_ms": {
+          "title": "log.roll.jitter.ms",
+          "description": "The maximum jitter to subtract from logRollTimeMillis (in milliseconds). If not set, the value in log.roll.jitter.hours is used",
+          "type": "integer"
+        },
         "log_roll_hours": {
           "title": "log.roll.hours",
           "description": "The maximum time before a new log segment is rolled out (in hours), secondary to log.roll.ms property",
           "type": "integer",
-          "default": 168
+          "default": 168,
+          "minimum": 1
         },
         "log_roll_jitter_hours": {
           "title": "log.roll.jitter.hours",
           "description": "The maximum jitter to subtract from logRollTimeMillis (in hours), secondary to log.roll.jitter.ms property",
           "type": "integer",
-          "default": 0
+          "default": 0,
+          "minimum": 0
         },
         "log_segment_bytes": {
           "title": "log.segment.bytes",
           "description": "The maximum size of a single log file",
           "type": "integer",
-          "default": 1073741824
+          "default": 1073741824,
+          "minimum": 14
         },
         "log_segment_delete_delay_ms": {
           "title": "log.segment.delete.delay.ms",
           "description": "The amount of time to wait before deleting a file from the filesystem",
           "type": "integer",
-          "default": 60000
+          "default": 60000,
+          "minimum": 0
         },
         "message_max_bytes": {
           "title": "message.max.bytes",
-          "description": "The maximum size of message that the server can receive",
+          "description": "The largest record batch size allowed by Kafka. If this is increased and there are consumers older than 0.10.2, the consumers' fetch size must also be increased so that the they can fetch record batches this large.\nIn the latest message format version, records are always grouped into batches for efficiency. In previous message format versions, uncompressed records are not grouped into batches and this limit only applies to a single record in that case.\nThis can be set per topic with the topic level max.message.bytes config.",
           "type": "integer",
-          "default": 1000012
+          "default": 1000012,
+          "minimum": 0
         },
         "min_insync_replicas": {
           "title": "min.insync.replicas",
-          "description": "define the minimum number of replicas in ISR needed to satisfy a produce request with required.acks=-1 (or all)",
+          "description": "When a producer sets acks to \"all\" (or \"-1\"), min.insync.replicas specifies the minimum number of replicas that must acknowledge a write for the write to be considered successful. If this minimum cannot be met, then the producer will raise an exception (either NotEnoughReplicas or NotEnoughReplicasAfterAppend).\nWhen used together, min.insync.replicas and acks allow you to enforce greater durability guarantees. A typical scenario would be to create a topic with a replication factor of 3, set min.insync.replicas to 2, and produce with acks of \"all\". This will ensure that the producer raises an exception if a majority of replicas do not receive a write.",
           "type": "integer",
-          "default": 1
+          "default": 1,
+          "minimum": 1
         },
         "num_io_threads": {
-          "title": "num.io.thread",
-          "description": "The number of io threads that the server uses for carrying out network requests",
+          "title": "num.io.threads",
+          "description": "The number of threads that the server uses for processing requests, which may include disk I/O",
           "type": "integer",
-          "default": 8
+          "default": 8,
+          "minimum": 1
         },
         "num_network_threads": {
           "title": "num.network.threads",
-          "description": "The number of network threads that the server uses for handling network requests",
+          "description": "The number of threads that the server uses for receiving requests from the network and sending responses to the network",
           "type": "integer",
-          "default": 3
+          "default": 3,
+          "minimum": 1
         },
         "num_recovery_threads_per_data_dir": {
           "title": "num.recovery.threads.per.data.dir",
           "description": "The number of threads per data directory to be used for log recovery at startup and flushing at shutdown",
           "type": "integer",
-          "default": 1
+          "default": 1,
+          "minimum": 1
         },
         "num_replica_fetchers": {
           "title": "num.replica.fetchers",
@@ -452,71 +501,85 @@
           "title": "offsets.commit.timeout.ms",
           "description": "Offset commit will be delayed until all replicas for the offsets topic receive the commit or this timeout is reached. This is similar to the producer request timeout.",
           "type": "integer",
-          "default": 5000
+          "default": 5000,
+          "minimum": 1
         },
         "offsets_load_buffer_size": {
           "title": "offsets.load.buffer.size",
           "description": "Batch size for reading from the offsets segments when loading offsets into the cache.",
           "type": "integer",
-          "default": 5242880
+          "default": 5242880,
+          "minimum": 1
         },
         "offsets_retention_check_interval_ms": {
           "title": "offsets.retention.check.interval.ms",
           "description": "Frequency at which to check for stale offsets",
           "type": "integer",
-          "default": 600000
+          "default": 600000,
+          "minimum": 1
         },
         "offsets_retention_minutes": {
           "title": "offsets.retention.minutes",
-          "description": "Log retention window in minutes for offsets topic",
+          "description": "Offsets older than this retention period will be discarded",
           "type": "integer",
-          "default": 1440
+          "default": 1440,
+          "minimum": 1
         },
         "offsets_topic_compression_codec": {
           "title": "offsets.topic.compression.codec",
-          "description": "Compression codec for the offsets topic - compression may be used to achieve 'atomic' commits",
+          "description": "Compression codec for the offsets topic - compression may be used to achieve \"atomic\" commits",
           "type": "integer",
           "default": 0
         },
         "offsets_topic_num_partitions": {
           "title": "offsets.topic.num.partitions",
-          "description": "The number of partitions for the offset commit topic (should not change after deployment).",
+          "description": "The number of partitions for the offset commit topic (should not change after deployment)",
           "type": "integer",
-          "default": 50
+          "default": 50,
+          "minimum": 1
         },
         "offsets_topic_replication_factor": {
           "title": "offsets.topic.replication.factor",
-          "description": "The replication factor for the offsets topic (set higher to ensure availability). To ensure that the effective replication factor of the offsets topic is the configured value, the number of alive brokers has to be at least the replication factor at the time of the first request for the offsets topic. If not, either the offsets topic creation will fail or it will get a replication factor of min(alive brokers, configured replication factor)",
+          "description": "The replication factor for the offsets topic (set higher to ensure availability). Internal topic creation will fail until the cluster size meets this replication factor requirement.",
           "type": "integer",
-          "default": 3
+          "default": 3,
+          "minimum": 1
         },
         "offsets_topic_segment_bytes": {
           "title": "offsets.topic.segment.bytes",
           "description": "The offsets topic segment bytes should be kept relatively small in order to facilitate faster log compaction and cache loads",
           "type": "integer",
-          "default": 104857600
+          "default": 104857600,
+          "minimum": 1
         },
         "queued_max_requests": {
           "title": "queued.max.requests",
-          "description": "The number of queued requests allowed before blocking the network threads ",
+          "description": "The number of queued requests allowed before blocking the network threads",
           "type": "integer",
-          "default": 500
+          "default": 500,
+          "minimum": 1
+        },
+        "queued_max_request_bytes": {
+          "title": "queued.max.request.bytes",
+          "description": "The number of queued bytes allowed before no more requests are read",
+          "type": "integer",
+          "default": -1
         },
         "quota_consumer_default": {
           "title": "quota.consumer.default",
-          "description": "Any consumer distinguished by clientId/consumer group will get throttled if it fetches more bytes than this value per-second",
+          "description": "Used only when dynamic default quotas are not configured for or in Zookeeper. Any consumer distinguished by clientId/consumer group will get throttled if it fetches more bytes than this value per-second",
           "type": "string",
           "default": "9223372036854775807"
         },
         "quota_producer_default": {
           "title": "quota.producer.default",
-          "description": "Any producer distinguished by clientId will get throttled if it produces more bytes than this value per-second",
+          "description": "Used only when dynamic default quotas are not configured for , or in Zookeeper. Any producer distinguished by clientId will get throttled if it produces more bytes than this value per-second",
           "type": "string",
           "default": "9223372036854775807"
         },
         "replica_fetch_max_bytes": {
           "title": "replica.fetch.max.bytes",
-          "description": "The number of byes of messages to attempt to fetch",
+          "description": "The number of bytes of messages to attempt to fetch for each partition. This is not an absolute maximum, if the first record batch in the first non-empty partition of the fetch is larger than this value, the record batch will still be returned to ensure that progress can be made. The maximum record batch size accepted by the broker is defined via message.max.bytes (broker config) or max.message.bytes (topic config).",
           "type": "integer",
           "default": 1048576
         },
@@ -531,6 +594,13 @@
           "description": "Max wait time for each fetcher request issued by follower replicas. This value should always be less than the replica.lag.time.max.ms at all times to prevent frequent shrinking of ISR for low throughput topics",
           "type": "integer",
           "default": 500
+        },
+        "replica_fetch_response_max_bytes": {
+          "title": "replica.fetch.response.max.bytes",
+          "description": "Maximum bytes expected for the entire fetch response. Records are fetched in batches, and if the first record batch in the first non-empty partition of the fetch is larger than this value, the record batch will still be returned to ensure that progress can be made. As such, this is not an absolute maximum. The maximum record batch size accepted by the broker is defined via message.max.bytes (broker config) or max.message.bytes (topic config).",
+          "type": "integer",
+          "default": 10485760,
+          "minimum": 0
         },
         "replica_high_watermark_checkpoint_interval_ms": {
           "title": "replica.high.watermark.checkpoint.interval.ms",
@@ -556,6 +626,20 @@
           "type": "integer",
           "default": 30000
         },
+        "replication_quota_window_num": {
+          "title": "replication.quota.window.num",
+          "description": "The number of samples to retain in memory for replication quotas",
+          "type": "integer",
+          "default": 11,
+          "minimum": 1
+        },
+        "replication_quota_window_size_seconds": {
+          "title": "replication.quota.window.size.seconds",
+          "description": "The time span of each sample for replication quotas",
+          "type": "integer",
+          "default": 1,
+          "minimum": 1
+        },
         "request_timeout_ms": {
           "title": "request.timeout.ms",
           "description": "The configuration controls the maximum amount of time the client will wait for the response of a request. If the response is not received before the timeout elapses the client will resend the request if necessary or fail the request if retries are exhausted.",
@@ -564,7 +648,7 @@
         },
         "socket_receive_buffer_bytes": {
           "title": "socket.receive.buffer.bytes",
-          "description": "The SO_RCVBUF buffer of the socket sever sockets",
+          "description": "The SO_RCVBUF buffer of the socket sever sockets. If the value is -1, the OS default will be used.",
           "type": "integer",
           "default": 102400
         },
@@ -572,11 +656,12 @@
           "title": "socket.request.max.bytes",
           "description": "The maximum number of bytes in a socket request",
           "type": "integer",
-          "default": 104857600
+          "default": 104857600,
+          "minimum": 1
         },
         "socket_send_buffer_bytes": {
           "title": "socket.send.buffer.bytes",
-          "description": "The SO_SNDBUF buffer of the socket sever sockets",
+          "description": "The SO_SNDBUF buffer of the socket sever sockets. If the value is -1, the OS default will be used.",
           "type": "integer",
           "default": 102400
         },
@@ -584,7 +669,7 @@
           "title": "unclean.leader.election.enable",
           "description": "Indicates whether to enable replicas not in the ISR set to be elected as leader as a last resort, even though doing so may result in data loss",
           "type": "boolean",
-          "default": true
+          "default": false
         },
         "zookeeper_session_timeout_ms": {
           "title": "zookeeper.session.timeout.ms",
@@ -636,15 +721,21 @@
         },
         "group_max_session_timeout_ms": {
           "title": "group.max.session.timeout.ms",
-          "description": "The maximum allowed session timeout for registered consumers",
+          "description": "The maximum allowed session timeout for registered consumers. Longer timeouts give consumers more time to process messages in between heartbeats at the cost of a longer time to detect failures.",
           "type": "integer",
           "default": 300000
         },
         "group_min_session_timeout_ms": {
           "title": "group.min.session.timeout.ms",
-          "description": "The minimum allowed session timeout for registered consumers",
+          "description": "The minimum allowed session timeout for registered consumers. Shorter timeouts result in quicker failure detection at the cost of more frequent consumer heartbeating, which can overwhelm broker resources.",
           "type": "integer",
           "default": 6000
+        },
+        "group_initial_rebalance_delay_ms": {
+          "title": "group.initial.rebalance.delay.ms",
+          "description": "The amount of time the group coordinator will wait for more consumers to join a new group before performing the first rebalance. A longer delay means potentially fewer rebalances, but increases the time until processing begins.",
+          "type": "integer",
+          "default": 3000
         },
         "inter_broker_protocol_version": {
           "type": "string",
@@ -662,7 +753,8 @@
           "title": "log.cleaner.backoff.ms",
           "description": "The amount of time to sleep when there are no logs to clean",
           "type": "integer",
-          "default": 15000
+          "default": 15000,
+          "minimum": 0
         },
         "log_cleaner_dedupe_buffer_size": {
           "title": "log.cleaner.dedupe.buffer.size",
@@ -678,7 +770,7 @@
         },
         "log_cleaner_enable": {
           "title": "log.cleaner.enable",
-          "description": "Enable the log cleaner process to run on the server? Should be enabled if using any topics with a cleanup.policy=compact including the internal offsets topic. If disabled those topics will not be compacted and continually grow in size.",
+          "description": "Enable the log cleaner process to run on the server. Should be enabled if using any topics with a cleanup.policy=compact including the internal offsets topic. If disabled those topics will not be compacted and continually grow in size.",
           "type": "boolean",
           "default": true
         },
@@ -692,13 +784,14 @@
           "title": "log.cleaner.io.buffer.size",
           "description": "The total memory used for log cleaner I/O buffers across all cleaner threads",
           "type": "integer",
-          "default": 524288
+          "default": 524288,
+          "minimum": 0
         },
         "log_cleaner_io_max_bytes_per_second": {
           "title": "log.cleaner.io.max.bytes.per.second",
           "description": "The log cleaner will be throttled so that the sum of its read and write i/o will be less than this value on average",
           "type": "number",
-          "default": 1.7976931348623157e+308
+          "default": 1.7976931348623157E308
         },
         "log_cleaner_min_cleanable_ratio": {
           "title": "log.cleaner.min.cleanable.ratio",
@@ -706,29 +799,38 @@
           "type": "number",
           "default": 0.5
         },
+        "log_cleaner_min_compaction_lag_ms": {
+          "title": "log.cleaner.min.compaction.lag.ms",
+          "description": "The minimum time a message will remain uncompacted in the log. Only applicable for logs that are being compacted.",
+          "type": "integer",
+          "default": 0
+        },
         "log_cleaner_threads": {
           "title": "log.cleaner.threads",
           "description": "The number of background threads to use for log cleaning",
           "type": "integer",
-          "default": 1
+          "default": 1,
+          "minimum": 0
         },
         "log_cleanup_policy": {
           "type": "string",
           "title": "log.cleanup.policy",
-          "description": "The default cleanup policy for segments beyond the retention window, must be either 'delete' or 'compact'",
+          "description": "The default cleanup policy for segments beyond the retention window. A comma separated list of valid policies. Valid policies are: \"delete\" and \"compact\"",
           "default": "delete"
         },
         "log_index_interval_bytes": {
           "title": "log.index.interval.bytes",
           "description": "The interval with which we add an entry to the offset index",
           "type": "integer",
-          "default": 4096
+          "default": 4096,
+          "minimum": 0
         },
         "log_index_size_max_bytes": {
           "title": "log.index.size.max.bytes",
           "description": "The maximum size in bytes of the offset index",
           "type": "integer",
-          "default": 10485760
+          "default": 10485760,
+          "minimum": 4
         },
         "log_preallocate": {
           "title": "log.preallocate",
@@ -740,13 +842,15 @@
           "title": "log.retention.check.interval.ms",
           "description": "The frequency in milliseconds that the log cleaner checks whether any log is eligible for deletion",
           "type": "integer",
-          "default": 300000
+          "default": 300000,
+          "minimum": 1
         },
         "max_connections_per_ip": {
           "title": "max.connections.per.ip",
-          "description": "mum number of connections we allow from each ip address",
+          "description": "The maximum number of connections we allow from each ip address",
           "type": "integer",
-          "default": 2147483647
+          "default": 2147483647,
+          "minimum": 1
         },
         "max_connections_per_ip_overrides": {
           "type": "string",
@@ -758,7 +862,8 @@
           "title": "num.partitions",
           "description": "The default number of log partitions per topic",
           "type": "integer",
-          "default": 1
+          "default": 1,
+          "minimum": 1
         },
         "producer_purgatory_purge_interval_requests": {
           "title": "producer.purgatory.purge.interval.requests",
@@ -770,13 +875,15 @@
           "title": "replica.fetch.backoff.ms",
           "description": "The amount of time to sleep when fetch partition error occurs.",
           "type": "integer",
-          "default": 1000
+          "default": 1000,
+          "minimum": 0
         },
         "reserved_broker_max_id": {
           "title": "reserved.broker.max.id",
           "description": "Max number that can be used for a broker.id",
           "type": "integer",
-          "default": 1000
+          "default": 1000,
+          "minimum": 0
         },
         "kafka_metrics_reporters": {
           "title": "kafka.metric.reporters",
@@ -794,25 +901,92 @@
           "title": "metrics.num.samples",
           "description": "The number of samples maintained to compute metrics.",
           "type": "integer",
-          "default": 2
+          "default": 2,
+          "minimum": 1
         },
         "metrics_sample_window_ms": {
           "title": "metrics.sample.window.ms",
-          "description": "The number of samples maintained to compute metrics.",
+          "description": "The window of time a metrics sample is computed over.",
           "type": "integer",
-          "default": 30000
+          "default": 30000,
+          "minimum": 1
         },
         "quota_window_num": {
           "title": "quota.window.num",
-          "description": "The number of samples to retain in memory",
+          "description": "The number of samples to retain in memory for client quotas",
           "type": "integer",
-          "default": 11
+          "default": 11,
+          "minimum": 1
         },
         "quota_window_size_seconds": {
           "title": "quota.window.size.seconds",
-          "description": "The time span of each sample",
+          "description": "The time span of each sample for client quotas",
           "type": "integer",
-          "default": 1
+          "default": 1,
+          "minimum": 1
+        },
+        "transaction_state_log_segment_bytes": {
+          "title": "transaction.state.log.segment.bytes",
+          "description": "The transaction topic segment bytes should be kept relatively small in order to facilitate faster log compaction and cache loads",
+          "type": "integer",
+          "default": 104857600,
+          "minimum": 1
+        },
+        "transaction_remove_expired_transaction_cleanup_interval_ms": {
+          "title": "transaction.remove.expired.transaction.cleanup.interval.ms",
+          "description": "The interval at which to remove transactions that have expired due to transactional.id.expiration.ms passing",
+          "type": "integer",
+          "default": 3600000,
+          "minimum": 1
+        },
+        "transaction_max_timeout_ms": {
+          "title": "transaction.max.timeout.ms",
+          "description": "The maximum allowed timeout for transactions. If a client\u2019s requested transaction time exceed this, then the broker will return an error in InitProducerIdRequest. This prevents a client from too large of a timeout, which can stall consumers reading from topics included in the transaction.",
+          "type": "integer",
+          "default": 900000,
+          "minimum": 1
+        },
+        "transaction_state_log_num_partitions": {
+          "title": "transaction.state.log.num.partitions",
+          "description": "The number of partitions for the transaction topic (should not change after deployment).",
+          "type": "integer",
+          "default": 50,
+          "minimum": 1
+        },
+        "transaction_abort_timed_out_transaction_cleanup_interval_ms": {
+          "title": "transaction.abort.timed.out.transaction.cleanup.interval.ms",
+          "description": "The interval at which to rollback transactions that have timed out",
+          "type": "integer",
+          "default": 60000,
+          "minimum": 1
+        },
+        "transaction_state_log_load_buffer_size": {
+          "title": "transaction.state.log.load.buffer.size",
+          "description": "Batch size for reading from the transaction log segments when loading producer ids and transactions into the cache.",
+          "type": "integer",
+          "default": 5242880,
+          "minimum": 1
+        },
+        "transaction_state_log_replication_factor": {
+          "title": "transaction.state.log.replication.factor",
+          "description": "The replication factor for the transaction topic (set higher to ensure availability). Internal topic creation will fail until the cluster size meets this replication factor requirement.",
+          "type": "integer",
+          "default": 3,
+          "minimum": 1
+        },
+        "transaction_state_log_min_isr": {
+          "title": "transaction.state.log.min.isr",
+          "description": "Overridden min.insync.replicas config for the transaction topic.",
+          "type": "integer",
+          "default": 2,
+          "minimum": 1
+        },
+        "transactional_id_expiration_ms": {
+          "title": "transactional.id.expiration.ms",
+          "description": "The maximum amount of time in ms that the transaction coordinator will wait before proactively expire a producer's transactional id without receiving any transaction status updates from it.",
+          "type": "integer",
+          "default": 604800000,
+          "minimum": 1
         },
         "zookeeper_sync_time_ms": {
           "title": "zookeeper.sync.time.ms",

--- a/frameworks/kafka/universe/marathon.json.mustache
+++ b/frameworks/kafka/universe/marathon.json.mustache
@@ -201,7 +201,41 @@
     "TASKCFG_ALL_KAFKA_REPLICA_HIGH_WATERMARK_CHECKPOINT_INTERVAL_MS": "{{kafka.replica_high_watermark_checkpoint_interval_ms}}",
     "TASKCFG_ALL_KAFKA_OFFSETS_TOPIC_SEGMENT_BYTES": "{{kafka.offsets_topic_segment_bytes}}",
     "TASKCFG_ALL_KAFKA_LOG_CLEANER_IO_MAX_BYTES_PER_SECOND": "{{kafka.log_cleaner_io_max_bytes_per_second}}",
-    "TASKCFG_ALL_KAFKA_COMPRESSION_TYPE": "{{kafka.compression_type}}"
+    "TASKCFG_ALL_KAFKA_COMPRESSION_TYPE": "{{kafka.compression_type}}",
+
+    {{#kafka.log_flush_interval_ms}}
+    "TASKCFG_ALL_KAFKA_LOG_FLUSH_INTERVAL_MS": "{{kafka.log_flush_interval_ms}}",
+    {{/kafka.log_flush_interval_ms}}
+    {{#kafka.log_retention_ms}}
+    "TASKCFG_ALL_KAFKA_LOG_RETENTION_MS": "{{kafka.log_retention_ms}}",
+    {{/kafka.log_retention_ms}}
+    {{#kafka.log_retention_minutes}}
+    "TASKCFG_ALL_KAFKA_LOG_RETENTION_MINUTES": "{{kafka.log_retention_minutes}}",
+    {{/kafka.log_retention_minutes}}
+    {{#kafka.log_roll_jitter_ms}}
+    "TASKCFG_ALL_KAFKA_LOG_ROLL_JITTER_MS": "{{kafka.log_roll_jitter_ms}}",
+    {{/kafka.log_roll_jitter_ms}}
+    {{#kafka.log_roll_ms}}
+    "TASKCFG_ALL_KAFKA_LOG_ROLL_MS": "{{kafka.log_roll_ms}}",
+    {{/kafka.log_roll_ms}}
+
+    "TASKCFG_ALL_KAFKA_TRANSACTION_STATE_LOG_SEGMENT_BYTES": "{{kafka.transaction_state_log_segment_bytes}}",
+    "TASKCFG_ALL_KAFKA_TRANSACTION_REMOVE_EXPIRED_TRANSACTION_CLEANUP_INTERVAL_MS": "{{kafka.transaction_remove_expired_transaction_cleanup_interval_ms}}",
+    "TASKCFG_ALL_KAFKA_QUEUED_MAX_REQUEST_BYTES": "{{kafka.queued_max_request_bytes}}",
+    "TASKCFG_ALL_KAFKA_TRANSACTION_MAX_TIMEOUT_MS": "{{kafka.transaction_max_timeout_ms}}",
+    "TASKCFG_ALL_KAFKA_LOG_CLEANER_MIN_COMPACTION_LAG_MS": "{{kafka.log_cleaner_min_compaction_lag_ms}}",
+    "TASKCFG_ALL_KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS": "{{kafka.group_initial_rebalance_delay_ms}}",
+    "TASKCFG_ALL_KAFKA_TRANSACTION_STATE_LOG_NUM_PARTITIONS": "{{kafka.transaction_state_log_num_partitions}}",
+    "TASKCFG_ALL_KAFKA_REPLICA_FETCH_RESPONSE_MAX_BYTES": "{{kafka.replica_fetch_response_max_bytes}}",
+    "TASKCFG_ALL_KAFKA_LOG_FLUSH_START_OFFSET_CHECKPOINT_INTERVAL_MS": "{{kafka.log_flush_start_offset_checkpoint_interval_ms}}",
+    "TASKCFG_ALL_KAFKA_DELETE_RECORDS_PURGATORY_PURGE_INTERVAL_REQUESTS": "{{kafka.delete_records_purgatory_purge_interval_requests}}",
+    "TASKCFG_ALL_KAFKA_TRANSACTION_ABORT_TIMED_OUT_TRANSACTION_CLEANUP_INTERVAL_MS": "{{kafka.transaction_abort_timed_out_transaction_cleanup_interval_ms}}",
+    "TASKCFG_ALL_KAFKA_TRANSACTION_STATE_LOG_LOAD_BUFFER_SIZE": "{{kafka.transaction_state_log_load_buffer_size}}",
+    "TASKCFG_ALL_KAFKA_TRANSACTIONAL_ID_EXPIRATION_MS": "{{kafka.transactional_id_expiration_ms}}",
+    "TASKCFG_ALL_KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR": "{{kafka.transaction_state_log_replication_factor}}",
+    "TASKCFG_ALL_KAFKA_TRANSACTION_STATE_LOG_MIN_ISR": "{{kafka.transaction_state_log_min_isr}}",
+    "TASKCFG_ALL_KAFKA_REPLICATION_QUOTA_WINDOW_NUM": "{{kafka.replication_quota_window_num}}",
+    "TASKCFG_ALL_KAFKA_REPLICATION_QUOTA_WINDOW_SIZE_SECONDS": "{{kafka.replication_quota_window_size_seconds}}"
   },
   "uris": [
     "{{resource.assets.uris.bootstrap-zip}}",


### PR DESCRIPTION
* Add all the missing properties to the plumbing

* Use templating to only include values when they're enabled

* Add a bunch of minimums
Fix a mistake in a number type parameter
Remove Apache Kafka's confusing Deprecation notice

* Fix bad JSON after adding new parameters / moving some parameters

* I've been convinced to set topic delete back to false by the fact we have a test that makes sure it is false.

Backport of #2323 