### PR TITLE
Clean up logic in region matching and report region mismatch correctly

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/config/validate/RegionCannotChange.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/config/validate/RegionCannotChange.java
@@ -21,17 +21,10 @@ public class RegionCannotChange implements ConfigValidator<ServiceSpec> {
         }
 
         List<ConfigValidationError> errors = new ArrayList<>();
-        boolean regionWasAdded = oldConfig.isPresent() && !oldConfig.get().getRegion().isPresent() &&
-                newConfig.getRegion().isPresent();
-        boolean regionWasUnset = oldConfig.isPresent() && oldConfig.get().getRegion().isPresent() &&
-                !newConfig.getRegion().isPresent();
-        boolean regionWasChanged = oldConfig.isPresent() && oldConfig.get().getRegion().isPresent() &&
-                newConfig.getRegion().isPresent() &&
-                !newConfig.getRegion().get().equals(oldConfig.get().getRegion().get());
-        if (regionWasAdded || regionWasUnset || regionWasChanged) {
+        if (!oldConfig.get().getRegion().equals(newConfig.getRegion())) {
             errors.add(ConfigValidationError.transitionError(
                     "region",
-                    oldConfig.get().getUser(),
+                    oldConfig.get().getRegion().toString(),
                     newConfig.getUser(),
                     "Region for old service must remain the same across deployments."
             ));

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/config/validate/RegionCannotChange.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/config/validate/RegionCannotChange.java
@@ -25,7 +25,7 @@ public class RegionCannotChange implements ConfigValidator<ServiceSpec> {
             errors.add(ConfigValidationError.transitionError(
                     "region",
                     oldConfig.get().getRegion().toString(),
-                    newConfig.getUser(),
+                    newConfig.getRegion().toString(),
                     "Region for old service must remain the same across deployments."
             ));
         }


### PR DESCRIPTION
This fixes error reporting when a region config update fails to validate. Unfortunately, localizing creation of `IsLocalRegionRule` to `RegionRuleFactory` is not compatible with the current interface to `RuleFactory`, and so I'll defer that to a later cleanup.