### PR TITLE
[ELASTIC-179] Fix Kibana command on 1.9 with localized change.

### DIFF
--- a/frameworks/elastic/tests/config.py
+++ b/frameworks/elastic/tests/config.py
@@ -112,7 +112,14 @@ def wait_for_expected_nodes_to_exist(service_name=SERVICE_NAME, task_count=DEFAU
     stop_max_delay=DEFAULT_ELASTIC_TIMEOUT*1000,
     retry_on_result=lambda res: not res)
 def check_kibana_plugin_installed(plugin_name, service_name=SERVICE_NAME):
-    cmd = "bash -c '$MESOS_SANDBOX/kibana-$ELASTIC_VERSION-linux-x86_64/bin/kibana-plugin list'"
+    task_sandbox = sdk_cmd.get_task_sandbox_path(service_name)
+    # Environment variables aren't available on DC/OS 1.9 so we manually inject
+    # MESOS_SANDBOX (and can't use ELASTIC_VERSION).
+    #
+    # TODO(mpereira): improve this by making task environment variables
+    # available in sdk_cmd.task_exec commands on 1.9.
+    # Ticket: https://jira.mesosphere.com/browse/INFINITY-3360
+    cmd = "bash -c 'KIBANA_DIRECTORY=$(ls -d {}/kibana-*-linux-x86_64); $KIBANA_DIRECTORY/bin/kibana-plugin list'".format(task_sandbox)
     _, stdout, _ = sdk_cmd.task_exec(service_name, cmd)
     return plugin_name in stdout
 


### PR DESCRIPTION
ELASTIC-177 made all `sdk_cmd.task_exec` commands be run with `bash -c '<command>'` so that every command had access to environment variables being injected manually, i.e. `bash -c 'FOO=1; <command>'`. Previously only `./bootstrap` commands would use the `bash -c` invocation since bootstrap needs `LIBPROCESS_IP` set.

This broke a few of those commands that previously didn't run under `bash -c '<command>'`, in two different ways: 1. curl requests with JSON bodies (the Elastic CI failure) due to double quotes present in the JSON body and 2. processes needing access to environment variables (the Kafka CI failure) due to the splitting of setting variables and running commands (the `;`, which was introduced so that things like `bash -c 'A=1 B=$A; echo $B'` would work).

Example of #1:

Doesn't work, single-quotes from curl body mess it up. Would require manually escaping single quotes inside `bash -c '<command>'`:

    bash -c 'curl localhost -d '{"a": 1}''

Works:

    curl localhost -d '{"a": 1}'

Quoting the string sent to `bash -c` with double quotes (i.e. `bash -c "<command>"` is also an issue:

Example of #1:

Doesn't work, double-quotes from JSON mess it up. Would require manually escaping double quotes inside `bash -c "<command>"`:

    bash -c "curl localhost -d '{"a": 1}'"

Works:

    curl localhost -d '{"a": 1}'

The real fix for #1 seems to be a bit tricky so I'm gonna leave it for a future date since a quick fix is good enough for now, 1.9 test improvements not being really a priority.

For #2, the semicolon in `FOO=1; ./some_command` causes the `FOO` environment variable to not be accessible to `some_command`. Exporting would fix it. This PR makes a localized change and doesn't touch `sdk_cmd.task_exec` at all, so it's a non issue.