### PR TITLE
Install botocore first to fix CI issue with dcos-launch (#2380)

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,3 +1,4 @@
+botocore
 py==1.5.1
 git+https://github.com/dcos/dcos-cli.git@f1fd38c9e72e1d521cf8120fe4948a789fb40cbc#egg=dcoscli&subdirectory=cli
 git+https://github.com/dcos/dcos-cli.git@f1fd38c9e72e1d521cf8120fe4948a789fb40cbc


### PR DESCRIPTION
This is a backport of #2380 which aligns the sdk-0.40 docker file with that in master.