### PR TITLE
[INFINITY-3328] Remove stub from ZooKeeper tests

### DIFF
--- a/frameworks/kafka/tests/config.py
+++ b/frameworks/kafka/tests/config.py
@@ -5,6 +5,10 @@ import sdk_utils
 PACKAGE_NAME = sdk_utils.get_package_name("kafka")
 SERVICE_NAME = sdk_utils.get_service_name(PACKAGE_NAME.lstrip("beta-"))
 
+ZOOKEEPER_PACKAGE_NAME = "kafka-zookeeper"
+ZOOKEEPER_SERVICE_NAME = "kafka-zookeeper"
+ZOOKEEPER_TASK_COUNT = 6
+
 DEFAULT_BROKER_COUNT = 3
 DEFAULT_PARTITION_COUNT = 1
 DEFAULT_REPLICATION_FACTOR = 1

--- a/frameworks/kafka/tests/test_active_directory_zookeeper_auth.py
+++ b/frameworks/kafka/tests/test_active_directory_zookeeper_auth.py
@@ -37,7 +37,7 @@ def kerberos(configure_security):
 def zookeeper_server(kerberos):
     service_kerberos_options = {
         "service": {
-            "name": "kafka-zookeeper",
+            "name": config.ZOOKEEPER_SERVICE_NAME,
             "security": {
                 "kerberos": {
                     "enabled": True,
@@ -53,18 +53,18 @@ def zookeeper_server(kerberos):
     }
 
     try:
-        sdk_install.uninstall("beta-kafka-zookeeper", "kafka-zookeeper")
+        sdk_install.uninstall(config.ZOOKEEPER_PACKAGE_NAME, config.ZOOKEEPER_SERVICE_NAME)
         sdk_install.install(
-            "beta-kafka-zookeeper",
-            "kafka-zookeeper",
-            6,
+            config.ZOOKEEPER_PACKAGE_NAME,
+            config.ZOOKEEPER_SERVICE_NAME,
+            config.ZOOKEEPER_TASK_COUNT,
             additional_options=service_kerberos_options,
             timeout_seconds=30 * 60)
 
-        yield {**service_kerberos_options, **{"package_name": "beta-kafka-zookeeper"}}
+        yield {**service_kerberos_options, **{"package_name": config.ZOOKEEPER_PACKAGE_NAME}}
 
     finally:
-        sdk_install.uninstall("beta-kafka-zookeeper", "kafka-zookeeper")
+        sdk_install.uninstall(config.ZOOKEEPER_PACKAGE_NAME, config.ZOOKEEPER_SERVICE_NAME)
 
 
 @pytest.fixture(scope='module', autouse=True)

--- a/frameworks/kafka/tests/test_zookeeper.py
+++ b/frameworks/kafka/tests/test_zookeeper.py
@@ -1,41 +1,19 @@
 import pytest
-import retrying
+
 import sdk_cmd
-import sdk_hosts
 import sdk_install
-import sdk_marathon
-import sdk_metrics
 import sdk_plan
-import sdk_tasks
-import sdk_upgrade
 import sdk_security
 import sdk_utils
-import sdk_repository
-import shakedown
+
 from tests import config, test_utils
 
 
-ZK_PACKAGE = "kafka-zookeeper"
-ZK_SERVICE_NAME = "kafka-zookeeper"
-
-
-# NOTE: This can be removed after we publish a zookeeper that
-# has at least through sha a0d96b28769e4cb871b3e2424f4c6b889f5a06dd
 @pytest.fixture(scope='module', autouse=True)
-def install_zookeeper_stub():
-    try:
-        zk_url = "https://universe-converter.mesosphere.com/transform?url=https://infinity-artifacts.s3.amazonaws.com/permanent/kafka-zookeeper/assets/sha-a0d96b28769e4cb871b3e2424f4c6b889f5a06dd/stub-universe-kafka-zookeeper.json"
-
-        stub_urls = sdk_repository.add_stub_universe_urls([zk_url, ])
-        yield
-    finally:
-        sdk_repository.remove_universe_repos(stub_urls)
-
-
-@pytest.fixture(scope='module', autouse=True)
-def configure_zookeeper(configure_security, install_zookeeper_stub):
+def zookeeper_server(configure_security):
     service_options = {
         "service": {
+            "name": config.ZOOKEEPER_SERVICE_NAME,
             "virtual_network_enabled": True
         }
     }
@@ -44,7 +22,7 @@ def configure_zookeeper(configure_security, install_zookeeper_stub):
     zk_secret = "test-zookeeper-secret"
 
     try:
-        sdk_install.uninstall(ZK_PACKAGE, ZK_SERVICE_NAME)
+        sdk_install.uninstall(config.ZOOKEEPER_PACKAGE_NAME, config.ZOOKEEPER_SERVICE_NAME)
         if sdk_utils.is_strict_mode():
             service_options = sdk_install.merge_dictionaries({
                 'service': {
@@ -53,37 +31,43 @@ def configure_zookeeper(configure_security, install_zookeeper_stub):
                 }
             }, service_options)
 
-            sdk_security.setup_security(ZK_SERVICE_NAME, zk_account, zk_secret)
+            sdk_security.setup_security(config.ZOOKEEPER_SERVICE_NAME, zk_account, zk_secret)
 
         sdk_install.install(
-            ZK_PACKAGE,
-            ZK_SERVICE_NAME,
-            6,
+            config.ZOOKEEPER_PACKAGE_NAME,
+            config.ZOOKEEPER_SERVICE_NAME,
+            config.ZOOKEEPER_TASK_COUNT,
             additional_options=service_options,
             timeout_seconds=30 * 60,
             insert_strict_options=False)
 
-        yield
+        yield {**service_options, **{"package_name": config.ZOOKEEPER_PACKAGE_NAME}}
+
     finally:
-        sdk_install.uninstall(ZK_PACKAGE, ZK_SERVICE_NAME)
+        sdk_install.uninstall(config.ZOOKEEPER_PACKAGE_NAME, config.ZOOKEEPER_SERVICE_NAME)
         if sdk_utils.is_strict_mode():
             sdk_security.delete_service_account(
                 service_account_name=zk_account, service_account_secret=zk_secret)
 
 
 @pytest.fixture(scope='module', autouse=True)
-def configure_package(configure_zookeeper):
+def kafka_server(zookeeper_server):
     try:
+
+        # Get the zookeeper DNS values
+        zookeeper_dns = sdk_cmd.svc_cli(zookeeper_server["package_name"],
+                                        zookeeper_server["service"]["name"],
+                                        "endpoint clientport", json=True)["dns"]
+
         sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
 
-        zookeeper_framework_host = "{}.autoip.dcos.thisdcos.directory:1140".format(ZK_SERVICE_NAME)
         config.install(
             config.PACKAGE_NAME,
             config.SERVICE_NAME,
             config.DEFAULT_BROKER_COUNT,
             additional_options={
                 "kafka": {
-                    "kafka_zookeeper_uri": "zookeeper-0-server.{host},zookeeper-0-server.{host},zookeeper-0-server.{host}".format(host=zookeeper_framework_host)
+                    "kafka_zookeeper_uri": ",".join(zookeeper_dns)
                 }
             })
 
@@ -98,27 +82,28 @@ def configure_package(configure_zookeeper):
 
 @pytest.mark.sanity
 @pytest.mark.zookeeper
-def test_zookeeper_reresolution():
+def test_zookeeper_reresolution(kafka_server):
 
     def restart_zookeeper_node(id: int):
-        sdk_cmd.svc_cli(ZK_PACKAGE, ZK_SERVICE_NAME, "pod restart zookeeper-{}".format(id))
+        sdk_cmd.svc_cli(config.ZOOKEEPER_PACKAGE_NAME, config.ZOOKEEPER_SERVICE_NAME,
+                        "pod restart zookeeper-{}".format(id))
 
-        sdk_plan.wait_for_kicked_off_recovery(ZK_SERVICE_NAME)
-        sdk_plan.wait_for_completed_recovery(ZK_SERVICE_NAME)
+        sdk_plan.wait_for_kicked_off_recovery(config.ZOOKEEPER_SERVICE_NAME)
+        sdk_plan.wait_for_completed_recovery(config.ZOOKEEPER_SERVICE_NAME)
 
     # Restart each zookeeper node, so that each one receives a new IP address
     # (it's on a virtual network). This will force Kafka to re-resolve ZK nodes.
-    for id in range(0, 3):
+    for id in range(0, int(config.ZOOKEEPER_TASK_COUNT / 2)):
         restart_zookeeper_node(id)
 
     # Now, verify that Kafka remains happy
     def check_broker(id: int):
-        rc, stdout, stderr = sdk_cmd.run_raw_cli("task log kafka-{}-broker --lines 15".format(id))
+        rc, stdout, _ = sdk_cmd.run_raw_cli("task log kafka-{}-broker --lines 15".format(id))
 
         if rc or not stdout:
             raise Exception("No task logs for kafka-{}-broker".format(id))
 
         assert "java.net.NoRouteToHostException: No route to host" not in stdout
 
-    for id in range(0, 3):
+    for id in range(0, config.DEFAULT_BROKER_COUNT):
         check_broker(id)

--- a/frameworks/kafka/tests/test_zookeeper_auth.py
+++ b/frameworks/kafka/tests/test_zookeeper_auth.py
@@ -44,7 +44,7 @@ def kerberos(configure_security):
 
         principals = auth.get_service_principals(config.SERVICE_NAME,
                                                  kerberos_env.get_realm())
-        principals.extend(get_zookeeper_principals("kafka-zookeeper",
+        principals.extend(get_zookeeper_principals(config.ZOOKEEPER_SERVICE_NAME,
                                                    kerberos_env.get_realm()))
 
         kerberos_env.add_principals(principals)
@@ -60,7 +60,7 @@ def kerberos(configure_security):
 def zookeeper_server(kerberos):
     service_kerberos_options = {
         "service": {
-            "name": "kafka-zookeeper",
+            "name": config.ZOOKEEPER_SERVICE_NAME,
             "security": {
                 "kerberos": {
                     "enabled": True,
@@ -87,20 +87,20 @@ def zookeeper_server(kerberos):
         }, service_kerberos_options)
 
     try:
-        sdk_install.uninstall("beta-kafka-zookeeper", "kafka-zookeeper")
-        sdk_security.setup_security("kafka-zookeeper", zk_account, zk_secret)
+        sdk_install.uninstall(config.ZOOKEEPER_PACKAGE_NAME, config.ZOOKEEPER_SERVICE_NAME)
+        sdk_security.setup_security(config.ZOOKEEPER_SERVICE_NAME, zk_account, zk_secret)
         sdk_install.install(
-            "beta-kafka-zookeeper",
-            "kafka-zookeeper",
-            6,
+            config.ZOOKEEPER_PACKAGE_NAME,
+            config.ZOOKEEPER_SERVICE_NAME,
+            config.ZOOKEEPER_TASK_COUNT,
             additional_options=service_kerberos_options,
             timeout_seconds=30 * 60,
             insert_strict_options=False)
 
-        yield {**service_kerberos_options, **{"package_name": "beta-kafka-zookeeper"}}
+        yield {**service_kerberos_options, **{"package_name": config.ZOOKEEPER_PACKAGE_NAME}}
 
     finally:
-        sdk_install.uninstall("beta-kafka-zookeeper", "kafka-zookeeper")
+        sdk_install.uninstall(config.ZOOKEEPER_PACKAGE_NAME, config.ZOOKEEPER_SERVICE_NAME)
 
 
 @pytest.fixture(scope='module', autouse=True)


### PR DESCRIPTION
This PR removes the use of a ZooKeeper stub from the kafka integration tests as this version of ZK has been published to the universe.

It also does some minor cleanup of the ZooKeeper-related tests in Kafka.