### PR TITLE
[INFINITY-3329] Fix dryrun for package version and md5 hash (#2360)

### DIFF
--- a/tools/publish_aws.py
+++ b/tools/publish_aws.py
@@ -100,7 +100,7 @@ class AWSPublisher(object):
     def upload(self):
         '''generates a unique directory, then uploads artifacts and a new stub universe to that directory'''
         package_info = universe.Package(self._pkg_name, self._pkg_version)
-        package_manager = universe.PackageManager()
+        package_manager = universe.PackageManager(dry_run=self._dry_run)
         builder = universe.UniversePackageBuilder(
             package_info, package_manager,
             self._input_dir_path, self._http_directory_url, self._artifact_paths,

--- a/tools/universe/package_builder.py
+++ b/tools/universe/package_builder.py
@@ -96,8 +96,8 @@ class UniversePackageBuilder(object):
         if self._dry_run:
             logger.info("(dryrun) Generating hash for DRY_RUN")
             hasher = hashlib.sha256()
-            hasher.update(manifest_url)
-            hasher.update(filename)
+            hasher.update(manifest_url.encode('utf-8'))
+            hasher.update(filename.encode('utf-8'))
             return hasher.hexdigest()
 
         with urllib.request.urlopen(manifest_url) as manifest_file:

--- a/tools/universe/package_manager.py
+++ b/tools/universe/package_manager.py
@@ -25,8 +25,10 @@ class PackageManager:
     """A simple package manager for retrieving universe packages"""
     def __init__(self, universe_url="https://universe.mesosphere.com/repo",
                  dcos_version="1.10",
-                 package_version="4"):
+                 package_version="4",
+                 dry_run=False):
 
+        self._dry_run = dry_run
         self._universe_url = universe_url
         self._headers = {
             "User-Agent": "dcos/{}".format(dcos_version),
@@ -61,6 +63,9 @@ class PackageManager:
 
     def get_packages(self):
         """Query the uninverse to get a list of packages"""
+        if self._dry_run:
+            return DryRunPackages()
+
         if not self.__package_cache:
             LOGGER.info("Package cache is empty. Retrieving package information")
             raw_package_list = self._get_packages(self._universe_url, self._headers)
@@ -126,3 +131,9 @@ def _get_packages_with_requests(universe_url, headers):
         packages = []
 
     return packages
+
+
+class DryRunPackages:
+    def get(self, package_name, default):
+        return [package.Package(package_name,
+                                package.Version(0, "DRY_RUN_VERSION")), ]


### PR DESCRIPTION
This is a backport of #2360.

* Fix dryrun for package version and md5 hash
* Use snapshot verison