### PR TITLE
Backport refactor of security templates

### DIFF
--- a/docs/pages/_data/services/cassandra.yml
+++ b/docs/pages/_data/services/cassandra.yml
@@ -3,6 +3,7 @@
 packageName: beta-cassandra
 serviceName: cassandra
 techName: Apache Cassandra
+techShortName: Cassandra
 
 # Values specific to certain templates:
 
@@ -18,3 +19,6 @@ managing:
 supportedVersions:
   techExampleVersion: 3.0.13
   techLink: "[Cassandra](http://cassandra.apache.org/download/)"
+
+security:
+  plaintext: ", \"allow_plaintext\": <true|false default false>"

--- a/docs/pages/_data/services/elastic.yml
+++ b/docs/pages/_data/services/elastic.yml
@@ -3,6 +3,7 @@
 packageName: beta-elastic
 serviceName: elastic
 techName: Elastic
+techShortName: Elastic
 
 # Values specific to certain templates:
 
@@ -18,3 +19,9 @@ managing:
 supportedVersions:
   techExampleVersion: 6.1.3
   techLink: "the [Elastic Stack](https://www.elastic.co/downloads/elasticsearch) and [X-Pack](https://www.elastic.co/downloads/x-pack)"
+
+security:
+  extras: ",
+    \"elasticsearch\": {
+        \"xpack_enabled\": true
+    }"

--- a/docs/pages/_data/services/hdfs.yml
+++ b/docs/pages/_data/services/hdfs.yml
@@ -2,7 +2,8 @@
 
 packageName: beta-hdfs
 serviceName: hdfs
-techName: HDFS
+techName: Apache HDFS
+techShortName: HDFS
 
 # Values specific to certain templates:
 
@@ -19,3 +20,11 @@ managing:
 supportedVersions:
   techExampleVersion: 2.9.0
   techLink: "[HDFS](http://hadoop.apache.org/releases.html)"
+
+security:
+  plaintext: ", \"allow_plaintext\": <true|false default false>"
+
+kerberos:
+  spn: example/name-0-node.agoodexample.autoip.dcos.thisdcos.directory
+  upn: example/name-0-node.agoodexample.autoip.dcos.thisdcos.directory@EXAMPLE
+  principal: example/name-0-node.agoodexample.autoip.dcos.thisdcos.directory@EXAMPLE

--- a/docs/pages/_data/services/kafka.yml
+++ b/docs/pages/_data/services/kafka.yml
@@ -3,6 +3,7 @@
 packageName: beta-kafka
 serviceName: kafka
 techName: Apache Kafka
+techShortName: Kafka
 
 # Values specific to certain templates:
 
@@ -19,8 +20,17 @@ supportedVersions:
   techExampleVersion: 0.11.0.2
   techLink: "[Apache Kafka](https://kafka.apache.org/downloads)"
 
+security:
+  plaintext: ", \"allow_plaintext\": <true|false default false>"
+
+kerberos:
+  spn: example/kafka-0-broker.agoodexample.autoip.dcos.thisdcos.directory
+  upn: example/kafka-0-broker.agoodexample.autoip.dcos.thisdcos.directory@EXAMPLE
+  principal: example/kafka-0-broker.agoodexample.autoip.dcos.thisdcos.directory@EXAMPLE
+
 # Values specific to Kafka's own docs content:
 
 kafka:
   zookeeperPackageName: beta-kafka-zookeeper
   zookeeperServiceName: kafka-zookeeper
+  zookeeperTechName: Apache Zookeeper

--- a/docs/pages/_includes/services/security-configure-transport-encryption.md
+++ b/docs/pages/_includes/services/security-configure-transport-encryption.md
@@ -18,7 +18,7 @@ dcos:adminrouter:ops:ca:ro full
 where `<service name>` is the name of the service to be installed.
 
 #### Install the service
-Install the DC/OS {{ include.techName }} service including the following options in addition to your own:
+Install the DC/OS {{ include.data.techName }} service including the following options in addition to your own:
 ```json
 {
     "service": {
@@ -26,10 +26,9 @@ Install the DC/OS {{ include.techName }} service including the following options
         "service_account_secret": "<full path of service secret>",
         "security": {
             "transport_encryption": {
-                {% if include.plaintext == "true" %}"enabled": true,
-                "allow_plaintext": <true|false default false>{% else %}"enabled": true{% endif %}
+                "enabled": true{{ include.data.security.plaintext }}
             }
         }
-    }{{ include.extras }}
+    }{{ include.data.security.extras }}
 }
 ```

