### PR TITLE
Switch to LoggingUtils wrapper for creating Loggers

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/config/DefaultConfigurationUpdater.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/config/DefaultConfigurationUpdater.java
@@ -7,6 +7,7 @@ import com.google.protobuf.TextFormat;
 import com.mesosphere.sdk.config.validate.ConfigValidationError;
 import com.mesosphere.sdk.config.validate.ConfigValidator;
 import com.mesosphere.sdk.dcos.DcosConstants;
+import com.mesosphere.sdk.offer.LoggingUtils;
 import com.mesosphere.sdk.offer.TaskException;
 import com.mesosphere.sdk.offer.taskdata.TaskLabelReader;
 import com.mesosphere.sdk.offer.taskdata.TaskLabelWriter;
@@ -22,7 +23,6 @@ import difflib.DiffUtils;
 import org.apache.mesos.Protos;
 import org.apache.mesos.Protos.TaskInfo;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.*;
 
@@ -32,7 +32,7 @@ import java.util.*;
  */
 public class DefaultConfigurationUpdater implements ConfigurationUpdater<ServiceSpec> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultConfigurationUpdater.class);
+    private static final Logger LOGGER = LoggingUtils.getLogger(DefaultConfigurationUpdater.class);
 
     private final StateStore stateStore;
     private final ConfigStore<ServiceSpec> configStore;

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/config/YAMLConfigurationLoader.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/config/YAMLConfigurationLoader.java
@@ -2,11 +2,12 @@ package com.mesosphere.sdk.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.mesosphere.sdk.offer.LoggingUtils;
+
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.text.StrLookup;
 import org.apache.commons.lang3.text.StrSubstitutor;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -18,7 +19,7 @@ import java.nio.file.Paths;
  * override pre-configured configuration values.
  */
 public class YAMLConfigurationLoader {
-    public static final Logger LOGGER = LoggerFactory.getLogger(YAMLConfigurationLoader.class);
+    public static final Logger LOGGER = LoggingUtils.getLogger(YAMLConfigurationLoader.class);
 
     public static <T> T loadConfigFromEnv(Class<T> configurationClass, final String path)
         throws IOException {

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/curator/CuratorLocker.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/curator/CuratorLocker.java
@@ -6,9 +6,9 @@ import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.recipes.locks.InterProcessSemaphoreMutex;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.mesosphere.sdk.offer.LoggingUtils;
 import com.mesosphere.sdk.scheduler.SchedulerErrorCode;
 import com.mesosphere.sdk.scheduler.SchedulerUtils;
 import com.mesosphere.sdk.specification.ServiceSpec;
@@ -19,7 +19,7 @@ import com.mesosphere.sdk.storage.PersisterUtils;
  * same service.
  */
 public class CuratorLocker {
-    private static final Logger LOGGER = LoggerFactory.getLogger(CuratorUtils.class);
+    private static final Logger LOGGER = LoggingUtils.getLogger(CuratorUtils.class);
 
     private static final int LOCK_ATTEMPTS = 3;
     static final String LOCK_PATH_NAME = "lock";

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/curator/CuratorPersister.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/curator/CuratorPersister.java
@@ -29,7 +29,7 @@ import java.util.stream.Collectors;
  */
 public class CuratorPersister implements Persister {
 
-    private static final Logger logger = LoggingUtils.getLogger(CuratorPersister.class);
+    private static final Logger LOGGER = LoggingUtils.getLogger(CuratorPersister.class);
 
     /**
      * Number of times to attempt an atomic write transaction in storeMany().
@@ -200,7 +200,7 @@ public class CuratorPersister implements Persister {
              * The best we can do is to wipe everything under the root node. A proposed way to "fix" things
              * lives at https://jira.mesosphere.com/browse/INFINITY-1470.
              */
-            logger.debug("Deleting children of root {}", path);
+            LOGGER.debug("Deleting children of root {}", path);
             try {
                 CuratorTransactionFinal transaction = client.inTransaction().check().forPath(serviceRootPath).and();
                 Set<String> pendingDeletePaths = new HashSet<>();
@@ -222,7 +222,7 @@ public class CuratorPersister implements Persister {
             set(unprefixedPath, null);
         } else {
             // Normal case: Delete node itself and any/all children.
-            logger.debug("Deleting {} (and any children)", path);
+            LOGGER.debug("Deleting {} (and any children)", path);
             try {
                 client.delete().deletingChildrenIfNeeded().forPath(path);
             } catch (KeeperException.NoNodeException e) {
@@ -237,7 +237,7 @@ public class CuratorPersister implements Persister {
     @Override
     public void set(String unprefixedPath, byte[] bytes) throws PersisterException {
         final String path = withFrameworkPrefix(unprefixedPath);
-        logger.debug("Setting {} => {}", path, getInfo(bytes));
+        LOGGER.debug("Setting {} => {}", path, getInfo(bytes));
         try {
             try {
                 client.create().creatingParentsIfNeeded().forPath(path, bytes);
@@ -260,7 +260,7 @@ public class CuratorPersister implements Persister {
         for (Map.Entry<String, byte[]> entry : unprefixedPathBytesMap.entrySet()) {
             pathBytesMap.put(withFrameworkPrefix(entry.getKey()), entry.getValue());
         }
-        logger.debug("Updating {} entries: {}", pathBytesMap.size(), pathBytesMap.keySet());
+        LOGGER.debug("Updating {} entries: {}", pathBytesMap.size(), pathBytesMap.keySet());
         runTransactionWithRetries(new SetTransactionFactory(pathBytesMap));
     }
 
@@ -272,7 +272,7 @@ public class CuratorPersister implements Persister {
         Collection<String> paths = unprefixedPaths.stream()
                 .map(unprefixedPath -> withFrameworkPrefix(unprefixedPath))
                 .collect(Collectors.toList());
-        logger.debug("Deleting {} entries: {}", paths.size(), paths);
+        LOGGER.debug("Deleting {} entries: {}", paths.size(), paths);
         runTransactionWithRetries(new ClearTransactionFactory(paths));
     }
 
@@ -289,7 +289,7 @@ public class CuratorPersister implements Persister {
                     } catch (Exception e) {
                         // Transaction failed! Bad connection? Existence check rendered invalid?
                         // Swallow exception and try again
-                        logger.error(String.format("Failed to complete transaction attempt %d/%d: %s",
+                        LOGGER.error(String.format("Failed to complete transaction attempt %d/%d: %s",
                                 i + 1, ATOMIC_WRITE_ATTEMPTS, transaction), e);
                     }
                 } else {
@@ -307,7 +307,7 @@ public class CuratorPersister implements Persister {
         if (unprefixedPaths.isEmpty()) {
             return Collections.emptyMap();
         }
-        logger.debug("Getting {} entries: {}", unprefixedPaths.size(), unprefixedPaths);
+        LOGGER.debug("Getting {} entries: {}", unprefixedPaths.size(), unprefixedPaths);
 
         Map<String, byte[]> result = new TreeMap<>();
         // Unlike with writes, there is not an atomic read operation. Therefore we wing it with a series of plain reads.

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/curator/CuratorPersister.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/curator/CuratorPersister.java
@@ -1,6 +1,7 @@
 package com.mesosphere.sdk.curator;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.mesosphere.sdk.offer.LoggingUtils;
 import com.mesosphere.sdk.specification.ServiceSpec;
 import com.mesosphere.sdk.storage.Persister;
 import com.mesosphere.sdk.storage.PersisterException;
@@ -16,7 +17,6 @@ import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.data.ACL;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.nio.charset.StandardCharsets;
 import java.util.*;
@@ -29,7 +29,7 @@ import java.util.stream.Collectors;
  */
 public class CuratorPersister implements Persister {
 
-    private static final Logger logger = LoggerFactory.getLogger(CuratorPersister.class);
+    private static final Logger logger = LoggingUtils.getLogger(CuratorPersister.class);
 
     /**
      * Number of times to attempt an atomic write transaction in storeMany().

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/dcos/Capabilities.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/dcos/Capabilities.java
@@ -2,10 +2,9 @@ package com.mesosphere.sdk.dcos;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.mesosphere.sdk.dcos.clients.DcosVersionClient;
-
+import com.mesosphere.sdk.offer.LoggingUtils;
 import com.mesosphere.sdk.scheduler.SchedulerConfig;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 
@@ -13,7 +12,7 @@ import java.io.IOException;
  * This class represents a set of capabilities that may or may not be supported in a given version of DC/OS.
  */
 public class Capabilities {
-    private static final Logger LOGGER = LoggerFactory.getLogger(Capabilities.class);
+    private static final Logger LOGGER = LoggingUtils.getLogger(Capabilities.class);
     private static final Object lock = new Object();
     private static Capabilities capabilities;
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/dcos/DcosConstants.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/dcos/DcosConstants.java
@@ -5,14 +5,15 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
+import com.mesosphere.sdk.offer.LoggingUtils;
 
 /**
  * This class encapsulates constants common to DC/OS and its services.
  */
 public class DcosConstants {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(DcosConstants.class);
+    private static final Logger LOGGER = LoggingUtils.getLogger(DcosConstants.class);
 
     private static final String MESOS_MASTER = "master.mesos";
     private static final String MESOS_LEADER = "leader.mesos";

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/dcos/clients/CertificateAuthorityClient.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/dcos/clients/CertificateAuthorityClient.java
@@ -19,10 +19,10 @@ import org.apache.http.client.fluent.Response;
 import org.apache.http.entity.ContentType;
 import org.json.JSONObject;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.mesosphere.sdk.dcos.DcosConstants;
 import com.mesosphere.sdk.dcos.DcosHttpExecutor;
+import com.mesosphere.sdk.offer.LoggingUtils;
 import com.mesosphere.sdk.offer.evaluate.security.PEMUtils;
 
 /**
@@ -31,7 +31,7 @@ import com.mesosphere.sdk.offer.evaluate.security.PEMUtils;
  */
 public class CertificateAuthorityClient {
 
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private final Logger logger = LoggingUtils.getLogger(getClass());
 
     private DcosHttpExecutor httpExecutor;
     private CertificateFactory certificateFactory;

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/dcos/clients/SecretsClient.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/dcos/clients/SecretsClient.java
@@ -14,11 +14,11 @@ import org.apache.http.client.fluent.Request;
 import org.apache.http.entity.ContentType;
 import org.json.JSONObject;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mesosphere.sdk.dcos.DcosConstants;
 import com.mesosphere.sdk.dcos.DcosHttpExecutor;
+import com.mesosphere.sdk.offer.LoggingUtils;
 
 /**
  * Client for communicating with DC/OS secret service API.
@@ -72,7 +72,7 @@ public class SecretsClient {
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private final Logger logger = LoggingUtils.getLogger(getClass());
 
     private DcosHttpExecutor httpExecutor;
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/http/ArtifactResource.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/http/ArtifactResource.java
@@ -1,5 +1,6 @@
 package com.mesosphere.sdk.http;
 
+import com.mesosphere.sdk.offer.LoggingUtils;
 import com.mesosphere.sdk.specification.ConfigFileSpec;
 import com.mesosphere.sdk.specification.PodSpec;
 import com.mesosphere.sdk.specification.ServiceSpec;
@@ -9,7 +10,6 @@ import com.mesosphere.sdk.state.ConfigStoreException;
 import com.mesosphere.sdk.storage.StorageError.Reason;
 
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -30,7 +30,7 @@ import java.util.stream.Collectors;
 public class ArtifactResource {
     private static final String ARTIFACT_URI_FORMAT = "http://%s/v1/artifacts/template/%s/%s/%s/%s";
 
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private final Logger logger = LoggingUtils.getLogger(getClass());
 
     private final ConfigStore<ServiceSpec> configStore;
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/http/ConfigResource.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/http/ConfigResource.java
@@ -12,13 +12,13 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.core.Response;
 
 import com.mesosphere.sdk.http.types.PrettyJsonResource;
+import com.mesosphere.sdk.offer.LoggingUtils;
 import com.mesosphere.sdk.state.ConfigStore;
 import com.mesosphere.sdk.state.ConfigStoreException;
 import com.mesosphere.sdk.storage.StorageError.Reason;
 
 import org.json.JSONArray;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * A read-only API for accessing active and inactive configurations from persistent storage.
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
 @Path("/v1/configurations")
 public class ConfigResource<T extends ConfigStore<?>> extends PrettyJsonResource {
 
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private final Logger logger = LoggingUtils.getLogger(getClass());
 
     private final T configStore;
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/http/EndpointsResource.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/http/EndpointsResource.java
@@ -14,6 +14,7 @@ import javax.ws.rs.core.Response;
 import com.google.protobuf.TextFormat;
 import com.mesosphere.sdk.http.types.EndpointProducer;
 import com.mesosphere.sdk.offer.Constants;
+import com.mesosphere.sdk.offer.LoggingUtils;
 import com.mesosphere.sdk.offer.TaskException;
 import com.mesosphere.sdk.offer.taskdata.AuxLabelAccess;
 import com.mesosphere.sdk.offer.taskdata.TaskLabelReader;
@@ -29,14 +30,13 @@ import org.apache.mesos.Protos.TaskStatus;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * A read-only API for accessing information about how to connect to the service.
  */
 @Path("/v1/endpoints")
 public class EndpointsResource {
-    private static final Logger LOGGER = LoggerFactory.getLogger(EndpointsResource.class);
+    private static final Logger LOGGER = LoggingUtils.getLogger(EndpointsResource.class);
 
     private static final String RESPONSE_KEY_DNS = "dns";
     private static final String RESPONSE_KEY_ADDRESS = "address";

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/http/OfferOutcomeResource.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/http/OfferOutcomeResource.java
@@ -1,9 +1,6 @@
 package com.mesosphere.sdk.http;
 
 import com.mesosphere.sdk.offer.history.OfferOutcomeTracker;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.QueryParam;
@@ -15,8 +12,6 @@ import javax.ws.rs.core.Response;
  */
 @Path("/v1/debug/offers")
 public class OfferOutcomeResource {
-    private static final Logger LOGGER = LoggerFactory.getLogger(OfferOutcomeResource.class);
-
     private final OfferOutcomeTracker offerOutcomeTracker;
 
     public OfferOutcomeResource(OfferOutcomeTracker offerOutcomeTracker) {

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/http/PlansResource.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/http/PlansResource.java
@@ -2,6 +2,7 @@ package com.mesosphere.sdk.http;
 
 import com.mesosphere.sdk.http.types.PlanInfo;
 import com.mesosphere.sdk.http.types.PrettyJsonResource;
+import com.mesosphere.sdk.offer.LoggingUtils;
 import com.mesosphere.sdk.offer.evaluate.placement.RegexMatcher;
 import com.mesosphere.sdk.offer.evaluate.placement.StringMatcher;
 import com.mesosphere.sdk.scheduler.plan.*;
@@ -9,7 +10,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
@@ -33,7 +33,7 @@ public class PlansResource extends PrettyJsonResource {
 
     private static final StringMatcher ENVVAR_MATCHER = RegexMatcher.create("[A-Za-z_][A-Za-z0-9_]*");
 
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private final Logger logger = LoggingUtils.getLogger(getClass());
 
     private final Collection<PlanManager> planManagers = new ArrayList<>();
     private final Object planManagersLock = new Object();

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/http/PodResource.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/http/PodResource.java
@@ -3,6 +3,7 @@ package com.mesosphere.sdk.http;
 import com.mesosphere.sdk.http.types.GroupedTasks;
 import com.mesosphere.sdk.http.types.PrettyJsonResource;
 import com.mesosphere.sdk.http.types.TaskInfoAndStatus;
+import com.mesosphere.sdk.offer.LoggingUtils;
 import com.mesosphere.sdk.offer.taskdata.TaskLabelReader;
 import com.mesosphere.sdk.scheduler.TaskKiller;
 import com.mesosphere.sdk.scheduler.recovery.RecoveryType;
@@ -15,7 +16,6 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -34,7 +34,7 @@ import java.util.stream.Collectors;
  */
 @Path("/v1/pod")
 public class PodResource extends PrettyJsonResource {
-    private static final Logger LOGGER = LoggerFactory.getLogger(PodResource.class);
+    private static final Logger LOGGER = LoggingUtils.getLogger(PodResource.class);
 
     /**
      * Pod 'name' to use in responses for tasks which have no pod information.

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/http/StateResource.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/http/StateResource.java
@@ -1,6 +1,7 @@
 package com.mesosphere.sdk.http;
 
 import com.mesosphere.sdk.http.types.PropertyDeserializer;
+import com.mesosphere.sdk.offer.LoggingUtils;
 import com.mesosphere.sdk.offer.TaskUtils;
 import com.mesosphere.sdk.state.StateStore;
 import com.mesosphere.sdk.state.StateStoreException;
@@ -16,7 +17,6 @@ import org.glassfish.jersey.media.multipart.FormDataParam;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
@@ -34,7 +34,7 @@ import java.util.stream.Collectors;
 @Path("/v1/state")
 public class StateResource {
 
-    private static final Logger logger = LoggerFactory.getLogger(StateResource.class);
+    private static final Logger logger = LoggingUtils.getLogger(StateResource.class);
     protected static final String FILE_NAME_PREFIX = "file-";
     protected static final Charset FILE_ENCODING = StandardCharsets.UTF_8;
     protected static final int FILE_SIZE = 1024; // state store shouldn't be holding big files anyway...

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/http/StateResource.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/http/StateResource.java
@@ -34,7 +34,7 @@ import java.util.stream.Collectors;
 @Path("/v1/state")
 public class StateResource {
 
-    private static final Logger logger = LoggingUtils.getLogger(StateResource.class);
+    private static final Logger LOGGER = LoggingUtils.getLogger(StateResource.class);
     protected static final String FILE_NAME_PREFIX = "file-";
     protected static final Charset FILE_ENCODING = StandardCharsets.UTF_8;
     protected static final int FILE_SIZE = 1024; // state store shouldn't be holding big files anyway...
@@ -80,11 +80,11 @@ public class StateResource {
                 JSONArray idArray = new JSONArray(Arrays.asList(frameworkIDOptional.get().getValue()));
                 return ResponseUtils.jsonOkResponse(idArray);
             } else {
-                logger.warn("No framework ID exists");
+                LOGGER.warn("No framework ID exists");
                 return Response.status(Response.Status.NOT_FOUND).build();
             }
         } catch (StateStoreException ex) {
-            logger.error("Failed to fetch framework ID", ex);
+            LOGGER.error("Failed to fetch framework ID", ex);
             return Response.serverError().build();
         }
 
@@ -97,7 +97,7 @@ public class StateResource {
             JSONArray keyArray = new JSONArray(stateStore.fetchPropertyKeys());
             return ResponseUtils.jsonOkResponse(keyArray);
         } catch (StateStoreException ex) {
-            logger.error("Failed to fetch list of property keys", ex);
+            LOGGER.error("Failed to fetch list of property keys", ex);
             return Response.serverError().build();
         }
     }
@@ -107,11 +107,11 @@ public class StateResource {
     @GET
     public Response getFiles() {
         try {
-            logger.info("Getting all files");
+            LOGGER.info("Getting all files");
             Collection<String> fileNames = getFileNames(stateStore);
             return ResponseUtils.plainOkResponse(fileNames.toString());
         } catch (StateStoreException e) {
-            logger.error("Failed to get a list of files", e);
+            LOGGER.error("Failed to get a list of files", e);
             return Response.serverError().build();
         }
     }
@@ -121,16 +121,16 @@ public class StateResource {
     @GET
     public Response getFile(@PathParam("file") String fileName) {
         try {
-            logger.info("Getting file {}", fileName);
+            LOGGER.info("Getting file {}", fileName);
             return ResponseUtils.plainOkResponse(getFile(stateStore, fileName));
         } catch (StateStoreException e) {
-            logger.error("Failed to get file {}: {}", fileName, e);
+            LOGGER.error("Failed to get file {}: {}", fileName, e);
             return ResponseUtils.plainResponse(
                     String.format("Failed to get the file"),
                     Response.Status.NOT_FOUND
             );
         } catch (UnsupportedEncodingException e) {
-            logger.error("Cannot encode data: ", e);
+            LOGGER.error("Cannot encode data: ", e);
             return Response.serverError().build();
         }
     }
@@ -148,7 +148,7 @@ public class StateResource {
             @FormDataParam("file") InputStream uploadedInputStream,
             @FormDataParam("file") FormDataContentDisposition fileDetails
     ) {
-        logger.info(fileDetails.toString());
+        LOGGER.info(fileDetails.toString());
         String fileName = fileDetails.getFileName();
         if (uploadedInputStream == null || fileName == null) {
             return ResponseUtils.plainResponse(NO_FILE_ERROR_MESSAGE, Response.Status.BAD_REQUEST);
@@ -159,11 +159,11 @@ public class StateResource {
         }
 
         try {
-            logger.info("Storing {}", fileName);
+            LOGGER.info("Storing {}", fileName);
             storeFile(stateStore, fileName, uploadedInputStream, fileDetails);
             return Response.status(Response.Status.OK).build();
         } catch (StateStoreException | IOException e) {
-            logger.error("Failed to store file {}: {}", fileName, e);
+            LOGGER.error("Failed to store file {}: {}", fileName, e);
             return Response.serverError().build();
         }
     }
@@ -177,7 +177,7 @@ public class StateResource {
         try {
             return ResponseUtils.jsonOkResponse(new JSONObject(getTasksZones(stateStore)));
         } catch (StateStoreException ex) {
-            logger.error("Failed to fetch the zone information for the service's tasks: ", ex);
+            LOGGER.error("Failed to fetch the zone information for the service's tasks: ", ex);
             return Response.serverError().build();
         }
     }
@@ -193,11 +193,11 @@ public class StateResource {
             if (tasksZones.containsKey(taskName)) {
                 return ResponseUtils.plainOkResponse(tasksZones.get(taskName));
             } else {
-                logger.error("No zone exists for the specified task");
+                LOGGER.error("No zone exists for the specified task");
                 return Response.status(Response.Status.NOT_FOUND).build();
             }
         } catch (StateStoreException ex) {
-            logger.error("Failed to fetch the zone information for the service's task: ", ex);
+            LOGGER.error("Failed to fetch the zone information for the service's task: ", ex);
             return Response.serverError().build();
         }
     }
@@ -211,12 +211,12 @@ public class StateResource {
         try {
             String zone = getZoneFromTaskNameAndIP(stateStore, podType, ip);
             if (zone.isEmpty()) {
-                logger.error("Failed to find a zone for pod type = %s, ip address = %s", podType, ip);
+                LOGGER.error("Failed to find a zone for pod type = %s, ip address = %s", podType, ip);
                 return Response.status(Response.Status.NOT_FOUND).build();
             }
             return ResponseUtils.plainOkResponse(zone);
         } catch (StateStoreException ex) {
-            logger.error("Failed to fetch the zone information for the service's task: ", ex);
+            LOGGER.error("Failed to fetch the zone information for the service's task: ", ex);
             return Response.serverError().build();
         }
     }
@@ -230,20 +230,20 @@ public class StateResource {
     public Response getProperty(@PathParam("key") String key) {
         try {
             if (propertyDeserializer == null) {
-                logger.warn("Cannot deserialize requested Property '{}': " +
+                LOGGER.warn("Cannot deserialize requested Property '{}': " +
                         "No deserializer was provided to StateResource constructor", key);
                 return Response.status(Response.Status.CONFLICT).build();
             } else {
-                logger.info("Attempting to fetch property '{}'", key);
+                LOGGER.info("Attempting to fetch property '{}'", key);
                 return ResponseUtils.jsonResponseBean(
                         propertyDeserializer.toJsonString(key, stateStore.fetchProperty(key)), Response.Status.OK);
             }
         } catch (StateStoreException ex) {
             if (ex.getReason() == Reason.NOT_FOUND) {
-                logger.warn(String.format("Requested property '%s' wasn't found", key), ex);
+                LOGGER.warn(String.format("Requested property '%s' wasn't found", key), ex);
                 return Response.status(Response.Status.NOT_FOUND).build();
             }
-            logger.error(String.format("Failed to fetch requested property '%s'", key), ex);
+            LOGGER.error(String.format("Failed to fetch requested property '%s'", key), ex);
             return Response.serverError().build();
         }
     }
@@ -257,22 +257,22 @@ public class StateResource {
     public Response refreshCache() {
         PersisterCache cache = getPersisterCache(stateStore);
         if (cache == null) {
-            logger.warn("State store is not cached: Refresh is not applicable");
+            LOGGER.warn("State store is not cached: Refresh is not applicable");
             return Response.status(Response.Status.CONFLICT).build();
         }
         try {
-            logger.info("Refreshing state store cache...");
-            logger.info("Before:\n- tasks: {}\n- properties: {}",
+            LOGGER.info("Refreshing state store cache...");
+            LOGGER.info("Before:\n- tasks: {}\n- properties: {}",
                     stateStore.fetchTaskNames(), stateStore.fetchPropertyKeys());
 
             cache.refresh();
 
-            logger.info("After:\n- tasks: {}\n- properties: {}",
+            LOGGER.info("After:\n- tasks: {}\n- properties: {}",
                     stateStore.fetchTaskNames(), stateStore.fetchPropertyKeys());
 
             return ResponseUtils.jsonOkResponse(getCommandResult("refresh"));
         } catch (PersisterException ex) {
-            logger.error("Failed to refresh state cache", ex);
+            LOGGER.error("Failed to refresh state cache", ex);
             return Response.serverError().build();
         }
     }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/http/types/GroupedTasks.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/http/types/GroupedTasks.java
@@ -14,8 +14,8 @@ import org.apache.mesos.Protos.TaskID;
 import org.apache.mesos.Protos.TaskInfo;
 import org.apache.mesos.Protos.TaskStatus;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+import com.mesosphere.sdk.offer.LoggingUtils;
 import com.mesosphere.sdk.offer.taskdata.TaskLabelReader;
 import com.mesosphere.sdk.specification.PodInstance;
 import com.mesosphere.sdk.state.StateStore;
@@ -24,7 +24,7 @@ import com.mesosphere.sdk.state.StateStore;
  * Utility class for sorting/grouping {@link TaskInfo}s and/or their associated {@link TaskStatus}es into pods.
  */
 public class GroupedTasks {
-    private static final Logger LOGGER = LoggerFactory.getLogger(GroupedTasks.class);
+    private static final Logger LOGGER = LoggingUtils.getLogger(GroupedTasks.class);
 
     /**
      * Mapping of pod type => pod index => to tasks in that pod.

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/LoggingUtils.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/LoggingUtils.java
@@ -9,8 +9,6 @@ import org.slf4j.LoggerFactory;
  */
 public class LoggingUtils {
 
-    private static boolean loggingNamesEnabled = true;
-
     private LoggingUtils() {
         // do not instantiate
     }
@@ -21,9 +19,7 @@ public class LoggingUtils {
      * @param clazz the class using this logger
      */
     public static Logger getLogger(Class<?> clazz) {
-        // Note: This currently results in a name like "LoggingUtils" in logs.
-        // Consider including an abbreviated package prefix, e.g. "c.m.s.o.LoggingUtils"?
-        return LoggerFactory.getLogger(clazz.getSimpleName());
+        return LoggerFactory.getLogger(getClassName(clazz));
     }
 
     /**
@@ -33,19 +29,19 @@ public class LoggingUtils {
      * @param name  an additional context label detailing e.g. the name of the service being managed
      */
     public static Logger getLogger(Class<?> clazz, String name) {
-        if (StringUtils.isEmpty(name) || !loggingNamesEnabled) {
+        if (StringUtils.isEmpty(name)) {
             return getLogger(clazz);
         } else {
-            return LoggerFactory.getLogger(String.format("(%s) %s", name, clazz.getSimpleName()));
+            return LoggerFactory.getLogger(String.format("(%s) %s", name, getClassName(clazz)));
         }
     }
 
     /**
-     * Disables logger names in output.
+     * Returns a class name suitable for using in logs.
      *
-     * @see #getLogger(Class, String)
+     * <p>At the moment this results in a class name of just e.g. "{@code LoggingUtils}".
      */
-    public static void disableNames() {
-        loggingNamesEnabled = false;
+    private static String getClassName(Class<?> clazz) {
+        return clazz.getSimpleName();
     }
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/LoggingUtils.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/LoggingUtils.java
@@ -29,7 +29,7 @@ public class LoggingUtils {
      * @param name  an additional context label detailing e.g. the name of the service being managed
      */
     public static Logger getLogger(Class<?> clazz, String name) {
-        if (StringUtils.isEmpty(name)) {
+        if (StringUtils.isBlank(name)) {
             return getLogger(clazz);
         } else {
             return LoggerFactory.getLogger(String.format("(%s) %s", name, getClassName(clazz)));

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/LoggingUtils.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/LoggingUtils.java
@@ -1,0 +1,51 @@
+package com.mesosphere.sdk.offer;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Utility methods around construction of loggers.
+ */
+public class LoggingUtils {
+
+    private static boolean loggingNamesEnabled = true;
+
+    private LoggingUtils() {
+        // do not instantiate
+    }
+
+    /**
+     * Creates a logger which is tagged with the provided class.
+     *
+     * @param clazz the class using this logger
+     */
+    public static Logger getLogger(Class<?> clazz) {
+        // Note: This currently results in a name like "LoggingUtils" in logs.
+        // Consider including an abbreviated package prefix, e.g. "c.m.s.o.LoggingUtils"?
+        return LoggerFactory.getLogger(clazz.getSimpleName());
+    }
+
+    /**
+     * Creates a logger which is tagged with the provided class and the provided custom label.
+     *
+     * @param clazz the class using this logger
+     * @param name  an additional context label detailing e.g. the name of the service being managed
+     */
+    public static Logger getLogger(Class<?> clazz, String name) {
+        if (StringUtils.isEmpty(name) || !loggingNamesEnabled) {
+            return getLogger(clazz);
+        } else {
+            return LoggerFactory.getLogger(String.format("(%s) %s", name, clazz.getSimpleName()));
+        }
+    }
+
+    /**
+     * Disables logger names in output.
+     *
+     * @see #getLogger(Class, String)
+     */
+    public static void disableNames() {
+        loggingNamesEnabled = false;
+    }
+}

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/MesosResourcePool.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/MesosResourcePool.java
@@ -14,7 +14,7 @@ import java.util.*;
  * consumption of the {@link Offer}'s resources.
  */
 public class MesosResourcePool {
-    private static final Logger logger = LoggingUtils.getLogger(MesosResourcePool.class);
+    private static final Logger LOGGER = LoggingUtils.getLogger(MesosResourcePool.class);
     private Offer offer;
 
     /**
@@ -99,7 +99,7 @@ public class MesosResourcePool {
                 if (sufficientValue(value, mesosResource.getValue())) {
                     dynamicallyReservedPoolByResourceId.remove(resourceId);
                 } else {
-                    logger.warn("Reserved atomic quantity of {} is insufficient: desired {}, reserved {}",
+                    LOGGER.warn("Reserved atomic quantity of {} is insufficient: desired {}, reserved {}",
                             name,
                             TextFormat.shortDebugString(value),
                             TextFormat.shortDebugString(mesosResource.getValue()));
@@ -119,7 +119,7 @@ public class MesosResourcePool {
                 }
             }
         } else {
-            logger.warn("Failed to find reserved {} resource with ID: {}. Reserved resource IDs are: {}",
+            LOGGER.warn("Failed to find reserved {} resource with ID: {}. Reserved resource IDs are: {}",
                     name,
                     resourceId,
                     dynamicallyReservedPoolByResourceId.keySet());
@@ -152,9 +152,9 @@ public class MesosResourcePool {
 
         if (!sufficientResource.isPresent()) {
             if (atomicResources == null) {
-                logger.info("Offer lacks any atomic resources named {}", resourceName);
+                LOGGER.info("Offer lacks any atomic resources named {}", resourceName);
             } else {
-                logger.info("Offered quantity in all {} instances of {} is insufficient: desired {}",
+                LOGGER.info("Offered quantity in all {} instances of {} is insufficient: desired {}",
                         atomicResources.size(),
                         resourceName,
                         value);
@@ -167,7 +167,7 @@ public class MesosResourcePool {
     public Optional<MesosResource> consumeReservableMerged(String name, Value desiredValue, String preReservedRole) {
         Map<String, Value> pool = reservableMergedPoolByRole.get(preReservedRole);
         if (pool == null) {
-            logger.info("No unreserved resources available for role '{}'. Reservable roles are: {}",
+            LOGGER.info("No unreserved resources available for role '{}'. Reservable roles are: {}",
                     preReservedRole, reservableMergedPoolByRole.keySet());
             return Optional.empty();
         }
@@ -190,9 +190,9 @@ public class MesosResourcePool {
             return Optional.of(new MesosResource(builder.build()));
         } else {
             if (availableValue == null) {
-                logger.info("Offer lacks any unreserved {} resources for role {}", name, preReservedRole);
+                LOGGER.info("Offer lacks any unreserved {} resources for role {}", name, preReservedRole);
             } else {
-                logger.info("Offered quantity of {} for role {} is insufficient: desired {}, offered {}",
+                LOGGER.info("Offered quantity of {} for role {} is insufficient: desired {}, offered {}",
                         name,
                         preReservedRole,
                         TextFormat.shortDebugString(desiredValue),
@@ -203,7 +203,7 @@ public class MesosResourcePool {
     }
 
     public void free(MesosResource mesosResource) {
-        logger.info("Freeing resource: {}",  mesosResource.toString());
+        LOGGER.info("Freeing resource: {}",  mesosResource.toString());
         if (mesosResource.isAtomic()) {
             freeAtomicResource(mesosResource);
             return;
@@ -216,7 +216,7 @@ public class MesosResourcePool {
     private void freeMergedResource(MesosResource mesosResource) {
         if (mesosResource.getResourceId().isPresent()) {
             dynamicallyReservedPoolByResourceId.remove(mesosResource.getResourceId().get());
-            logger.info("Freed resource: {}", !dynamicallyReservedPoolByResourceId
+            LOGGER.info("Freed resource: {}", !dynamicallyReservedPoolByResourceId
                     .containsKey(mesosResource.getResourceId().get()));
         }
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/MesosResourcePool.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/MesosResourcePool.java
@@ -6,7 +6,6 @@ import org.apache.mesos.Protos.Offer;
 import org.apache.mesos.Protos.Resource;
 import org.apache.mesos.Protos.Value;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.*;
 
@@ -15,7 +14,7 @@ import java.util.*;
  * consumption of the {@link Offer}'s resources.
  */
 public class MesosResourcePool {
-    private static final Logger logger = LoggerFactory.getLogger(MesosResourcePool.class);
+    private static final Logger logger = LoggingUtils.getLogger(MesosResourcePool.class);
     private Offer offer;
 
     /**

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/OfferAccepter.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/OfferAccepter.java
@@ -8,7 +8,6 @@ import org.apache.mesos.Protos.Offer.Operation;
 import org.apache.mesos.Protos.OfferID;
 import org.apache.mesos.SchedulerDriver;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.*;
 
@@ -17,7 +16,7 @@ import java.util.*;
  * Operations.
  */
 public class OfferAccepter {
-    private static final Logger LOGGER = LoggerFactory.getLogger(OfferAccepter.class);
+    private static final Logger LOGGER = LoggingUtils.getLogger(OfferAccepter.class);
     private static final Filters FILTERS = Filters.newBuilder().setRefuseSeconds(1).build();
 
     private final Collection<OperationRecorder> recorders = new ArrayList<>();

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/OfferUtils.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/OfferUtils.java
@@ -5,7 +5,6 @@ import com.mesosphere.sdk.scheduler.Metrics;
 import org.apache.mesos.Protos;
 import org.apache.mesos.SchedulerDriver;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
 import java.util.List;
@@ -16,7 +15,7 @@ import java.util.stream.Collectors;
  * This class provides commonly used utilities for offer handling.
  */
 public class OfferUtils {
-    private static final Logger LOGGER = LoggerFactory.getLogger(OfferUtils.class);
+    private static final Logger LOGGER = LoggingUtils.getLogger(OfferUtils.class);
 
     /**
      * Filters out accepted offers and returns back a list of unused offers.

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/ResourceCleaner.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/ResourceCleaner.java
@@ -4,7 +4,6 @@ import org.apache.mesos.Protos;
 import org.apache.mesos.Protos.Offer;
 import org.apache.mesos.Protos.Resource;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.TextFormat;
@@ -22,7 +21,7 @@ import java.util.stream.Collectors;
  */
 public class ResourceCleaner {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(ResourceCleaner.class);
+    private static final Logger LOGGER = LoggingUtils.getLogger(ResourceCleaner.class);
 
     private final Collection<Resource> expectedResources;
     private final Protos.FrameworkInfo frameworkInfo;

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/TaskUtils.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/TaskUtils.java
@@ -17,7 +17,6 @@ import org.apache.mesos.Protos.TaskInfo;
 import org.apache.mesos.Protos.TaskState;
 import org.apache.mesos.Protos.TaskStatus;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -28,7 +27,7 @@ import static com.mesosphere.sdk.offer.Constants.PORTS_RESOURCE_TYPE;
  * Various utility methods for manipulating data in {@link TaskInfo}s.
  */
 public class TaskUtils {
-    private static final Logger LOGGER = LoggerFactory.getLogger(TaskUtils.class);
+    private static final Logger LOGGER = LoggingUtils.getLogger(TaskUtils.class);
 
     private TaskUtils() {
         // do not instantiate

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/ExecutorResourceMapper.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/ExecutorResourceMapper.java
@@ -3,12 +3,12 @@ package com.mesosphere.sdk.offer.evaluate;
 import com.google.protobuf.TextFormat;
 import com.mesosphere.sdk.offer.ResourceUtils;
 import com.mesosphere.sdk.offer.Constants;
+import com.mesosphere.sdk.offer.LoggingUtils;
 import com.mesosphere.sdk.specification.PodSpec;
 import com.mesosphere.sdk.specification.ResourceSpec;
 import com.mesosphere.sdk.specification.VolumeSpec;
 import org.apache.mesos.Protos;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -18,8 +18,7 @@ import java.util.stream.Collectors;
  * of expected {@link VolumeSpec}s for that Executor.
  */
 public class ExecutorResourceMapper {
-    private static final Logger LOGGER = LoggerFactory.getLogger(ExecutorResourceMapper.class);
-    private final Protos.ExecutorInfo executorInfo;
+    private static final Logger LOGGER = LoggingUtils.getLogger(ExecutorResourceMapper.class);
     private final Collection<ResourceSpec> resourceSpecs;
     private final Collection<VolumeSpec> volumeSpecs;
     private final List<Protos.Resource> resources;
@@ -32,7 +31,6 @@ public class ExecutorResourceMapper {
             Collection<ResourceSpec> resourceSpecs,
             Protos.ExecutorInfo executorInfo,
             boolean useDefaultExecutor) {
-        this.executorInfo = executorInfo;
         this.volumeSpecs = podSpec.getVolumes();
         this.resourceSpecs = resourceSpecs;
         this.resources = executorInfo.getResourcesList();

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluationUtils.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluationUtils.java
@@ -5,7 +5,6 @@ import com.mesosphere.sdk.offer.*;
 import com.mesosphere.sdk.specification.*;
 import org.apache.mesos.Protos;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -18,7 +17,7 @@ import static com.mesosphere.sdk.offer.evaluate.EvaluationOutcome.pass;
  * This class encapsulates shared offer evaluation logic for evaluation stages.
  */
 class OfferEvaluationUtils {
-    private static final Logger LOGGER = LoggerFactory.getLogger(OfferEvaluationUtils.class);
+    private static final Logger LOGGER = LoggingUtils.getLogger(OfferEvaluationUtils.class);
 
     private OfferEvaluationUtils() {
         // Do not instantiate this class.

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluator.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluator.java
@@ -15,7 +15,6 @@ import com.mesosphere.sdk.state.GoalStateOverride;
 import com.mesosphere.sdk.state.StateStore;
 import org.apache.mesos.Protos;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.*;
@@ -28,7 +27,7 @@ import java.util.stream.Collectors;
  * in reference to {@link PodInstanceRequirement}s.
  */
 public class OfferEvaluator {
-    private static final Logger logger = LoggerFactory.getLogger(OfferEvaluator.class);
+    private static final Logger logger = LoggingUtils.getLogger(OfferEvaluator.class);
 
     private final StateStore stateStore;
     private final OfferOutcomeTracker offerOutcomeTracker;

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluator.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluator.java
@@ -27,7 +27,7 @@ import java.util.stream.Collectors;
  * in reference to {@link PodInstanceRequirement}s.
  */
 public class OfferEvaluator {
-    private static final Logger logger = LoggingUtils.getLogger(OfferEvaluator.class);
+    private static final Logger LOGGER = LoggingUtils.getLogger(OfferEvaluator.class);
 
     private final StateStore stateStore;
     private final OfferOutcomeTracker offerOutcomeTracker;
@@ -113,7 +113,7 @@ public class OfferEvaluator {
             }
 
             if (failedOutcomeCount != 0) {
-                logger.info("Offer {}, {}: failed {} of {} evaluation stages:\n{}",
+                LOGGER.info("Offer {}, {}: failed {} of {} evaluation stages:\n{}",
                         i + 1,
                         offer.getId().getValue(),
                         failedOutcomeCount,
@@ -130,7 +130,7 @@ public class OfferEvaluator {
                         .map(outcome -> outcome.getOfferRecommendations())
                         .flatMap(xs -> xs.stream())
                         .collect(Collectors.toList());
-                logger.info("Offer {}: passed all {} evaluation stages, returning {} recommendations:\n{}",
+                LOGGER.info("Offer {}: passed all {} evaluation stages, returning {} recommendations:\n{}",
                         i + 1, evaluationStages.size(), recommendations.size(), outcomeDetails.toString());
 
                 offerOutcomeTracker.track(new OfferOutcome(
@@ -175,7 +175,7 @@ public class OfferEvaluator {
             description = "existing";
             shouldGetNewRequirement = false;
         }
-        logger.info("Generating requirement for {} pod '{}' containing tasks: {}.",
+        LOGGER.info("Generating requirement for {} pod '{}' containing tasks: {}.",
                 description,
                 podInstanceRequirement.getPodInstance().getName(),
                 podInstanceRequirement.getTasksToLaunch());
@@ -223,7 +223,7 @@ public class OfferEvaluator {
 
         for (Protos.TaskInfo taskInfo : executorReuseCandidates) {
             if (taskHasReusableExecutor(taskInfo)) {
-                logger.info("Using existing executor: {}", TextFormat.shortDebugString(taskInfo.getExecutor()));
+                LOGGER.info("Using existing executor: {}", TextFormat.shortDebugString(taskInfo.getExecutor()));
                 return taskInfo.getExecutor();
             }
         }
@@ -234,7 +234,7 @@ public class OfferEvaluator {
                 .getExecutor().toBuilder()
                 .setExecutorId(Protos.ExecutorID.newBuilder().setValue(""))
                 .build();
-        logger.info("Using old executor: {}", TextFormat.shortDebugString(executorInfo));
+        LOGGER.info("Using old executor: {}", TextFormat.shortDebugString(executorInfo));
 
         return executorInfo;
     }
@@ -462,7 +462,7 @@ public class OfferEvaluator {
             Protos.TaskInfo taskInfo =
                     getTaskInfoSharingResourceSet(podInstanceRequirement.getPodInstance(), taskSpec, podTasks);
             if (taskInfo == null) {
-                logger.error("Failed to fetch task {}.  Cannot generate resource map.", taskInstanceName);
+                LOGGER.error("Failed to fetch task {}.  Cannot generate resource map.", taskInstanceName);
                 return Collections.emptyList();
             }
 
@@ -522,7 +522,7 @@ public class OfferEvaluator {
             try {
                 return new TaskLabelReader(taskInfo).getTargetConfiguration();
             } catch (TaskException e) {
-                logger.error(String.format(
+                LOGGER.error(String.format(
                         "Falling back to current target configuration '%s'. " +
                                 "Failed to determine target configuration for task: %s",
                                 targetConfigId, TextFormat.shortDebugString(taskInfo)), e);

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/PodInfoBuilder.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/PodInfoBuilder.java
@@ -20,7 +20,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.mesos.Protos;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.net.URI;
 import java.util.*;
@@ -34,7 +33,7 @@ import java.util.stream.Collectors;
  * to which they are attached.
  */
 public class PodInfoBuilder {
-    private static final Logger LOGGER = LoggerFactory.getLogger(PodInfoBuilder.class);
+    private static final Logger LOGGER = LoggingUtils.getLogger(PodInfoBuilder.class);
     private static final String CONFIG_TEMPLATE_KEY_FORMAT = "CONFIG_TEMPLATE_%s";
     private static final String CONFIG_TEMPLATE_DOWNLOAD_PATH = "config-templates/";
     private Set<Long> assignedOverlayPorts = new HashSet<>();

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/PortEvaluationStage.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/PortEvaluationStage.java
@@ -10,7 +10,6 @@ import com.mesosphere.sdk.specification.TaskSpec;
 
 import org.apache.mesos.Protos;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -25,7 +24,7 @@ import java.util.stream.IntStream;
  * environments.
  */
 public class PortEvaluationStage implements OfferEvaluationStage {
-    private static final Logger LOGGER = LoggerFactory.getLogger(PortEvaluationStage.class);
+    private static final Logger LOGGER = LoggingUtils.getLogger(PortEvaluationStage.class);
 
     private final PortSpec portSpec;
     private final String taskName;

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/TLSEvaluationStage.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/TLSEvaluationStage.java
@@ -5,6 +5,7 @@ import com.mesosphere.sdk.dcos.DcosHttpClientBuilder;
 import com.mesosphere.sdk.dcos.DcosHttpExecutor;
 import com.mesosphere.sdk.dcos.clients.CertificateAuthorityClient;
 import com.mesosphere.sdk.dcos.clients.SecretsClient;
+import com.mesosphere.sdk.offer.LoggingUtils;
 import com.mesosphere.sdk.offer.MesosResourcePool;
 import com.mesosphere.sdk.offer.evaluate.security.*;
 import com.mesosphere.sdk.scheduler.SchedulerConfig;
@@ -14,7 +15,6 @@ import org.apache.http.client.methods.HttpPut;
 import org.apache.http.impl.client.LaxRedirectStrategy;
 import org.apache.mesos.Protos;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.*;
@@ -25,7 +25,7 @@ import java.util.*;
  */
 public class TLSEvaluationStage implements OfferEvaluationStage {
 
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private final Logger logger = LoggingUtils.getLogger(getClass());
 
     private final String serviceName;
     private final String taskName;

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/TaskResourceMapper.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/TaskResourceMapper.java
@@ -2,12 +2,12 @@ package com.mesosphere.sdk.offer.evaluate;
 
 import com.google.protobuf.TextFormat;
 import com.mesosphere.sdk.offer.Constants;
+import com.mesosphere.sdk.offer.LoggingUtils;
 import com.mesosphere.sdk.offer.RangeUtils;
 import com.mesosphere.sdk.offer.ResourceUtils;
 import com.mesosphere.sdk.specification.*;
 import org.apache.mesos.Protos;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -17,7 +17,7 @@ import java.util.stream.Collectors;
  * of expected {@link ResourceSpec}s for that task.
  */
 class TaskResourceMapper {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private final Logger logger = LoggingUtils.getLogger(getClass());
     private final List<Protos.Resource> orphanedResources = new ArrayList<>();
     private final List<OfferEvaluationStage> evaluationStages;
     private final String taskSpecName;

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/VolumeEvaluationStage.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/VolumeEvaluationStage.java
@@ -5,7 +5,6 @@ import com.mesosphere.sdk.offer.*;
 import com.mesosphere.sdk.specification.VolumeSpec;
 import org.apache.mesos.Protos.Resource;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.*;
 
@@ -19,7 +18,7 @@ import static com.mesosphere.sdk.offer.evaluate.EvaluationOutcome.pass;
  * {@link com.mesosphere.sdk.offer.CreateOfferRecommendation} as necessary.
  */
 public class VolumeEvaluationStage implements OfferEvaluationStage {
-    private static final Logger logger = LoggerFactory.getLogger(VolumeEvaluationStage.class);
+    private static final Logger logger = LoggingUtils.getLogger(VolumeEvaluationStage.class);
     private final VolumeSpec volumeSpec;
     private final Optional<String> persistenceId;
     private final String taskName;

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/VolumeEvaluationStage.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/VolumeEvaluationStage.java
@@ -18,7 +18,7 @@ import static com.mesosphere.sdk.offer.evaluate.EvaluationOutcome.pass;
  * {@link com.mesosphere.sdk.offer.CreateOfferRecommendation} as necessary.
  */
 public class VolumeEvaluationStage implements OfferEvaluationStage {
-    private static final Logger logger = LoggingUtils.getLogger(VolumeEvaluationStage.class);
+    private static final Logger LOGGER = LoggingUtils.getLogger(VolumeEvaluationStage.class);
     private final VolumeSpec volumeSpec;
     private final Optional<String> persistenceId;
     private final String taskName;
@@ -151,7 +151,7 @@ public class VolumeEvaluationStage implements OfferEvaluationStage {
 
             if (!resourceId.isPresent()) {
                 // Initial reservation of resources
-                logger.info("    Resource '{}' requires a RESERVE operation", volumeSpec.getName());
+                LOGGER.info("    Resource '{}' requires a RESERVE operation", volumeSpec.getName());
                 offerRecommendations.add(new ReserveOfferRecommendation(
                         mesosResourcePool.getOffer(),
                         resource));
@@ -159,11 +159,11 @@ public class VolumeEvaluationStage implements OfferEvaluationStage {
         }
 
         if (createsVolume()) {
-            logger.info("    Resource '{}' requires a CREATE operation", volumeSpec.getName());
+            LOGGER.info("    Resource '{}' requires a CREATE operation", volumeSpec.getName());
             offerRecommendations.add(new CreateOfferRecommendation(mesosResourcePool.getOffer(), resource));
         }
 
-        logger.info("  Generated '{}' resource for task: [{}]",
+        LOGGER.info("  Generated '{}' resource for task: [{}]",
                 volumeSpec.getName(), TextFormat.shortDebugString(resource));
         OfferEvaluationUtils.setProtos(podInfoBuilder, resource, getTaskName());
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/AbstractRoundRobinRule.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/AbstractRoundRobinRule.java
@@ -1,6 +1,7 @@
 package com.mesosphere.sdk.offer.evaluate.placement;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.mesosphere.sdk.offer.LoggingUtils;
 import com.mesosphere.sdk.offer.evaluate.EvaluationOutcome;
 import com.mesosphere.sdk.specification.PodInstance;
 import org.apache.commons.lang3.builder.EqualsBuilder;
@@ -8,7 +9,6 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.mesos.Protos.Offer;
 import org.apache.mesos.Protos.TaskInfo;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -20,7 +20,7 @@ import java.util.Optional;
  */
 abstract class AbstractRoundRobinRule implements PlacementRule {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractRoundRobinRule.class);
+    private static final Logger LOGGER = LoggingUtils.getLogger(AbstractRoundRobinRule.class);
 
     protected final StringMatcher taskFilter;
     protected final Optional<Integer> distinctKeyCount;

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/MarathonConstraintParser.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/MarathonConstraintParser.java
@@ -3,9 +3,10 @@ package com.mesosphere.sdk.offer.evaluate.placement;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
+import com.mesosphere.sdk.offer.LoggingUtils;
+
 import jersey.repackaged.com.google.common.collect.Lists;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.*;
@@ -17,7 +18,7 @@ import java.util.*;
  */
 public class MarathonConstraintParser {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(MarathonConstraintParser.class);
+    private static final Logger LOGGER = LoggingUtils.getLogger(MarathonConstraintParser.class);
     private static final char ESCAPE_CHAR = '\\';
 
     private static final Map<String, Operator> SUPPORTED_OPERATORS = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/MaxPerHostnameRule.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/MaxPerHostnameRule.java
@@ -2,6 +2,7 @@ package com.mesosphere.sdk.offer.evaluate.placement;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.mesosphere.sdk.offer.LoggingUtils;
 import com.mesosphere.sdk.offer.TaskException;
 import com.mesosphere.sdk.offer.evaluate.EvaluationOutcome;
 import com.mesosphere.sdk.offer.taskdata.TaskLabelReader;
@@ -10,7 +11,6 @@ import com.mesosphere.sdk.specification.validation.ValidationUtils;
 import org.apache.mesos.Protos.Offer;
 import org.apache.mesos.Protos.TaskInfo;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.validation.Valid;
 import javax.validation.constraints.Min;
@@ -41,7 +41,7 @@ import java.util.Collections;
  */
 public class MaxPerHostnameRule extends MaxPerRule {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(MaxPerHostnameRule.class);
+    private static final Logger LOGGER = LoggingUtils.getLogger(MaxPerHostnameRule.class);
 
     @Valid
     @Min(1)

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/PlacementUtils.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/PlacementUtils.java
@@ -1,5 +1,6 @@
 package com.mesosphere.sdk.offer.evaluate.placement;
 
+import com.mesosphere.sdk.offer.LoggingUtils;
 import com.mesosphere.sdk.offer.TaskException;
 import com.mesosphere.sdk.offer.TaskUtils;
 import com.mesosphere.sdk.specification.PodInstance;
@@ -7,7 +8,6 @@ import com.mesosphere.sdk.specification.PodSpec;
 import org.apache.mesos.Protos;
 import org.apache.mesos.Protos.TaskInfo;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.*;
 
@@ -16,7 +16,7 @@ import java.util.*;
  */
 public class PlacementUtils {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(PlacementUtils.class);
+    private static final Logger LOGGER = LoggingUtils.getLogger(PlacementUtils.class);
 
     private static final String HOSTNAME_FIELD_LEGACY = "hostname";
     private static final String HOSTNAME_FIELD = "@hostname";

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/RoundRobinByHostnameRule.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/RoundRobinByHostnameRule.java
@@ -2,13 +2,13 @@ package com.mesosphere.sdk.offer.evaluate.placement;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.mesosphere.sdk.offer.LoggingUtils;
 import com.mesosphere.sdk.offer.TaskException;
 import com.mesosphere.sdk.offer.taskdata.TaskLabelReader;
 
 import org.apache.mesos.Protos.Offer;
 import org.apache.mesos.Protos.TaskInfo;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -43,7 +43,7 @@ import java.util.Optional;
  */
 public class RoundRobinByHostnameRule extends AbstractRoundRobinRule {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(RoundRobinByHostnameRule.class);
+    private static final Logger LOGGER = LoggingUtils.getLogger(RoundRobinByHostnameRule.class);
 
     public RoundRobinByHostnameRule(Optional<Integer> agentCount) {
         this(agentCount, null);

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/security/TLSArtifactsUpdater.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/security/TLSArtifactsUpdater.java
@@ -1,11 +1,11 @@
 package com.mesosphere.sdk.offer.evaluate.security;
 
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.mesosphere.sdk.dcos.clients.CertificateAuthorityClient;
 import com.mesosphere.sdk.dcos.clients.SecretsClient;
+import com.mesosphere.sdk.offer.LoggingUtils;
 
 import java.util.Collection;
 import java.util.Map;
@@ -18,7 +18,7 @@ import java.util.stream.Collectors;
  */
 public class TLSArtifactsUpdater {
 
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private final Logger logger = LoggingUtils.getLogger(getClass());
 
     private final String serviceName;
     private final SecretsClient secretsClient;

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/taskdata/AuxLabelAccess.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/taskdata/AuxLabelAccess.java
@@ -10,12 +10,12 @@ import java.util.UUID;
 import org.apache.mesos.Protos;
 import org.apache.mesos.Protos.Label;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Splitter;
 import com.mesosphere.sdk.dcos.DcosConstants;
 import com.mesosphere.sdk.http.EndpointUtils;
 import com.mesosphere.sdk.http.EndpointUtils.VipInfo;
+import com.mesosphere.sdk.offer.LoggingUtils;
 import com.mesosphere.sdk.specification.NamedVIPSpec;
 
 /**
@@ -26,7 +26,7 @@ import com.mesosphere.sdk.specification.NamedVIPSpec;
  */
 public class AuxLabelAccess {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(AuxLabelAccess.class);
+    private static final Logger LOGGER = LoggingUtils.getLogger(AuxLabelAccess.class);
 
     private AuxLabelAccess() {
         // do not instantiate

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/queue/OfferQueue.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/queue/OfferQueue.java
@@ -1,9 +1,10 @@
 package com.mesosphere.sdk.queue;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.mesosphere.sdk.offer.LoggingUtils;
+
 import org.apache.mesos.Protos;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
 import java.util.Collection;
@@ -20,7 +21,7 @@ import java.util.stream.Collectors;
 public class OfferQueue {
     private static final int DEFAULT_CAPACITY = 100;
     private static final Duration DEFAULT_OFFER_WAIT = Duration.ofSeconds(5);
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private final Logger logger = LoggingUtils.getLogger(getClass());
     private final BlockingQueue<Protos.Offer> queue;
 
     public OfferQueue() {

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/reconciliation/Reconciler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/reconciliation/Reconciler.java
@@ -7,10 +7,11 @@ import com.mesosphere.sdk.scheduler.Driver;
 import org.apache.mesos.Protos;
 import org.apache.mesos.Protos.TaskStatus;
 import org.apache.mesos.SchedulerDriver;
+
+import com.mesosphere.sdk.offer.LoggingUtils;
 import com.mesosphere.sdk.offer.TaskUtils;
 import com.mesosphere.sdk.state.StateStore;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -21,7 +22,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  */
 public class Reconciler {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(Reconciler.class);
+    private static final Logger LOGGER = LoggingUtils.getLogger(Reconciler.class);
 
     // Exponential backoff between explicit reconcile requests: minimum 8s, maximum 30s
     private static final int MULTIPLIER = 2;

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/AbstractScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/AbstractScheduler.java
@@ -3,6 +3,7 @@ package com.mesosphere.sdk.scheduler;
 import com.codahale.metrics.Timer;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.TextFormat;
+import com.mesosphere.sdk.offer.LoggingUtils;
 import com.mesosphere.sdk.offer.OfferUtils;
 import com.mesosphere.sdk.offer.evaluate.placement.IsLocalRegionRule;
 import com.mesosphere.sdk.queue.OfferQueue;
@@ -16,7 +17,6 @@ import org.apache.mesos.Protos;
 import org.apache.mesos.Scheduler;
 import org.apache.mesos.SchedulerDriver;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.*;
 import java.util.concurrent.ExecutorService;
@@ -30,7 +30,7 @@ import java.util.stream.Collectors;
  */
 public abstract class AbstractScheduler {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractScheduler.class);
+    private static final Logger LOGGER = LoggingUtils.getLogger(AbstractScheduler.class);
 
     protected final Protos.FrameworkInfo frameworkInfo;
     protected final StateStore stateStore;

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/DefaultScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/DefaultScheduler.java
@@ -17,7 +17,6 @@ import com.mesosphere.sdk.storage.Persister;
 import com.mesosphere.sdk.storage.PersisterException;
 import org.apache.mesos.Protos;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -29,7 +28,7 @@ import java.util.stream.Collectors;
  */
 public class DefaultScheduler extends AbstractScheduler {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultScheduler.class);
+    private static final Logger LOGGER = LoggingUtils.getLogger(DefaultScheduler.class);
 
     private final OfferAccepter offerAccepter;
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/ReviveManager.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/ReviveManager.java
@@ -1,12 +1,12 @@
 package com.mesosphere.sdk.scheduler;
 
+import com.mesosphere.sdk.offer.LoggingUtils;
 import com.mesosphere.sdk.scheduler.plan.PodInstanceRequirement;
 import com.mesosphere.sdk.scheduler.plan.Step;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.mesos.SchedulerDriver;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
 import java.util.HashSet;
@@ -18,7 +18,7 @@ import java.util.stream.Collectors;
  * This class determines whether offers should be revived based on changes to the work being processed by the scheduler.
  */
 public class ReviveManager {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private final Logger logger = LoggingUtils.getLogger(getClass());
     private final TokenBucket tokenBucket;
     private Set<WorkItem> candidates = new HashSet<>();
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerApiServer.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerApiServer.java
@@ -1,6 +1,8 @@
 package com.mesosphere.sdk.scheduler;
 
 import com.codahale.metrics.jetty9.InstrumentedHandler;
+import com.mesosphere.sdk.offer.LoggingUtils;
+
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.servlet.ServletContextHandler;
@@ -11,7 +13,6 @@ import org.glassfish.jersey.media.multipart.MultiPartFeature;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.servlet.ServletContainer;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.core.UriBuilder;
 import java.time.Duration;
@@ -24,7 +25,7 @@ import java.util.TimerTask;
  * The SchedulerApiServer runs the Jetty {@link Server} that exposes the Scheduler's API.
  */
 public class SchedulerApiServer {
-    private static final Logger LOGGER = LoggerFactory.getLogger(SchedulerApiServer.class);
+    private static final Logger LOGGER = LoggingUtils.getLogger(SchedulerApiServer.class);
 
     private final int port;
     private final Server server;

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerBuilder.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerBuilder.java
@@ -11,6 +11,7 @@ import com.mesosphere.sdk.curator.CuratorPersister;
 import com.mesosphere.sdk.dcos.Capabilities;
 import com.mesosphere.sdk.http.types.EndpointProducer;
 import com.mesosphere.sdk.offer.Constants;
+import com.mesosphere.sdk.offer.LoggingUtils;
 import com.mesosphere.sdk.offer.evaluate.placement.AndRule;
 import com.mesosphere.sdk.offer.evaluate.placement.IsLocalRegionRule;
 import com.mesosphere.sdk.offer.evaluate.placement.PlacementRule;
@@ -40,7 +41,6 @@ import com.mesosphere.sdk.storage.PersisterException;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.mesos.Protos;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
 import java.util.*;
@@ -51,7 +51,7 @@ import java.util.stream.Collectors;
  */
 public class SchedulerBuilder {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(SchedulerBuilder.class);
+    private static final Logger LOGGER = LoggingUtils.getLogger(SchedulerBuilder.class);
     private static final int TWO_WEEK_SEC = 2 * 7 * 24 * 60 * 60;
 
     private ServiceSpec serviceSpec;

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerDriverFactory.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerDriverFactory.java
@@ -5,6 +5,8 @@ import com.google.protobuf.TextFormat;
 import com.mesosphere.mesos.HTTPAdapter.MesosToSchedulerDriverAdapter;
 import com.mesosphere.mesos.protobuf.EvolverDevolver;
 import com.mesosphere.sdk.dcos.Capabilities;
+import com.mesosphere.sdk.offer.LoggingUtils;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.mesos.MesosSchedulerDriver;
 import org.apache.mesos.Protos.Credential;
@@ -14,14 +16,13 @@ import org.apache.mesos.SchedulerDriver;
 import org.apache.mesos.v1.scheduler.Mesos;
 import org.apache.mesos.v1.scheduler.V0Mesos;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Factory class for creating {@link MesosSchedulerDriver}s.
  */
 public class SchedulerDriverFactory {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(SchedulerDriverFactory.class);
+    private static final Logger LOGGER = LoggingUtils.getLogger(SchedulerDriverFactory.class);
 
     /**
      * Creates and returns a new {@link SchedulerDriver} without a credential secret.

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerRunner.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerRunner.java
@@ -6,6 +6,7 @@ import com.mesosphere.sdk.generated.SDKBuildInfo;
 import com.mesosphere.sdk.http.HealthResource;
 import com.mesosphere.sdk.http.PlansResource;
 import com.mesosphere.sdk.offer.Constants;
+import com.mesosphere.sdk.offer.LoggingUtils;
 import com.mesosphere.sdk.scheduler.plan.DefaultPlanManager;
 import com.mesosphere.sdk.scheduler.plan.Phase;
 import com.mesosphere.sdk.scheduler.plan.Plan;
@@ -22,7 +23,6 @@ import org.apache.mesos.Scheduler;
 import org.eclipse.jetty.util.component.AbstractLifeCycle;
 import org.eclipse.jetty.util.component.LifeCycle;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.time.Instant;
@@ -32,7 +32,7 @@ import java.util.*;
  * Class which sets up and executes the correct {@link AbstractScheduler} instance.
  */
 public class SchedulerRunner implements Runnable {
-    private static final Logger LOGGER = LoggerFactory.getLogger(SchedulerRunner.class);
+    private static final Logger LOGGER = LoggingUtils.getLogger(SchedulerRunner.class);
 
     private final SchedulerBuilder schedulerBuilder;
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/TaskKiller.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/TaskKiller.java
@@ -1,11 +1,12 @@
 package com.mesosphere.sdk.scheduler;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.mesosphere.sdk.offer.LoggingUtils;
+
 import org.apache.mesos.Protos;
 import org.apache.mesos.Protos.TaskID;
 import org.apache.mesos.SchedulerDriver;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
 import java.util.HashSet;
@@ -22,7 +23,7 @@ import java.util.stream.Collectors;
  * Mesos doesn't know anything about this task.
  */
 public final class TaskKiller {
-    private static final Logger LOGGER = LoggerFactory.getLogger(TaskKiller.class);
+    private static final Logger LOGGER = LoggingUtils.getLogger(TaskKiller.class);
 
     private static final Duration KILL_INTERVAL = Duration.ofSeconds(5);
     private static final Set<TaskID> TASKS_TO_KILL = new HashSet<>();

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/TokenBucket.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/TokenBucket.java
@@ -1,7 +1,8 @@
 package com.mesosphere.sdk.scheduler;
 
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
+import com.mesosphere.sdk.offer.LoggingUtils;
 
 import java.time.Duration;
 import java.util.concurrent.Executors;
@@ -18,7 +19,7 @@ public class TokenBucket {
     public static final Duration DEFAULT_ACQUIRE_INTEVAL = Duration.ofSeconds(5);
     public static final Duration DEFAULT_INCREMENT_INTERVAL = Duration.ofSeconds(DEFAULT_CAPACITY);
 
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private final Logger logger = LoggingUtils.getLogger(getClass());
     private final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
     private final int initial;
     private final int capacity;

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/decommission/DecommissionPlanFactory.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/decommission/DecommissionPlanFactory.java
@@ -2,6 +2,7 @@ package com.mesosphere.sdk.scheduler.decommission;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.mesosphere.sdk.offer.Constants;
+import com.mesosphere.sdk.offer.LoggingUtils;
 import com.mesosphere.sdk.offer.ResourceUtils;
 import com.mesosphere.sdk.offer.TaskException;
 import com.mesosphere.sdk.offer.taskdata.TaskLabelReader;
@@ -17,7 +18,6 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.mesos.Protos;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -45,7 +45,7 @@ import java.util.stream.Collectors;
  * one pod at a time, and only unreserve pods that are marked as DECOMMISSIONED+IN_PROGRESS.</li></ul>
  */
 public class DecommissionPlanFactory {
-    private static final Logger LOGGER = LoggerFactory.getLogger(DecommissionPlanFactory.class);
+    private static final Logger LOGGER = LoggingUtils.getLogger(DecommissionPlanFactory.class);
 
     /**
      * The status for a task whose resources should be unreserved because its resources are currently being

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/decommission/DecommissionRecorder.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/decommission/DecommissionRecorder.java
@@ -5,7 +5,6 @@ import com.mesosphere.sdk.scheduler.plan.Step;
 import com.mesosphere.sdk.state.StateStore;
 import org.apache.mesos.Protos;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -15,7 +14,7 @@ import java.util.stream.Collectors;
  * by removing the destroyed resources from the stored TaskInfos.
  */
 public class DecommissionRecorder implements OperationRecorder {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private final Logger logger = LoggingUtils.getLogger(getClass());
     private final StateStore stateStore;
     private final Collection<Step> resourceSteps;
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/decommission/EraseTaskStateStep.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/decommission/EraseTaskStateStep.java
@@ -3,8 +3,8 @@ package com.mesosphere.sdk.scheduler.decommission;
 import java.util.Optional;
 
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+import com.mesosphere.sdk.offer.LoggingUtils;
 import com.mesosphere.sdk.scheduler.plan.PodInstanceRequirement;
 import com.mesosphere.sdk.scheduler.plan.Status;
 import com.mesosphere.sdk.scheduler.uninstall.UninstallStep;
@@ -14,7 +14,7 @@ import com.mesosphere.sdk.state.StateStore;
  * A step which erases a specified task's state from zookeeper.
  */
 public class EraseTaskStateStep extends UninstallStep {
-    private static final Logger LOGGER = LoggerFactory.getLogger(EraseTaskStateStep.class);
+    private static final Logger LOGGER = LoggingUtils.getLogger(EraseTaskStateStep.class);
 
     private final StateStore stateStore;
     private final String taskName;

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/decommission/TriggerDecommissionStep.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/decommission/TriggerDecommissionStep.java
@@ -1,5 +1,6 @@
 package com.mesosphere.sdk.scheduler.decommission;
 
+import com.mesosphere.sdk.offer.LoggingUtils;
 import com.mesosphere.sdk.scheduler.TaskKiller;
 import com.mesosphere.sdk.scheduler.plan.PodInstanceRequirement;
 import com.mesosphere.sdk.scheduler.plan.Status;
@@ -8,7 +9,6 @@ import com.mesosphere.sdk.state.StateStore;
 
 import org.apache.mesos.Protos;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.Optional;
 
@@ -16,7 +16,7 @@ import java.util.Optional;
  * Step which marks a task as being decommissioned and kills it.
  */
 public class TriggerDecommissionStep extends UninstallStep {
-    private static final Logger LOGGER = LoggerFactory.getLogger(DecommissionPlanFactory.class);
+    private static final Logger LOGGER = LoggingUtils.getLogger(DecommissionPlanFactory.class);
 
     private final StateStore stateStore;
     private final Protos.TaskInfo taskInfo;

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/AbstractStep.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/AbstractStep.java
@@ -3,7 +3,8 @@ package com.mesosphere.sdk.scheduler.plan;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
+import com.mesosphere.sdk.offer.LoggingUtils;
 
 import java.util.Objects;
 import java.util.UUID;
@@ -16,7 +17,7 @@ public abstract class AbstractStep implements Step {
     /**
      * Non-static to ensure that we inherit the names of subclasses.
      */
-    protected final Logger logger = LoggerFactory.getLogger(getClass());
+    protected final Logger logger = LoggingUtils.getLogger(getClass());
 
     protected UUID id = UUID.randomUUID();
     private final String name;

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/DefaultPlanCoordinator.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/DefaultPlanCoordinator.java
@@ -2,7 +2,8 @@ package com.mesosphere.sdk.scheduler.plan;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
+import com.mesosphere.sdk.offer.LoggingUtils;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -13,7 +14,7 @@ import java.util.stream.Collectors;
  * A {@link DefaultPlanCoordinator} is an {@link Observable} and will forward updates from its plans.
  */
 public class DefaultPlanCoordinator implements PlanCoordinator {
-    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultPlanCoordinator.class);
+    private static final Logger LOGGER = LoggingUtils.getLogger(DefaultPlanCoordinator.class);
 
     private final List<PlanManager> planManagers = new LinkedList<>();
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/DefaultPlanScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/DefaultPlanScheduler.java
@@ -11,7 +11,6 @@ import org.apache.mesos.Protos.Offer;
 import org.apache.mesos.Protos.OfferID;
 import org.apache.mesos.Protos.TaskInfo;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.*;
@@ -22,7 +21,7 @@ import java.util.stream.Collectors;
  */
 public class DefaultPlanScheduler implements PlanScheduler {
 
-    private static final Logger logger = LoggerFactory.getLogger(DefaultPlanScheduler.class);
+    private static final Logger logger = LoggingUtils.getLogger(DefaultPlanScheduler.class);
 
     private final OfferAccepter offerAccepter;
     private final OfferEvaluator offerEvaluator;

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/DefaultStepFactory.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/DefaultStepFactory.java
@@ -2,6 +2,7 @@ package com.mesosphere.sdk.scheduler.plan;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.mesosphere.sdk.dcos.Capabilities;
+import com.mesosphere.sdk.offer.LoggingUtils;
 import com.mesosphere.sdk.offer.TaskException;
 import com.mesosphere.sdk.offer.TaskUtils;
 import com.mesosphere.sdk.offer.taskdata.TaskLabelReader;
@@ -15,7 +16,6 @@ import com.mesosphere.sdk.state.StateStore;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.mesos.Protos;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -24,7 +24,7 @@ import java.util.stream.Collectors;
  * This class is a default implementation of the {@link StepFactory} interface.
  */
 public class DefaultStepFactory implements StepFactory {
-    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultStepFactory.class);
+    private static final Logger LOGGER = LoggingUtils.getLogger(DefaultStepFactory.class);
 
     private final ConfigTargetStore configTargetStore;
     private final StateStore stateStore;

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/ParentElement.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/ParentElement.java
@@ -1,10 +1,10 @@
 package com.mesosphere.sdk.scheduler.plan;
 
 import com.google.protobuf.TextFormat;
+import com.mesosphere.sdk.offer.LoggingUtils;
 import com.mesosphere.sdk.scheduler.plan.strategy.Strategy;
 import org.apache.mesos.Protos;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -16,7 +16,7 @@ import java.util.stream.Collectors;
  * @param <C> the type of the child elements
  */
 public interface ParentElement<C extends Element> extends Element, Interruptible {
-    static final Logger LOGGER = LoggerFactory.getLogger(ParentElement.class);
+    static final Logger LOGGER = LoggingUtils.getLogger(ParentElement.class);
 
     /**
      * Gets the children of this Element.

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/PlanUtils.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/PlanUtils.java
@@ -1,11 +1,11 @@
 package com.mesosphere.sdk.scheduler.plan;
 
+import com.mesosphere.sdk.offer.LoggingUtils;
 import com.mesosphere.sdk.offer.TaskUtils;
 
 import org.apache.mesos.Protos.Offer;
 import org.apache.mesos.Protos.OfferID;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -15,7 +15,7 @@ import java.util.stream.Collectors;
  */
 public class PlanUtils {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(PlanUtils.class);
+    private static final Logger LOGGER = LoggingUtils.getLogger(PlanUtils.class);
 
     private PlanUtils() {
         // do not instantiate

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/recovery/DefaultRecoveryPlanManager.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/recovery/DefaultRecoveryPlanManager.java
@@ -2,6 +2,7 @@ package com.mesosphere.sdk.scheduler.recovery;
 
 import com.mesosphere.sdk.config.SerializationUtils;
 import com.mesosphere.sdk.http.types.PlanInfo;
+import com.mesosphere.sdk.offer.LoggingUtils;
 import com.mesosphere.sdk.offer.TaskException;
 import com.mesosphere.sdk.offer.TaskUtils;
 import com.mesosphere.sdk.scheduler.plan.*;
@@ -16,7 +17,6 @@ import com.mesosphere.sdk.state.StateStore;
 import com.mesosphere.sdk.state.StateStoreUtils;
 import org.apache.mesos.Protos;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.*;
@@ -32,7 +32,7 @@ import java.util.stream.Collectors;
 public class DefaultRecoveryPlanManager implements PlanManager {
     public static final String DEFAULT_RECOVERY_PLAN_NAME = "recovery";
     public static final String DEFAULT_RECOVERY_PHASE_NAME = "default";
-    protected final Logger logger = LoggerFactory.getLogger(getClass());
+    protected final Logger logger = LoggingUtils.getLogger(getClass());
     protected final ConfigStore<ServiceSpec> configStore;
     private final List<RecoveryPlanOverrider> recoveryPlanOverriders;
     private final Set<String> recoverableTaskNames;

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/recovery/DefaultTaskFailureListener.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/recovery/DefaultTaskFailureListener.java
@@ -1,5 +1,6 @@
 package com.mesosphere.sdk.scheduler.recovery;
 
+import com.mesosphere.sdk.offer.LoggingUtils;
 import com.mesosphere.sdk.offer.TaskException;
 import com.mesosphere.sdk.offer.TaskUtils;
 import com.mesosphere.sdk.specification.PodInstance;
@@ -8,7 +9,6 @@ import com.mesosphere.sdk.state.ConfigStore;
 import com.mesosphere.sdk.state.StateStore;
 import org.apache.mesos.Protos;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
 import java.util.HashSet;
@@ -18,7 +18,7 @@ import java.util.Set;
  * This class provides a default implementation of the {@link TaskFailureListener} interface.
  */
 public class DefaultTaskFailureListener implements TaskFailureListener {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private final Logger logger = LoggingUtils.getLogger(getClass());
     private final StateStore stateStore;
     private final ConfigStore<ServiceSpec> configStore;
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/recovery/constrain/TimedLaunchConstrainer.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/recovery/constrain/TimedLaunchConstrainer.java
@@ -1,9 +1,9 @@
 package com.mesosphere.sdk.scheduler.recovery.constrain;
 
 import com.mesosphere.sdk.offer.LaunchOfferRecommendation;
+import com.mesosphere.sdk.offer.LoggingUtils;
 import com.mesosphere.sdk.scheduler.recovery.RecoveryType;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicLong;
@@ -13,7 +13,7 @@ import java.util.concurrent.atomic.AtomicLong;
  * rate-limiting purposes.
  */
 public class TimedLaunchConstrainer implements LaunchConstrainer {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private final Logger logger = LoggingUtils.getLogger(getClass());
 
     private AtomicLong lastPermanentRecoveryLaunchMs;
     private Duration minDelay;

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/uninstall/TLSCleanupStep.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/uninstall/TLSCleanupStep.java
@@ -2,6 +2,7 @@ package com.mesosphere.sdk.scheduler.uninstall;
 
 import com.google.protobuf.TextFormat;
 import com.mesosphere.sdk.dcos.clients.SecretsClient;
+import com.mesosphere.sdk.offer.LoggingUtils;
 import com.mesosphere.sdk.offer.OfferRecommendation;
 import com.mesosphere.sdk.offer.evaluate.security.TLSArtifact;
 import com.mesosphere.sdk.offer.evaluate.security.TLSArtifactPaths;
@@ -10,7 +11,6 @@ import com.mesosphere.sdk.scheduler.plan.PodInstanceRequirement;
 import com.mesosphere.sdk.scheduler.plan.Status;
 import org.apache.mesos.Protos;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.*;
@@ -23,7 +23,7 @@ public class TLSCleanupStep extends AbstractStep {
     private final SecretsClient secretsClient;
     private final String namespace;
 
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private final Logger logger = LoggingUtils.getLogger(getClass());
 
     /**
      * Creates a new instance with initial {@code status}.

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/uninstall/UninstallPlanBuilder.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/uninstall/UninstallPlanBuilder.java
@@ -10,12 +10,12 @@ import java.util.stream.Collectors;
 import org.apache.http.impl.client.LaxRedirectStrategy;
 import org.apache.mesos.Protos;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.mesosphere.sdk.dcos.DcosHttpClientBuilder;
 import com.mesosphere.sdk.dcos.DcosHttpExecutor;
 import com.mesosphere.sdk.dcos.clients.SecretsClient;
 import com.mesosphere.sdk.offer.Constants;
+import com.mesosphere.sdk.offer.LoggingUtils;
 import com.mesosphere.sdk.offer.ResourceUtils;
 import com.mesosphere.sdk.offer.TaskUtils;
 import com.mesosphere.sdk.scheduler.SchedulerConfig;
@@ -36,7 +36,7 @@ import com.mesosphere.sdk.state.StateStore;
  * Handles creation of the uninstall plan, returning information about the plan contents back to the caller.
  */
 public class UninstallPlanBuilder {
-    private static final Logger LOGGER = LoggerFactory.getLogger(UninstallPlanBuilder.class);
+    private static final Logger LOGGER = LoggingUtils.getLogger(UninstallPlanBuilder.class);
 
     private static final String TASK_KILL_PHASE = "kill-tasks";
     private static final String RESOURCE_PHASE = "unreserve-resources";

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/uninstall/UninstallRecorder.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/uninstall/UninstallRecorder.java
@@ -5,7 +5,6 @@ import com.mesosphere.sdk.offer.*;
 import com.mesosphere.sdk.state.StateStore;
 import org.apache.mesos.Protos;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -17,7 +16,7 @@ import static com.mesosphere.sdk.offer.Constants.TOMBSTONE_MARKER;
  * service by marking them with a tombstone id, then notifying the uninstall plan of the changes.
  */
 public class UninstallRecorder implements OperationRecorder {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private final Logger logger = LoggingUtils.getLogger(getClass());
     private final StateStore stateStore;
     private final Collection<ResourceCleanupStep> resourceSteps;
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/uninstall/UninstallScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/uninstall/UninstallScheduler.java
@@ -16,7 +16,6 @@ import com.mesosphere.sdk.state.StateStoreUtils;
 import org.apache.mesos.Protos;
 import org.apache.mesos.Scheduler;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.*;
@@ -27,7 +26,7 @@ import java.util.stream.Collectors;
  */
 public class UninstallScheduler extends AbstractScheduler {
 
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private final Logger logger = LoggingUtils.getLogger(getClass());
 
     private final Optional<SecretsClient> secretsClient;
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultPlanGenerator.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultPlanGenerator.java
@@ -1,6 +1,7 @@
 package com.mesosphere.sdk.specification;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.mesosphere.sdk.offer.LoggingUtils;
 import com.mesosphere.sdk.scheduler.plan.*;
 import com.mesosphere.sdk.scheduler.plan.strategy.StrategyFactory;
 import com.mesosphere.sdk.specification.yaml.RawPhase;
@@ -9,7 +10,6 @@ import com.mesosphere.sdk.specification.yaml.WriteOnceLinkedHashMap;
 import com.mesosphere.sdk.state.ConfigTargetStore;
 import com.mesosphere.sdk.state.StateStore;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -18,7 +18,7 @@ import java.util.stream.Collectors;
  * Default implementation of {@link PlanGenerator}.
  */
 public class DefaultPlanGenerator implements PlanGenerator {
-    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultPlanGenerator.class);
+    private static final Logger LOGGER = LoggingUtils.getLogger(DefaultPlanGenerator.class);
     private final StepFactory stepFactory;
 
     public DefaultPlanGenerator(ConfigTargetStore configTargetStore, StateStore stateStore) {

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultServiceSpec.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultServiceSpec.java
@@ -45,7 +45,7 @@ import java.util.stream.Collectors;
  */
 public class DefaultServiceSpec implements ServiceSpec {
     private static final Comparator COMPARATOR = new Comparator();
-    private static final Logger logger = LoggingUtils.getLogger(DefaultServiceSpec.class);
+    private static final Logger LOGGER = LoggingUtils.getLogger(DefaultServiceSpec.class);
 
     @NotNull(message = "Service name cannot be empty")
     @Size(min = 1, message = "Service name cannot be empty")
@@ -285,8 +285,8 @@ public class DefaultServiceSpec implements ServiceSpec {
             // Serialize and then deserialize:
             loopbackSpecification = factory.parse(serviceSpec.getBytes());
         } catch (Exception e) {
-            logger.error("Failed to parse JSON for loopback validation", e);
-            logger.error("JSON to be parsed was:\n{}",
+            LOGGER.error("Failed to parse JSON for loopback validation", e);
+            LOGGER.error("JSON to be parsed was:\n{}",
                     new String(serviceSpec.getBytes(), StandardCharsets.UTF_8));
             throw e;
         }
@@ -426,7 +426,7 @@ public class DefaultServiceSpec implements ServiceSpec {
                 } else if (value.equals("RUNNING")) {
                     return GoalState.RUNNING;
                 } else {
-                    logger.warn("Found unknown goal state in config store: {}", value);
+                    LOGGER.warn("Found unknown goal state in config store: {}", value);
                     return GoalState.UNKNOWN;
                 }
             }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultServiceSpec.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultServiceSpec.java
@@ -16,6 +16,7 @@ import com.mesosphere.sdk.config.ConfigurationFactory;
 import com.mesosphere.sdk.config.SerializationUtils;
 import com.mesosphere.sdk.config.TaskEnvRouter;
 import com.mesosphere.sdk.dcos.DcosConstants;
+import com.mesosphere.sdk.offer.LoggingUtils;
 import com.mesosphere.sdk.offer.evaluate.placement.*;
 import com.mesosphere.sdk.scheduler.SchedulerConfig;
 import com.mesosphere.sdk.specification.validation.UniquePodType;
@@ -28,7 +29,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
@@ -45,7 +45,7 @@ import java.util.stream.Collectors;
  */
 public class DefaultServiceSpec implements ServiceSpec {
     private static final Comparator COMPARATOR = new Comparator();
-    private static final Logger logger = LoggerFactory.getLogger(DefaultServiceSpec.class);
+    private static final Logger logger = LoggingUtils.getLogger(DefaultServiceSpec.class);
 
     @NotNull(message = "Service name cannot be empty")
     @Size(min = 1, message = "Service name cannot be empty")

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/RawServiceSpec.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/RawServiceSpec.java
@@ -23,7 +23,7 @@ import org.slf4j.Logger;
  * Root of the parsed YAML object model.
  */
 public class RawServiceSpec {
-    private static final Logger LOGGER = LoggingUtils.getLogger(Builder.class);
+    private static final Logger LOGGER = LoggingUtils.getLogger(RawServiceSpec.class);
     private static final ObjectMapper YAML_MAPPER = new ObjectMapper(new YAMLFactory());
 
     /**

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/RawServiceSpec.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/RawServiceSpec.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.google.common.annotations.VisibleForTesting;
+import com.mesosphere.sdk.offer.LoggingUtils;
 
 import java.io.File;
 import java.io.IOException;
@@ -17,13 +18,12 @@ import java.util.Map;
 
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Root of the parsed YAML object model.
  */
 public class RawServiceSpec {
-    private static final Logger LOGGER = LoggerFactory.getLogger(Builder.class);
+    private static final Logger LOGGER = LoggingUtils.getLogger(Builder.class);
     private static final ObjectMapper YAML_MAPPER = new ObjectMapper(new YAMLFactory());
 
     /**

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/state/ConfigStore.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/state/ConfigStore.java
@@ -2,12 +2,12 @@ package com.mesosphere.sdk.state;
 
 import com.mesosphere.sdk.config.Configuration;
 import com.mesosphere.sdk.config.ConfigurationFactory;
+import com.mesosphere.sdk.offer.LoggingUtils;
 import com.mesosphere.sdk.storage.Persister;
 import com.mesosphere.sdk.storage.PersisterException;
 import com.mesosphere.sdk.storage.PersisterUtils;
 import com.mesosphere.sdk.storage.StorageError.Reason;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.nio.charset.StandardCharsets;
 import java.util.*;
@@ -28,7 +28,7 @@ import java.util.*;
  */
 public class ConfigStore<T extends Configuration> implements ConfigTargetStore {
 
-    private static final Logger logger = LoggerFactory.getLogger(ConfigStore.class);
+    private static final Logger logger = LoggingUtils.getLogger(ConfigStore.class);
 
     /**
      * @see SchemaVersionStore#CURRENT_SCHEMA_VERSION

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/state/ConfigStore.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/state/ConfigStore.java
@@ -28,7 +28,7 @@ import java.util.*;
  */
 public class ConfigStore<T extends Configuration> implements ConfigTargetStore {
 
-    private static final Logger logger = LoggingUtils.getLogger(ConfigStore.class);
+    private static final Logger LOGGER = LoggingUtils.getLogger(ConfigStore.class);
 
     /**
      * @see SchemaVersionStore#CURRENT_SCHEMA_VERSION
@@ -97,7 +97,7 @@ public class ConfigStore<T extends Configuration> implements ConfigTargetStore {
         }
 
         String path = getConfigPath(id);
-        logger.info("Fetching configuration with ID={} from {}", id, path);
+        LOGGER.info("Fetching configuration with ID={} from {}", id, path);
         byte[] data;
         try {
             data = persister.get(path);
@@ -130,7 +130,7 @@ public class ConfigStore<T extends Configuration> implements ConfigTargetStore {
         } catch (PersisterException e) {
             if (e.getReason() == Reason.NOT_FOUND) {
                 // Clearing a non-existent Configuration should not result in an exception.
-                logger.warn("Requested configuration '{}' to be deleted does not exist at path '{}'", id, path);
+                LOGGER.warn("Requested configuration '{}' to be deleted does not exist at path '{}'", id, path);
                 return;
             } else {
                 throw new ConfigStoreException(e, String.format(
@@ -161,7 +161,7 @@ public class ConfigStore<T extends Configuration> implements ConfigTargetStore {
         } catch (PersisterException e) {
             if (e.getReason() == Reason.NOT_FOUND) {
                 // Clearing a non-existent Configuration should not result in an exception.
-                logger.warn("Configuration list at path '{}' does not exist: returning empty list",
+                LOGGER.warn("Configuration list at path '{}' does not exist: returning empty list",
                         CONFIGURATIONS_PATH_NAME);
                 return new ArrayList<>();
             } else {

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/state/PersistentLaunchRecorder.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/state/PersistentLaunchRecorder.java
@@ -7,7 +7,6 @@ import com.mesosphere.sdk.scheduler.plan.DefaultPodInstance;
 import com.mesosphere.sdk.specification.*;
 import org.apache.mesos.Protos;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -16,7 +15,7 @@ import java.util.stream.Collectors;
  * Records the result of launched tasks to persistent storage.
  */
 public class PersistentLaunchRecorder implements OperationRecorder {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private final Logger logger = LoggingUtils.getLogger(getClass());
     private final StateStore stateStore;
     private final ServiceSpec serviceSpec;
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/state/SchemaVersionStore.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/state/SchemaVersionStore.java
@@ -24,7 +24,7 @@ public class SchemaVersionStore {
      */
     private static final Charset CHARSET = StandardCharsets.UTF_8;
 
-    private static final Logger logger = LoggingUtils.getLogger(SchemaVersionStore.class);
+    private static final Logger LOGGER = LoggingUtils.getLogger(SchemaVersionStore.class);
 
     /**
      * Increment this whenever CuratorStateStore or CuratorConfigStore change in a way that
@@ -70,14 +70,14 @@ public class SchemaVersionStore {
      */
     public int fetch() throws StateStoreException {
         try {
-            logger.debug("Fetching schema version from '{}'", SCHEMA_VERSION_NAME);
+            LOGGER.debug("Fetching schema version from '{}'", SCHEMA_VERSION_NAME);
             byte[] bytes = persister.get(SCHEMA_VERSION_NAME);
             if (bytes.length == 0) {
                 throw new StateStoreException(Reason.SERIALIZATION_ERROR, String.format(
                         "Invalid data when fetching schema version in '%s'", SCHEMA_VERSION_NAME));
             }
             String rawString = new String(bytes, CHARSET);
-            logger.debug("Schema version retrieved from '{}': {}", SCHEMA_VERSION_NAME, rawString);
+            LOGGER.debug("Schema version retrieved from '{}': {}", SCHEMA_VERSION_NAME, rawString);
             try {
                 return Integer.parseInt(rawString);
             } catch (NumberFormatException e) {
@@ -88,7 +88,7 @@ public class SchemaVersionStore {
         } catch (PersisterException e) {
             if (e.getReason() == Reason.NOT_FOUND) {
                 // The schema version doesn't exist yet. Initialize to the current version.
-                logger.debug("Schema version not found at path: {}. New service install? " +
+                LOGGER.debug("Schema version not found at path: {}. New service install? " +
                         "Initializing path to schema version: {}.",
                         SCHEMA_VERSION_NAME, CURRENT_SCHEMA_VERSION);
                 store(CURRENT_SCHEMA_VERSION);
@@ -109,7 +109,7 @@ public class SchemaVersionStore {
     public void store(int version) throws StateStoreException {
         try {
             String versionStr = String.valueOf(version);
-            logger.debug("Storing schema version: '{}' into path: {}",
+            LOGGER.debug("Storing schema version: '{}' into path: {}",
                     versionStr, SCHEMA_VERSION_NAME);
             persister.set(SCHEMA_VERSION_NAME, versionStr.getBytes(CHARSET));
         } catch (Exception e) {

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/state/SchemaVersionStore.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/state/SchemaVersionStore.java
@@ -1,5 +1,6 @@
 package com.mesosphere.sdk.state;
 
+import com.mesosphere.sdk.offer.LoggingUtils;
 import com.mesosphere.sdk.storage.Persister;
 import com.mesosphere.sdk.storage.PersisterException;
 import com.mesosphere.sdk.storage.StorageError.Reason;
@@ -7,7 +8,6 @@ import com.mesosphere.sdk.storage.StorageError.Reason;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Used by StateStore and ConfigStore implementations to retrieve and validate the Schema Version against whatever
@@ -24,7 +24,7 @@ public class SchemaVersionStore {
      */
     private static final Charset CHARSET = StandardCharsets.UTF_8;
 
-    private static final Logger logger = LoggerFactory.getLogger(SchemaVersionStore.class);
+    private static final Logger logger = LoggingUtils.getLogger(SchemaVersionStore.class);
 
     /**
      * Increment this whenever CuratorStateStore or CuratorConfigStore change in a way that

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/state/StateStore.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/state/StateStore.java
@@ -41,7 +41,7 @@ import java.util.*;
  */
 public class StateStore {
 
-    private static final Logger logger = LoggingUtils.getLogger(StateStore.class);
+    private static final Logger LOGGER = LoggingUtils.getLogger(StateStore.class);
 
     /**
      * @see SchemaVersionStore#CURRENT_SCHEMA_VERSION
@@ -112,7 +112,7 @@ public class StateStore {
         } catch (PersisterException e) {
             if (e.getReason() == Reason.NOT_FOUND) {
                 // Clearing a non-existent FrameworkID should not result in an exception from us.
-                logger.warn("Cleared unset FrameworkID, continuing silently", e);
+                LOGGER.warn("Cleared unset FrameworkID, continuing silently", e);
             } else {
                 throw new StateStoreException(e);
             }
@@ -136,7 +136,7 @@ public class StateStore {
             }
         } catch (PersisterException e) {
             if (e.getReason() == Reason.NOT_FOUND) {
-                logger.warn("No FrameworkId found at: {}", FWK_ID_PATH_NAME);
+                LOGGER.warn("No FrameworkId found at: {}", FWK_ID_PATH_NAME);
                 return Optional.empty();
             } else {
                 throw new StateStoreException(e);
@@ -196,7 +196,7 @@ public class StateStore {
         }
 
         String path = getTaskStatusPath(taskName);
-        logger.info("Storing status '{}' for '{}' in '{}'", status.getState(), taskName, path);
+        LOGGER.info("Storing status '{}' for '{}' in '{}'", status.getState(), taskName, path);
 
         try {
             persister.set(path, status.toByteArray());
@@ -217,7 +217,7 @@ public class StateStore {
         } catch (PersisterException e) {
             if (e.getReason() == Reason.NOT_FOUND) {
                 // Clearing a non-existent Task should not result in an exception from us.
-                logger.warn("Cleared nonexistent Task, continuing silently: {}", taskName, e);
+                LOGGER.warn("Cleared nonexistent Task, continuing silently: {}", taskName, e);
             } else {
                 throw new StateStoreException(e);
             }
@@ -291,7 +291,7 @@ public class StateStore {
             }
         } catch (PersisterException e) {
             if (e.getReason() == Reason.NOT_FOUND) {
-                logger.warn("No TaskInfo found for the requested name: {} at: {}", taskName, path);
+                LOGGER.warn("No TaskInfo found for the requested name: {} at: {}", taskName, path);
                 return Optional.empty();
             } else {
                 throw new StateStoreException(e, String.format("Failed to retrieve task named %s", taskName));
@@ -350,7 +350,7 @@ public class StateStore {
             }
         } catch (PersisterException e) {
             if (e.getReason() == Reason.NOT_FOUND) {
-                logger.warn("No TaskStatus found for the requested name: {} at: {}", taskName, path);
+                LOGGER.warn("No TaskStatus found for the requested name: {} at: {}", taskName, path);
                 return Optional.empty();
             } else {
                 throw new StateStoreException(e);
@@ -376,7 +376,7 @@ public class StateStore {
         validateValue(value);
         try {
             final String path = PersisterUtils.join(PROPERTIES_PATH_NAME, key);
-            logger.debug("Storing property key: {} into path: {}", key, path);
+            LOGGER.debug("Storing property key: {} into path: {}", key, path);
             persister.set(path, value);
         } catch (PersisterException e) {
             throw new StateStoreException(e);
@@ -395,7 +395,7 @@ public class StateStore {
         validateKey(key);
         try {
             final String path = PersisterUtils.join(PROPERTIES_PATH_NAME, key);
-            logger.debug("Fetching property key: {} from path: {}", key, path);
+            LOGGER.debug("Fetching property key: {} from path: {}", key, path);
             return persister.get(path);
         } catch (PersisterException e) {
             throw new StateStoreException(e);
@@ -431,12 +431,12 @@ public class StateStore {
         validateKey(key);
         try {
             final String path = PersisterUtils.join(PROPERTIES_PATH_NAME, key);
-            logger.debug("Removing property key: {} from path: {}", key, path);
+            LOGGER.debug("Removing property key: {} from path: {}", key, path);
             persister.recursiveDelete(path);
         } catch (PersisterException e) {
             if (e.getReason() == Reason.NOT_FOUND) {
                 // Clearing a non-existent Property should not result in an exception from us.
-                logger.warn("Cleared nonexistent Property, continuing silently: {}", key, e);
+                LOGGER.warn("Cleared nonexistent Property, continuing silently: {}", key, e);
             } else {
                 throw new StateStoreException(e);
             }
@@ -490,7 +490,7 @@ public class StateStore {
                 return GoalStateOverride.Status.INACTIVE;
             } else if (nameBytes == null || statusBytes == null) {
                 // This shouldn't happen, but let's just play it safe and assume that the override shouldn't be set.
-                logger.error("Task is missing override name or override status. Expected either both or neither: {}",
+                LOGGER.error("Task is missing override name or override status. Expected either both or neither: {}",
                         values);
                 return GoalStateOverride.Status.INACTIVE;
             }
@@ -510,7 +510,7 @@ public class StateStore {
         // The override name isn't recognized. This could happen during a downgrade or similar scenario where a task
         // previously has an override that is no longer recognized by the scheduler. The most reasonable thing in this
         // case would be to fall back to a no-override state.
-        logger.warn("Task '{}' has unrecognized override named '{}'. Left over from a recent upgrade/downgrade? "
+        LOGGER.warn("Task '{}' has unrecognized override named '{}'. Left over from a recent upgrade/downgrade? "
                 + "Falling back to inactive override target.", taskName, overrideName);
         return GoalStateOverride.Status.INACTIVE.target;
     }
@@ -526,7 +526,7 @@ public class StateStore {
         // The progress name isn't recognized. This could happen during a downgrade or similar scenario where a task
         // previously has a state that is no longer recognized by the scheduler. The most reasonable thing in this
         // case is to fall back to a no-override state.
-        logger.warn("Task '{}' has unrecognized override progress '{}'. Left over from a recent upgrade/downgrade? "
+        LOGGER.warn("Task '{}' has unrecognized override progress '{}'. Left over from a recent upgrade/downgrade? "
                 + "Falling back to inactive override progress.", taskName, progressName);
         return GoalStateOverride.Status.INACTIVE.progress;
     }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/state/StateStore.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/state/StateStore.java
@@ -1,6 +1,7 @@
 package com.mesosphere.sdk.state;
 
 import com.google.protobuf.InvalidProtocolBufferException;
+import com.mesosphere.sdk.offer.LoggingUtils;
 import com.mesosphere.sdk.offer.TaskUtils;
 import com.mesosphere.sdk.storage.Persister;
 import com.mesosphere.sdk.storage.PersisterException;
@@ -10,7 +11,6 @@ import com.mesosphere.sdk.storage.StorageError.Reason;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.mesos.Protos;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.nio.charset.StandardCharsets;
 import java.util.*;
@@ -41,7 +41,7 @@ import java.util.*;
  */
 public class StateStore {
 
-    private static final Logger logger = LoggerFactory.getLogger(StateStore.class);
+    private static final Logger logger = LoggingUtils.getLogger(StateStore.class);
 
     /**
      * @see SchemaVersionStore#CURRENT_SCHEMA_VERSION

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/state/StateStoreUtils.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/state/StateStoreUtils.java
@@ -2,6 +2,7 @@ package com.mesosphere.sdk.state;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.TextFormat;
+import com.mesosphere.sdk.offer.LoggingUtils;
 import com.mesosphere.sdk.offer.TaskException;
 import com.mesosphere.sdk.offer.TaskUtils;
 import com.mesosphere.sdk.scheduler.recovery.FailureUtils;
@@ -12,7 +13,6 @@ import com.mesosphere.sdk.specification.TaskSpec;
 import com.mesosphere.sdk.storage.StorageError.Reason;
 import org.apache.mesos.Protos;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -24,7 +24,7 @@ import java.util.stream.Collectors;
  */
 public class StateStoreUtils {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(StateStoreUtils.class);
+    private static final Logger LOGGER = LoggingUtils.getLogger(StateStoreUtils.class);
     private static final String UNINSTALLING_PROPERTY_KEY = "uninstalling";
     private static final String LAST_COMPLETED_UPDATE_TYPE_KEY = "last-completed-update-type";
     private static final String PROPERTY_TASK_INFO_SUFFIX = ":task-status";

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/storage/PersisterCache.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/storage/PersisterCache.java
@@ -7,7 +7,8 @@ import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
+import com.mesosphere.sdk.offer.LoggingUtils;
 
 /**
  * A transparent write-through cache for an underlying {@link Persister} instance. Each cache instance is thread-safe,
@@ -15,7 +16,7 @@ import org.slf4j.LoggerFactory;
  */
 public class PersisterCache implements Persister {
 
-    private static final Logger logger = LoggerFactory.getLogger(PersisterCache.class);
+    private static final Logger logger = LoggingUtils.getLogger(PersisterCache.class);
 
     private final ReadWriteLock internalLock = new ReentrantReadWriteLock();
     private final Lock rlock = internalLock.readLock();

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/storage/PersisterCache.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/storage/PersisterCache.java
@@ -16,7 +16,7 @@ import com.mesosphere.sdk.offer.LoggingUtils;
  */
 public class PersisterCache implements Persister {
 
-    private static final Logger logger = LoggingUtils.getLogger(PersisterCache.class);
+    private static final Logger LOGGER = LoggingUtils.getLogger(PersisterCache.class);
 
     private final ReadWriteLock internalLock = new ReentrantReadWriteLock();
     private final Lock rlock = internalLock.readLock();
@@ -107,7 +107,7 @@ public class PersisterCache implements Persister {
                 // We don't throw an exception here if our 'data' cache lacks the value. In theory 'persister' should've
                 // thrown in that case anyway -- so we're effectively replicating what the underlying persister does.
                 // This shouldn't happen assuming a well-behaved Persisters, but just in case...
-                logger.error("Didn't find value {} in cache to delete, but underlying storage had the value", path);
+                LOGGER.error("Didn't find value {} in cache to delete, but underlying storage had the value", path);
             }
         } finally {
             rwlock.unlock();
@@ -134,7 +134,7 @@ public class PersisterCache implements Persister {
         rwlock.lock();
         try {
             if (cache != null) {
-                logger.info("Cache content before refresh:\n{}", cache.getDebugString());
+                LOGGER.info("Cache content before refresh:\n{}", cache.getDebugString());
             }
             cache = null;
             getCache(); // recreate cache
@@ -147,7 +147,7 @@ public class PersisterCache implements Persister {
         if (cache == null) {
             // We already have our own locking, so we can disable locking in the underlying MemPersister:
             cache = new MemPersister(MemPersister.LockMode.DISABLED, PersisterUtils.getAllData(persister));
-            logger.info("Loaded data from persister:\n{}", cache.getDebugString());
+            LOGGER.info("Loaded data from persister:\n{}", cache.getDebugString());
         }
         return cache;
     }

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/AbstractSchedulerTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/AbstractSchedulerTest.java
@@ -12,11 +12,11 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.apache.mesos.Protos;
 import org.apache.mesos.SchedulerDriver;
 
 import com.mesosphere.sdk.dcos.clients.SecretsClient;
+import com.mesosphere.sdk.offer.LoggingUtils;
 import com.mesosphere.sdk.scheduler.plan.PlanCoordinator;
 import com.mesosphere.sdk.scheduler.plan.Step;
 import com.mesosphere.sdk.specification.ServiceSpec;
@@ -32,7 +32,7 @@ import com.mesosphere.sdk.testutils.TestConstants;
  */
 public class AbstractSchedulerTest {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractSchedulerTest.class);
+    private static final Logger LOGGER = LoggingUtils.getLogger(AbstractSchedulerTest.class);
 
     private StateStore stateStore;
     private final Protos.FrameworkInfo frameworkInfo = Protos.FrameworkInfo.newBuilder()

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/storage/PersisterCacheTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/storage/PersisterCacheTest.java
@@ -6,8 +6,8 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+import com.mesosphere.sdk.offer.LoggingUtils;
 import com.mesosphere.sdk.storage.StorageError.Reason;
 
 import java.nio.charset.StandardCharsets;
@@ -22,7 +22,7 @@ import static org.mockito.Mockito.when;
  */
 public class PersisterCacheTest {
 
-    private static final Logger logger = LoggerFactory.getLogger(PersisterCacheTest.class);
+    private static final Logger logger = LoggingUtils.getLogger(PersisterCacheTest.class);
 
     private static final String KEY = "key";
     private static final byte[] VAL = "someval".getBytes(StandardCharsets.UTF_8);

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/storage/PersisterCacheTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/storage/PersisterCacheTest.java
@@ -22,7 +22,7 @@ import static org.mockito.Mockito.when;
  */
 public class PersisterCacheTest {
 
-    private static final Logger logger = LoggingUtils.getLogger(PersisterCacheTest.class);
+    private static final Logger LOGGER = LoggingUtils.getLogger(PersisterCacheTest.class);
 
     private static final String KEY = "key";
     private static final byte[] VAL = "someval".getBytes(StandardCharsets.UTF_8);
@@ -317,7 +317,7 @@ public class PersisterCacheTest {
                 @Override
                 public void uncaughtException(Thread t, Throwable e) {
                     synchronized (lock) {
-                        logger.error(t.getName(), e);
+                        LOGGER.error(t.getName(), e);
                         errors.add(e);
                     }
                 }

--- a/sdk/testing/src/main/java/com/mesosphere/sdk/testing/ConfigValidatorUtils.java
+++ b/sdk/testing/src/main/java/com/mesosphere/sdk/testing/ConfigValidatorUtils.java
@@ -55,7 +55,7 @@ public class ConfigValidatorUtils {
 
         testRunner
                 .setSchedulerEnv(placementEnvKey, newPlacement)
-                .setCustomValidators(configValidator)
+                .addCustomValidator(configValidator)
                 .setState(result)
                 .run(ticks);
     }

--- a/sdk/testing/src/main/java/com/mesosphere/sdk/testing/ServiceTestRunner.java
+++ b/sdk/testing/src/main/java/com/mesosphere/sdk/testing/ServiceTestRunner.java
@@ -56,7 +56,7 @@ public class ServiceTestRunner {
     private final Map<String, Map<String, String>> customPodEnvs = new HashMap<>();
     private RecoveryPlanOverriderFactory recoveryManagerFactory;
     private boolean supportsDefaultExecutor = true;
-    private List<ConfigValidator<ServiceSpec>> validators = Collections.emptyList();
+    private List<ConfigValidator<ServiceSpec>> validators = new ArrayList<>();
 
     /**
      * Returns a {@link File} object for the service's {@code src/main/dist} directory. Does not check if the directory
@@ -242,8 +242,8 @@ public class ServiceTestRunner {
         return this;
     }
 
-    public ServiceTestRunner setCustomValidators(ConfigValidator<ServiceSpec>... validators) {
-        this.validators = Arrays.asList(validators);
+    public ServiceTestRunner addCustomValidator(ConfigValidator<ServiceSpec> validator) {
+        this.validators.add(validator);
         return this;
     }
 

--- a/sdk/testing/src/main/java/com/mesosphere/sdk/testing/ServiceTestRunner.java
+++ b/sdk/testing/src/main/java/com/mesosphere/sdk/testing/ServiceTestRunner.java
@@ -2,6 +2,7 @@ package com.mesosphere.sdk.testing;
 
 import com.mesosphere.sdk.config.validate.ConfigValidator;
 import com.mesosphere.sdk.dcos.Capabilities;
+import com.mesosphere.sdk.offer.LoggingUtils;
 import com.mesosphere.sdk.offer.evaluate.PodInfoBuilder;
 import com.mesosphere.sdk.scheduler.AbstractScheduler;
 import com.mesosphere.sdk.scheduler.DefaultScheduler;
@@ -19,7 +20,6 @@ import com.mesosphere.sdk.storage.Persister;
 import org.apache.mesos.SchedulerDriver;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.util.*;
@@ -30,7 +30,7 @@ import java.util.*;
  */
 public class ServiceTestRunner {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(ServiceTestRunner.class);
+    private static final Logger LOGGER = LoggingUtils.getLogger(ServiceTestRunner.class);
     private static final Random RANDOM = new Random();
 
     /**


### PR DESCRIPTION
Adds a wrapper around `LoggingFactory`. To start with, this will result in logs omitting the `com.full.package.path` when displaying the class name, making logs much easier to read. `LoggingFactory`'s `getLogger(Class<?>)` method is hardcoded to the full class name, with package, whereas `getLogger(String)` allows us to customize.
If we want to revisit the format later, we can just do it in `LoggingUtils`.