### PR TITLE
Clear pod replace check in multi-region tests

### DIFF
--- a/frameworks/helloworld/tests/test_region_awareness.py
+++ b/frameworks/helloworld/tests/test_region_awareness.py
@@ -81,15 +81,8 @@ def test_region_config_update_does_not_succeed(local_service):
     sdk_plan.wait_for_completed_deployment(config.SERVICE_NAME)
     change_region_config(REMOTE_REGION)
     plan = sdk_plan.get_deployment_plan(config.SERVICE_NAME)
+
     assert plan.get('errors', [])
-
-    sdk_cmd.svc_cli(config.PACKAGE_NAME, config.SERVICE_NAME, 'pod replace hello-0')
-    sdk_plan.wait_for_in_progress_recovery(config.SERVICE_NAME)
-    sdk_plan.wait_for_completed_recovery(config.SERVICE_NAME)
-
-    pod_region = get_pod_region(config.SERVICE_NAME, 'hello-0')
-
-    assert pod_region == LOCAL_REGION
 
 
 def change_region_config(region_name):


### PR DESCRIPTION
This change successfully passes against a multi-region cluster. The check for pod replace has been removed, since the scheduler permits no further pod actions after an erroneous config has been specified (meaning that recovery will never be initiated since the pod will not be killed by a replace), instead maintaining the last valid target configuration until the current configuration is fixed. This is the desired behavior.