### PR TITLE
Add region config change validator and builder method for ensuring single-region constraint

### DIFF
--- a/frameworks/helloworld/src/main/java/com/mesosphere/sdk/helloworld/scheduler/Main.java
+++ b/frameworks/helloworld/src/main/java/com/mesosphere/sdk/helloworld/scheduler/Main.java
@@ -49,6 +49,15 @@ public class Main {
                         schedulerConfig,
                         yamlSpecFile.getParentFile());
                 break;
+            case MULTI_REGION:
+                yamlSpecFile = new File(args[0]);
+                serviceSpec = DefaultServiceSpec
+                        .newGenerator(yamlSpecFile, SchedulerConfig.fromEnv())
+                        .build();
+                builder = DefaultScheduler.newBuilder(serviceSpec, SchedulerConfig.fromEnv())
+                        .withSingleRegionConstraint();
+                runner = SchedulerRunner.fromSchedulerBuilder(builder);
+                break;
             case CUSTOM_PLAN:
                 yamlSpecFile = new File(args[0]);
                 serviceSpec = DefaultServiceSpec
@@ -78,7 +87,8 @@ public class Main {
         YAML,
         Java,
         CUSTOM_PLAN,
-        CUSTOM_DECOMMISSION
+        CUSTOM_DECOMMISSION,
+        MULTI_REGION
     }
 
     private static final String SCENARIO_KEY = "SCENARIO";
