### PR TITLE
[INFINITY-3321] Kibana CI install failure

### DIFF
--- a/testing/sdk_repository.py
+++ b/testing/sdk_repository.py
@@ -52,8 +52,8 @@ def add_stub_universe_urls(stub_universe_urls: list) -> dict:
         return stub_urls
 
     log.info('Adding stub URLs: {}'.format(stub_universe_urls))
-    for url in stub_universe_urls:
-        log.info('url: {}'.format(url))
+    for idx, url in enumerate(stub_universe_urls):
+        log.info('URL {}: {}'.format(idx, repr(url)))
         package_name = 'testpkg-'
         package_name += ''.join(random.choice(string.ascii_lowercase +
                                               string.digits) for _ in range(8))

--- a/testing/sdk_repository.py
+++ b/testing/sdk_repository.py
@@ -9,10 +9,31 @@ import logging
 import os
 import random
 import string
+from itertools import chain, imap
 
 import sdk_cmd
 
 log = logging.getLogger(__name__)
+
+
+def flatmap(f, items):
+    """
+    lines = ["one,two", "three", "four,five"]
+    f     = lambda s: s.split(",")
+
+    >>> map(f, lines)
+    [['one', 'two'], ['three'], ['four', 'five']]
+
+    >>> flatmap(f, lines)
+    ['one', 'two', 'three', 'four', 'five'] 
+    """
+    return chain.from_iterable(imap(f, items))
+
+
+def parse_stub_universe_url_string(stub_universe_url_string):
+    """Handles newline- and comma-separated strings."""
+    lines = stub_universe_url_string.split("\n")
+    filter(None, flatmap(lambda s: s.split(","), lines))
 
 
 def add_universe_repos():
@@ -21,7 +42,7 @@ def add_universe_repos():
     # prepare needed universe repositories
     stub_universe_urls = os.environ.get('STUB_UNIVERSE_URL', "")
 
-    return add_stub_universe_urls(stub_universe_urls.split(","))
+    return add_stub_universe_urls(parse_stub_universe_url_string(stub_universe_urls))
 
 
 def add_stub_universe_urls(stub_universe_urls: list) -> dict:

--- a/testing/sdk_repository.py
+++ b/testing/sdk_repository.py
@@ -9,7 +9,7 @@ import logging
 import os
 import random
 import string
-from itertools import chain, imap
+from itertools import chain
 
 import sdk_cmd
 
@@ -27,14 +27,13 @@ def flatmap(f, items):
     >>> flatmap(f, lines)
     ['one', 'two', 'three', 'four', 'five'] 
     """
-    return chain.from_iterable(imap(f, items))
+    return chain.from_iterable(map(f, items))
 
 
 def parse_stub_universe_url_string(stub_universe_url_string):
     """Handles newline- and comma-separated strings."""
     lines = stub_universe_url_string.split("\n")
-    filter(None, flatmap(lambda s: s.split(","), lines))
-
+    list(filter(None, flatmap(lambda s: s.split(","), lines)))
 
 def add_universe_repos():
     log.info('Adding universe repos')

--- a/testing/sdk_repository.py
+++ b/testing/sdk_repository.py
@@ -25,7 +25,7 @@ def flatmap(f, items):
     [['one', 'two'], ['three'], ['four', 'five']]
 
     >>> flatmap(f, lines)
-    ['one', 'two', 'three', 'four', 'five'] 
+    ['one', 'two', 'three', 'four', 'five']
     """
     return chain.from_iterable(map(f, items))
 
@@ -33,7 +33,7 @@ def flatmap(f, items):
 def parse_stub_universe_url_string(stub_universe_url_string):
     """Handles newline- and comma-separated strings."""
     lines = stub_universe_url_string.split("\n")
-    list(filter(None, flatmap(lambda s: s.split(","), lines)))
+    return list(filter(None, flatmap(lambda s: s.split(","), lines)))
 
 def add_universe_repos():
     log.info('Adding universe repos')

--- a/testing/sdk_repository.py
+++ b/testing/sdk_repository.py
@@ -68,8 +68,12 @@ def add_stub_universe_urls(stub_universe_urls: list) -> dict:
 
     # add the needed universe repositories
     for name, url in stub_urls.items():
-        log.info('Adding stub URL: {}'.format(url))
-        sdk_cmd.run_cli('package repo add --index=0 {} {}'.format(name, url))
+        log.info('Adding stub repo {} URL: {}'.format(name, url))
+        rc, stdout, stderr = sdk_cmd.run_raw_cli('package repo add --index=0 {} {}'.format(name, url))
+        if rc != 0 or stderr:
+            raise Exception(
+                'Failed to add stub repo {} ({}): stdout=[{}], stderr=[{}]'.format(
+                    name, url, stdout, stderr))
 
     log.info('Finished adding universe repos')
 


### PR DESCRIPTION
The build script for the Elastic service builds 2 packages: Elastic and Kibana. A stub Universe is created for each, and for PR builds their URLs are appended to a file (`$UNIVERSE_URL_PATH`), one URL per line.

https://github.com/mesosphere/dcos-commons/blob/3814626ec94197386a0fe2ced623b988e5d4507b/tools/publish_aws.py#L93-L98
https://github.com/mesosphere/dcos-commons/blob/3814626ec94197386a0fe2ced623b988e5d4507b/frameworks/elastic/build.sh#L35

The TC test runner script (TEST_SCRIPT in the TC build parameters) runs `export STUB_UNIVERSE_URL=$(cat $UNIVERSE_URL_PATH)`, making `$STUB_UNIVERSE_URL` a newline-separated string.

During PR build test runs the code that adds the stub Universe repos splits that string by comma (instead of by newline), ending up sending a 2 line command to sdk_cmd, which interprets each line as a separate command.

https://github.com/mesosphere/dcos-commons/blob/3814626ec94197386a0fe2ced623b988e5d4507b/testing/sdk_repository.py#L22-L24

The Elastic repo is added successfully (first line), but the Kibana repo (second line) is interpreted as a shell command, which fails.

```
[2018-03-09 12:45:08,919|sdk_cmd|INFO]: STDERR:
/bin/sh: 2: https://universe-converter.mesosphere.com/transform?url=https://infinity-artifacts-ci.s3.amazonaws.com/autodelete7d/kibana/20180309-123133-S99ev8xdsYyxzKbU/stub-universe-kibana.json: not found
```

This means Kibana tests have been running against the Universe version for some time now, which explains some weirdness I had been seeing when working on the TLS tickets.

This PR:
1. Makes PR test builds fail when there's an error adding the PR's branch build as a stub Universe (what's the point of testing a PR against what's on the official Universe, right?)
2. Fixes the issue with Kibana, making the PR branch Kibana build repo be added successfully. I decided to make the python code that parses `$UNIVERSE_URL_PATH` more robust instead of just making the build shell script append to the same line (or change the TC script), but we could do either one of those instead too.