### PR TITLE
[INFINITY-3203] Skip agent-based recovery tests on 1.9 (#2401)

### DIFF
--- a/frameworks/helloworld/tests/test_zzzrecovery.py
+++ b/frameworks/helloworld/tests/test_zzzrecovery.py
@@ -212,6 +212,8 @@ def test_zk_killed():
 
 
 @pytest.mark.recovery
+@pytest.mark.skipif(sdk_utils.dcos_version_less_than("1.10"),
+                    reason="BLOCKED-INFINITY-3203: Skipping recovery tests on 1.9")
 def test_config_update_then_kill_task_in_node():
     # kill 1 of 2 world tasks
     world_ids = sdk_tasks.get_task_ids(config.SERVICE_NAME, 'world')
@@ -222,6 +224,8 @@ def test_config_update_then_kill_task_in_node():
 
 
 @pytest.mark.recovery
+@pytest.mark.skipif(sdk_utils.dcos_version_less_than("1.10"),
+                    reason="BLOCKED-INFINITY-3203: Skipping recovery tests on 1.9")
 def test_config_update_then_kill_all_task_in_node():
     #  kill both world tasks
     world_ids = sdk_tasks.get_task_ids(config.SERVICE_NAME, 'world')
@@ -233,6 +237,8 @@ def test_config_update_then_kill_all_task_in_node():
 
 
 @pytest.mark.recovery
+@pytest.mark.skipif(sdk_utils.dcos_version_less_than("1.10"),
+                    reason="BLOCKED-INFINITY-3203: Skipping recovery tests on 1.9")
 def test_config_update_then_scheduler_died():
     world_ids = sdk_tasks.get_task_ids(config.SERVICE_NAME, 'world')
     host = sdk_marathon.get_scheduler_host(config.SERVICE_NAME)
@@ -243,6 +249,8 @@ def test_config_update_then_scheduler_died():
 
 
 @pytest.mark.recovery
+@pytest.mark.skipif(sdk_utils.dcos_version_less_than("1.10"),
+                    reason="BLOCKED-INFINITY-3203: Skipping recovery tests on 1.9")
 def test_config_update_then_executor_killed():
     world_ids = sdk_tasks.get_task_ids(config.SERVICE_NAME, 'world')
     config.bump_world_cpus()
@@ -252,6 +260,8 @@ def test_config_update_then_executor_killed():
 
 
 @pytest.mark.recovery
+@pytest.mark.skipif(sdk_utils.dcos_version_less_than("1.10"),
+                    reason="BLOCKED-INFINITY-3203: Skipping recovery tests on 1.9")
 def test_config_updates_then_all_executors_killed():
     world_ids = sdk_tasks.get_task_ids(config.SERVICE_NAME, 'world')
     hosts = shakedown.get_service_ips(config.SERVICE_NAME)
@@ -294,6 +304,8 @@ def test_pod_replace():
 
 
 @pytest.mark.recovery
+@pytest.mark.skipif(sdk_utils.dcos_version_less_than("1.10"),
+                    reason="BLOCKED-INFINITY-3203: Skipping recovery tests on 1.9")
 def test_config_update_while_partitioned():
     world_ids = sdk_tasks.get_task_ids(config.SERVICE_NAME, 'world')
     host = sdk_hosts.system_host(config.SERVICE_NAME, "world-0-server")
@@ -318,6 +330,8 @@ def test_config_update_while_partitioned():
 # WARNING: THIS MUST BE THE LAST TEST IN THIS FILE. ANY TEST THAT FOLLOWS WILL BE FLAKY.
 # @@@@@@@
 @pytest.mark.sanity
+@pytest.mark.skipif(sdk_utils.dcos_version_less_than("1.10"),
+                    reason="BLOCKED-INFINITY-3203: Skipping recovery tests on 1.9")
 def test_shutdown_host():
     candidate_tasks = sdk_tasks.get_tasks_avoiding_scheduler(
         config.SERVICE_NAME, re.compile('^(hello|world)-[0-9]+-server$'))


### PR DESCRIPTION
This is a clean backport of #2401 