@@ -86,6 +96,8 @@ public class Main {
     private static final String JAVA_FLAG = "JAVA";
     private static final String CUSTOM_PLAN_FLAG = "CUSTOM_PLAN";
     private static final String CUSTOM_DECOMISSION_FLAG = "CUSTOM_DECOMMISSION";
+    private static final String MULTI_REGION_FLAG = "MULTI_REGION";
+
 
     private static Scenario getScenario() {
         String flag = System.getenv().get(SCENARIO_KEY);
@@ -97,6 +109,8 @@ public class Main {
                 return Scenario.CUSTOM_PLAN;
             case CUSTOM_DECOMISSION_FLAG:
                 return Scenario.CUSTOM_DECOMMISSION;
+            case MULTI_REGION_FLAG:
+                return Scenario.MULTI_REGION;
             case YAML_FLAG:
             default:
                 return Scenario.YAML;

--- a/frameworks/helloworld/tests/test_region_awareness.py
+++ b/frameworks/helloworld/tests/test_region_awareness.py
@@ -18,7 +18,11 @@ POD_NAMES = ['hello-0', 'world-0', 'world-1']
 @pytest.mark.region_awareness
 @sdk_utils.dcos_ee_only
 def test_nodes_deploy_to_local_region_by_default():
-    sdk_install.install(config.PACKAGE_NAME, config.SERVICE_NAME, 3)
+    sdk_install.install(
+        config.PACKAGE_NAME,
+        config.SERVICE_NAME,
+        3,
+        additional_options={"service": {"scenario": "MULTI_REGION"}})
 
     sdk_plan.wait_for_completed_deploy(config.SERVICE_NAME)
 
@@ -42,7 +46,7 @@ def test_nodes_can_deploy_to_remote_region():
         config.PACKAGE_NAME,
         config.SERVICE_NAME,
         3,
-        additional_options={"service": {"region": "Europe"}})
+        additional_options={"service": {"scenario": "MULTI_REGION", "region": "Europe"}})
 
     sdk_plan.wait_for_completed_deploy(config.SERVICE_NAME)
 
@@ -63,7 +67,11 @@ def test_nodes_can_deploy_to_remote_region():
 @pytest.mark.region_awareness
 @sdk_utils.dcos_ee_only
 def test_region_config_update_does_not_succeed():
-    sdk_install.install(config.PACKAGE_NAME, config.SERVICE_NAME, 3)
+    sdk_install.install(
+        config.PACKAGE_NAME,
+        config.SERVICE_NAME,
+        3,
+        additional_options={"service": {"scenario": "MULTI_REGION"}})
 
     sdk_plan.wait_for_completed_deploy(config.SERVICE_NAME)
     change_region_config('Europe')

--- a/frameworks/helloworld/tests/test_region_awareness.py
+++ b/frameworks/helloworld/tests/test_region_awareness.py
@@ -1,0 +1,88 @@
+import json
+import logging
+
+import pytest
+import sdk_cmd
+import sdk_install
+import sdk_marathon
+import sdk_plan
+import sdk_utils
+from tests import config
+
+log = logging.getLogger(__name__)
+
+POD_NAMES = ['hello-0', 'world-0', 'world-1']
+
+
+@pytest.mark.dcos_min_version('1.11')
+@pytest.mark.region_awareness
+@sdk_utils.dcos_ee_only
+def test_nodes_deploy_to_local_region_by_default():
+    sdk_install.install(config.PACKAGE_NAME, config.SERVICE_NAME, 3)
+
+    sdk_plan.wait_for_completed_deploy(config.SERVICE_NAME)
+
+    for pod_name in POD_NAMES:
+        info = sdk_cmd.service_request(
+            'GET', config.SERVICE_NAME, '/v1/pod/{}/info'.format(pod_name)
+        ).json()[0]['info']
+
+        assert (
+            [l['value'] for l in info['labels']['labels'] if l['key'] == 'offer_region'][0] == 'USA'
+        )
+    
+    sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
+
+
+@pytest.mark.dcos_min_version('1.11')
+@pytest.mark.region_awareness
+@sdk_utils.dcos_ee_only
+def test_nodes_can_deploy_to_remote_region():
+    sdk_install.install(
+        config.PACKAGE_NAME,
+        config.SERVICE_NAME,
+        3,
+        additional_options={"service": "region": "Europe"})
+
+    sdk_plan.wait_for_completed_deploy(config.SERVICE_NAME)
+
+    for pod_name in POD_NAMES:
+        info = sdk_cmd.service_request(
+            'GET', config.SERVICE_NAME, '/v1/pod/{}/info'.format(pod_name)
+        ).json()[0]['info']
+
+        assert (
+            [l['value'] for l in info['labels']['labels'] if l['key'] == 'offer_region'][0] ==
+            'Europe'
+        )
+
+    sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
+
+
+@pytest.mark.dcos_min_version('1.11')
+@pytest.mark.region_awareness
+@sdk_utils.dcos_ee_only
+def test_region_config_update_does_not_succeed():
+    sdk_install.install(config.PACKAGE_NAME, config.SERVICE_NAME, 3)
+
+    sdk_plan.wait_for_completed_deploy(config.SERVICE_NAME)
+    change_region_config('Europe')
+    sdk_plan.wait_for_completed_deploy(config.SERVICE_NAME)
+
+    for pod_name in POD_NAMES:
+        info = sdk_cmd.service_request(
+            'GET', config.SERVICE_NAME, '/v1/pod/{}/info'.format(pod_name)
+        ).json()[0]['info']
+
+        assert (
+            [l['value'] for l in info['labels']['labels'] if l['key'] == 'offer_region'][0] == 'USA'
+        )
+    
+
+    sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
+
+
+def change_region_config(region_name):
+    config = sdk_marathon.get_config(config.SERVICE_NAME)
+    config['env']['SERVICE_REGION'] = region_name
+    sdk_marathon.update_app(config.SERVICE_NAME, config)

--- a/frameworks/helloworld/tests/test_region_awareness.py
+++ b/frameworks/helloworld/tests/test_region_awareness.py
@@ -42,7 +42,7 @@ def test_nodes_can_deploy_to_remote_region():
         config.PACKAGE_NAME,
         config.SERVICE_NAME,
         3,
-        additional_options={"service": "region": "Europe"})
+        additional_options={"service": {"region": "Europe"}})
 
     sdk_plan.wait_for_completed_deploy(config.SERVICE_NAME)
 

--- a/frameworks/helloworld/tests/test_region_awareness.py
+++ b/frameworks/helloworld/tests/test_region_awareness.py
@@ -69,15 +69,16 @@ def test_region_config_update_does_not_succeed():
     change_region_config('Europe')
     sdk_plan.wait_for_completed_deploy(config.SERVICE_NAME)
 
