### PR TITLE
Filter out resources not intended for this framework

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/OfferUtils.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/OfferUtils.java
@@ -86,15 +86,10 @@ public class OfferUtils {
         offerIds.forEach(offerId -> driver.get().declineOffer(offerId, filters));
     }
 
-    public static boolean isProcessable(Protos.Resource resource, Protos.FrameworkInfo frameworkInfo) {
-        boolean hasDynamicReservations = ResourceUtils.getDynamicReservations(resource).size() > 0;
-        return !hasDynamicReservations || ResourceUtils.isOwnedByThisFramework(resource, frameworkInfo);
-    }
-
     public static Protos.Offer clean(Protos.Offer offer, Protos.FrameworkInfo frameworkInfo) {
         List<Protos.Resource> cleanResources = new ArrayList<>();
         for (Protos.Resource resource : offer.getResourcesList()) {
-            if (isProcessable(resource, frameworkInfo)) {
+            if (ResourceUtils.isProcessable(resource, frameworkInfo)) {
                 cleanResources.add(resource);
             } else {
                 LOGGER.warn("Ignoring alien resource: {}", TextFormat.shortDebugString(resource));

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/ResourceUtils.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/ResourceUtils.java
@@ -132,6 +132,24 @@ public class ResourceUtils {
         return hasResourceId && matchingRoles;
     }
 
+    public static Collection<Resource.ReservationInfo> getReservations(Resource resource) {
+        Set<Resource.ReservationInfo> reservations =
+                new HashSet<>(resource.getReservationsList().stream().collect(Collectors.toSet()));
+        if (resource.hasReservation()) {
+            reservations.add(resource.getReservation());
+        }
+
+        return reservations;
+    }
+
+    public static Collection<Resource.ReservationInfo> getDynamicReservations(Resource resource) {
+        return getReservations(resource).stream()
+                .filter(reservationInfo -> reservationInfo.hasType())
+                .filter(reservationInfo -> reservationInfo.getType()
+                        .equals(Protos.Resource.ReservationInfo.Type.DYNAMIC))
+                .collect(Collectors.toSet());
+    }
+
     private static Set<String> getRoles(FrameworkInfo frameworkInfo) {
         Set<String> roles = frameworkInfo.getRolesList().stream().collect(Collectors.toSet());
         if (frameworkInfo.hasRole()) {
@@ -142,26 +160,16 @@ public class ResourceUtils {
     }
 
     private static Set<String> getRoles(Resource resource) {
-        Set<Resource.ReservationInfo> reservations =
-                new HashSet<>(resource.getReservationsList().stream().collect(Collectors.toSet()));
-        if (resource.hasReservation()) {
-            reservations.add(resource.getReservation());
-        }
-
+        Collection<Resource.ReservationInfo> reservations = getDynamicReservations(resource);
         Set<String> roles =
                 new HashSet<>(
                         reservations.stream()
-                                .filter(
-                                        reservationInfo ->
-                                                reservationInfo.getType()
-                                                        .equals(Resource.ReservationInfo.Type.DYNAMIC))
                                 .map(Resource.ReservationInfo::getRole)
                                 .collect(Collectors.toSet()));
 
         if (resource.hasRole()) {
             roles.add(resource.getRole());
         }
-
 
         return roles.stream().filter(role -> !role.equals(Constants.ANY_ROLE)).collect(Collectors.toSet());
     }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/ResourceUtils.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/ResourceUtils.java
@@ -150,6 +150,11 @@ public class ResourceUtils {
                 .collect(Collectors.toSet());
     }
 
+    public static boolean isProcessable(Protos.Resource resource, Protos.FrameworkInfo frameworkInfo) {
+        boolean hasDynamicReservations = ResourceUtils.getDynamicReservations(resource).size() > 0;
+        return !hasDynamicReservations || ResourceUtils.isOwnedByThisFramework(resource, frameworkInfo);
+    }
+
     private static Set<String> getRoles(FrameworkInfo frameworkInfo) {
         Set<String> roles = frameworkInfo.getRolesList().stream().collect(Collectors.toSet());
         if (frameworkInfo.hasRole()) {

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/queue/OfferQueue.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/queue/OfferQueue.java
@@ -1,6 +1,7 @@
 package com.mesosphere.sdk.queue;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.mesosphere.sdk.offer.OfferUtils;
 import org.apache.mesos.Protos;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -22,9 +23,10 @@ public class OfferQueue {
     private static final Duration DEFAULT_OFFER_WAIT = Duration.ofSeconds(5);
     private final Logger logger = LoggerFactory.getLogger(getClass());
     private final BlockingQueue<Protos.Offer> queue;
+    private final Protos.FrameworkInfo frameworkInfo;
 
-    public OfferQueue() {
-        this(DEFAULT_CAPACITY);
+    public OfferQueue(Protos.FrameworkInfo frameworkInfo) {
+        this(frameworkInfo, DEFAULT_CAPACITY);
     }
 
     /**
@@ -32,7 +34,8 @@ public class OfferQueue {
      *
      * @param capacity the maximum size of the queue, or zero for unlimited queue size
      */
-    public OfferQueue(int capacity) {
+    public OfferQueue(Protos.FrameworkInfo frameworkInfo, int capacity) {
+        this.frameworkInfo = frameworkInfo;
         this.queue = capacity == 0 ? new LinkedBlockingQueue<>() : new LinkedBlockingQueue<>(capacity);
     }
 
@@ -73,7 +76,7 @@ public class OfferQueue {
      * @return true if the Offer was successfully put in the queue, false otherwise
      */
     public boolean offer(Protos.Offer offer) {
-        return queue.offer(offer);
+        return queue.offer(OfferUtils.clean(offer, frameworkInfo));
     }
 
     /**

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/queue/OfferQueueTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/queue/OfferQueueTest.java
@@ -13,16 +13,21 @@ import java.util.UUID;
  */
 public class OfferQueueTest {
     private static final int TEST_CAPACITY = 10;
+    private static final Protos.FrameworkInfo frameworkInfo =  Protos.FrameworkInfo.newBuilder()
+            .setName(TestConstants.SERVICE_NAME)
+            .setUser(TestConstants.SERVICE_USER)
+            .addRoles(TestConstants.ROLE)
+            .build();
 
     @Test
     public void testEmptyQueue() {
-        OfferQueue offerQueue = new OfferQueue();
+        OfferQueue offerQueue = new OfferQueue(frameworkInfo);
         Assert.assertTrue(offerQueue.isEmpty());
     }
 
     @Test
     public void testEnqueueOffer() {
-        OfferQueue offerQueue = new OfferQueue(TEST_CAPACITY);
+        OfferQueue offerQueue = new OfferQueue(frameworkInfo, TEST_CAPACITY);
         offerQueue.offer(getOffer());
         Assert.assertEquals(1, offerQueue.getSize());
         Assert.assertEquals(TEST_CAPACITY - 1, offerQueue.getRemainingCapacity());
@@ -30,7 +35,7 @@ public class OfferQueueTest {
 
     @Test
     public void testExceedCapacity() {
-        OfferQueue offerQueue = new OfferQueue();
+        OfferQueue offerQueue = new OfferQueue(frameworkInfo);
         int capacity = offerQueue.getRemainingCapacity();
         for (int i = 0; i < capacity; i++) {
             Assert.assertTrue(offerQueue.offer(getOffer()));
@@ -42,7 +47,7 @@ public class OfferQueueTest {
 
     @Test
     public void testTakeOne() {
-        OfferQueue offerQueue = new OfferQueue(TEST_CAPACITY);
+        OfferQueue offerQueue = new OfferQueue(frameworkInfo, TEST_CAPACITY);
         offerQueue.offer(getOffer());
         List<Protos.Offer> offers = offerQueue.takeAll();
         Assert.assertEquals(1, offers.size());
@@ -51,7 +56,7 @@ public class OfferQueueTest {
 
     @Test
     public void testTakeMultiple() {
-        OfferQueue offerQueue = new OfferQueue(TEST_CAPACITY);
+        OfferQueue offerQueue = new OfferQueue(frameworkInfo, TEST_CAPACITY);
         int halfCapacity = offerQueue.getRemainingCapacity() / 2;
         for (int i = 0; i < halfCapacity; i++) {
             offerQueue.offer(getOffer());
@@ -64,7 +69,7 @@ public class OfferQueueTest {
 
     @Test
     public void testTakeFull() {
-        OfferQueue offerQueue = new OfferQueue(TEST_CAPACITY);
+        OfferQueue offerQueue = new OfferQueue(frameworkInfo, TEST_CAPACITY);
         int capacity = offerQueue.getRemainingCapacity();
         for (int i = 0; i < capacity; i++) {
             offerQueue.offer(getOffer());
@@ -77,7 +82,7 @@ public class OfferQueueTest {
 
     @Test
     public void testRemoveFromEmptyQueue() {
-        OfferQueue offerQueue = new OfferQueue();
+        OfferQueue offerQueue = new OfferQueue(frameworkInfo);
         Assert.assertTrue(offerQueue.isEmpty());
         offerQueue.remove(TestConstants.OFFER_ID);
         Assert.assertTrue(offerQueue.isEmpty());
@@ -85,7 +90,7 @@ public class OfferQueueTest {
 
     @Test
     public void testRemoveFromSingleOfferQueue() {
-        OfferQueue offerQueue = new OfferQueue();
+        OfferQueue offerQueue = new OfferQueue(frameworkInfo);
         offerQueue.offer(getOffer());
         Assert.assertEquals(1, offerQueue.getSize());
         offerQueue.remove(TestConstants.OFFER_ID);
@@ -94,7 +99,7 @@ public class OfferQueueTest {
 
     @Test
     public void testRemoveUnknownOffer() {
-        OfferQueue offerQueue = new OfferQueue();
+        OfferQueue offerQueue = new OfferQueue(frameworkInfo);
         offerQueue.offer(getOffer(UUID.randomUUID().toString()));
         Assert.assertEquals(1, offerQueue.getSize());
         offerQueue.remove(TestConstants.OFFER_ID);
@@ -103,7 +108,7 @@ public class OfferQueueTest {
 
     @Test
     public void testRemoveOneLeaveOthers() {
-        OfferQueue offerQueue = new OfferQueue();
+        OfferQueue offerQueue = new OfferQueue(frameworkInfo);
         int halfCapacity = offerQueue.getRemainingCapacity() / 2;
         // Add many offers with random ids
         for (int i = 0; i < halfCapacity; i++) {


### PR DESCRIPTION
In order to provide a guarantee of safety regarding offer handling we should not even consider resources which are not intended for us.  [The crux of the logic is here](https://github.com/mesosphere/dcos-commons/compare/resource_filter?expand=1#diff-07dc1ba43f35caa9802d00f9ddf66dc0R154).

If no dynamic reservations have been applied then we can feel free to consume the resource.  If reservations have been applied we should be certain it we applied them.