### PR TITLE
[INFINITY-3363] Skip ZooKeeper reresolution test

### DIFF
--- a/frameworks/kafka/tests/test_zookeeper.py
+++ b/frameworks/kafka/tests/test_zookeeper.py
@@ -10,6 +10,9 @@ import sdk_utils
 from tests import config, test_utils
 
 
+pytestmark = pytest.mark.skip(reason="INFINITY-3363: Skipping test until it is better implemented")
+
+
 @pytest.fixture(scope='module', autouse=True)
 def zookeeper_server(configure_security):
     service_options = {


### PR DESCRIPTION
This PR skips the ZooKeeper reresolution test that has been causing problems. It will be properly addressed as part of INFINITY-3363.