### PR TITLE
[INFINITY-3080] Use fine-grained permissions for DC/OS 1.11. (#2310)

### DIFF
--- a/frameworks/cassandra/tests/test_tls.py
+++ b/frameworks/cassandra/tests/test_tls.py
@@ -8,8 +8,10 @@ import sdk_cmd
 import sdk_install
 import sdk_jobs
 import sdk_plan
-import sdk_security
 import sdk_utils
+
+from security import transport_encryption
+
 from tests import config
 
 
@@ -25,20 +27,18 @@ def dcos_ca_bundle():
 
 
 @pytest.fixture(scope='module')
-def service_account():
+def service_account(configure_security):
     """
-    Creates service account with `hello-world` name and yields the name.
+    Sets up a service account for use with TLS.
     """
-    # This name should be same as SERVICE_NAME as it determines scheduler DCOS_LABEL value.
-    name = config.SERVICE_NAME
-    sdk_security.create_service_account(
-        service_account_name=name, service_account_secret=name)
-    # TODO(mh): Fine grained permissions needs to be addressed in DCOS-16475
-    sdk_cmd.run_cli(
-        "security org groups add_user superusers {name}".format(name=name))
-    yield name
-    sdk_security.delete_service_account(
-        service_account_name=name, service_account_secret=name)
+    try:
+        name = config.SERVICE_NAME
+        service_account_info = transport_encryption.setup_service_account(name)
+
+        yield service_account_info
+    finally:
+        transport_encryption.cleanup_service_account(config.SERVICE_NAME,
+                                                     service_account_info)
 
 
 @pytest.fixture(scope='module')
@@ -46,12 +46,12 @@ def cassandra_service_tls(service_account):
     sdk_install.uninstall(package_name=config.PACKAGE_NAME, service_name=config.SERVICE_NAME)
     sdk_install.install(
         config.PACKAGE_NAME,
-        service_account,
+        config.SERVICE_NAME,
         config.DEFAULT_TASK_COUNT,
         additional_options={
             "service": {
-                "service_account_secret": service_account,
-                "service_account": service_account,
+                "service_account": service_account["name"],
+                "service_account_secret": service_account["secret"],
                 "security": {
                     "transport_encryption": {
                         "enabled": True
@@ -90,7 +90,8 @@ def test_tls_connection(cassandra_service_tls, dcos_ca_bundle):
 
         key_id = os.getenv('AWS_ACCESS_KEY_ID')
         if not key_id:
-            assert False, 'AWS credentials are required for this test. Disable test with e.g. TEST_TYPES="sanity and not aws"'
+            assert False, 'AWS credentials are required for this test. ' \
+                          'Disable test with e.g. TEST_TYPES="sanity and not aws"'
         plan_parameters = {
             'AWS_ACCESS_KEY_ID': key_id,
             'AWS_SECRET_ACCESS_KEY': os.getenv('AWS_SECRET_ACCESS_KEY'),

--- a/frameworks/cassandra/tests/test_toggle_tls.py
+++ b/frameworks/cassandra/tests/test_toggle_tls.py
@@ -8,7 +8,6 @@ import sdk_cmd
 import sdk_install
 import sdk_jobs
 import sdk_plan
-import sdk_security
 import sdk_utils
 
 from security import transport_encryption
@@ -21,20 +20,16 @@ log = logging.getLogger(__name__)
 @pytest.fixture(scope='module')
 def service_account(configure_security):
     """
-    Creates service account and secret and yields dict containing both.
+    Sets up a service account for use with TLS.
     """
     try:
         name = config.SERVICE_NAME
-        secret = "{}-secret".format(name)
-        sdk_security.create_service_account(
-            service_account_name=name, service_account_secret=secret)
-        # TODO(mh): Fine grained permissions needs to be addressed in DCOS-16475
-        sdk_cmd.run_cli(
-            "security org groups add_user superusers {name}".format(name=name))
-        yield {"name": name, "secret": secret}
+        service_account_info = transport_encryption.setup_service_account(name)
+
+        yield service_account_info
     finally:
-        sdk_security.delete_service_account(
-            service_account_name=name, service_account_secret=secret)
+        transport_encryption.cleanup_service_account(config.SERVICE_NAME,
+                                                     service_account_info)
 
 
 @pytest.fixture(scope='module')

--- a/frameworks/hdfs/tests/test_kerberos_auth.py
+++ b/frameworks/hdfs/tests/test_kerberos_auth.py
@@ -7,10 +7,10 @@ import sdk_cmd
 import sdk_hosts
 import sdk_install
 import sdk_marathon
-import sdk_security
 import sdk_utils
 
 from security import kerberos as krb5
+from security import transport_encryption
 
 from tests import auth
 from tests import config
@@ -26,19 +26,16 @@ pytestmark = pytest.mark.skipif(sdk_utils.is_open_dcos(),
 @pytest.fixture(scope='module', autouse=True)
 def service_account(configure_security):
     """
-    Creates service account and yields the name.
+    Sets up a service account for use with TLS.
     """
     try:
         name = config.SERVICE_NAME
-        sdk_security.create_service_account(
-            service_account_name=name, service_account_secret=name)
-        # TODO(mh): Fine grained permissions needs to be addressed in DCOS-16475
-        sdk_cmd.run_cli(
-            "security org groups add_user superusers {name}".format(name=name))
-        yield name
+        service_account_info = transport_encryption.setup_service_account(name)
+
+        yield service_account_info
     finally:
-        sdk_security.delete_service_account(
-            service_account_name=name, service_account_secret=name)
+        transport_encryption.cleanup_service_account(config.SERVICE_NAME,
+                                                     service_account_info)
 
 
 @pytest.fixture(scope='module', autouse=True)
@@ -66,8 +63,8 @@ def hdfs_server(kerberos, service_account):
     service_kerberos_options = {
         "service": {
             "name": config.FOLDERED_SERVICE_NAME,
-            "service_account": service_account,
-            "service_account_secret": service_account,
+            "service_account": service_account["name"],
+            "service_account_secret": service_account["secret"],
             "security": {
                 "kerberos": {
                     "enabled": True,

--- a/frameworks/hdfs/tests/test_ssl_kerberos_auth.py
+++ b/frameworks/hdfs/tests/test_ssl_kerberos_auth.py
@@ -7,7 +7,6 @@ import sdk_cmd
 import sdk_hosts
 import sdk_install
 import sdk_marathon
-import sdk_security
 import sdk_utils
 
 from security import kerberos as krb5
@@ -27,19 +26,16 @@ pytestmark = pytest.mark.skipif(sdk_utils.is_open_dcos(),
 @pytest.fixture(scope='module', autouse=True)
 def service_account(configure_security):
     """
-    Creates service account and yields the name.
+    Sets up a service account for use with TLS.
     """
     try:
         name = config.SERVICE_NAME
-        sdk_security.create_service_account(
-            service_account_name=name, service_account_secret=name)
-        # TODO(mh): Fine grained permissions needs to be addressed in DCOS-16475
-        sdk_cmd.run_cli(
-            "security org groups add_user superusers {name}".format(name=name))
-        yield name
+        service_account_info = transport_encryption.setup_service_account(name)
+
+        yield service_account_info
     finally:
-        sdk_security.delete_service_account(
-            service_account_name=name, service_account_secret=name)
+        transport_encryption.cleanup_service_account(config.SERVICE_NAME,
+                                                     service_account_info)
 
 
 @pytest.fixture(scope='module', autouse=True)
@@ -67,8 +63,8 @@ def hdfs_server(kerberos, service_account):
     service_kerberos_options = {
         "service": {
             "name": config.SERVICE_NAME,
-            "service_account": service_account,
-            "service_account_secret": service_account,
+            "service_account": service_account["name"],
+            "service_account_secret": service_account["secret"],
             "security": {
                 "kerberos": {
                     "enabled": True,

--- a/frameworks/hdfs/tests/test_tls.py
+++ b/frameworks/hdfs/tests/test_tls.py
@@ -1,13 +1,14 @@
 import pytest
 
-import sdk_cmd
 import sdk_install
 import sdk_hosts
 import sdk_plan
-import sdk_security
 import sdk_utils
 import retrying
 import shakedown
+
+from security import transport_encryption
+
 from tests import config
 
 
@@ -19,19 +20,16 @@ DEFAULT_DATA_NODE_TLS_PORT = 9006
 @pytest.fixture(scope='module')
 def service_account(configure_security):
     """
-    Creates service account and yields the name.
+    Sets up a service account for use with TLS.
     """
     try:
         name = config.SERVICE_NAME
-        sdk_security.create_service_account(
-            service_account_name=name, service_account_secret=name)
-        # TODO(mh): Fine grained permissions needs to be addressed in DCOS-16475
-        sdk_cmd.run_cli(
-            "security org groups add_user superusers {name}".format(name=name))
-        yield name
+        service_account_info = transport_encryption.setup_service_account(name)
+
+        yield service_account_info
     finally:
-        sdk_security.delete_service_account(
-            service_account_name=name, service_account_secret=name)
+        transport_encryption.cleanup_service_account(config.SERVICE_NAME,
+                                                     service_account_info)
 
 
 @pytest.fixture(scope='module')
@@ -44,8 +42,8 @@ def hdfs_service_tls(service_account):
             expected_running_tasks=config.DEFAULT_TASK_COUNT,
             additional_options={
                 "service": {
-                    "service_account_secret": service_account,
-                    "service_account": service_account,
+                    "service_account_secret": service_account["name"],
+                    "service_account": service_account["secret"],
                     "security": {
                         "transport_encryption": {
                             "enabled": True

--- a/frameworks/kafka/tests/test_ssl_kerberos_auth.py
+++ b/frameworks/kafka/tests/test_ssl_kerberos_auth.py
@@ -4,10 +4,8 @@ import pytest
 
 import sdk_auth
 import sdk_cmd
-import sdk_hosts
 import sdk_install
 import sdk_marathon
-import sdk_security
 import sdk_utils
 
 
@@ -29,17 +27,16 @@ pytestmark = pytest.mark.skipif(sdk_utils.is_open_dcos(),
 @pytest.fixture(scope='module', autouse=True)
 def service_account(configure_security):
     """
-    Creates service account and yields the name.
+    Sets up a service account for use with TLS.
     """
-    name = config.SERVICE_NAME
-    sdk_security.create_service_account(
-        service_account_name=name, service_account_secret=name)
-    # TODO(mh): Fine grained permissions needs to be addressed in DCOS-16475
-    sdk_cmd.run_cli(
-        "security org groups add_user superusers {name}".format(name=name))
-    yield name
-    sdk_security.delete_service_account(
-        service_account_name=name, service_account_secret=name)
+    try:
+        name = config.SERVICE_NAME
+        service_account_info = transport_encryption.setup_service_account(name)
+
+        yield service_account_info
+    finally:
+        transport_encryption.cleanup_service_account(config.SERVICE_NAME,
+                                                     service_account_info)
 
 
 @pytest.fixture(scope='module', autouse=True)
@@ -68,8 +65,8 @@ def kafka_server(kerberos, service_account):
     service_kerberos_options = {
         "service": {
             "name": config.SERVICE_NAME,
-            "service_account": service_account,
-            "service_account_secret": service_account,
+            "service_account": service_account["name"],
+            "service_account_secret": service_account["secret"],
             "security": {
                 "kerberos": {
                     "enabled": True,

--- a/frameworks/kafka/tests/test_tls.py
+++ b/frameworks/kafka/tests/test_tls.py
@@ -1,12 +1,12 @@
 import pytest
-import shakedown
 
 import sdk_cmd
 import sdk_install
 import sdk_networks
 import sdk_plan
-import sdk_security
 import sdk_utils
+
+from security import transport_encryption
 
 from tests import config
 
@@ -17,19 +17,16 @@ BROKER_TLS_ENDPOINT = 'broker-tls'
 @pytest.fixture(scope='module')
 def service_account(configure_security):
     """
-    Creates service account and yields the name.
+    Sets up a service account for use with TLS.
     """
     try:
         name = config.SERVICE_NAME
-        sdk_security.create_service_account(
-            service_account_name=name, service_account_secret=name)
-        # TODO(mh): Fine grained permissions needs to be addressed in DCOS-16475
-        sdk_cmd.run_cli(
-            "security org groups add_user superusers {name}".format(name=name))
-        yield name
+        service_account_info = transport_encryption.setup_service_account(name)
+
+        yield service_account_info
     finally:
-        sdk_security.delete_service_account(
-            service_account_name=name, service_account_secret=name)
+        transport_encryption.cleanup_service_account(config.SERVICE_NAME,
+                                                     service_account_info)
 
 
 @pytest.fixture(scope='module')
@@ -42,8 +39,8 @@ def kafka_service_tls(service_account):
             config.DEFAULT_BROKER_COUNT,
             additional_options={
                 "service": {
-                    "service_account": service_account,
-                    "service_account_secret": service_account,
+                    "service_account": service_account["name"],
+                    "service_account_secret": service_account["secret"],
                     "security": {
                         "transport_encryption": {
                             "enabled": True
@@ -70,7 +67,8 @@ def test_tls_endpoints(kafka_service_tls):
     assert BROKER_TLS_ENDPOINT in endpoints
 
     # Test that broker-tls endpoint is available
-    endpoint_tls = sdk_cmd.svc_cli(config.PACKAGE_NAME, config.SERVICE_NAME, 'endpoints {name}'.format(name=BROKER_TLS_ENDPOINT), json=True)
+    endpoint_tls = sdk_cmd.svc_cli(config.PACKAGE_NAME, config.SERVICE_NAME,
+                                   'endpoints {name}'.format(name=BROKER_TLS_ENDPOINT), json=True)
     assert len(endpoint_tls['dns']) == config.DEFAULT_BROKER_COUNT
 
 
@@ -82,13 +80,19 @@ def test_tls_endpoints(kafka_service_tls):
 def test_producer_over_tls(kafka_service_tls):
     sdk_cmd.svc_cli(config.PACKAGE_NAME, config.SERVICE_NAME, 'topic create {}'.format(config.DEFAULT_TOPIC_NAME))
 
-    topic_info = sdk_cmd.svc_cli(config.PACKAGE_NAME, config.SERVICE_NAME, 'topic describe {}'.format(config.DEFAULT_TOPIC_NAME), json=True)
+    topic_info = sdk_cmd.svc_cli(config.PACKAGE_NAME, config.SERVICE_NAME,
+                                 'topic describe {}'.format(config.DEFAULT_TOPIC_NAME),
+                                 json=True)
     assert len(topic_info['partitions']) == config.DEFAULT_PARTITION_COUNT
 
     # Write twice: Warm up TLS connections
     num_messages = 10
-    write_info = sdk_cmd.svc_cli(config.PACKAGE_NAME, config.SERVICE_NAME, 'topic producer_test_tls {} {}'.format(config.DEFAULT_TOPIC_NAME, num_messages), json=True)
+    write_info = sdk_cmd.svc_cli(config.PACKAGE_NAME, config.SERVICE_NAME,
+                                 'topic producer_test_tls {} {}'.format(config.DEFAULT_TOPIC_NAME, num_messages),
+                                 json=True)
 
-    write_info = sdk_cmd.svc_cli(config.PACKAGE_NAME, config.SERVICE_NAME, 'topic producer_test_tls {} {}'.format(config.DEFAULT_TOPIC_NAME, num_messages), json=True)
+    write_info = sdk_cmd.svc_cli(config.PACKAGE_NAME, config.SERVICE_NAME,
+                                 'topic producer_test_tls {} {}'.format(config.DEFAULT_TOPIC_NAME, num_messages),
+                                 json=True)
     assert len(write_info) == 1
     assert write_info['message'].startswith('Output: {} records sent'.format(num_messages))

--- a/testing/sdk_security.py
+++ b/testing/sdk_security.py
@@ -6,7 +6,7 @@ SHOULD ALSO BE APPLIED TO sdk_security IN ANY OTHER PARTNER REPOS
 '''
 import logging
 import os
-from typing import List, Tuple
+from typing import List
 
 import retrying
 import sdk_cmd
@@ -54,16 +54,14 @@ def _grant(user: str, acl: str, description: str, action: str="create") -> None:
         raise_on_error=False,
         json={'description': description})
     # 201=created, 409=already exists
-    assert r.status_code == 201 or r.status_code == 409, '{} failed {}: {}'.format(
-        create_endpoint, r.status_code, r.text)
+    assert r.status_code in [201, 409, ], '{} failed {}: {}'.format(r.url, r.status_code, r.text)
 
     # Assign the user to the ACL
     r = sdk_cmd.cluster_request(
         'PUT', '/acs/api/v1/acls/{acl}/users/{user}/{action}'.format(acl=acl, user=user, action=action),
         raise_on_error=False)
     # 204=success, 409=already exists
-    assert r.status_code == 204 or r.status_code == 409, '{} failed {}: {}'.format(
-        create_endpoint, r.status_code, r.text)
+    assert r.status_code in [204, 409, ], '{} failed {}: {}'.format(r.url, r.status_code, r.text)
 
 
 def _revoke(user: str, acl: str, description: str, action: str="create") -> None:
@@ -73,7 +71,7 @@ def _revoke(user: str, acl: str, description: str, action: str="create") -> None
 
 def get_permissions(service_account_name: str, role: str, linux_user: str) -> List[dict]:
     return [
-        ## registration permissions
+        # registration permissions
         {
             'user': service_account_name,
             'acl': "dcos:mesos:master:framework:role:{}".format(role),
@@ -81,7 +79,7 @@ def get_permissions(service_account_name: str, role: str, linux_user: str) -> Li
                 service_account_name, role),
         },
 
-        ## task execution permissions
+        # task execution permissions
         {
             'user': service_account_name,
             'acl': "dcos:mesos:master:task:user:{}".format(linux_user),
@@ -89,7 +87,7 @@ def get_permissions(service_account_name: str, role: str, linux_user: str) -> Li
                 service_account_name, linux_user)
         },
 
-        # XXX 1.10 curerrently requires this mesos:agent permission as well as
+        # XXX 1.10 currently requires this mesos:agent permission as well as
         # mesos:task permission.  unclear if this will be ongoing requirement.
         # See DCOS-15682
         {
@@ -99,7 +97,7 @@ def get_permissions(service_account_name: str, role: str, linux_user: str) -> Li
                 service_account_name, linux_user)
         },
 
-        ## resource permissions
+        # resource permissions
         {
             'user': service_account_name,
             'acl': "dcos:mesos:master:reservation:role:{}".format(role),
@@ -114,7 +112,7 @@ def get_permissions(service_account_name: str, role: str, linux_user: str) -> Li
             'action': "delete",
         },
 
-        ## volume permissions
+        # volume permissions
         {
             'user': service_account_name,
             'acl': "dcos:mesos:master:volume:role:{}".format(role),
@@ -147,12 +145,14 @@ def revoke_permissions(linux_user: str, role_name: str, service_account_name: st
 
 
 def create_service_account(service_account_name: str, service_account_secret: str) -> None:
+    """
+    Creates a servive account. If it already exists, it is deleted.
+    """
+    install_enterprise_cli()
+
     log.info('Creating service account for account={account} secret={secret}'.format(
         account=service_account_name,
         secret=service_account_secret))
-
-    log.info('Install cli necessary for security')
-    sdk_cmd.run_cli('package install dcos-enterprise-cli --yes')
 
     log.info('Remove any existing service account and/or secret')
     delete_service_account(service_account_name, service_account_secret)
@@ -161,9 +161,8 @@ def create_service_account(service_account_name: str, service_account_secret: st
     sdk_cmd.run_cli('security org service-accounts keypair private-key.pem public-key.pem')
 
     log.info('Create service account')
-    sdk_cmd.run_cli(
-        'security org service-accounts create -p public-key.pem -d "Service account for integration tests" "{account}"'.format(
-            account=service_account_name))
+    sdk_cmd.run_cli('security org service-accounts create -p public-key.pem '
+                    '-d "Service account for integration tests" "{account}"'.format(account=service_account_name))
 
     log.info('Create secret')
     sdk_cmd.run_cli(
@@ -200,41 +199,60 @@ def delete_secret(secret: str) -> None:
     sdk_cmd.run_cli("security secrets delete {}".format(secret))
 
 
-def setup_security(framework_name: str, service_account: str = 'service-acct', service_account_secret: str = 'secret') -> None:
-    log.info('Setting up strict-mode security')
-    create_service_account(service_account_name=service_account, service_account_secret=service_account_secret)
+def setup_security(framework_name: str,
+                   service_account: str="service-acct",
+                   service_account_secret: str="secret") -> dict:
+
+    create_service_account(service_account_name=service_account,
+                           service_account_secret=service_account_secret)
+
+    service_account_info = {"name": service_account, "secret": service_account_secret}
+
+    if not sdk_utils.is_strict_mode():
+        log.info("Skipping strict-mode security setup on non-strict cluster")
+        return service_account_info
+
+    log.info("Setting up strict-mode security")
     grant_permissions(
-        linux_user='nobody',
-        role_name='{}-role'.format(framework_name),
+        linux_user="nobody",
+        role_name="{}-role".format(framework_name),
         service_account_name=service_account
     )
     grant_permissions(
-        linux_user='nobody',
-        role_name='slave_public%252F{}-role'.format(framework_name),
+        linux_user="nobody",
+        role_name="slave_public%252F{}-role".format(framework_name),
         service_account_name=service_account
     )
     grant_permissions(
-        linux_user='nobody',
-        role_name='test__integration__{}-role'.format(framework_name),
+        linux_user="nobody",
+        role_name="test__integration__{}-role".format(framework_name),
         service_account_name=service_account
     )
-    log.info('Finished setting up strict-mode security')
+    log.info("Finished setting up strict-mode security")
+
+    return service_account_info
 
 
-def cleanup_security(framework_name: str) -> None:
-    log.info('Cleaning up strict-mode security')
-    revoke_permissions(
-        linux_user='nobody',
-        role_name='{}-role'.format(framework_name),
-        service_account_name='service-acct'
-    )
-    revoke_permissions(
-        linux_user='nobody',
-        role_name='test__integration__{}-role'.format(framework_name),
-        service_account_name='service-acct'
-    )
-    delete_service_account('service-acct', 'secret')
-    log.info('Finished cleaning up strict-mode security')
+def cleanup_security(framework_name: str,
+                     service_account: str="service-acct",
+                     service_account_secret: str="secret") -> None:
+
+    if sdk_utils.is_strict_mode():
+        log.info("Cleaning up strict-mode security")
+        revoke_permissions(
+            linux_user="nobody",
+            role_name="{}-role".format(framework_name),
+            service_account_name=service_account
+        )
+        revoke_permissions(
+            linux_user="nobody",
+            role_name="test__integration__{}-role".format(framework_name),
+            service_account_name=service_account
+        )
+
+    delete_service_account(service_account, service_account_secret)
+
+    log.info("Finished cleaning up strict-mode security")
 
 
 def security_session(framework_name: str) -> None:


### PR DESCRIPTION
This is a straight backport of #2310.

* Use fine-grained permissions for DC/OS 1.11.

* Add missing service_account element access.

* Correct typo in install

* Raise exception when service account is created in strict.

* Formatting changes to sdk_security.

* Improve docstring

* Set up propper permissions for strict mode TLS.

* Add missing service_name paratmer.