### PR TITLE
[INFINITY-3363] Add custom domain and testing for Kafka security

### DIFF
--- a/frameworks/helloworld/tests/test_custom_service_tld.py
+++ b/frameworks/helloworld/tests/test_custom_service_tld.py
@@ -4,6 +4,7 @@ import pytest
 import shakedown
 import time
 
+import sdk_hosts
 import sdk_install
 import sdk_networks
 
@@ -25,17 +26,7 @@ def configure_package(configure_security):
 
 @pytest.mark.sanity
 def test_custom_service_tld():
-    # Go figure out the crypto id...
-    ok, crypto_id = shakedown.run_command_on_master("curl localhost:62080/lashup/key/ | jq -r .zbase32_public_key")
-    assert ok
-
-    # Instead of using "autoip.dcos.thisdcos.directory", use "autoip.dcos.<cryptoid>.dcos.directory".
-    # These addresses are routable in the cluster, but let us verify that we're fully replacing
-    # all TLD usage with a different TLD.
-
-    # A service yaml is used which will make sure task DNS resolves and then sleep so advertised endpoints
-    # can be checked.
-    custom_tld = "autoip.dcos.{}.dcos.directory".format(crypto_id.strip())
+    custom_tld = sdk_hosts.get_crypto_id_domain()
     sdk_install.install(
         config.PACKAGE_NAME,
         config.SERVICE_NAME,

--- a/frameworks/kafka/tests/auth.py
+++ b/frameworks/kafka/tests/auth.py
@@ -18,7 +18,7 @@ USERS = [
 ]
 
 
-def get_service_principals(service_name: str, realm: str) -> list:
+def get_service_principals(service_name: str, realm: str, custom_domain: str = None) -> list:
     """
     Sets up the appropriate principals needed for a kerberized deployment of HDFS.
     :return: A list of said principals
@@ -30,7 +30,11 @@ def get_service_principals(service_name: str, realm: str) -> list:
         "kafka-1-broker",
         "kafka-2-broker",
     ]
-    instances = map(lambda task: sdk_hosts.autoip_host(service_name, task), tasks)
+
+    if custom_domain:
+        instances = map(lambda task: sdk_hosts.custom_host(service_name, task, custom_domain), tasks)
+    else:
+        instances = map(lambda task: sdk_hosts.autoip_host(service_name, task), tasks)
 
     principals = kerberos.generate_principal_list(primaries, instances, realm)
     principals.extend(kerberos.generate_principal_list(USERS, [None, ], realm))

--- a/frameworks/kafka/tests/test_ssl_kerberos_custom_domain_auth.py
+++ b/frameworks/kafka/tests/test_ssl_kerberos_custom_domain_auth.py
@@ -1,0 +1,204 @@
+import logging
+import uuid
+import pytest
+
+import sdk_auth
+import sdk_cmd
+import sdk_hosts
+import sdk_install
+import sdk_marathon
+import sdk_utils
+
+
+from security import transport_encryption
+
+
+from tests import auth
+from tests import config
+from tests import test_utils
+
+
+log = logging.getLogger(__name__)
+
+
+pytestmark = pytest.mark.skipif(sdk_utils.is_open_dcos(),
+                                reason='Feature only supported in DC/OS EE')
+
+
+@pytest.fixture(scope='module', autouse=True)
+def service_account(configure_security):
+    """
+    Sets up a service account for use with TLS.
+    """
+    try:
+        name = config.SERVICE_NAME
+        service_account_info = transport_encryption.setup_service_account(name)
+
+        yield service_account_info
+    finally:
+        transport_encryption.cleanup_service_account(config.SERVICE_NAME,
+                                                     service_account_info)
+
+
+@pytest.fixture(scope='module', autouse=True)
+def kerberos(configure_security):
+    try:
+        kerberos_env = sdk_auth.KerberosEnvironment()
+
+        principals = auth.get_service_principals(config.SERVICE_NAME,
+                                                 kerberos_env.get_realm(),
+                                                 sdk_hosts.get_crypto_id_domain())
+        kerberos_env.add_principals(principals)
+        kerberos_env.finalize()
+
+        yield kerberos_env
+
+    finally:
+        kerberos_env.cleanup()
+
+
+@pytest.fixture(scope='module', autouse=True)
+def kafka_server(kerberos, service_account):
+    """
+    A pytest fixture that installs a Kerberized kafka service.
+
+    On teardown, the service is uninstalled.
+    """
+    service_kerberos_options = {
+        "service": {
+            "name": config.SERVICE_NAME,
+            "service_account": service_account["name"],
+            "service_account_secret": service_account["secret"],
+            "security": {
+                "custom_domain": sdk_hosts.get_crypto_id_domain(),
+                "kerberos": {
+                    "enabled": True,
+                    "kdc": {
+                        "hostname": kerberos.get_host(),
+                        "port": int(kerberos.get_port())
+                    },
+                    "realm": sdk_auth.REALM,
+                    "keytab_secret": kerberos.get_keytab_path(),
+                },
+                "transport_encryption": {
+                    "enabled": True
+                }
+            }
+        }
+    }
+
+    sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
+    try:
+        sdk_install.install(
+            config.PACKAGE_NAME,
+            config.SERVICE_NAME,
+            config.DEFAULT_BROKER_COUNT,
+            additional_options=service_kerberos_options,
+            timeout_seconds=30 * 60)
+
+        yield {**service_kerberos_options, **{"package_name": config.PACKAGE_NAME}}
+    finally:
+        sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
+
+
+@pytest.fixture(scope='module', autouse=True)
+def kafka_client(kerberos, kafka_server):
+
+    brokers = sdk_cmd.svc_cli(
+        kafka_server["package_name"],
+        kafka_server["service"]["name"],
+        "endpoint broker-tls", json=True)["dns"]
+
+    try:
+        client_id = "kafka-client"
+        client = {
+            "id": client_id,
+            "mem": 512,
+            "user": "nobody",
+            "container": {
+                "type": "MESOS",
+                "docker": {
+                    "image": "elezar/kafka-client:latest",
+                    "forcePullImage": True
+                },
+                "volumes": [
+                    {
+                        "containerPath": "/tmp/kafkaconfig/kafka-client.keytab",
+                        "secret": "kafka_keytab"
+                    }
+                ]
+            },
+            "secrets": {
+                "kafka_keytab": {
+                    "source": kerberos.get_keytab_path(),
+
+                }
+            },
+            "networks": [
+                {
+                    "mode": "host"
+                }
+            ],
+            "env": {
+                "JVM_MaxHeapSize": "512",
+                "KAFKA_CLIENT_MODE": "test",
+                "KAFKA_TOPIC": "securetest",
+                "KAFKA_BROKER_LIST": ",".join(brokers)
+            }
+        }
+
+        sdk_marathon.install_app(client)
+
+        transport_encryption.create_tls_artifacts(
+            cn="client",
+            task=client_id)
+
+        broker_hosts = list(map(lambda x: x.split(':')[0], brokers))
+        yield {**client, **{"brokers": broker_hosts}}
+
+    finally:
+        sdk_marathon.destroy_app(client_id)
+
+
+@pytest.mark.dcos_min_version('1.10')
+@sdk_utils.dcos_ee_only
+@pytest.mark.sanity
+def test_client_can_read_and_write(kafka_client, kafka_server, kerberos):
+    client_id = kafka_client["id"]
+
+    auth.wait_for_brokers(kafka_client["id"], kafka_client["brokers"])
+
+    topic_name = "authn.test"
+    sdk_cmd.svc_cli(kafka_server["package_name"], kafka_server["service"]["name"],
+                    "topic create {}".format(topic_name),
+                    json=True)
+
+    test_utils.wait_for_topic(kafka_server["package_name"], kafka_server["service"]["name"], topic_name)
+
+    message = str(uuid.uuid4())
+
+    assert write_to_topic("client", client_id, topic_name, message, kerberos)
+
+    assert message in read_from_topic("client", client_id, topic_name, 1, kerberos)
+
+
+def get_client_properties(cn: str) -> str:
+    client_properties_lines = []
+    client_properties_lines.extend(auth.get_kerberos_client_properties(ssl_enabled=True))
+    client_properties_lines.extend(auth.get_ssl_client_properties(cn, True))
+
+    return client_properties_lines
+
+
+def write_to_topic(cn: str, task: str, topic: str, message: str, krb5: object) -> bool:
+
+    return auth.write_to_topic(cn, task, topic, message,
+                               get_client_properties(cn),
+                               environment=auth.setup_krb5_env(cn, task, krb5))
+
+
+def read_from_topic(cn: str, task: str, topic: str, messages: int, krb5: object) -> str:
+
+    return auth.read_from_topic(cn, task, topic, messages,
+                                get_client_properties(cn),
+                                environment=auth.setup_krb5_env(cn, task, krb5))

--- a/frameworks/kafka/universe/config.json
+++ b/frameworks/kafka/universe/config.json
@@ -213,6 +213,10 @@
                   "default": false
                 }
               }
+            },
+            "custom_domain": {
+              "type": "string",
+              "description": "A custom domain to be used in place of autoip.dcos.thisdcos.directory. This can be used to expose the service securely outside of the cluster, but requires setting up external DNS. See the service documentation for details."
             }
           }
         }

--- a/frameworks/kafka/universe/marathon.json.mustache
+++ b/frameworks/kafka/universe/marathon.json.mustache
@@ -81,6 +81,11 @@
     "VIRTUAL_NETWORK_PLUGIN_LABELS": "{{service.virtual_network_plugin_labels}}",
     {{/service.virtual_network_enabled}}
 
+    {{#service.security.custom_domain}}
+    "SERVICE_TLD": "{{service.security.custom_domain}}",
+    {{/service.security.custom_domain}}
+
+
     {{#service.security.transport_encryption.enabled}}
     "BROKER_PORT_TLS": "{{brokers.port_tls}}",
     "TASKCFG_ALL_SECURITY_TRANSPORT_ENCRYPTION_ENABLED": "{{service.security.transport_encryption.enabled}}",

--- a/testing/sdk_hosts.py
+++ b/testing/sdk_hosts.py
@@ -5,6 +5,7 @@ FOR THE TIME BEING WHATEVER MODIFICATIONS ARE APPLIED TO THIS FILE
 SHOULD ALSO BE APPLIED TO sdk_hosts IN ANY OTHER PARTNER REPOS
 ************************************************************************
 '''
+import json
 import logging
 import shakedown
 
@@ -128,8 +129,9 @@ def get_crypto_id_domain():
     These addresses are routable within the cluster but can be used to test setting a custom
     service domain.
     """
-    # Go figure out the crypto id...
-    ok, crypto_id = shakedown.run_command_on_master("curl localhost:62080/lashup/key/ | jq -r .zbase32_public_key")
+    ok, lashup_response = shakedown.run_command_on_master("curl localhost:62080/lashup/key/")
     assert ok
 
-    return "autoip.dcos.{}.dcos.directory".format(crypto_id.strip())
+    crypto_id = json.loads(lashup_response.strip())["zbase32_public_key"]
+
+    return "autoip.dcos.{}.dcos.directory".format(crypto_id)

--- a/testing/sdk_hosts.py
+++ b/testing/sdk_hosts.py
@@ -6,6 +6,7 @@ SHOULD ALSO BE APPLIED TO sdk_hosts IN ANY OTHER PARTNER REPOS
 ************************************************************************
 '''
 import logging
+import shakedown
 
 import sdk_cmd
 import sdk_utils
@@ -42,6 +43,17 @@ def autoip_host(service_name, task_name, port=-1):
         AUTOIP_HOST_SUFFIX,
         port)
 
+
+def custom_host(service_name, task_name, custom_domain, port=-1):
+    """
+    Returns a properly constructed hostname for the container of the given task using the
+    supplied custom domain.
+    """
+    return _to_host(
+        _safe_name(task_name),
+        _safe_name(service_name),
+        custom_domain,
+        port)
 
 def vip_host(service_name, vip_name, port=-1):
     '''Returns the hostname of a specified service VIP, with handling of foldered services.'''
@@ -107,3 +119,17 @@ def get_foldered_dns_name(service_name):
     if sdk_utils.dcos_version_less_than('1.10'):
         return service_name
     return sdk_utils.get_foldered_name(service_name).replace("/", "")
+
+
+def get_crypto_id_domain():
+    """
+    Returns the cluster cryptographic ID equivalent of autoip.dcos.thisdcos.directory.
+
+    These addresses are routable within the cluster but can be used to test setting a custom
+    service domain.
+    """
+    # Go figure out the crypto id...
+    ok, crypto_id = shakedown.run_command_on_master("curl localhost:62080/lashup/key/ | jq -r .zbase32_public_key")
+    assert ok
+
+    return "autoip.dcos.{}.dcos.directory".format(crypto_id.strip())


### PR DESCRIPTION
This PR:
1. Extracts the behavior to get the cluster crypto domain into sdk_hosts
2. Updates the relevant HWorld test
3. Adds plumbing to allow the user to set service.security.custom_host in Kafka
4. Adds a test that this works for TLS and Kerberos