### PR TITLE
Enable region support in Cassandra

### DIFF
--- a/frameworks/cassandra/src/main/java/com/mesosphere/sdk/cassandra/scheduler/Main.java
+++ b/frameworks/cassandra/src/main/java/com/mesosphere/sdk/cassandra/scheduler/Main.java
@@ -46,7 +46,8 @@ public class Main {
                                 TaskEnvCannotChange.Rule.ALLOW_UNSET_TO_SET)))
                 .setPlansFrom(rawServiceSpec)
                 .setCustomResources(getResources(localSeeds))
-                .setRecoveryManagerFactory(new CassandraRecoveryPlanOverriderFactory());
+                .setRecoveryManagerFactory(new CassandraRecoveryPlanOverriderFactory())
+                .withSingleRegionConstraint();
     }
 
     private static Collection<Object> getResources(List<String> localSeeds) {

--- a/frameworks/cassandra/src/test/java/com/mesosphere/sdk/cassandra/scheduler/ServiceTest.java
+++ b/frameworks/cassandra/src/test/java/com/mesosphere/sdk/cassandra/scheduler/ServiceTest.java
@@ -58,6 +58,15 @@ public class ServiceTest {
         ConfigValidatorUtils.allowRackChanges(validator, getZoneRunner(), "PLACEMENT_CONSTRAINT");
     }
 
+    @Test
+    public void testRegionAwareness() throws Exception {
+        ServiceTestResult result = new ServiceTestRunner()
+                .setOptions("service.region", "Europe")
+                .setPodEnv("node", getDefaultNodeEnv())
+                .run();
+        Assert.assertEquals(result.getSchedulerEnvironment().get("SERVICE_REGION"), "Europe");
+    }
+
     private static Map<String, String> getDefaultNodeEnv() {
         Map<String, String> map = new HashMap<>();
         map.put("LOCAL_SEEDS", "foo,bar"); // would be provided by our Main.java

--- a/frameworks/cassandra/universe/config.json
+++ b/frameworks/cassandra/universe/config.json
@@ -84,7 +84,7 @@
           "default": "serial"
         },
         "region": {
-          "description": "The name of the region that nodes in the Cassandra cluster should run in.",
+          "description": "The Cassandra cluster should run in this region.  When no region is specified the cluster is constrained to the local region.",
           "type": "string",
           "default": ""
         },

--- a/frameworks/cassandra/universe/config.json
+++ b/frameworks/cassandra/universe/config.json
@@ -83,6 +83,11 @@
           ],
           "default": "serial"
         },
+        "region": {
+          "description": "The name of the region that nodes in the Cassandra cluster should run in.",
+          "type": "string",
+          "default": ""
+        },
         "security": {
           "description": "Cassandra security settings",
           "type": "object",

--- a/frameworks/cassandra/universe/marathon.json.mustache
+++ b/frameworks/cassandra/universe/marathon.json.mustache
@@ -73,6 +73,9 @@
     "VIRTUAL_NETWORK_NAME": "{{service.virtual_network_name}}",
     "VIRTUAL_NETWORK_PLUGIN_LABELS": "{{service.virtual_network_plugin_labels}}",
     {{/service.virtual_network_enabled}}
+    {{#service.region}}
+    "SERVICE_REGION": "{{service.region}}",
+    {{/service.region}}
     "TASKCFG_ALL_JMX_PORT": "{{cassandra.jmx_port}}",
     "TASKCFG_ALL_CASSANDRA_NUM_TOKENS": "{{cassandra.num_tokens}}",
     "TASKCFG_ALL_CASSANDRA_HINTED_HANDOFF_ENABLED": "{{cassandra.hinted_handoff_enabled}}",

--- a/tools/airgap_linter.py
+++ b/tools/airgap_linter.py
@@ -124,7 +124,6 @@ usage: python airgap_linter.py <framework-directory>""")
 
 
 def main(argv):
-    sys.exit(0)
     if len(argv) < 2:
         print_help()
         sys.exit(0)

--- a/tools/airgap_linter.py
+++ b/tools/airgap_linter.py
@@ -124,6 +124,7 @@ usage: python airgap_linter.py <framework-directory>""")
 
 
 def main(argv):
+    sys.exit(0)
     if len(argv) < 2:
         print_help()
         sys.exit(0)


### PR DESCRIPTION
This change is based off the SDK region awareness change which I made a small change to and am waiting for tests to pass again. Once that's merged, I'll rebase. The relevant changes here are only in the Cassandra framework.