### PR TITLE
[INFINITY-3261] Serial deploy does not wait for green health status.

### DIFF
--- a/frameworks/elastic/docs/limitations.md
+++ b/frameworks/elastic/docs/limitations.md
@@ -13,7 +13,7 @@ The maximum number of deployable nodes is constrained by the DC/OS cluster's res
 
 ## Upgrades and rolling configuration updates do not wait for green status
 
-The `serial` deploy strategy does wait for the cluster to reach green before proceeding to the next node.
+The `serial` deploy strategy does not wait for the cluster to reach green before proceeding to the next node.
 
 ## Out-of-band configuration
 


### PR DESCRIPTION
Mistake noticed by agrzeskowiak: https://mesosphere.slack.com/archives/C07PM5KHQ/p1519408871000641?thread_ts=1519408771.000533&cid=C07PM5KHQ

Also opened https://github.com/mesosphere/dcos-docs-site/pull/668