-    for pod_name in POD_NAMES:
-        info = sdk_cmd.service_request(
-            'GET', config.SERVICE_NAME, '/v1/pod/{}/info'.format(pod_name)
-        ).json()[0]['info']
+    sdk_cmd.svc_cli(config.PACKAGE_NAME, config.SERVICE_NAME, 'pod replace hello-0')
+    sdk_plan.wait_for_completed_recovery(config.SERVICE_NAME)
 
-        assert (
-            [l['value'] for l in info['labels']['labels'] if l['key'] == 'offer_region'][0] == 'USA'
-        )
-    
+    info = sdk_cmd.service_request(
+        'GET', config.SERVICE_NAME, '/v1/pod/hello-0/info'.format(pod_name)
+    ).json()[0]['info']
+
+    assert (
+        [l['value'] for l in info['labels']['labels'] if l['key'] == 'offer_region'][0] == 'USA'
+    )
 
     sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
 

--- a/frameworks/helloworld/universe/config.json
+++ b/frameworks/helloworld/universe/config.json
@@ -49,6 +49,11 @@
           ],
           "default": "INFO"
         },
+        "region": {
+          "description": "The region that the service's tasks should run in.",
+          "type": "string",
+          "default": ""
+        },
         "sleep": {
           "description": "The sleep duration in seconds before tasks exit.",
           "type": "number",
@@ -66,7 +71,8 @@
             "YAML",
             "JAVA",
             "CUSTOM_PLAN",
-            "CUSTOM_DECOMMISSION"
+            "CUSTOM_DECOMMISSION",
+            "MULTI_REGION"
           ],
           "default": "YAML"
         },

