### PR TITLE
Revert "[ELASTIC-177] Fix Kibana test failure on 1.9. (#2381)"

### DIFF
--- a/frameworks/elastic/tests/config.py
+++ b/frameworks/elastic/tests/config.py
@@ -112,7 +112,7 @@ def wait_for_expected_nodes_to_exist(service_name=SERVICE_NAME, task_count=DEFAU
     stop_max_delay=DEFAULT_ELASTIC_TIMEOUT*1000,
     retry_on_result=lambda res: not res)
 def check_kibana_plugin_installed(plugin_name, service_name=SERVICE_NAME):
-    cmd = "bash -c 'KIBANA_DIRECTORY=$(ls -d $MESOS_SANDBOX/kibana-*-linux-x86_64); $KIBANA_DIRECTORY/bin/kibana-plugin list'"
+    cmd = "bash -c '$MESOS_SANDBOX/kibana-$ELASTIC_VERSION-linux-x86_64/bin/kibana-plugin list'"
     _, stdout, _ = sdk_cmd.task_exec(service_name, cmd)
     return plugin_name in stdout
 


### PR DESCRIPTION
This reverts commit 546feeef26bad42ecb3f32f6ad05ccad96801206.

The change had side-effects that caused the kafka tests on 1.9 to fail because environment variables in the command line are different for bash commands (the `;` is required) or for executables like `./bootstrap` (either `export` or no `;` is required).