--- a/docs/pages/_includes/services/security-kerberos-ad.md
+++ b/docs/pages/_includes/services/security-kerberos-ad.md
@@ -10,10 +10,10 @@ servicePrincipalName = <primary>/<host>
 userPrincipalName = <primary>/<host>@<REALM>
 ```
 
-For example, with the Kerberos principal `{{ include.principal }}`, then the correct mapping would be,
+For example, with the Kerberos principal `{{ include.data.kerberos.principal }}`, then the correct mapping would be,
 ```
-servicePrincipalName = {{ include.spn }}
-userPrincipalName = {{ include.upn }}
+servicePrincipalName = {{ include.data.kerberos.spn }}
+userPrincipalName = {{ include.data.kerberos.upn }}
 ```
 
 If either mapping is incorrect or not present, the service will fail to authenticate that Principal. The symptom in the Kerberos debug logs will be an error of the form

--- a/docs/pages/_includes/services/security-service-keytab.md
+++ b/docs/pages/_includes/services/security-service-keytab.md
@@ -1,6 +1,6 @@
 #### Place Service Keytab in DC/OS Secret Store
 
-The DC/OS {{ include.techName }} service uses a keytab containing all node principals (service keytab). After creating the principals above, generate the service keytab making sure to include all the node principals. This will be stored as a secret in the DC/OS Secret Store.
+The DC/OS {{ include.data.techName }} service uses a keytab containing all node principals (service keytab). After creating the principals above, generate the service keytab making sure to include all the node principals. This will be stored as a secret in the DC/OS Secret Store.
 
 *Note*: DC/OS 1.10 does not support adding binary secrets directly to the secret store, only text files are supported. Instead, first base64 encode the file, and save it to the secret store as `/desired/path/__dcos_base64__secret_name`. The DC/OS security modules will handle decoding the file when it is used by the service. More details [here](https://docs.mesosphere.com/services/ops-guide/overview/#binary-secrets).
 

--- a/docs/pages/_includes/services/security-transport-encryption-lead-in.md
+++ b/docs/pages/_includes/services/security-transport-encryption-lead-in.md
@@ -1,3 +1,3 @@
-With transport encryption enabled, DC/OS {{ include.techName }} will automatically deploy all nodes with the correct configuration to encrypt communication via SSL. The nodes will communicate securely between themselves using SSL.{% if include.plaintext == "true" %} Optionally, plaintext communication can be left open to clients.{% endif %}
+With transport encryption enabled, DC/OS {{ include.data.techName }} will automatically deploy all nodes with the correct configuration to encrypt communication via SSL. The nodes will communicate securely between themselves using SSL.
 
 The service uses the [DC/OS CA](https://docs.mesosphere.com/latest/security/ent/tls-ssl/) to generate the SSL artifacts that it uses to secure the service. Any client that trusts the DC/OS CA will consider the service's certificates valid.

--- a/frameworks/cassandra/docs/security.md
+++ b/frameworks/cassandra/docs/security.md
@@ -6,21 +6,20 @@ title: Security
 menuWeight: 22
 ---
 
-# DC/OS Apache Cassandra Security
+{% assign data = site.data.services.cassandra %}
 
-The DC/OS Apache Cassandra service supports Apache Cassandra's native transport encryption mechanisms. The service provides automation and orchestration to simplify the usage of these important features. At this time, Apache Cassandra's authentication and authorization features are not supported.
+# DC/OS {{ data.techName }} Security
+
+The DC/OS {{ data.techName }} service supports {{ data.techName }}'s native transport encryption mechanisms. The service provides automation and orchestration to simplify the usage of these important features. At this time, {{ data.techName }}'s authentication and authorization features are not supported.
 
 *Note*: These security features are only available on DC/OS Enterprise 1.10 and above.
 
 ## Transport Encryption
 
-{% include services/security-transport-encryption-lead-in.md
-    techName="Apache Cassandra" plaintext="false" %}
+{% include services/security-transport-encryption-lead-in.md data=data %}
 
-{% include services/security-configure-transport-encryption.md
-    techName="Apache Cassandra"
-    plaintext="true" %}
+{% include services/security-configure-transport-encryption.md data=data %}
 
-*Note*: It is possible to update a running DC/OS Apache Cassandra service to enable transport encryption after initial installation, but the service may be unavailable during the transition. Additionally, your clients will need to be reconfigured unless `service.security.transport_encryption.allow_plaintext` is set to `true`.
+*Note*: It is possible to update a running DC/OS {{ data.techName }} service to enable transport encryption after initial installation, but the service may be unavailable during the transition. Additionally, your clients will need to be reconfigured unless `service.security.transport_encryption.allow_plaintext` is set to `true`.
 
 {% include services/security-transport-encryption-clients.md %}

--- a/frameworks/elastic/docs/security.md
+++ b/frameworks/elastic/docs/security.md
@@ -6,9 +6,11 @@ title: Security
 menuWeight: 22
 ---
 
-# DC/OS Elastic Security
+{% assign data = site.data.services.elastic %}
 
-The DC/OS Elastic service supports Elastic's X-Pack transport encryption mechanisms. The service provides automation and orchestration to simplify the usage of these important features. At this time, X-Pack's authentication and authorization features are not supported.
+# DC/OS {{ data.techName }} Security
+
+The DC/OS {{ data.techName }} service supports {{ data.techName }}'s X-Pack transport encryption mechanisms. The service provides automation and orchestration to simplify the usage of these important features. At this time, X-Pack's authentication and authorization features are not supported.
 
 A good overview of X-Pack can be found [here](https://www.elastic.co/guide/en/x-pack/current/xpack-introduction.html).
 
@@ -16,18 +18,11 @@ A good overview of X-Pack can be found [here](https://www.elastic.co/guide/en/x-
 
 ## Transport Encryption
 
-{% include services/security-transport-encryption-lead-in.md
-    techName="Elastic" plaintext="false" %}
+{% include services/security-transport-encryption-lead-in.md data=data %}
 
 *Note*: X-Pack is required to enable Transport Encryption.
 
-{% include services/security-configure-transport-encryption.md
-    techName="Elastic"
-    plaintext="false"
-    extras=",
-    \"elasticsearch\": {
-        \"xpack_enabled\": true
-    }" %}
+{% include services/security-configure-transport-encryption.md data=data %}
 
 *Note* It is possible to enable Transport Encryption after initial installation, but it requires setting `service.update_strategy` to `parallel`. After the update is complete, `service.update_strategy` should be set back to `serial`. Because the update must occur in parallel, the service **WILL** be unavailable during the transition. Additionally, clients will need to be reconfigured after the transition.
 
@@ -36,7 +31,7 @@ A good overview of X-Pack can be found [here](https://www.elastic.co/guide/en/x-
 
 #### Kibana
 
-To use the DC/OS Kibana service in tandem with DC/OS Elastic when the latter has Transport Encryption enabled, install (or update) Kibana with the following options in addition to your own:
+To use the DC/OS Kibana service in tandem with DC/OS {{ data.techName }} when the latter has Transport Encryption enabled, install (or update) Kibana with the following options in addition to your own:
 ```json
 {
     "kibana": {
@@ -46,6 +41,6 @@ To use the DC/OS Kibana service in tandem with DC/OS Elastic when the latter has
     }
 }
 ```
-This configures the Kibana service to connect securely to the Elastic service.
+This configures the Kibana service to connect securely to the {{ data.techName }} service.
 
 *Note*: Currently, the Kibana service does not support Transport Encryption for its own clients.

--- a/frameworks/hdfs/docs/security.md
+++ b/frameworks/hdfs/docs/security.md
@@ -6,9 +6,11 @@ title: Security
 menuWeight: 22
 ---
 
-# DC/OS Apache HDFS Security
+{% assign data = site.data.services.hdfs %}
 
-The DC/OS Apache HDFS service supports HDFS's native transport encryption, authentication, and authorization mechanisms. The service provides automation and orchestration to simplify the usage of these important features.
+# DC/OS {{ data.techName }} Security
+
+The DC/OS {{ data.techName }} service supports {{ data.techShortName }}'s native transport encryption, authentication, and authorization mechanisms. The service provides automation and orchestration to simplify the usage of these important features.
 
 A good overview of these features can be found [here](https://hadoop.apache.org/docs/r2.6.0/hadoop-project-dist/hadoop-common/SecureMode.html).
 
@@ -16,27 +18,25 @@ A good overview of these features can be found [here](https://hadoop.apache.org/
 
 ## Transport Encryption
 
-{% include services/security-transport-encryption-lead-in.md
-    techName="Apache HDFS" plaintext="true" %}
+{% include services/security-transport-encryption-lead-in.md data=data %}
 
 *Note*: Enabling transport encryption is not _required_ to use [Kerberos authentication](#kerberos-authentication), but transport encryption _can_ be combined with Kerberos authentication.
 
-{% include services/security-configure-transport-encryption.md
-    techName="Apache HDFS" plaintext="true" %}
+{% include services/security-configure-transport-encryption.md data=data %}
 
 {% include services/security-transport-encryption-clients.md %}
 
 <!--
 TO BE CONFIRMED
-*Note*: It is possible to update a running DC/OS Apache HDFS service to enable transport encryption after initial installation, but the service may be unavilable during the transition. Additionally, your HDFS clients will need to be reconfigured unless `service.security.transport_encryption.allow_plaintext` is set to true. -->
+*Note*: It is possible to update a running DC/OS {{ data.techName }} service to enable transport encryption after initial installation, but the service may be unavilable during the transition. Additionally, your {{ data.techShortName }} clients will need to be reconfigured unless `service.security.transport_encryption.allow_plaintext` is set to true. -->
 
 ## Authentication
 
-DC/OS Apache HDFS supports Kerberos authentication.
+DC/OS {{ data.techName }} supports Kerberos authentication.
 
 ### Kerberos Authentication
 
-Kerberos authentication relies on a central authority to verify that HDFS clients are who they say they are. DC/OS Apache HDFS integrates with your existing Kerberos infrastructure to verify the identity of clients.
+Kerberos authentication relies on a central authority to verify that {{ data.techShortName }} clients are who they say they are. DC/OS {{ data.techName }} integrates with your existing Kerberos infrastructure to verify the identity of clients.
 
 #### Prerequisites
 - The hostname and port of a KDC reachable from your DC/OS cluster
@@ -49,12 +49,12 @@ Kerberos authentication relies on a central authority to verify that HDFS client
 
 #### Create principals
 
-The DC/OS Apache HDFS service requires Kerberos principals for each node to be deployed. The overall topology of the HDFS service is:
+The DC/OS {{ data.techName }} service requires Kerberos principals for each node to be deployed. The overall topology of the {{ data.techShortName }} service is:
 - 3 journal nodes
 - 2 name nodes (with ZKFC)
 - A configurable number of data nodes
 
-*Note:* Apache HDFS requires a principal for both the `service primary` and `HTTP`. The latter is used by the HTTP api.
+*Note:* {{ data.techName }} requires a principal for both the `service primary` and `HTTP`. The latter is used by the HTTP api.
 
 The required Kerberos principals will have the form:
 ```
