### PR TITLE
Fix snapshot cleanup for Cassandra

### DIFF
--- a/frameworks/cassandra/src/main/dist/svc.yml
+++ b/frameworks/cassandra/src/main/dist/svc.yml
@@ -152,7 +152,7 @@ pods:
         cmd: >
                 export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jdk*/jre/) ;
                 ./apache-cassandra-{{CASSANDRA_VERSION}}/bin/nodetool clearsnapshot -p ${JMX_PORT} -t "$SNAPSHOT_NAME" -- $(eval "echo $CASSANDRA_KEYSPACES") ;
-                rm -r container-path/snapshot
+                rm -rf container-path/snapshot
         resource-set: sidecar-resources
       fetch-s3:
         goal: ONCE
@@ -376,3 +376,11 @@ plans:
         pod: node
         steps:
           - default: [[restore-snapshot]]
+  cleanup-snapshots:
+    strategy: serial
+    phases:
+      cleanup-snapshots:
+        strategy: {{BACKUP_RESTORE_STRATEGY}}
+        pod: node
+        steps:
+          - default: [[cleanup-snapshot]]


### PR DESCRIPTION
This fixes our inability to recover from a backup which fails part way through.  After an abortive backup attempt running the `cleanup-snapshots` plan will allow a new attempt to succeed.

Testing is proving challenging so I'd like to get the fix in while I work on that.
[Testing JIRA](https://jira.mesosphere.com/browse/CASSANDRA-678)
[Docs JIRA](https://jira.mesosphere.com/browse/CASSANDRA-679)