--- a/frameworks/helloworld/universe/marathon.json.mustache
+++ b/frameworks/helloworld/universe/marathon.json.mustache
@@ -47,6 +47,9 @@
     {{#world.kill_grace_period}}
     "WORLD_KILL_GRACE_PERIOD": "{{world.kill_grace_period}}",
     {{/world.kill_grace_period}}
+    {{#service.region}}
+    "SERVICE_REGION": "{{service.region}}",
+    {{/service.region}}
     "SLEEP_DURATION": "{{service.sleep}}",
     "JAVA_URI": "{{resource.assets.uris.jre-tar-gz}}",
     "EXECUTOR_URI": "{{resource.assets.uris.executor-zip}}",

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/config/validate/DefaultConfigValidators.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/config/validate/DefaultConfigValidators.java
@@ -26,6 +26,7 @@ public class DefaultConfigValidators {
                 new UserCannotChange(),
                 new TLSRequiresServiceAccount(schedulerConfig),
                 new DomainCapabilityValidator(),
-                new PlacementRuleIsValid());
+                new PlacementRuleIsValid(),
+                new RegionCannotChange());
     }
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/config/validate/RegionCannotChange.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/config/validate/RegionCannotChange.java
@@ -1,0 +1,4 @@
+package com.mesosphere.sdk.config.validate;
+
+public class RegionCannotChange {
+}

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/config/validate/RegionCannotChange.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/config/validate/RegionCannotChange.java
@@ -21,7 +21,14 @@ public class RegionCannotChange implements ConfigValidator<ServiceSpec> {
         }
 
         List<ConfigValidationError> errors = new ArrayList<>();
-        if (oldConfig.get().getRegion() != null && !oldConfig.get().getRegion().equals(newConfig.getRegion())) {
+        boolean regionWasAdded = oldConfig.isPresent() && !oldConfig.get().getRegion().isPresent() &&
+                newConfig.getRegion().isPresent();
+        boolean regionWasUnset = oldConfig.isPresent() && oldConfig.get().getRegion().isPresent() &&
+                !newConfig.getRegion().isPresent();
+        boolean regionWasChanged = oldConfig.isPresent() && oldConfig.get().getRegion().isPresent() &&
+                newConfig.getRegion().isPresent() &&
+                !newConfig.getRegion().get().equals(oldConfig.get().getRegion().get());
+        if (regionWasAdded || regionWasUnset || regionWasChanged) {
             errors.add(ConfigValidationError.transitionError(
                     "region",
                     oldConfig.get().getUser(),

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/config/validate/RegionCannotChange.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/config/validate/RegionCannotChange.java
@@ -1,4 +1,36 @@
 package com.mesosphere.sdk.config.validate;
 
-public class RegionCannotChange {
+import com.mesosphere.sdk.specification.ServiceSpec;
+
+import java.util.*;
+
+/**
+ * Configuration validator which validates that a {@link com.mesosphere.sdk.specification.ServiceSpec}'s region
+ * cannot change between deployments.
+ *
+ * This is to prevent a pod deployed in one region from being deployed in another region if it is replaced, since we
+ * do not support multi-region deployments. Since region awareness is implemented with placement constraints,
+ * a pod replace would otherwise break this assumption.
+ */
+public class RegionCannotChange implements ConfigValidator<ServiceSpec> {
+
+    @Override
+    public Collection<ConfigValidationError> validate(Optional<ServiceSpec> oldConfig, ServiceSpec newConfig) {
+        if (!oldConfig.isPresent()) {
+            return Collections.emptyList();
+        }
+
+        List<ConfigValidationError> errors = new ArrayList<>();
+        if (oldConfig.get().getRegion() != null && !oldConfig.get().getRegion().equals(newConfig.getRegion())) {
+            errors.add(ConfigValidationError.transitionError(
+                    "region",
+                    oldConfig.get().getUser(),
+                    newConfig.getUser(),
+                    "Region for old service must remain the same across deployments."
+            ));
+        }
+
+        return errors;
+    }
 }
+

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerBuilder.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerBuilder.java
@@ -230,7 +230,8 @@ public class SchedulerBuilder {
          return this;
     }
 
-    private static PlacementRule getRegionRule(String schedulerRegion) {
+    @VisibleForTesting
+    static PlacementRule getRegionRule(String schedulerRegion) {
         if (schedulerRegion == null) {
             return new IsLocalRegionRule();
         }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerBuilder.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerBuilder.java
@@ -218,7 +218,7 @@ public class SchedulerBuilder {
     }
 
     public SchedulerBuilder withSingleRegionConstraint() {
-         String schedulerRegion = schedulerConfig.getSchedulerRegion();
+         Optional<String> schedulerRegion = schedulerConfig.getSchedulerRegion();
          PlacementRule regionRule = getRegionRule(schedulerRegion);
 
          List<PodSpec> updatedPodSpecs = serviceSpec.getPods().stream()
@@ -231,12 +231,12 @@ public class SchedulerBuilder {
     }
 
     @VisibleForTesting
-    static PlacementRule getRegionRule(String schedulerRegion) {
-        if (schedulerRegion == null) {
+    static PlacementRule getRegionRule(Optional<String> schedulerRegion) {
+        if (!schedulerRegion.isPresent()) {
             return new IsLocalRegionRule();
         }
 
-        return RegionRuleFactory.getInstance().require(ExactMatcher.create(schedulerRegion));
+        return RegionRuleFactory.getInstance().require(ExactMatcher.create(schedulerRegion.get()));
     }
 
     private static PodSpec podWithPlacementRule(PodSpec podSpec, PlacementRule placementRule) {

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerBuilder.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerBuilder.java
@@ -225,7 +225,11 @@ public class SchedulerBuilder {
                  .map(p -> podWithPlacementRule(p, regionRule))
                  .collect(Collectors.toList());
 
-         serviceSpec = DefaultServiceSpec.newBuilder(serviceSpec).pods(updatedPodSpecs).build();
+         DefaultServiceSpec.Builder builder = DefaultServiceSpec.newBuilder(serviceSpec).pods(updatedPodSpecs);
+         if (schedulerRegion.isPresent()) {
+             builder.region(schedulerRegion.get());
+         }
+         serviceSpec = builder.build();
 
          return this;
     }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerConfig.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerConfig.java
@@ -24,6 +24,7 @@ import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.RSAPublicKeySpec;
 import java.time.Duration;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * This class encapsulates global Scheduler settings retrieved from the environment. Presented as a non-static object
@@ -226,8 +227,8 @@ public class SchedulerConfig {
         return envStore.getOptional(MARATHON_APP_ID_ENV, "/");
     }
 
-    public String getSchedulerRegion() {
-        return envStore.getOptional(SERVICE_REGION_ENV, null);
+    public Optional<String> getSchedulerRegion() {
+        return Optional.ofNullable(envStore.getOptional(SERVICE_REGION_ENV, null));
     }
 
     public String getSecretsNamespace(String serviceName) {

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerConfig.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerConfig.java
@@ -136,6 +136,11 @@ public class SchedulerConfig {
     private static final String PACKAGE_BUILD_TIME_EPOCH_MS_ENV = "PACKAGE_BUILD_TIME_EPOCH_MS";
 
     /**
+     * An environment variable that advertises to the service what region its tasks should run in.
+     */
+    private static final String SERVICE_REGION_ENV = "SERVICE_REGION";
+
+    /**
      * Environment variables for configuring metrics reporting behavior.
      */
     private static final String STATSD_POLL_INTERVAL_S_ENV = "STATSD_POLL_INTERVAL_S";
@@ -219,6 +224,10 @@ public class SchedulerConfig {
             return value;
         }
         return envStore.getOptional(MARATHON_APP_ID_ENV, "/");
+    }
+
+    public String getSchedulerRegion() {
+        return envStore.getOptional(SERVICE_REGION_ENV, null);
     }
 
     public String getSecretsNamespace(String serviceName) {

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultServiceSpec.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultServiceSpec.java
@@ -66,6 +66,8 @@ public class DefaultServiceSpec implements ServiceSpec {
     @Valid
     private ReplacementFailurePolicy replacementFailurePolicy;
 
+    private String region;
+
     @JsonCreator
     public DefaultServiceSpec(
             @JsonProperty("name") String name,
@@ -75,7 +77,8 @@ public class DefaultServiceSpec implements ServiceSpec {
             @JsonProperty("zookeeper") String zookeeperConnection,
             @JsonProperty("pod-specs") List<PodSpec> pods,
             @JsonProperty("replacement-failure-policy") ReplacementFailurePolicy replacementFailurePolicy,
-            @JsonProperty("user") String user) {
+            @JsonProperty("user") String user,
+            @JsonProperty("region") String region) {
         this.name = name;
         this.role = role;
         this.principal = principal;
@@ -86,6 +89,7 @@ public class DefaultServiceSpec implements ServiceSpec {
         this.pods = pods;
         this.replacementFailurePolicy = replacementFailurePolicy;
         this.user = getUser(user, pods);
+        this.region = region;
         ValidationUtils.validate(this);
     }
 
@@ -118,7 +122,8 @@ public class DefaultServiceSpec implements ServiceSpec {
                 builder.zookeeperConnection,
                 builder.pods,
                 builder.replacementFailurePolicy,
-                builder.user);
+                builder.user,
+                builder.region);
     }
 
     /**
@@ -174,6 +179,7 @@ public class DefaultServiceSpec implements ServiceSpec {
         builder.pods = copy.getPods();
         builder.replacementFailurePolicy = copy.getReplacementFailurePolicy().orElse(null);
         builder.user = copy.getUser();
+        builder.region = copy.getRegion().orElse(null);
         return builder;
     }
 
@@ -210,6 +216,11 @@ public class DefaultServiceSpec implements ServiceSpec {
     @Override
     public Optional<ReplacementFailurePolicy> getReplacementFailurePolicy() {
         return Optional.ofNullable(replacementFailurePolicy);
+    }
+
+    @Override
+    public Optional<String> getRegion() {
+        return Optional.ofNullable(region);
     }
 
     @Override
@@ -503,6 +514,7 @@ public class DefaultServiceSpec implements ServiceSpec {
         private List<PodSpec> pods = new ArrayList<>();
         private ReplacementFailurePolicy replacementFailurePolicy;
         private String user;
+        private String region;
 
         private Builder() {
         }
@@ -562,6 +574,18 @@ public class DefaultServiceSpec implements ServiceSpec {
          */
         public Builder user(String user) {
             this.user = user;
+            return this;
+        }
+
+        /**
+         * Sets the {@code region} and returns a reference to this Builder so that the methods can be chained
+         * together.
+         *
+         * @param region the {@code region} to set
+         * @return a reference to this Builder
+         */
+        public Builder region(String region) {
+            this.region = region;
             return this;
         }
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/ServiceSpec.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/ServiceSpec.java
@@ -33,4 +33,7 @@ public interface ServiceSpec extends Configuration {
 
     @JsonProperty("user")
     String getUser();
+
+    @JsonProperty("region")
+    Optional<String> getRegion();
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/validation/RegionValidator.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/validation/RegionValidator.java
@@ -1,0 +1,70 @@
+package com.mesosphere.sdk.specification.validation;
+
+import com.mesosphere.sdk.config.validate.ConfigValidationError;
+import com.mesosphere.sdk.offer.evaluate.placement.PlacementRule;
+import com.mesosphere.sdk.offer.evaluate.placement.PlacementUtils;
+import com.mesosphere.sdk.specification.PodSpec;
+import com.mesosphere.sdk.specification.ServiceSpec;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * This class validates that referencing Regions in placement constraints can only support the following transitions.
+ *
+ * 1. null  --> false
+ * 2. true  --> true
+ * 3. false --> false
+ */
+public class RegionValidator {
+    public static Collection<ConfigValidationError> validate(
+            Optional<ServiceSpec> oldConfig, ServiceSpec newConfig, String... podTypes) {
+        return Arrays.asList(podTypes).stream()
+                .flatMap(p -> validate(oldConfig, newConfig, p).stream())
+                .collect(Collectors.toList());
+    }
+
+    private static Collection<ConfigValidationError> validate(
+            Optional<ServiceSpec> oldConfig,
+            ServiceSpec newConfig,
+            String podType) {
+        if (!oldConfig.isPresent()) {
+            return Collections.emptyList();
+        }
+
+        Optional<PodSpec> oldPod = getPodSpec(oldConfig.get(), podType);
+        if (!oldPod.isPresent()) {
+            return Collections.emptyList();
+        }
+
+        Optional<PodSpec> newPod = getPodSpec(newConfig, podType);
+        if (!newPod.isPresent()) {
+            throw new IllegalArgumentException(String.format("Unable to find requested pod=%s, in config: %s",
+                    podType, newConfig));
+        }
+
+        boolean oldReferencesRegions = PlacementUtils.placementRuleReferencesRegion(oldPod.get());
+        boolean newReferencesRegions = PlacementUtils.placementRuleReferencesRegion(newPod.get());
+
+        if (oldReferencesRegions != newReferencesRegions) {
+            Optional<PlacementRule> oldRule = oldPod.get().getPlacementRule();
+            Optional<PlacementRule> newRule = newPod.get().getPlacementRule();
+            ConfigValidationError error = ConfigValidationError.transitionError(
+                    String.format("%s.PlacementRule", podType),
+                    oldRule.toString(), newRule.toString(),
+                    String.format("PlacementRule cannot change from %s to %s", oldRule, newRule));
+            return Arrays.asList(error);
+        }
+
+        return Collections.emptyList();
+    }
+
+    private static Optional<PodSpec> getPodSpec(ServiceSpec serviceSpecification, String podType) {
+        return serviceSpecification.getPods().stream()
+                .filter(pod -> pod.getType().equals(podType))
+                .findFirst();
+    }
+}

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/config/validate/RegionCannotChangeTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/config/validate/RegionCannotChangeTest.java
@@ -1,0 +1,113 @@
+package com.mesosphere.sdk.config.validate;
+
+import com.mesosphere.sdk.specification.DefaultServiceSpec;
+import com.mesosphere.sdk.specification.PodSpec;
+import com.mesosphere.sdk.specification.ServiceSpec;
+import com.mesosphere.sdk.testutils.TestConstants;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import static org.mockito.Mockito.when;
+
+public class RegionCannotChangeTest {
+    private static final ConfigValidator<ServiceSpec> VALIDATOR = new RegionCannotChange();
+    private static final String REGION_A = "A";
+    private static final String REGION_B = "B";
+
+    @Mock
+    private PodSpec mockPodSpec;
+
+    @Before
+    public void beforeEach() {
+        MockitoAnnotations.initMocks(this);
+        when(mockPodSpec.getUser()).thenReturn(Optional.of(TestConstants.SERVICE_USER));
+        when(mockPodSpec.getType()).thenReturn("node-1");
+    }
+
+    @Test
+    public void testSameRegion() {
+        ServiceSpec oldServiceSpec = DefaultServiceSpec.newBuilder()
+                .name("svc")
+                .role(TestConstants.ROLE)
+                .principal(TestConstants.PRINCIPAL)
+                .pods(Arrays.asList(mockPodSpec))
+                .region(REGION_A)
+                .build();
+
+        ServiceSpec newServiceSpec = DefaultServiceSpec.newBuilder()
+                .name("svc")
+                .role(TestConstants.ROLE)
+                .principal(TestConstants.PRINCIPAL)
+                .pods(Arrays.asList(mockPodSpec))
+                .region(REGION_A)
+                .build();
+
+        Assert.assertEquals(0, VALIDATOR.validate(Optional.of(oldServiceSpec), newServiceSpec).size());
+    }
+
+    @Test
+    public void testDifferentRegion() {
+        ServiceSpec oldServiceSpec = DefaultServiceSpec.newBuilder()
+                .name("svc")
+                .role(TestConstants.ROLE)
+                .principal(TestConstants.PRINCIPAL)
+                .pods(Arrays.asList(mockPodSpec))
+                .region(REGION_A)
+                .build();
+
+        ServiceSpec newServiceSpec = DefaultServiceSpec.newBuilder()
+                .name("svc")
+                .role(TestConstants.ROLE)
+                .principal(TestConstants.PRINCIPAL)
+                .pods(Arrays.asList(mockPodSpec))
+                .region(REGION_B)
+                .build();
+
+        Assert.assertEquals(1, VALIDATOR.validate(Optional.of(oldServiceSpec), newServiceSpec).size());
+    }
+
+    @Test
+    public void testOldRegionUnset() {
+        ServiceSpec oldServiceSpec = DefaultServiceSpec.newBuilder()
+                .name("svc")
+                .role(TestConstants.ROLE)
+                .principal(TestConstants.PRINCIPAL)
+                .pods(Arrays.asList(mockPodSpec))
+                .build();
+
+        ServiceSpec newServiceSpec = DefaultServiceSpec.newBuilder()
+                .name("svc")
+                .role(TestConstants.ROLE)
+                .principal(TestConstants.PRINCIPAL)
+                .pods(Arrays.asList(mockPodSpec))
+                .region(REGION_A)
+                .build();
+
+        Assert.assertEquals(1, VALIDATOR.validate(Optional.of(oldServiceSpec), newServiceSpec).size());
+    }
+
+    @Test
+    public void testNoRegion() {
+        ServiceSpec oldServiceSpec = DefaultServiceSpec.newBuilder()
+                .name("svc")
+                .role(TestConstants.ROLE)
+                .principal(TestConstants.PRINCIPAL)
+                .pods(Arrays.asList(mockPodSpec))
+                .build();
+
+        ServiceSpec newServiceSpec = DefaultServiceSpec.newBuilder()
+                .name("svc")
+                .role(TestConstants.ROLE)
+                .principal(TestConstants.PRINCIPAL)
+                .pods(Arrays.asList(mockPodSpec))
+                .build();
+
+        Assert.assertEquals(0, VALIDATOR.validate(Optional.of(oldServiceSpec), newServiceSpec).size());
+    }
+}

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/config/validate/RegionCannotChangeTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/config/validate/RegionCannotChangeTest.java
@@ -79,6 +79,7 @@ public class RegionCannotChangeTest {
                 .role(TestConstants.ROLE)
                 .principal(TestConstants.PRINCIPAL)
                 .pods(Arrays.asList(mockPodSpec))
+                .region(REGION_A)
                 .build();
 
         ServiceSpec newServiceSpec = DefaultServiceSpec.newBuilder()
@@ -86,7 +87,6 @@ public class RegionCannotChangeTest {
                 .role(TestConstants.ROLE)
                 .principal(TestConstants.PRINCIPAL)
                 .pods(Arrays.asList(mockPodSpec))
-                .region(REGION_A)
                 .build();
 
         Assert.assertEquals(1, VALIDATOR.validate(Optional.of(oldServiceSpec), newServiceSpec).size());
@@ -109,5 +109,25 @@ public class RegionCannotChangeTest {
                 .build();
 
         Assert.assertEquals(0, VALIDATOR.validate(Optional.of(oldServiceSpec), newServiceSpec).size());
+    }
+
+    @Test
+    public void testUpdateToRegionFromBlank() {
+        ServiceSpec oldServiceSpec = DefaultServiceSpec.newBuilder()
+                .name("svc")
+                .role(TestConstants.ROLE)
+                .principal(TestConstants.PRINCIPAL)
+                .pods(Arrays.asList(mockPodSpec))
+                .build();
+
+        ServiceSpec newServiceSpec = DefaultServiceSpec.newBuilder()
+                .name("svc")
+                .role(TestConstants.ROLE)
+                .principal(TestConstants.PRINCIPAL)
+                .pods(Arrays.asList(mockPodSpec))
+                .region(REGION_A)
+                .build();
+
+        Assert.assertEquals(1, VALIDATOR.validate(Optional.of(oldServiceSpec), newServiceSpec).size());
     }
 }

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/SchedulerBuilderTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/SchedulerBuilderTest.java
@@ -9,6 +9,8 @@ import com.mesosphere.sdk.testutils.TestPodFactory;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.Optional;
+
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -60,7 +62,7 @@ public class SchedulerBuilderTest {
         PlacementRule placementRule = SchedulerBuilder.getRegionRule(null);
         Assert.assertTrue(placementRule instanceof IsLocalRegionRule);
 
-        placementRule = SchedulerBuilder.getRegionRule("USA");
+        placementRule = SchedulerBuilder.getRegionRule(Optional.of("USA"));
         Assert.assertTrue(placementRule instanceof RegionRule);
     }
 

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/SchedulerBuilderTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/SchedulerBuilderTest.java
@@ -55,6 +55,15 @@ public class SchedulerBuilderTest {
         Assert.assertTrue(PlacementUtils.placementRuleReferencesRegion(updatedPodSpec));
     }
 
+    @Test
+    public void constraintToSingleRegion() {
+        PlacementRule placementRule = SchedulerBuilder.getRegionRule(null);
+        Assert.assertTrue(placementRule instanceof IsLocalRegionRule);
+
+        placementRule = SchedulerBuilder.getRegionRule("USA");
+        Assert.assertTrue(placementRule instanceof RegionRule);
+    }
+
     private PlacementRule getRemoteRegionRule() {
         return RegionRuleFactory.getInstance().require(ExactMatcher.create(TestConstants.REMOTE_REGION));
     }

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/SchedulerBuilderTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/SchedulerBuilderTest.java
@@ -58,8 +58,8 @@ public class SchedulerBuilderTest {
     }
 
     @Test
-    public void constraintToSingleRegion() {
-        PlacementRule placementRule = SchedulerBuilder.getRegionRule(null);
+    public void constrainToSingleRegion() {
+        PlacementRule placementRule = SchedulerBuilder.getRegionRule(Optional.empty());
         Assert.assertTrue(placementRule instanceof IsLocalRegionRule);
 
         placementRule = SchedulerBuilder.getRegionRule(Optional.of("USA"));

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/specification/validation/ZoneValidatorTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/specification/validation/ZoneValidatorTest.java
@@ -150,6 +150,7 @@ public class ZoneValidatorTest {
                 "http://zookeeper",
                 Arrays.asList(podSpec),
                 null,
-                TestConstants.SERVICE_USER);
+                TestConstants.SERVICE_USER,
+                null);
     }
 }


### PR DESCRIPTION
Adding tests for this functionality now, but I wanted to make sure we were all on the same page about how it works. The downside I can see is that, if you have placed your scheduler in a single region explicitly and then change that region in your config, `RegionValidator` won't catch that and so you'll only find out once offers start getting rejected. This is a hazard of `ZoneValidator` too, though, and since computing equality over things like a regex-based placement rule isn't feasible I think that's a limitation we'll have to accept.