@@ -127,17 +127,13 @@ example/data-2-node.agoodexample.autoip.dcos.thisdcos.directory@EXAMPLE
 HTTP/data-2-node.agoodexample.autoip.dcos.thisdcos.directory@EXAMPLE
 ```
 
-{% include services/security-kerberos-ad.md
-    principal="example/name-0-node.agoodexample.autoip.dcos.thisdcos.directory@EXAMPLE"
-    spn="example/name-0-node.agoodexample.autoip.dcos.thisdcos.directory"
-    upn="example/name-0-node.agoodexample.autoip.dcos.thisdcos.directory@EXAMPLE" %}
+{% include services/security-kerberos-ad.md data=data %}
 
-{% include services/security-service-keytab.md
-    techName="Apache HDFS" %}
+{% include services/security-service-keytab.md data=data %}
 
 #### Install the Service
 
-Install the DC/OS Apache HDFS service with the following options in addition to your own:
+Install the DC/OS {{ data.techName }} service with the following options in addition to your own:
 ```json
 {
     "service": {
@@ -158,11 +154,11 @@ Install the DC/OS Apache HDFS service with the following options in addition to 
 }
 ```
 
-<!-- TO BE DETERMINED *Note*: It is possible to enable Kerberos after initial installation but the service may be unavailable during the transition. Additionally, your HDFS clients will need to be reconfigured. -->
+<!-- TO BE DETERMINED *Note*: It is possible to enable Kerberos after initial installation but the service may be unavailable during the transition. Additionally, your {{ data.techShortName }} clients will need to be reconfigured. -->
 
 ## Authorization
 
-The DC/OS Apache HDFS service supports HDFS's native authorization, which behaves similarly to UNIX file permissions. If Kerberos is enabled as detailed [above](#kerberos-authentication), then Kerberos principals are mapped to HDFS users against which permissions can be assigned.
+The DC/OS {{ data.techName }} service supports {{ data.techShortName }}'s native authorization, which behaves similarly to UNIX file permissions. If Kerberos is enabled as detailed [above](#kerberos-authentication), then Kerberos principals are mapped to {{ data.techShortName }} users against which permissions can be assigned.
 
 ### Enable Authorization
 

--- a/frameworks/kafka/docs/security.md
+++ b/frameworks/kafka/docs/security.md
@@ -6,41 +6,41 @@ title: Security
 menuWeight: 22
 ---
 
-# DC/OS Apache Kafka Security
+{% assign data = site.data.services.kafka %}
 
-The DC/OS Apache Kafka service supports Kafka's native transport encryption, authentication, and authorization mechanisms. The service provides automation and orchestration to simplify the usage of these important features.
+# DC/OS {{ data.techName }} Security
 
-A good overview of these features can be found [here](https://www.confluent.io/blog/apache-kafka-security-authorization-authentication-encryption/), and Kafka's security documentation can be found [here](http://kafka.apache.org/documentation/#security).
+The DC/OS {{ data.techName }} service supports {{ data.techShortName }}'s native transport encryption, authentication, and authorization mechanisms. The service provides automation and orchestration to simplify the usage of these important features.
+
+A good overview of these features can be found [here](https://www.confluent.io/blog/apache-kafka-security-authorization-authentication-encryption/), and {{ data.techShortName }}'s security documentation can be found [here](http://kafka.apache.org/documentation/#security).
 
 *Note*: These security features are only available on DC/OS Enterprise 1.10 and above.
 
 ## Transport Encryption
 
-{% include services/security-transport-encryption-lead-in.md
-    techName="Apache Kafka" plaintext="true" %}
+{% include services/security-transport-encryption-lead-in.md data=data %}
 
 *Note*: Enabling transport encryption is _required_ to use [SSL authentication](#ssl-authentication) for [authentication](#authentication), but is optional for [Kerberos authentication](#kerberos-authentication).
 
-{% include services/security-configure-transport-encryption.md
-    techName="Apache Kafka" plaintext="true" %}
+{% include services/security-configure-transport-encryption.md data=data %}
 
-*Note*: It is possible to update a running DC/OS Apache Kafka service to enable transport encryption after initial installation, but the service may be unavailable during the transition. Additionally, your Kafka clients will need to be reconfigured unless `service.security.transport_encryption.allow_plaintext` is set to true.
+*Note*: It is possible to update a running DC/OS {{ data.techName }} service to enable transport encryption after initial installation, but the service may be unavailable during the transition. Additionally, your {{ data.techShortName }} clients will need to be reconfigured unless `service.security.transport_encryption.allow_plaintext` is set to true.
 
 #### Verify Transport Encryption Enabled
 
-After service deployment completes, check the list of [Kafka endpoints](../api-reference/#connection-information) for the endpoint `broker-tls`. If `service.security.transport_encryption.allow_plaintext` is `true`, then the `broker` endpoint will also be available.
+After service deployment completes, check the list of [{{ data.techShortName }} endpoints](../api-reference/#connection-information) for the endpoint `broker-tls`. If `service.security.transport_encryption.allow_plaintext` is `true`, then the `broker` endpoint will also be available.
 
 {% include services/security-transport-encryption-clients.md %}
 
 ## Authentication
 
-DC/OS Apache Kafka supports two authentication mechanisms, SSL and Kerberos. The two are supported independently and may not be combined. If both SSL and Kerberos authentication are enabled, the service will use Kerberos authentication.
+DC/OS {{ data.techName }} supports two authentication mechanisms, SSL and Kerberos. The two are supported independently and may not be combined. If both SSL and Kerberos authentication are enabled, the service will use Kerberos authentication.
 
 *Note*: Kerberos authentication can, however, be combined with transport encryption.
 
 ### Kerberos Authentication
 
-Kerberos authentication relies on a central authority to verify that Kafka clients (be it broker, consumer, or producer) are who they say they are. DC/OS Apache Kafka integrates with your existing Kerberos infrastructure to verify the identity of clients.
+Kerberos authentication relies on a central authority to verify that {{ data.techShortName }} clients (be it broker, consumer, or producer) are who they say they are. DC/OS {{ data.techName }} integrates with your existing Kerberos infrastructure to verify the identity of clients.
 
 #### Prerequisites
 - The hostname and port of a KDC reachable from your DC/OS cluster
@@ -53,7 +53,7 @@ Kerberos authentication relies on a central authority to verify that Kafka clien
 
 #### Create principals
 
-The DC/OS Apache Kafka service requires a Kerberos principal for each broker to be deployed. Each principal must be of the form
+The DC/OS {{ data.techName }} service requires a Kerberos principal for each broker to be deployed. Each principal must be of the form
 ```
 <service primary>/kafka-<broker index>-broker.<service subdomain>.autoip.dcos.thisdcos.directory@<service realm>
 ```
@@ -86,17 +86,13 @@ example/kafka-0-broker.agoodexample.autoip.dcos.thisdcos.directory@EXAMPLE
 example/kafka-1-broker.agoodexample.autoip.dcos.thisdcos.directory@EXAMPLE
 example/kafka-2-broker.agoodexample.autoip.dcos.thisdcos.directory@EXAMPLE
 ```
-{% include services/security-kerberos-ad.md
-    principal="example/kafka-0-broker.agoodexample.autoip.dcos.thisdcos.directory@EXAMPLE"
-    spn="example/kafka-0-broker.agoodexample.autoip.dcos.thisdcos.directory"
-    upn="example/kafka-0-broker.agoodexample.autoip.dcos.thisdcos.directory@EXAMPLE" %}
+{% include services/security-kerberos-ad.md data=data %}
 
-{% include services/security-service-keytab.md
-    techName="Apache Kafka" %}
+{% include services/security-service-keytab.md data=data %}
 
 #### Install the Service
 
-Install the DC/OS Apache Kafka service with the following options in addition to your own:
+Install the DC/OS {{ data.techName }} service with the following options in addition to your own:
 ```json
 {
     "service": {
@@ -118,7 +114,7 @@ Install the DC/OS Apache Kafka service with the following options in addition to
 }
 ```
 
-*Note*: If `service.kerberos.enabled_for_zookeeper` is set to true, then the additional setting `kafka.kafka_zookeeper_uri` must be configured to point at a kerberized Apache ZooKeeper as follows:
+*Note*: If `service.kerberos.enabled_for_zookeeper` is set to true, then the additional setting `kafka.kafka_zookeeper_uri` must be configured to point at a kerberized {{ data.kafka.zookeeperTechName }} as follows:
 ```json
 {
     "kafka": {
@@ -126,21 +122,21 @@ Install the DC/OS Apache Kafka service with the following options in addition to
     }
 }
 ```
-The DC/OS Apache ZooKeeper service (`kafka-zookeeper` package) is intended for this purpose and supports Kerberos.
+The DC/OS {{ data.kafka.zookeeperTechName }} service (`{{ data.kafka.zookeeperPackageName }}` package) is intended for this purpose and supports Kerberos.
 
-*Note*: It is possible to enable Kerberos after initial installation but the service may be unavailable during the transition. Additionally, your Kafka clients will need to be reconfigured.
+*Note*: It is possible to enable Kerberos after initial installation but the service may be unavailable during the transition. Additionally, your {{ data.techShortName }} clients will need to be reconfigured.
 
 
 ### SSL Authentication
 
-SSL authentication requires that all clients be they brokers, producers, or consumers present a valid certificate from which their identity can be derived. DC/OS Apache Kafka uses the `CN` of the SSL certificate as the principal for a given client. For example, from the certificate `CN=bob@example.com,OU=,O=Example,L=London,ST=London,C=GB` the principal `bob@example.com` will be extracted.
+SSL authentication requires that all clients be they brokers, producers, or consumers present a valid certificate from which their identity can be derived. DC/OS {{ data.techName }} uses the `CN` of the SSL certificate as the principal for a given client. For example, from the certificate `CN=bob@example.com,OU=,O=Example,L=London,ST=London,C=GB` the principal `bob@example.com` will be extracted.
 
 #### Prerequisites
 - Completion of the section [Transport Encryption](#transport-encryption) above
 
 #### Install the Service
 
-Install the DC/OS Apache Kafka service with the following options in addition to your own:
+Install the DC/OS {{ data.techName }} service with the following options in addition to your own:
 ```json
 {
     "service": {
@@ -158,11 +154,11 @@ Install the DC/OS Apache Kafka service with the following options in addition to
 }
 ```
 
-*Note*: It is possible to enable SSL authentication after initial installation, but the service may be unavailable during the transition. Additionally, your Kafka clients will need to be reconfigured.
+*Note*: It is possible to enable SSL authentication after initial installation, but the service may be unavailable during the transition. Additionally, your {{ data.techShortName }} clients will need to be reconfigured.
 
 #### Authenticating a Client
 
-To authenticate a client against DC/OS Apache Kafka, you will need to configure it to use a certificate signed by the DC/OS CA. After generating a [certificate signing request](https://www.ssl.com/how-to/manually-generate-a-certificate-signing-request-csr-using-openssl/), you can issue it to the DC/OS CA by calling the API `<dcos-cluster>/ca/api/v2/sign`. Using `curl` the request would look like:
+To authenticate a client against DC/OS {{ data.techName }}, you will need to configure it to use a certificate signed by the DC/OS CA. After generating a [certificate signing request](https://www.ssl.com/how-to/manually-generate-a-certificate-signing-request-csr-using-openssl/), you can issue it to the DC/OS CA by calling the API `<dcos-cluster>/ca/api/v2/sign`. Using `curl` the request would look like:
 ```bash
 $ curl -X POST \
     -H "Authorization: token=$(dcos config show core.dcos_acs_token)" \
@@ -174,7 +170,7 @@ The response will contain a signed public certificate. Full details on the DC/OS
 
 ## Authorization
 
-The DC/OS Apache Kafka service supports Kafka's [ACL-based](https://docs.confluent.io/current/kafka/authorization.html#using-acls) authorization system. To use Kafka's ACLs, either SSL or Kerberos authentication must be enabled as detailed above.
+The DC/OS {{ data.techName }} service supports {{ data.techShortName }}'s [ACL-based](https://docs.confluent.io/current/kafka/authorization.html#using-acls) authorization system. To use {{ data.techShortName }}'s ACLs, either SSL or Kerberos authentication must be enabled as detailed above.
 
 ### Enable Authorization
 
@@ -183,7 +179,7 @@ The DC/OS Apache Kafka service supports Kafka's [ACL-based](https://docs.conflue
 
 #### Install the Service
 
-Install the DC/OS Apache Kafka service with the following options in addition to your own (remember, either SSL authentication or Kerberos _must_ be enabled):
+Install the DC/OS {{ data.techName }} service with the following options in addition to your own (remember, either SSL authentication or Kerberos _must_ be enabled):
 ```json
 {
     "service": {
@@ -198,7 +194,7 @@ Install the DC/OS Apache Kafka service with the following options in addition to
 }
 ```
 
-`service.security.authorization.super_users` should be set to a semi-colon delimited list of principals to treat as super users (all permissions). The format of the list is `User:<user1>;User:<user2>;...`. Using Kerberos authentication, the "user" value is the Kerberos primary, and for SSL authentication the "user" value is the `CN` of the certificate. The Kafka brokers themselves are automatically designated as super users.
+`service.security.authorization.super_users` should be set to a semi-colon delimited list of principals to treat as super users (all permissions). The format of the list is `User:<user1>;User:<user2>;...`. Using Kerberos authentication, the "user" value is the Kerberos primary, and for SSL authentication the "user" value is the `CN` of the certificate. The {{ data.techShortName }} brokers themselves are automatically designated as super users.
 
 <!-- TODO. @Evan, did you write something for this already? Or am I mis-remembering? -->
-*Note*:  It is possible to enable Authorization after initial installation, but the service may be unavailable during the transition. Additionally, Kafka clients may fail to function if they do not have the correct ACLs assigned to their principals. During the transition `service.security.authorization.allow_everyone_if_no_acl_found` can be set to `true` to prevent clients from being failing until their ACLs can be set correctly. After the transition, `service.security.authorization.allow_everyone_if_no_acl_found` should be reversed to `false`
+*Note*:  It is possible to enable Authorization after initial installation, but the service may be unavailable during the transition. Additionally, {{ data.techShortName }} clients may fail to function if they do not have the correct ACLs assigned to their principals. During the transition `service.security.authorization.allow_everyone_if_no_acl_found` can be set to `true` to prevent clients from being failing until their ACLs can be set correctly. After the transition, `service.security.authorization.allow_everyone_if_no_acl_found` should be reversed to `false`


### PR DESCRIPTION
* Update templates and security.md's to the right format for docs-site-repo

* Tweak the allow plaintext include in the config

* Take out unsupported mustache conditional