### PR TITLE
[INFINITY-2971] improve kafka authz test coverage

### DIFF
--- a/frameworks/kafka/src/main/dist/server.properties.mustache
+++ b/frameworks/kafka/src/main/dist/server.properties.mustache
@@ -92,9 +92,11 @@ socket.request.max.bytes={{KAFKA_SOCKET_REQUEST_MAX_BYTES}}
 authorizer.class.name=kafka.security.auth.SimpleAclAuthorizer
 super.users={{SETUP_HELPER_SUPER_USERS}}
 allow.everyone.if.no.acl.found={{SECURITY_AUTHORIZATION_ALLOW_EVERYONE_IF_NO_ACL_FOUND}}
+{{^SECURITY_KERBEROS_ENABLED}}
 {{#SECURITY_SSL_AUTHENTICATION_ENABLED}}
 principal.builder.class=de.thmshmm.kafka.CustomPrincipalBuilder
 {{/SECURITY_SSL_AUTHENTICATION_ENABLED}}
+{{/SECURITY_KERBEROS_ENABLED}}
 {{/SECURITY_AUTHORIZATION_ENABLED}}
 
 ############################# Log Basics #############################

--- a/frameworks/kafka/tests/client.py
+++ b/frameworks/kafka/tests/client.py
@@ -1,0 +1,191 @@
+"""
+A collection of client utilites for Kafka.
+"""
+import logging
+import uuid
+
+import sdk_auth
+import sdk_cmd
+import sdk_marathon
+
+from tests import auth
+from tests import test_utils
+from tests import topics
+
+
+log = logging.getLogger(__name__)
+
+
+class KafkaService:
+    """
+    A light wrapper around a Kafka service installed as part of the integration tests.
+    """
+    def __init__(self, service_options: dict):
+        self._package_name = service_options["package_name"]
+        self._service_name = service_options["service"]["name"]
+
+    def get_zookeeper_connect(self) -> str:
+        return str(sdk_cmd.svc_cli(self._package_name, self._service_name,
+                   "endpoint zookeeper")).strip()
+
+    def get_brokers_endpoints(self, endpoint_name: str) -> list:
+        brokers = sdk_cmd.svc_cli(
+            self._package_name,
+            self._service_name,
+            "endpoint {}".format(endpoint_name), json=True)["dns"]
+
+        return brokers
+
+    def wait_for_topic(self, topic_name: str):
+        if not topic_name:
+            return True
+
+        test_utils.wait_for_topic(self._package_name, self._service_name, topic_name)
+
+        return True
+
+
+class KafkaClient:
+
+    def __init__(self, id: str):
+
+        self.id = id
+        self.MESSAGES = []
+
+        self._is_kerberos = True
+        self._is_tls = False
+
+        self.brokers = None
+        self.topic_name = None
+
+    def get_id(self) -> str:
+        return self.id
+
+    def install(self, kerberos: sdk_auth.KerberosEnvironment):
+        options = {
+            "id": self.id,
+            "mem": 512,
+            "container": {
+                "type": "MESOS",
+                "docker": {
+                    "image": "elezar/kafka-client:latest",
+                    "forcePullImage": True
+                },
+                "volumes": [
+                    {
+                        "containerPath": "/tmp/kafkaconfig/kafka-client.keytab",
+                        "secret": "kafka_keytab"
+                    }
+                ]
+            },
+            "secrets": {
+                "kafka_keytab": {
+                    "source": kerberos.get_keytab_path(),
+
+                }
+            },
+            "networks": [
+                {
+                    "mode": "host"
+                }
+            ],
+            "env": {
+                "JVM_MaxHeapSize": "512",
+                "KAFKA_CLIENT_MODE": "test",
+                "KAFKA_TOPIC": "securetest"
+            }
+        }
+        sdk_marathon.install_app(options)
+
+        return options
+
+    def uninstall(self):
+        sdk_marathon.destroy_app(self.id)
+
+    def _get_cli_settings(self, user: str, kerberos: sdk_auth.KerberosEnvironment):
+        properties = []
+        environment = None
+
+        if self._is_kerberos:
+            properties.extend(auth.get_kerberos_client_properties(ssl_enabled=self._is_tls))
+            environment = auth.setup_krb5_env(user, self.id, kerberos)
+
+        if self._is_tls:
+            properties.extend(auth.get_ssl_client_properties(user,
+                                                             has_kerberos=self._is_kerberos))
+
+        return properties, environment
+
+    def get_endpoint_name(self) -> str:
+        if self._is_tls:
+            return "broker-tls"
+
+        return "broker"
+
+    def wait_for(self, kafka_server: dict, topic_name: str) -> bool:
+        """
+        Wait for the service to be visible from a client perspective.
+        """
+        service = KafkaService(kafka_server)
+
+        if not self.brokers:
+            brokers_list = service.get_brokers_endpoints(self.get_endpoint_name())
+            broker_hosts = map(lambda b: b.split(":")[0], brokers_list)
+            brokers = ",".join(brokers_list)
+
+            if not auth.wait_for_brokers(self.id, broker_hosts):
+                log.error("Failed to resolve brokers: %s", broker_hosts)
+                return False
+            self.brokers = brokers
+
+            return True
+
+        if self.topic_name != topic_name:
+            service.wait_for_topic(topic_name)
+            self.topic_name = topic_name
+
+        return True
+
+    def can_write_and_read(self, user: str, kafka_server: dict,
+                           topic_name: str, krb5: sdk_auth.KerberosEnvironment) -> tuple:
+
+        if not self.wait_for(kafka_server, topic_name):
+            return False, [], []
+
+        write_success = self.write_to_topic(user, topic_name, self.brokers, krb5)
+        read_sucesses, read_messages = self.read_from_topic(user, topic_name, self.brokers, krb5)
+
+        return write_success, read_sucesses, read_messages
+
+    def read_from_topic(self, user: str, topic_name: str, brokers: str,
+                        krb5: sdk_auth.KerberosEnvironment) -> list:
+
+        properties, environment = self._get_cli_settings(user, krb5)
+        read_messages = auth.read_from_topic(user, self.id, topic_name, len(self.MESSAGES),
+                                             properties, environment, brokers)
+
+        read_success = map(lambda m: m in read_messages, self.MESSAGES)
+
+        return read_success, read_messages
+
+    def write_to_topic(self, user: str, topic_name: str, brokers: str,
+                       krb5: sdk_auth.KerberosEnvironment) -> bool:
+
+        # Generate a unique message:
+        message = str(uuid.uuid4())
+
+        properties, environment = self._get_cli_settings(user, krb5)
+        write_success = auth.write_to_topic(user, self.id, topic_name, message,
+                                            properties, environment, brokers)
+
+        if write_success:
+            self.MESSAGES.append(message)
+
+        return write_success
+
+    def add_acls(self, user: str, kafka_server: dict, topic_name: str):
+        service = KafkaService(kafka_server)
+
+        # TODO: If zookeeper has Kerberos enabled, then the environment should be changed
+        environment = None
+        topics.add_acls(user, self.id, topic_name, service.get_zookeeper_connect(), environment)

--- a/frameworks/kafka/tests/client.py
+++ b/frameworks/kafka/tests/client.py
@@ -151,7 +151,7 @@ class KafkaClient:
             broker_hosts = map(lambda b: b.split(":")[0], brokers_list)
             brokers = ",".join(brokers_list)
 
-            if not sdk_cmd.resolve_hosts(self.id, broker_hosts, bootstrap_cmd='/opt/boostrap'):
+            if not sdk_cmd.resolve_hosts(self.id, broker_hosts, bootstrap_cmd='/opt/bootstrap'):
                 log.error("Failed to resolve brokers: %s", broker_hosts)
                 return False
             self.brokers = brokers

--- a/frameworks/kafka/tests/client.py
+++ b/frameworks/kafka/tests/client.py
@@ -211,3 +211,10 @@ class KafkaClient:
         # TODO: If zookeeper has Kerberos enabled, then the environment should be changed
         environment = None
         topics.add_acls(user, self.id, topic_name, service.get_zookeeper_connect(), environment)
+
+    def remove_acls(self, user: str, kafka_server: dict, topic_name: str):
+        service = KafkaService(kafka_server)
+
+        # TODO: If zookeeper has Kerberos enabled, then the environment should be changed
+        environment = None
+        topics.remove_acls(user, self.id, topic_name, service.get_zookeeper_connect(), environment)

--- a/frameworks/kafka/tests/client.py
+++ b/frameworks/kafka/tests/client.py
@@ -93,7 +93,7 @@ class KafkaClient:
             "container": {
                 "type": "MESOS",
                 "docker": {
-                    "image": "elezar/kafka-client:latest",
+                    "image": "elezar/kafka-client:4b9c060",
                     "forcePullImage": True
                 }
             },

--- a/frameworks/kafka/tests/test_active_directory_auth.py
+++ b/frameworks/kafka/tests/test_active_directory_auth.py
@@ -1,4 +1,3 @@
-import os
 import logging
 import pytest
 import uuid

--- a/frameworks/kafka/tests/test_active_directory_auth.py
+++ b/frameworks/kafka/tests/test_active_directory_auth.py
@@ -84,7 +84,7 @@ def kafka_client(kerberos, kafka_server):
             "container": {
                 "type": "MESOS",
                 "docker": {
-                    "image": "elezar/kafka-client:latest",
+                    "image": "elezar/kafka-client:4b9c060",
                     "forcePullImage": True
                 },
                 "volumes": [

--- a/frameworks/kafka/tests/test_active_directory_zookeeper_auth.py
+++ b/frameworks/kafka/tests/test_active_directory_zookeeper_auth.py
@@ -126,7 +126,7 @@ def kafka_client(kerberos, kafka_server):
             "container": {
                 "type": "MESOS",
                 "docker": {
-                    "image": "elezar/kafka-client:latest",
+                    "image": "elezar/kafka-client:4b9c060",
                     "forcePullImage": True
                 },
                 "volumes": [

--- a/frameworks/kafka/tests/test_kerberos_auth.py
+++ b/frameworks/kafka/tests/test_kerberos_auth.py
@@ -127,7 +127,9 @@ def kafka_client(kerberos, kafka_server):
 @sdk_utils.dcos_ee_only
 @pytest.mark.sanity
 def test_no_vip(kafka_client, kafka_server, kerberos):
-    endpoints = sdk_networks.get_and_test_endpoints(kafka_server["package_name"], kafka_server["service"]["name"], "broker", 2)
+    endpoints = sdk_networks.get_and_test_endpoints(kafka_server["package_name"],
+                                                    kafka_server["service"]["name"],
+                                                    "broker", 2)
     assert "vip" not in endpoints
 
 

--- a/frameworks/kafka/tests/test_kerberos_auth.py
+++ b/frameworks/kafka/tests/test_kerberos_auth.py
@@ -106,7 +106,7 @@ def test_client_can_read_and_write(kafka_client, kafka_server, kerberos):
     write_success, read_successes, _ = kafka_client.can_write_and_read(user, kafka_server, topic_name, kerberos)
     assert write_success, "Write failed (user={})".format(user)
     assert read_successes, "Read failed (user={}): " \
-                            "MESSAGES={} " \
-                            "read_successes={}".format(user,
-                                                       kafka_client.MESSAGES,
-                                                       read_successes)
+                           "MESSAGES={} " \
+                           "read_successes={}".format(user,
+                                                      kafka_client.MESSAGES,
+                                                      read_successes)

--- a/frameworks/kafka/tests/test_kerberos_auth.py
+++ b/frameworks/kafka/tests/test_kerberos_auth.py
@@ -1,17 +1,15 @@
 import logging
 import pytest
-import uuid
 
 import sdk_auth
 import sdk_cmd
 import sdk_install
-import sdk_marathon
 import sdk_utils
 import sdk_networks
 
 from tests import auth
+from tests import client
 from tests import config
-from tests import test_utils
 
 
 log = logging.getLogger(__name__)
@@ -72,61 +70,20 @@ def kafka_server(kerberos):
 
 
 @pytest.fixture(scope='module', autouse=True)
-def kafka_client(kerberos, kafka_server):
-
-    brokers = sdk_cmd.svc_cli(
-        kafka_server["package_name"],
-        kafka_server["service"]["name"],
-        "endpoint broker", json=True)["dns"]
-
+def kafka_client(kerberos):
     try:
-        client_id = "kafka-client"
-        client = {
-            "id": client_id,
-            "mem": 512,
-            "container": {
-                "type": "MESOS",
-                "docker": {
-                    "image": "elezar/kafka-client:latest",
-                    "forcePullImage": True
-                },
-                "volumes": [
-                    {
-                        "containerPath": "/tmp/kafkaconfig/kafka-client.keytab",
-                        "secret": "kafka_keytab"
-                    }
-                ]
-            },
-            "secrets": {
-                "kafka_keytab": {
-                    "source": kerberos.get_keytab_path(),
+        kafka_client = client.KafkaClient("kafka-client")
+        kafka_client.install(kerberos)
 
-                }
-            },
-            "networks": [
-                {
-                    "mode": "host"
-                }
-            ],
-            "env": {
-                "JVM_MaxHeapSize": "512",
-                "KAFKA_CLIENT_MODE": "test",
-                "KAFKA_TOPIC": "securetest",
-                "KAFKA_BROKER_LIST": ",".join(brokers)
-            }
-        }
-
-        sdk_marathon.install_app(client)
-        yield {**client, **{"brokers": list(map(lambda x: x.split(':')[0], brokers))}}
-
+        yield kafka_client
     finally:
-        sdk_marathon.destroy_app(client_id)
+        kafka_client.uninstall()
 
 
 @pytest.mark.dcos_min_version('1.10')
 @sdk_utils.dcos_ee_only
 @pytest.mark.sanity
-def test_no_vip(kafka_client, kafka_server, kerberos):
+def test_no_vip(kafka_server):
     endpoints = sdk_networks.get_and_test_endpoints(kafka_server["package_name"],
                                                     kafka_server["service"]["name"],
                                                     "broker", 2)
@@ -137,33 +94,19 @@ def test_no_vip(kafka_client, kafka_server, kerberos):
 @sdk_utils.dcos_ee_only
 @pytest.mark.sanity
 def test_client_can_read_and_write(kafka_client, kafka_server, kerberos):
-    client_id = kafka_client["id"]
-
-    auth.wait_for_brokers(kafka_client["id"], kafka_client["brokers"])
 
     topic_name = "authn.test"
     sdk_cmd.svc_cli(kafka_server["package_name"], kafka_server["service"]["name"],
                     "topic create {}".format(topic_name),
                     json=True)
 
-    test_utils.wait_for_topic(kafka_server["package_name"], kafka_server["service"]["name"], topic_name)
+    kafka_client.connect(kafka_server)
+    user = "client"
 
-    message = str(uuid.uuid4())
-
-    assert write_to_topic("client", client_id, topic_name, message, kerberos)
-
-    assert message in read_from_topic("client", client_id, topic_name, 1, kerberos)
-
-
-def write_to_topic(cn: str, task: str, topic: str, message: str, krb5: object) -> bool:
-
-    return auth.write_to_topic(cn, task, topic, message,
-                               auth.get_kerberos_client_properties(ssl_enabled=False),
-                               auth.setup_krb5_env(cn, task, krb5))
-
-
-def read_from_topic(cn: str, task: str, topic: str, messages: int, krb5: object) -> str:
-
-    return auth.read_from_topic(cn, task, topic, messages,
-                                auth.get_kerberos_client_properties(ssl_enabled=False),
-                                auth.setup_krb5_env(cn, task, krb5))
+    write_success, read_successes, _ = kafka_client.can_write_and_read(user, kafka_server, topic_name, kerberos)
+    assert write_success, "Write failed (user={})".format(user)
+    assert read_successes, "Read failed (user={}): " \
+                            "MESSAGES={} " \
+                            "read_successes={}".format(user,
+                                                       kafka_client.MESSAGES,
+                                                       read_successes)

--- a/frameworks/kafka/tests/test_kerberos_auth.py
+++ b/frameworks/kafka/tests/test_kerberos_auth.py
@@ -50,7 +50,7 @@ def kafka_server(kerberos):
                         "hostname": kerberos.get_host(),
                         "port": int(kerberos.get_port())
                     },
-                    "realm": sdk_auth.REALM,
+                    "realm": kerberos.get_realm(),
                     "keytab_secret": kerberos.get_keytab_path(),
                 }
             }

--- a/frameworks/kafka/tests/test_kerberos_authz.py
+++ b/frameworks/kafka/tests/test_kerberos_authz.py
@@ -10,7 +10,6 @@ import sdk_utils
 from tests import auth
 from tests import client
 from tests import config
-from tests import test_utils
 
 
 log = logging.getLogger(__name__)
@@ -101,7 +100,7 @@ def test_authz_acls_required(kafka_client: client.KafkaClient,
                     "topic create {}".format(topic_name),
                     json=True)
 
-    kafka_client.wait_for(kafka_server, topic_name)
+    kafka_client.connect(kafka_server)
 
     # Since no ACLs are specified, only the super user can read and write
     for user in ["super", ]:

--- a/frameworks/kafka/tests/test_kerberos_authz.py
+++ b/frameworks/kafka/tests/test_kerberos_authz.py
@@ -78,7 +78,7 @@ def kafka_server(kerberos):
 
 
 @pytest.fixture(scope='module', autouse=True)
-def kafka_client(kerberos, kafka_server):
+def kafka_client(kerberos):
     try:
         kafka_client = client.KafkaClient("kafka-client")
         kafka_client.install(kerberos)

--- a/frameworks/kafka/tests/test_kerberos_authz.py
+++ b/frameworks/kafka/tests/test_kerberos_authz.py
@@ -1,17 +1,15 @@
 import logging
-import uuid
 
 import pytest
 
 import sdk_auth
 import sdk_cmd
 import sdk_install
-import sdk_marathon
 import sdk_utils
 
 from tests import auth
+from tests import client
 from tests import config
-from tests import topics
 from tests import test_utils
 
 
@@ -44,7 +42,7 @@ def kafka_server(kerberos):
 
     super_principal = "super"
 
-    service_kerberos_options = {
+    service_options = {
         "service": {
             "name": config.SERVICE_NAME,
             "security": {
@@ -54,7 +52,7 @@ def kafka_server(kerberos):
                         "hostname": kerberos.get_host(),
                         "port": int(kerberos.get_port())
                     },
-                    "realm": sdk_auth.REALM,
+                    "realm": kerberos.get_realm(),
                     "keytab_secret": kerberos.get_keytab_path(),
                 },
                 "authorization": {
@@ -71,139 +69,73 @@ def kafka_server(kerberos):
             config.PACKAGE_NAME,
             config.SERVICE_NAME,
             config.DEFAULT_BROKER_COUNT,
-            additional_options=service_kerberos_options,
+            additional_options=service_options,
             timeout_seconds=30 * 60)
 
-        yield {**service_kerberos_options, **{"package_name": config.PACKAGE_NAME,
-                                              "super_principal": super_principal}}
+        yield {**service_options, **{"package_name": config.PACKAGE_NAME,
+                                     "super_principal": super_principal}}
     finally:
         sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
 
 
 @pytest.fixture(scope='module', autouse=True)
 def kafka_client(kerberos, kafka_server):
-
-    brokers = sdk_cmd.svc_cli(
-        kafka_server["package_name"],
-        kafka_server["service"]["name"],
-        "endpoint broker", json=True)["dns"]
-
     try:
-        client_id = "kafka-client"
-        client = {
-            "id": client_id,
-            "mem": 512,
-            "container": {
-                "type": "MESOS",
-                "docker": {
-                    "image": "elezar/kafka-client:latest",
-                    "forcePullImage": True
-                },
-                "volumes": [
-                    {
-                        "containerPath": "/tmp/kafkaconfig/kafka-client.keytab",
-                        "secret": "kafka_keytab"
-                    }
-                ]
-            },
-            "secrets": {
-                "kafka_keytab": {
-                    "source": kerberos.get_keytab_path(),
+        kafka_client = client.KafkaClient("kafka-client")
+        kafka_client.install(kerberos)
 
-                }
-            },
-            "networks": [
-                {
-                    "mode": "host"
-                }
-            ],
-            "env": {
-                "JVM_MaxHeapSize": "512",
-                "KAFKA_CLIENT_MODE": "test",
-                "KAFKA_TOPIC": "securetest",
-                "KAFKA_BROKER_LIST": ",".join(brokers)
-            }
-        }
-
-        sdk_marathon.install_app(client)
-        yield {**client, **{"brokers": list(map(lambda x: x.split(':')[0], brokers))}}
-
+        yield kafka_client
     finally:
-        sdk_marathon.destroy_app(client_id)
+        kafka_client.uninstall()
 
 
 @pytest.mark.dcos_min_version('1.10')
 @sdk_utils.dcos_ee_only
 @pytest.mark.sanity
-def test_authz_acls_required(kafka_client, kafka_server, kerberos):
-    client_id = kafka_client["id"]
-
-    auth.wait_for_brokers(kafka_client["id"], kafka_client["brokers"])
+def test_authz_acls_required(kafka_client: client.KafkaClient,
+                             kafka_server: dict,
+                             kerberos: sdk_auth.KerberosEnvironment):
 
     topic_name = "authz.test"
     sdk_cmd.svc_cli(kafka_server["package_name"], kafka_server["service"]["name"],
                     "topic create {}".format(topic_name),
                     json=True)
 
-    test_utils.wait_for_topic(kafka_server["package_name"], kafka_server["service"]["name"], topic_name)
+    kafka_client.wait_for(kafka_server, topic_name)
 
-    message = str(uuid.uuid4())
+    # Since no ACLs are specified, only the super user can read and write
+    for user in ["super", ]:
+        log.info("Checking write / read permissions for user=%s", user)
+        write_success, read_successes, _ = kafka_client.can_write_and_read(user, kafka_server, topic_name, kerberos)
+        assert write_success, "Write failed (user={})".format(user)
+        assert read_successes, "Read failed (user={}): " \
+                               "MESSAGES={} " \
+                               "read_successes={}".format(user,
+                                                          kafka_client.MESSAGES,
+                                                          read_successes)
 
-    log.info("Writing and reading: Writing to the topic, but not super user")
-    assert not write_to_topic("authorized", client_id, topic_name, message, kerberos)
+    for user in ["authorized", "unauthorized", ]:
+        log.info("Checking lack of write / read permissions for user=%s", user)
+        write_success, _, read_messages = kafka_client.can_write_and_read(user, kafka_server, topic_name, kerberos)
+        assert not write_success, "Write not expected to succeed (user={})".format(user)
+        assert auth.is_not_authorized(read_messages), "Unauthorized expected (user={}".format(user)
 
-    log.info("Writing and reading: Writing to the topic, as super user")
-    assert write_to_topic("super", client_id, topic_name, message, kerberos)
+    log.info("Writing and reading: Adding acl for authorized user")
+    kafka_client.add_acls("authorized", kafka_server, topic_name)
 
-    log.info("Writing and reading: Reading from the topic, but not super user")
-    assert auth.is_not_authorized(read_from_topic("authorized", client_id, topic_name, 1, kerberos))
+    # After adding ACLs the authorized user and super user should still have access to the topic.
+    for user in ["authorized", "super"]:
+        log.info("Checking write / read permissions for user=%s", user)
+        write_success, read_successes, _ = kafka_client.can_write_and_read(user, kafka_server, topic_name, kerberos)
+        assert write_success, "Write failed (user={})".format(user)
+        assert read_successes, "Read failed (user={}): " \
+                               "MESSAGES={} " \
+                               "read_successes={}".format(user,
+                                                          kafka_client.MESSAGES,
+                                                          read_successes)
 
-    log.info("Writing and reading: Reading from the topic, as super user")
-    assert message in read_from_topic("super", client_id, topic_name, 1, kerberos)
-
-    zookeeper_endpoint = sdk_cmd.svc_cli(
-        kafka_server["package_name"],
-        kafka_server["service"]["name"],
-        "endpoint zookeeper").strip()
-
-    # TODO: If zookeeper has Kerberos enabled, then the environment should be changed
-    topics.add_acls("authorized", client_id, topic_name, zookeeper_endpoint, env_str=None)
-
-    # Send a second message which should not be authorized
-    second_message = str(uuid.uuid4())
-    log.info("Writing and reading: Writing to the topic, but not super user")
-    assert write_to_topic("authorized", client_id, topic_name, second_message, kerberos)
-
-    log.info("Writing and reading: Writing to the topic, as super user")
-    assert write_to_topic("super", client_id, topic_name, second_message, kerberos)
-
-    log.info("Writing and reading: Reading from the topic, but not super user")
-    topic_output = read_from_topic("authorized", client_id, topic_name, 3, kerberos)
-    assert message in topic_output
-    assert second_message in topic_output
-
-    log.info("Writing and reading: Reading from the topic, as super user")
-    topic_output = read_from_topic("super", client_id, topic_name, 3, kerberos)
-    assert message in topic_output
-    assert second_message in topic_output
-
-    # Check that the unauthorized client can still not read or write from the topic.
-    log.info("Writing and reading: Writing to the topic, but not super user")
-    assert not write_to_topic("unauthorized", client_id, topic_name, second_message, kerberos)
-
-    log.info("Writing and reading: Reading from the topic, but not super user")
-    assert auth.is_not_authorized(read_from_topic("unauthorized", client_id, topic_name, 1, kerberos))
-
-
-def write_to_topic(cn: str, task: str, topic: str, message: str, krb5: object) -> bool:
-
-    return auth.write_to_topic(cn, task, topic, message,
-                               auth.get_kerberos_client_properties(ssl_enabled=False),
-                               auth.setup_krb5_env(cn, task, krb5))
-
-
-def read_from_topic(cn: str, task: str, topic: str, messages: int, krb5: object) -> str:
-
-    return auth.read_from_topic(cn, task, topic, messages,
-                                auth.get_kerberos_client_properties(ssl_enabled=False),
-                                auth.setup_krb5_env(cn, task, krb5))
+    for user in ["unauthorized", ]:
+        log.info("Checking lack of write / read permissions for user=%s", user)
+        write_success, _, read_messages = kafka_client.can_write_and_read(user, kafka_server, topic_name, kerberos)
+        assert not write_success, "Write not expected to succeed (user={})".format(user)
+        assert auth.is_not_authorized(read_messages), "Unauthorized expected (user={}".format(user)

--- a/frameworks/kafka/tests/test_kerberos_authz_no_acls_required.py
+++ b/frameworks/kafka/tests/test_kerberos_authz_no_acls_required.py
@@ -101,7 +101,7 @@ def test_authz_acls_not_required(kafka_client: client.KafkaClient,
                     "topic create {}".format(topic_name),
                     json=True)
 
-    kafka_client.wait_for(kafka_server, topic_name)
+    kafka_client.connect(kafka_server)
 
     # Since no ACLs are specified, all users can read and write.
     for user in ["authorized", "unauthorized", "super", ]:
@@ -131,8 +131,8 @@ def test_authz_acls_not_required(kafka_client: client.KafkaClient,
     for user in ["unauthorized", ]:
         log.info("Checking lack of write / read permissions for user=%s", user)
         write_success, _, read_messages = kafka_client.can_write_and_read(user,
-                                                                                       kafka_server,
-                                                                                       topic_name,
-                                                                                       kerberos)
+                                                                          kafka_server,
+                                                                          topic_name,
+                                                                          kerberos)
         assert not write_success, "Write not expected to succeed (user={})".format(user)
         assert auth.is_not_authorized(read_messages), "Unauthorized expected (user={}".format(user)

--- a/frameworks/kafka/tests/test_kerberos_authz_no_acls_required.py
+++ b/frameworks/kafka/tests/test_kerberos_authz_no_acls_required.py
@@ -1,0 +1,138 @@
+import logging
+
+import pytest
+
+import sdk_auth
+import sdk_cmd
+import sdk_install
+import sdk_utils
+
+from tests import auth
+from tests import client
+from tests import config
+
+
+log = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope='module', autouse=True)
+def kerberos(configure_security):
+    try:
+        kerberos_env = sdk_auth.KerberosEnvironment()
+
+        principals = auth.get_service_principals(config.SERVICE_NAME,
+                                                 kerberos_env.get_realm())
+        kerberos_env.add_principals(principals)
+        kerberos_env.finalize()
+
+        yield kerberos_env
+
+    finally:
+        kerberos_env.cleanup()
+
+
+@pytest.fixture(scope='module', autouse=True)
+def kafka_server(kerberos):
+    """
+    A pytest fixture that installs a Kerberized kafka service.
+
+    On teardown, the service is uninstalled.
+    """
+
+    super_principal = "super"
+
+    service_options = {
+        "service": {
+            "name": config.SERVICE_NAME,
+            "security": {
+                "kerberos": {
+                    "enabled": True,
+                    "kdc": {
+                        "hostname": kerberos.get_host(),
+                        "port": int(kerberos.get_port())
+                    },
+                    "realm": kerberos.get_realm(),
+                    "keytab_secret": kerberos.get_keytab_path(),
+                },
+                "authorization": {
+                    "enabled": True,
+                    "super_users": "User:{}".format(super_principal),
+                    "allow_everyone_if_no_acl_found": True
+                }
+            }
+        }
+    }
+
+    sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
+    try:
+        sdk_install.install(
+            config.PACKAGE_NAME,
+            config.SERVICE_NAME,
+            config.DEFAULT_BROKER_COUNT,
+            additional_options=service_options,
+            timeout_seconds=30 * 60)
+
+        yield {**service_options, **{"package_name": config.PACKAGE_NAME,
+                                     "super_principal": super_principal}}
+    finally:
+        sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
+
+
+@pytest.fixture(scope='module', autouse=True)
+def kafka_client(kerberos, kafka_server):
+    try:
+        kafka_client = client.KafkaClient("kafka-client")
+        kafka_client.install(kerberos)
+
+        yield kafka_client
+    finally:
+        kafka_client.uninstall()
+
+
+@pytest.mark.dcos_min_version('1.10')
+@sdk_utils.dcos_ee_only
+@pytest.mark.sanity
+def test_authz_acls_not_required(kafka_client: client.KafkaClient,
+                                 kafka_server: dict,
+                                 kerberos: sdk_auth.KerberosEnvironment):
+
+    topic_name = "authz.test"
+    sdk_cmd.svc_cli(kafka_server["package_name"], kafka_server["service"]["name"],
+                    "topic create {}".format(topic_name),
+                    json=True)
+
+    kafka_client.wait_for(kafka_server, topic_name)
+
+    # Since no ACLs are specified, all users can read and write.
+    for user in ["authorized", "unauthorized", "super", ]:
+        log.info("Checking write / read permissions for user=%s", user)
+        write_success, read_successes, _ = kafka_client.can_write_and_read(user, kafka_server, topic_name, kerberos)
+        assert write_success, "Write failed (user={})".format(user)
+        assert read_successes, "Read failed (user={}): " \
+                               "MESSAGES={} " \
+                               "read_successes={}".format(user,
+                                                          kafka_client.MESSAGES,
+                                                          read_successes)
+
+    log.info("Writing and reading: Adding acl for authorized user")
+    kafka_client.add_acls("authorized", kafka_server, topic_name)
+
+    # After adding ACLs the authorized user and super user should still have access to the topic.
+    for user in ["authorized", "super", ]:
+        log.info("Checking write / read permissions for user=%s", user)
+        write_success, read_successes, _ = kafka_client.can_write_and_read(user, kafka_server, topic_name, kerberos)
+        assert write_success, "Write failed (user={})".format(user)
+        assert read_successes, "Read failed (user={}): " \
+                               "MESSAGES={} " \
+                               "read_successes={}".format(user,
+                                                          kafka_client.MESSAGES,
+                                                          read_successes)
+
+    for user in ["unauthorized", ]:
+        log.info("Checking lack of write / read permissions for user=%s", user)
+        write_success, _, read_messages = kafka_client.can_write_and_read(user,
+                                                                                       kafka_server,
+                                                                                       topic_name,
+                                                                                       kerberos)
+        assert not write_success, "Write not expected to succeed (user={})".format(user)
+        assert auth.is_not_authorized(read_messages), "Unauthorized expected (user={}".format(user)

--- a/frameworks/kafka/tests/test_kerberos_authz_no_acls_required.py
+++ b/frameworks/kafka/tests/test_kerberos_authz_no_acls_required.py
@@ -79,7 +79,7 @@ def kafka_server(kerberos):
 
 
 @pytest.fixture(scope='module', autouse=True)
-def kafka_client(kerberos, kafka_server):
+def kafka_client(kerberos):
     try:
         kafka_client = client.KafkaClient("kafka-client")
         kafka_client.install(kerberos)

--- a/frameworks/kafka/tests/test_rack_awareness.py
+++ b/frameworks/kafka/tests/test_rack_awareness.py
@@ -3,7 +3,6 @@ import pytest
 import sdk_cmd
 import sdk_fault_domain
 import sdk_install
-import sdk_tasks
 import sdk_utils
 
 from tests import config, test_utils
@@ -39,7 +38,7 @@ def test_zones_not_referenced_in_placement_constraints():
             'broker get {}'.format(broker_id),
             json=True)
 
-        assert broker_info.get('rack') == None
+        assert broker_info.get('rack') is None
 
     sdk_install.uninstall(config.PACKAGE_NAME, foldered_name)
 

--- a/frameworks/kafka/tests/test_sanity.py
+++ b/frameworks/kafka/tests/test_sanity.py
@@ -58,6 +58,7 @@ def test_mesos_v0_api():
 @pytest.mark.sanity
 def test_endpoints_address():
     foldered_name = sdk_utils.get_foldered_name(config.SERVICE_NAME)
+
     @retrying.retry(
         wait_fixed=1000,
         stop_max_delay=120*1000,
@@ -143,7 +144,7 @@ def test_broker_invalid():
         assert False, "Should have failed"
     except AssertionError as arg:
         raise arg
-    except:
+    except Exception as e:
         pass  # expected to fail
 
 

--- a/frameworks/kafka/tests/test_ssl_auth.py
+++ b/frameworks/kafka/tests/test_ssl_auth.py
@@ -1,5 +1,4 @@
 import logging
-import uuid
 
 import pytest
 
@@ -12,8 +11,6 @@ from security import transport_encryption
 from tests import client
 from tests import config
 from tests import auth
-from tests import topics
-from tests import test_utils
 
 
 log = logging.getLogger(__name__)

--- a/frameworks/kafka/tests/test_ssl_auth.py
+++ b/frameworks/kafka/tests/test_ssl_auth.py
@@ -5,11 +5,11 @@ import pytest
 
 import sdk_cmd
 import sdk_install
-import sdk_marathon
 import sdk_utils
 
 from security import transport_encryption
 
+from tests import client
 from tests import config
 from tests import auth
 from tests import topics
@@ -40,47 +40,21 @@ def service_account(configure_security):
 
 @pytest.fixture(scope='module', autouse=True)
 def kafka_client():
-    brokers = ["kafka-0-broker.{}.autoip.dcos.thisdcos.directory:1030".format(config.SERVICE_NAME),
-               "kafka-1-broker.{}.autoip.dcos.thisdcos.directory:1030".format(config.SERVICE_NAME),
-               "kafka-2-broker.{}.autoip.dcos.thisdcos.directory:1030".format(config.SERVICE_NAME)]
-
     try:
-        client_id = "kafka-client"
-        client = {
-            "id": client_id,
-            "mem": 512,
-            "container": {
-                "type": "MESOS",
-                "docker": {
-                    "image": "elezar/kafka-client:latest",
-                    "forcePullImage": True
-                },
-            },
-            "networks": [
-                {
-                    "mode": "host"
-                }
-            ],
-            "env": {
-                "JVM_MaxHeapSize": "512",
-                "KAFKA_CLIENT_MODE": "test",
-                "KAFKA_BROKER_LIST": ",".join(brokers),
-                "KAFKA_OPTS": ""
-            }
-        }
+        kafka_client = client.KafkaClient("kafka-client")
+        kafka_client.install()
 
-        sdk_marathon.install_app(client)
+        # TODO: This flag should be set correctly.
+        kafka_client._is_tls = True
 
-        broker_hosts = list(map(lambda x: x.split(':')[0], brokers))
-        yield {**client, **{"brokers": broker_hosts}}
-
+        yield kafka_client
     finally:
-        sdk_marathon.destroy_app(client_id)
+        kafka_client.uninstall()
 
 
 @pytest.fixture(scope='module', autouse=True)
-def setup_principals(kafka_client):
-    client_id = kafka_client["id"]
+def setup_principals(kafka_client: client.KafkaClient):
+    client_id = kafka_client.get_id()
 
     transport_encryption.create_tls_artifacts(
         cn="kafka-tester",
@@ -99,49 +73,52 @@ def setup_principals(kafka_client):
 @pytest.mark.dcos_min_version('1.10')
 @pytest.mark.ee_only
 @pytest.mark.sanity
-def test_authn_client_can_read_and_write(kafka_client, service_account, setup_principals):
+def test_authn_client_can_read_and_write(kafka_client: client.KafkaClient, service_account, setup_principals):
     try:
         sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
+        service_options = {
+            "service": {
+                "name": config.SERVICE_NAME,
+                "service_account": service_account["name"],
+                "service_account_secret": service_account["secret"],
+                "security": {
+                    "transport_encryption": {
+                        "enabled": True
+                    },
+                    "ssl_authentication": {
+                        "enabled": True
+                    }
+                }
+            }
+        }
         config.install(
             config.PACKAGE_NAME,
             config.SERVICE_NAME,
             config.DEFAULT_BROKER_COUNT,
-            additional_options={
-                "brokers": {
-                    "port_tls": 1030
-                },
-                "service": {
-                    "service_account": service_account["name"],
-                    "service_account_secret": service_account["secret"],
-                    "security": {
-                        "transport_encryption": {
-                            "enabled": True
-                        },
-                        "ssl_authentication": {
-                            "enabled": True
-                        }
-                    }
-                }
-            })
+            additional_options=service_options)
 
-        client_id = kafka_client["id"]
-        auth.wait_for_brokers(client_id, kafka_client["brokers"])
+        kafka_server = {**service_options, **{"package_name": config.PACKAGE_NAME}}
 
-        sdk_cmd.svc_cli(config.PACKAGE_NAME, config.SERVICE_NAME,
-                        "topic create tls.topic",
+        topic_name = "tls.topic"
+        sdk_cmd.svc_cli(kafka_server["package_name"], kafka_server["service"]["name"],
+                        "topic create {}".format(topic_name),
                         json=True)
 
-        test_utils.wait_for_topic(config.PACKAGE_NAME, config.SERVICE_NAME, "tls.topic")
+        kafka_client.connect(kafka_server)
 
-        message = str(uuid.uuid4())
+        user = "kafka-tester"
+        write_success, read_successes, _ = kafka_client.can_write_and_read(user,
+                                                                           kafka_server,
+                                                                           topic_name,
+                                                                           None)
 
-        # Write to the topic
-        log.info("Writing and reading: Writing to the topic, with authn")
-        assert write_to_topic("kafka-tester", client_id, "tls.topic", message)
+        assert write_success, "Write failed (user={})".format(user)
+        assert read_successes, "Read failed (user={}): " \
+                               "MESSAGES={} " \
+                               "read_successes={}".format(user,
+                                                          kafka_client.MESSAGES,
+                                                          read_successes)
 
-        log.info("Writing and reading: reading from the topic, with authn")
-        # Read from the topic
-        assert message in read_from_topic("kafka-tester", client_id, "tls.topic", 1)
     finally:
         sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
 
@@ -149,72 +126,81 @@ def test_authn_client_can_read_and_write(kafka_client, service_account, setup_pr
 @pytest.mark.dcos_min_version('1.10')
 @pytest.mark.ee_only
 @pytest.mark.sanity
-def test_authz_acls_required(kafka_client, service_account, setup_principals):
-    client_id = kafka_client["id"]
+def test_authz_acls_required(kafka_client: client.KafkaClient, service_account, setup_principals):
 
     try:
         sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
+        service_options = {
+            "service": {
+                "name": config.SERVICE_NAME,
+                "service_account": service_account["name"],
+                "service_account_secret": service_account["secret"],
+                "security": {
+                    "transport_encryption": {
+                        "enabled": True
+                    },
+                    "ssl_authentication": {
+                        "enabled": True
+                    },
+                    "authorization": {
+                        "enabled": True,
+                        "super_users": "User:{}".format("super")
+                    }
+                }
+            }
+        }
         config.install(
             config.PACKAGE_NAME,
             config.SERVICE_NAME,
             config.DEFAULT_BROKER_COUNT,
-            additional_options={
-                "brokers": {
-                    "port_tls": 1030
-                },
-                "service": {
-                    "service_account": service_account["name"],
-                    "service_account_secret": service_account["secret"],
-                    "security": {
-                        "transport_encryption": {
-                            "enabled": True
-                        },
-                        "ssl_authentication": {
-                            "enabled": True
-                        },
-                        "authorization": {
-                            "enabled": True,
-                            "super_users": "User:{}".format("super")
-                        }
-                    }
-                }
-            })
+            additional_options=service_options)
 
-        auth.wait_for_brokers(client_id, kafka_client["brokers"])
+        kafka_server = {**service_options, **{"package_name": config.PACKAGE_NAME}}
 
-        sdk_cmd.svc_cli(config.PACKAGE_NAME, config.SERVICE_NAME,
-                        "topic create authz.test",
+        topic_name = "authz.test"
+        sdk_cmd.svc_cli(kafka_server["package_name"], kafka_server["service"]["name"],
+                        "topic create {}".format(topic_name),
                         json=True)
 
-        test_utils.wait_for_topic(config.PACKAGE_NAME, config.SERVICE_NAME, "authz.test")
+        kafka_client.connect(kafka_server)
 
-        super_message = str(uuid.uuid4())
-        authorized_message = str(uuid.uuid4())
+        # Since no ACLs are specified, only the super user can read and write
+        for user in ["super", ]:
+            log.info("Checking write / read permissions for user=%s", user)
+            write_success, read_successes, _ = kafka_client.can_write_and_read(user, kafka_server, topic_name, None)
+            assert write_success, "Write failed (user={})".format(user)
+            assert read_successes, "Read failed (user={}): " \
+                                   "MESSAGES={} " \
+                                   "read_successes={}".format(user,
+                                                              kafka_client.MESSAGES,
+                                                              read_successes)
 
-        log.info("Writing and reading: Writing to the topic, as authorized user")
-        assert not write_to_topic("authorized", client_id, "authz.test", authorized_message)
+        for user in ["authorized", "unauthorized", ]:
+            log.info("Checking lack of write / read permissions for user=%s", user)
+            write_success, _, read_messages = kafka_client.can_write_and_read(user, kafka_server, topic_name, None)
+            assert not write_success, "Write not expected to succeed (user={})".format(user)
+            assert auth.is_not_authorized(read_messages), "Unauthorized expected (user={}".format(user)
 
-        log.info("Writing and reading: Writing to the topic, as super user")
-        assert write_to_topic("super", client_id, "authz.test", super_message)
-
-        log.info("Writing and reading: Reading from the topic, as authorized user")
-        assert auth.is_not_authorized(read_from_topic("authorized", client_id, "authz.test", 1))
-
-        log.info("Writing and reading: Reading from the topic, as super user")
-        read_result = read_from_topic("super", client_id, "authz.test", 1)
-        assert super_message in read_result and authorized_message not in read_result
-
-        # Add acl
         log.info("Writing and reading: Adding acl for authorized user")
-        zookeeper_endpoint = str(sdk_cmd.svc_cli(
-            config.PACKAGE_NAME,
-            config.SERVICE_NAME,
-            "endpoint zookeeper")).strip()
-        topics.add_acls("authorized", client_id, "authz.test", zookeeper_endpoint, env_str=None)
+        kafka_client.add_acls("authorized", kafka_server, topic_name)
 
-        log.info("Writing and reading: Writing and reading as authorized user")
-        assert write_to_topic("authorized", client_id, "authz.test", authorized_message)
-        assert authorized_message in read_from_topic("authorized", client_id, "authz.test", 2)
+        # After adding ACLs the authorized user and super user should still have access to the topic.
+        for user in ["authorized", "super"]:
+            log.info("Checking write / read permissions for user=%s", user)
+            write_success, read_successes, _ = kafka_client.can_write_and_read(user, kafka_server, topic_name, None)
+            assert write_success, "Write failed (user={})".format(user)
+            assert read_successes, "Read failed (user={}): " \
+                                   "MESSAGES={} " \
+                                   "read_successes={}".format(user,
+                                                              kafka_client.MESSAGES,
+                                                              read_successes)
+
+        for user in ["unauthorized", ]:
+            log.info("Checking lack of write / read permissions for user=%s", user)
+            write_success, _, read_messages = kafka_client.can_write_and_read(user, kafka_server, topic_name, None)
+            assert not write_success, "Write not expected to succeed (user={})".format(user)
+            assert auth.is_not_authorized(read_messages), "Unauthorized expected (user={}".format(user)
+
     finally:
         sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
 
@@ -223,99 +209,78 @@ def test_authz_acls_required(kafka_client, service_account, setup_principals):
 @pytest.mark.ee_only
 @pytest.mark.sanity
 def test_authz_acls_not_required(kafka_client, service_account, setup_principals):
-    client_id = kafka_client["id"]
 
     try:
         sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
+        service_options = {
+            "service": {
+                "name": config.SERVICE_NAME,
+                "service_account": service_account["name"],
+                "service_account_secret": service_account["secret"],
+                "security": {
+                    "transport_encryption": {
+                        "enabled": True
+                    },
+                    "ssl_authentication": {
+                        "enabled": True
+                    },
+                    "authorization": {
+                        "enabled": True,
+                        "super_users": "User:{}".format("super"),
+                        "allow_everyone_if_no_acl_found": True
+                    }
+                }
+            }
+        }
         config.install(
             config.PACKAGE_NAME,
             config.SERVICE_NAME,
             config.DEFAULT_BROKER_COUNT,
-            additional_options={
-                "brokers": {
-                    "port_tls": 1030
-                },
-                "service": {
-                    "service_account": service_account["name"],
-                    "service_account_secret": service_account["secret"],
-                    "security": {
-                        "transport_encryption": {
-                            "enabled": True
-                        },
-                        "ssl_authentication": {
-                            "enabled": True
-                        },
-                        "authorization": {
-                            "enabled": True,
-                            "super_users": "User:{}".format("super"),
-                            "allow_everyone_if_no_acl_found": True
-                        }
-                    }
-                }
-            })
+            additional_options=service_options)
 
-        auth.wait_for_brokers(client_id, kafka_client["brokers"])
+        kafka_server = {**service_options, **{"package_name": config.PACKAGE_NAME}}
 
-        # Create the topic
-        sdk_cmd.svc_cli(config.PACKAGE_NAME, config.SERVICE_NAME,
-                        "topic create authz.test",
+        topic_name = "authz.test"
+        sdk_cmd.svc_cli(kafka_server["package_name"], kafka_server["service"]["name"],
+                        "topic create {}".format(topic_name),
                         json=True)
 
-        test_utils.wait_for_topic(config.PACKAGE_NAME, config.SERVICE_NAME, "authz.test")
+        kafka_client.connect(kafka_server)
 
-        super_message = str(uuid.uuid4())
-        authorized_message = str(uuid.uuid4())
-        unauthorized_message = str(uuid.uuid4())
-
-        log.info("Writing and reading: Writing to the topic, as authorized user")
-        assert write_to_topic("authorized", client_id, "authz.test", authorized_message)
-
-        log.info("Writing and reading: Writing to the topic, as unauthorized user")
-        assert write_to_topic("unauthorized", client_id, "authz.test", unauthorized_message)
-
-        log.info("Writing and reading: Writing to the topic, as super user")
-        assert write_to_topic("super", client_id, "authz.test", super_message)
-
-        log.info("Writing and reading: Reading from the topic, as authorized user")
-        assert authorized_message in read_from_topic("authorized", client_id, "authz.test", 3)
-
-        log.info("Writing and reading: Reading from the topic, as unauthorized user")
-        assert unauthorized_message in read_from_topic("unauthorized", client_id, "authz.test", 3)
-
-        log.info("Writing and reading: Reading from the topic, as super user")
-        assert super_message in read_from_topic("super", client_id, "authz.test", 3)
+        # Since no ACLs are specified, all users can read and write.
+        for user in ["authorized", "unauthorized", "super", ]:
+            log.info("Checking write / read permissions for user=%s", user)
+            write_success, read_successes, _ = kafka_client.can_write_and_read(user, kafka_server, topic_name, None)
+            assert write_success, "Write failed (user={})".format(user)
+            assert read_successes, "Read failed (user={}): " \
+                                   "MESSAGES={} " \
+                                   "read_successes={}".format(user,
+                                                              kafka_client.MESSAGES,
+                                                              read_successes)
 
         log.info("Writing and reading: Adding acl for authorized user")
-        zookeeper_endpoint = str(sdk_cmd.svc_cli(
-            config.PACKAGE_NAME,
-            config.SERVICE_NAME,
-            "endpoint zookeeper")).strip()
-        topics.add_acls("authorized", client_id, "authz.test", zookeeper_endpoint, env_str=None)
+        kafka_client.add_acls("authorized", kafka_server, topic_name)
 
-        # Re-roll the messages so we really prove auth is in place.
-        super_message = str(uuid.uuid4())
-        authorized_message = str(uuid.uuid4())
-        unauthorized_message = str(uuid.uuid4())
+        # After adding ACLs the authorized user and super user should still have access to the topic.
+        for user in ["authorized", "super", ]:
+            log.info("Checking write / read permissions for user=%s", user)
+            write_success, read_successes, _ = kafka_client.can_write_and_read(user, kafka_server, topic_name, None)
+            assert write_success, "Write failed (user={})".format(user)
+            assert read_successes, "Read failed (user={}): " \
+                                   "MESSAGES={} " \
+                                   "read_successes={}".format(user,
+                                                              kafka_client.MESSAGES,
+                                                              read_successes)
 
-        log.info("Writing and reading: Writing to the topic, as authorized user")
-        assert write_to_topic("authorized", client_id, "authz.test", authorized_message)
+        for user in ["unauthorized", ]:
+            log.info("Checking lack of write / read permissions for user=%s", user)
+            write_success, _, read_messages = kafka_client.can_write_and_read(user,
+                                                                              kafka_server,
+                                                                              topic_name,
+                                                                              None)
+            assert not write_success, "Write not expected to succeed (user={})".format(user)
+            assert auth.is_not_authorized(read_messages), "Unauthorized expected (user={}".format(user)
 
-        log.info("Writing and reading: Writing to the topic, as unauthorized user")
-        assert not write_to_topic("unauthorized", client_id, "authz.test", unauthorized_message)
-
-        log.info("Writing and reading: Writing to the topic, as super user")
-        assert write_to_topic("super", client_id, "authz.test", super_message)
-
-        log.info("Writing and reading: Reading from the topic, as authorized user")
-        read_result = read_from_topic("authorized", client_id, "authz.test", 5)
-        assert authorized_message in read_result and unauthorized_message not in read_result
-
-        log.info("Writing and reading: Reading from the topic, as unauthorized user")
-        assert auth.is_not_authorized(read_from_topic("unauthorized", client_id, "authz.test", 1))
-
-        log.info("Writing and reading: Reading from the topic, as super user")
-        read_result = read_from_topic("super", client_id, "authz.test", 5)
-        assert super_message in read_result and unauthorized_message not in read_result
     finally:
         sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
 

--- a/frameworks/kafka/tests/test_ssl_kerberos_auth.py
+++ b/frameworks/kafka/tests/test_ssl_kerberos_auth.py
@@ -74,7 +74,7 @@ def kafka_server(kerberos, service_account):
                         "hostname": kerberos.get_host(),
                         "port": int(kerberos.get_port())
                     },
-                    "realm": sdk_auth.REALM,
+                    "realm": kerberos.get_realm(),
                     "keytab_secret": kerberos.get_keytab_path(),
                 },
                 "transport_encryption": {

--- a/frameworks/kafka/tests/test_ssl_kerberos_auth.py
+++ b/frameworks/kafka/tests/test_ssl_kerberos_auth.py
@@ -1,11 +1,9 @@
 import logging
-import uuid
 import pytest
 
 import sdk_auth
 import sdk_cmd
 import sdk_install
-import sdk_marathon
 import sdk_utils
 
 
@@ -13,8 +11,8 @@ from security import transport_encryption
 
 
 from tests import auth
+from tests import client
 from tests import config
-from tests import test_utils
 
 
 log = logging.getLogger(__name__)
@@ -99,103 +97,44 @@ def kafka_server(kerberos, service_account):
 
 
 @pytest.fixture(scope='module', autouse=True)
-def kafka_client(kerberos, kafka_server):
-
-    brokers = sdk_cmd.svc_cli(
-        kafka_server["package_name"],
-        kafka_server["service"]["name"],
-        "endpoint broker-tls", json=True)["dns"]
-
+def kafka_client(kerberos):
     try:
-        client_id = "kafka-client"
-        client = {
-            "id": client_id,
-            "mem": 512,
-            "user": "nobody",
-            "container": {
-                "type": "MESOS",
-                "docker": {
-                    "image": "elezar/kafka-client:latest",
-                    "forcePullImage": True
-                },
-                "volumes": [
-                    {
-                        "containerPath": "/tmp/kafkaconfig/kafka-client.keytab",
-                        "secret": "kafka_keytab"
-                    }
-                ]
-            },
-            "secrets": {
-                "kafka_keytab": {
-                    "source": kerberos.get_keytab_path(),
+        kafka_client = client.KafkaClient("kafka-client")
+        kafka_client.install(kerberos)
 
-                }
-            },
-            "networks": [
-                {
-                    "mode": "host"
-                }
-            ],
-            "env": {
-                "JVM_MaxHeapSize": "512",
-                "KAFKA_CLIENT_MODE": "test",
-                "KAFKA_TOPIC": "securetest",
-                "KAFKA_BROKER_LIST": ",".join(brokers)
-            }
-        }
-
-        sdk_marathon.install_app(client)
+        # TODO: This flag should be set correctly.
+        kafka_client._is_tls = True
 
         transport_encryption.create_tls_artifacts(
             cn="client",
-            marathon_task=client_id)
+            marathon_task=kafka_client.get_id())
 
-        broker_hosts = list(map(lambda x: x.split(':')[0], brokers))
-        yield {**client, **{"brokers": broker_hosts}}
-
+        yield kafka_client
     finally:
-        sdk_marathon.destroy_app(client_id)
+        kafka_client.uninstall()
 
 
 @pytest.mark.dcos_min_version('1.10')
 @sdk_utils.dcos_ee_only
 @pytest.mark.sanity
-def test_client_can_read_and_write(kafka_client, kafka_server, kerberos):
-    client_id = kafka_client["id"]
+def test_client_can_read_and_write(kafka_client: client.KafkaClient, kafka_server, kerberos):
 
-    sdk_cmd.resolve_hosts(kafka_client["id"], kafka_client["brokers"])
-
-    topic_name = "authn.test"
+    topic_name = "tls.topic"
     sdk_cmd.svc_cli(kafka_server["package_name"], kafka_server["service"]["name"],
                     "topic create {}".format(topic_name),
                     json=True)
 
-    test_utils.wait_for_topic(kafka_server["package_name"], kafka_server["service"]["name"], topic_name)
+    kafka_client.connect(kafka_server)
 
-    message = str(uuid.uuid4())
+    user = "client"
+    write_success, read_successes, _ = kafka_client.can_write_and_read(user,
+                                                                       kafka_server,
+                                                                       topic_name,
+                                                                       kerberos)
 
-    assert write_to_topic("client", client_id, topic_name, message, kerberos)
-
-    assert message in read_from_topic("client", client_id, topic_name, 1, kerberos)
-
-
-def get_client_properties(cn: str) -> str:
-    client_properties_lines = []
-    client_properties_lines.extend(auth.get_kerberos_client_properties(ssl_enabled=True))
-    client_properties_lines.extend(auth.get_ssl_client_properties(cn, True))
-
-    return client_properties_lines
-
-
-def write_to_topic(cn: str, marathon_task: str, topic: str, message: str, krb5: object) -> bool:
-
-    return auth.write_to_topic(cn, marathon_task, topic, message,
-                               get_client_properties(cn),
-                               environment=auth.setup_krb5_env(cn, marathon_task, krb5))
-
-
-def read_from_topic(cn: str, marathon_task: str, topic: str, messages: int, krb5: object) -> str:
-
-    return auth.read_from_topic(cn, marathon_task, topic, messages,
-                                get_client_properties(cn),
-                                environment=auth.setup_krb5_env(cn, marathon_task, krb5))
+    assert write_success, "Write failed (user={})".format(user)
+    assert read_successes, "Read failed (user={}): " \
+                           "MESSAGES={} " \
+                           "read_successes={}".format(user,
+                                                      kafka_client.MESSAGES,
+                                                      read_successes)

--- a/frameworks/kafka/tests/test_ssl_kerberos_authz.py
+++ b/frameworks/kafka/tests/test_ssl_kerberos_authz.py
@@ -1,0 +1,301 @@
+import logging
+import pytest
+
+import sdk_auth
+import sdk_cmd
+import sdk_install
+import sdk_utils
+
+
+from security import transport_encryption
+
+
+from tests import auth
+from tests import client
+from tests import config
+
+
+log = logging.getLogger(__name__)
+
+
+pytestmark = pytest.mark.skipif(sdk_utils.is_open_dcos(),
+                                reason='Feature only supported in DC/OS EE')
+
+
+@pytest.fixture(scope='module', autouse=True)
+def service_account(configure_security):
+    """
+    Sets up a service account for use with TLS.
+    """
+    try:
+        name = config.SERVICE_NAME
+        service_account_info = transport_encryption.setup_service_account(name)
+
+        yield service_account_info
+    finally:
+        transport_encryption.cleanup_service_account(config.SERVICE_NAME,
+                                                     service_account_info)
+
+
+@pytest.fixture(scope='module', autouse=True)
+def kerberos(configure_security):
+    try:
+        kerberos_env = sdk_auth.KerberosEnvironment()
+
+        principals = auth.get_service_principals(config.SERVICE_NAME,
+                                                 kerberos_env.get_realm())
+        kerberos_env.add_principals(principals)
+        kerberos_env.finalize()
+
+        yield kerberos_env
+
+    finally:
+        kerberos_env.cleanup()
+
+
+@pytest.fixture(scope='module', autouse=True)
+def kafka_server(kerberos, service_account):
+    """
+    A pytest fixture that installs a Kerberized kafka service.
+
+    On teardown, the service is uninstalled.
+    """
+    service_kerberos_options = {
+        "service": {
+            "name": config.SERVICE_NAME,
+            "service_account": service_account["name"],
+            "service_account_secret": service_account["secret"],
+            "security": {
+                "kerberos": {
+                    "enabled": True,
+                    "kdc": {
+                        "hostname": kerberos.get_host(),
+                        "port": int(kerberos.get_port())
+                    },
+                    "realm": kerberos.get_realm(),
+                    "keytab_secret": kerberos.get_keytab_path(),
+                },
+                "transport_encryption": {
+                    "enabled": True
+                }
+            }
+        }
+    }
+
+    sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
+    try:
+        sdk_install.install(
+            config.PACKAGE_NAME,
+            config.SERVICE_NAME,
+            config.DEFAULT_BROKER_COUNT,
+            additional_options=service_kerberos_options,
+            timeout_seconds=30 * 60)
+
+        yield {**service_kerberos_options, **{"package_name": config.PACKAGE_NAME}}
+    finally:
+        sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
+
+
+@pytest.fixture(scope='module', autouse=True)
+def kafka_client(kerberos):
+    try:
+        kafka_client = client.KafkaClient("kafka-client")
+        kafka_client.install(kerberos)
+
+        # TODO: This flag should be set correctly.
+        kafka_client._is_tls = True
+
+        yield kafka_client
+    finally:
+        kafka_client.uninstall()
+
+
+@pytest.fixture(scope='module', autouse=True)
+def setup_principals(kafka_client: client.KafkaClient):
+    client_id = kafka_client.get_id()
+
+    transport_encryption.create_tls_artifacts(
+        cn="client",
+        marathon_task=client_id)
+    transport_encryption.create_tls_artifacts(
+        cn="authorized",
+        marathon_task=client_id)
+    transport_encryption.create_tls_artifacts(
+        cn="unauthorized",
+        marathon_task=client_id)
+    transport_encryption.create_tls_artifacts(
+        cn="super",
+        marathon_task=client_id)
+
+
+@pytest.mark.dcos_min_version('1.10')
+@sdk_utils.dcos_ee_only
+@pytest.mark.sanity
+def test_authz_acls_required(kafka_client: client.KafkaClient, kerberos, service_account, setup_principals):
+    try:
+        sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
+        service_options = {
+            "service": {
+                "name": config.SERVICE_NAME,
+                "service_account": service_account["name"],
+                "service_account_secret": service_account["secret"],
+                "security": {
+                    "kerberos": {
+                        "enabled": True,
+                        "kdc": {
+                            "hostname": kerberos.get_host(),
+                            "port": int(kerberos.get_port())
+                        },
+                        "realm": kerberos.get_realm(),
+                        "keytab_secret": kerberos.get_keytab_path(),
+                    },
+                    "authorization": {
+                        "enabled": True,
+                        "super_users": "User:{}".format("super")
+                    }
+                }
+            }
+        }
+        config.install(
+            config.PACKAGE_NAME,
+            config.SERVICE_NAME,
+            config.DEFAULT_BROKER_COUNT,
+            additional_options=service_options)
+
+        kafka_server = {**service_options, **{"package_name": config.PACKAGE_NAME}}
+
+        topic_name = "authz.test"
+        sdk_cmd.svc_cli(kafka_server["package_name"], kafka_server["service"]["name"],
+                        "topic create {}".format(topic_name),
+                        json=True)
+
+        kafka_client.connect(kafka_server)
+
+        # Clear the ACLs
+        kafka_client.remove_acls("authorized", kafka_server, topic_name)
+
+        # Since no ACLs are specified, only the super user can read and write
+        for user in ["super", ]:
+            log.info("Checking write / read permissions for user=%s", user)
+            write_success, read_successes, _ = kafka_client.can_write_and_read(user, kafka_server, topic_name, kerberos)
+            assert write_success, "Write failed (user={})".format(user)
+            assert read_successes, "Read failed (user={}): " \
+                                   "MESSAGES={} " \
+                                   "read_successes={}".format(user,
+                                                              kafka_client.MESSAGES,
+                                                              read_successes)
+
+        for user in ["authorized", "unauthorized", ]:
+            log.info("Checking lack of write / read permissions for user=%s", user)
+            write_success, _, read_messages = kafka_client.can_write_and_read(user, kafka_server, topic_name, kerberos)
+            assert not write_success, "Write not expected to succeed (user={})".format(user)
+            assert auth.is_not_authorized(read_messages), "Unauthorized expected (user={}".format(user)
+
+        log.info("Writing and reading: Adding acl for authorized user")
+        kafka_client.add_acls("authorized", kafka_server, topic_name)
+
+        # After adding ACLs the authorized user and super user should still have access to the topic.
+        for user in ["authorized", "super"]:
+            log.info("Checking write / read permissions for user=%s", user)
+            write_success, read_successes, _ = kafka_client.can_write_and_read(user, kafka_server, topic_name, kerberos)
+            assert write_success, "Write failed (user={})".format(user)
+            assert read_successes, "Read failed (user={}): " \
+                                   "MESSAGES={} " \
+                                   "read_successes={}".format(user,
+                                                              kafka_client.MESSAGES,
+                                                              read_successes)
+
+        for user in ["unauthorized", ]:
+            log.info("Checking lack of write / read permissions for user=%s", user)
+            write_success, _, read_messages = kafka_client.can_write_and_read(user, kafka_server, topic_name, kerberos)
+            assert not write_success, "Write not expected to succeed (user={})".format(user)
+            assert auth.is_not_authorized(read_messages), "Unauthorized expected (user={}".format(user)
+
+    finally:
+        sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
+
+
+@pytest.mark.dcos_min_version('1.10')
+@pytest.mark.ee_only
+@pytest.mark.sanity
+def test_authz_acls_not_required(kafka_client: client.KafkaClient, kerberos, service_account, setup_principals):
+    try:
+        sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
+        service_options = {
+            "service": {
+                "name": config.SERVICE_NAME,
+                "service_account": service_account["name"],
+                "service_account_secret": service_account["secret"],
+                "security": {
+                    "kerberos": {
+                        "enabled": True,
+                        "kdc": {
+                            "hostname": kerberos.get_host(),
+                            "port": int(kerberos.get_port())
+                        },
+                        "realm": kerberos.get_realm(),
+                        "keytab_secret": kerberos.get_keytab_path(),
+                    },
+                    "authorization": {
+                        "enabled": True,
+                        "super_users": "User:{}".format("super"),
+                        "allow_everyone_if_no_acl_found": True
+                    }
+                }
+            }
+        }
+
+        config.install(
+            config.PACKAGE_NAME,
+            config.SERVICE_NAME,
+            config.DEFAULT_BROKER_COUNT,
+            additional_options=service_options)
+
+        kafka_server = {**service_options, **{"package_name": config.PACKAGE_NAME}}
+
+        topic_name = "authz.test"
+        sdk_cmd.svc_cli(kafka_server["package_name"], kafka_server["service"]["name"],
+                        "topic create {}".format(topic_name),
+                        json=True)
+
+        kafka_client.connect(kafka_server)
+
+        # Clear the ACLs
+        kafka_client.remove_acls("authorized", kafka_server, topic_name)
+
+        # Since no ACLs are specified, all users can read and write.
+        for user in ["authorized", "unauthorized", "super", ]:
+            log.info("Checking write / read permissions for user=%s", user)
+            write_success, read_successes, _ = kafka_client.can_write_and_read(user, kafka_server, topic_name, kerberos)
+            assert write_success, "Write failed (user={})".format(user)
+            assert read_successes, "Read failed (user={}): " \
+                                   "MESSAGES={} " \
+                                   "read_successes={}".format(user,
+                                                              kafka_client.MESSAGES,
+                                                              read_successes)
+
+        log.info("Writing and reading: Adding acl for authorized user")
+        kafka_client.add_acls("authorized", kafka_server, topic_name)
+
+        # After adding ACLs the authorized user and super user should still have access to the topic.
+        for user in ["authorized", "super", ]:
+            log.info("Checking write / read permissions for user=%s", user)
+            write_success, read_successes, _ = kafka_client.can_write_and_read(user, kafka_server, topic_name, kerberos)
+            assert write_success, "Write failed (user={})".format(user)
+            assert read_successes, "Read failed (user={}): " \
+                                   "MESSAGES={} " \
+                                   "read_successes={}".format(user,
+                                                              kafka_client.MESSAGES,
+                                                              read_successes)
+
+        for user in ["unauthorized", ]:
+            log.info("Checking lack of write / read permissions for user=%s", user)
+            write_success, _, read_messages = kafka_client.can_write_and_read(user,
+                                                                              kafka_server,
+                                                                              topic_name,
+                                                                              kerberos)
+            assert not write_success, "Write not expected to succeed (user={})".format(user)
+            assert auth.is_not_authorized(read_messages), "Unauthorized expected (user={}".format(user)
+
+    finally:
+        sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)

--- a/frameworks/kafka/tests/test_ssl_kerberos_authz.py
+++ b/frameworks/kafka/tests/test_ssl_kerberos_authz.py
@@ -54,49 +54,6 @@ def kerberos(configure_security):
 
 
 @pytest.fixture(scope='module', autouse=True)
-def kafka_server(kerberos, service_account):
-    """
-    A pytest fixture that installs a Kerberized kafka service.
-
-    On teardown, the service is uninstalled.
-    """
-    service_kerberos_options = {
-        "service": {
-            "name": config.SERVICE_NAME,
-            "service_account": service_account["name"],
-            "service_account_secret": service_account["secret"],
-            "security": {
-                "kerberos": {
-                    "enabled": True,
-                    "kdc": {
-                        "hostname": kerberos.get_host(),
-                        "port": int(kerberos.get_port())
-                    },
-                    "realm": kerberos.get_realm(),
-                    "keytab_secret": kerberos.get_keytab_path(),
-                },
-                "transport_encryption": {
-                    "enabled": True
-                }
-            }
-        }
-    }
-
-    sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
-    try:
-        sdk_install.install(
-            config.PACKAGE_NAME,
-            config.SERVICE_NAME,
-            config.DEFAULT_BROKER_COUNT,
-            additional_options=service_kerberos_options,
-            timeout_seconds=30 * 60)
-
-        yield {**service_kerberos_options, **{"package_name": config.PACKAGE_NAME}}
-    finally:
-        sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
-
-
-@pytest.fixture(scope='module', autouse=True)
 def kafka_client(kerberos):
     try:
         kafka_client = client.KafkaClient("kafka-client")
@@ -148,6 +105,9 @@ def test_authz_acls_required(kafka_client: client.KafkaClient, kerberos, service
                         },
                         "realm": kerberos.get_realm(),
                         "keytab_secret": kerberos.get_keytab_path(),
+                    },
+                    "transport_encryption": {
+                        "enabled": True
                     },
                     "authorization": {
                         "enabled": True,
@@ -235,6 +195,9 @@ def test_authz_acls_not_required(kafka_client: client.KafkaClient, kerberos, ser
                         },
                         "realm": kerberos.get_realm(),
                         "keytab_secret": kerberos.get_keytab_path(),
+                    },
+                    "transport_encryption": {
+                        "enabled": True
                     },
                     "authorization": {
                         "enabled": True,

--- a/frameworks/kafka/tests/test_ssl_kerberos_custom_domain_auth.py
+++ b/frameworks/kafka/tests/test_ssl_kerberos_custom_domain_auth.py
@@ -116,7 +116,7 @@ def kafka_client(kerberos, kafka_server):
             "container": {
                 "type": "MESOS",
                 "docker": {
-                    "image": "elezar/kafka-client:latest",
+                    "image": "elezar/kafka-client:4b9c060",
                     "forcePullImage": True
                 },
                 "volumes": [

--- a/frameworks/kafka/tests/test_ssl_kerberos_custom_domain_auth.py
+++ b/frameworks/kafka/tests/test_ssl_kerberos_custom_domain_auth.py
@@ -77,7 +77,7 @@ def kafka_server(kerberos, service_account):
                         "hostname": kerberos.get_host(),
                         "port": int(kerberos.get_port())
                     },
-                    "realm": sdk_auth.REALM,
+                    "realm": kerberos.get_realm(),
                     "keytab_secret": kerberos.get_keytab_path(),
                 },
                 "transport_encryption": {

--- a/frameworks/kafka/tests/test_ssl_kerberos_custom_domain_auth.py
+++ b/frameworks/kafka/tests/test_ssl_kerberos_custom_domain_auth.py
@@ -1,21 +1,17 @@
 import logging
-import uuid
 import pytest
 
 import sdk_auth
 import sdk_cmd
 import sdk_hosts
 import sdk_install
-import sdk_marathon
 import sdk_utils
-
 
 from security import transport_encryption
 
-
 from tests import auth
+from tests import client
 from tests import config
-from tests import test_utils
 
 
 log = logging.getLogger(__name__)
@@ -100,103 +96,44 @@ def kafka_server(kerberos, service_account):
 
 
 @pytest.fixture(scope='module', autouse=True)
-def kafka_client(kerberos, kafka_server):
-
-    brokers = sdk_cmd.svc_cli(
-        kafka_server["package_name"],
-        kafka_server["service"]["name"],
-        "endpoint broker-tls", json=True)["dns"]
-
+def kafka_client(kerberos):
     try:
-        client_id = "kafka-client"
-        client = {
-            "id": client_id,
-            "mem": 512,
-            "user": "nobody",
-            "container": {
-                "type": "MESOS",
-                "docker": {
-                    "image": "elezar/kafka-client:4b9c060",
-                    "forcePullImage": True
-                },
-                "volumes": [
-                    {
-                        "containerPath": "/tmp/kafkaconfig/kafka-client.keytab",
-                        "secret": "kafka_keytab"
-                    }
-                ]
-            },
-            "secrets": {
-                "kafka_keytab": {
-                    "source": kerberos.get_keytab_path(),
+        kafka_client = client.KafkaClient("kafka-client")
+        kafka_client.install(kerberos)
 
-                }
-            },
-            "networks": [
-                {
-                    "mode": "host"
-                }
-            ],
-            "env": {
-                "JVM_MaxHeapSize": "512",
-                "KAFKA_CLIENT_MODE": "test",
-                "KAFKA_TOPIC": "securetest",
-                "KAFKA_BROKER_LIST": ",".join(brokers)
-            }
-        }
-
-        sdk_marathon.install_app(client)
+        # TODO: This flag should be set correctly.
+        kafka_client._is_tls = True
 
         transport_encryption.create_tls_artifacts(
             cn="client",
-            marathon_task=client_id)
+            marathon_task=kafka_client.get_id())
 
-        broker_hosts = list(map(lambda x: x.split(':')[0], brokers))
-        yield {**client, **{"brokers": broker_hosts}}
-
+        yield kafka_client
     finally:
-        sdk_marathon.destroy_app(client_id)
+        kafka_client.uninstall()
 
 
 @pytest.mark.dcos_min_version('1.10')
 @sdk_utils.dcos_ee_only
 @pytest.mark.sanity
-def test_client_can_read_and_write(kafka_client, kafka_server, kerberos):
-    client_id = kafka_client["id"]
-
-    sdk_cmd.resolve_hosts(kafka_client["id"], kafka_client["brokers"])
+def test_client_can_read_and_write(kafka_client: client.KafkaClient, kafka_server, kerberos):
 
     topic_name = "authn.test"
     sdk_cmd.svc_cli(kafka_server["package_name"], kafka_server["service"]["name"],
                     "topic create {}".format(topic_name),
                     json=True)
 
-    test_utils.wait_for_topic(kafka_server["package_name"], kafka_server["service"]["name"], topic_name)
+    kafka_client.connect(kafka_server)
 
-    message = str(uuid.uuid4())
+    user = "client"
+    write_success, read_successes, _ = kafka_client.can_write_and_read(user,
+                                                                       kafka_server,
+                                                                       topic_name,
+                                                                       kerberos)
 
-    assert write_to_topic("client", client_id, topic_name, message, kerberos)
-
-    assert message in read_from_topic("client", client_id, topic_name, 1, kerberos)
-
-
-def get_client_properties(cn: str) -> str:
-    client_properties_lines = []
-    client_properties_lines.extend(auth.get_kerberos_client_properties(ssl_enabled=True))
-    client_properties_lines.extend(auth.get_ssl_client_properties(cn, True))
-
-    return client_properties_lines
-
-
-def write_to_topic(cn: str, task: str, topic: str, message: str, krb5: object) -> bool:
-
-    return auth.write_to_topic(cn, task, topic, message,
-                               get_client_properties(cn),
-                               environment=auth.setup_krb5_env(cn, task, krb5))
-
-
-def read_from_topic(cn: str, task: str, topic: str, messages: int, krb5: object) -> str:
-
-    return auth.read_from_topic(cn, task, topic, messages,
-                                get_client_properties(cn),
-                                environment=auth.setup_krb5_env(cn, task, krb5))
+    assert write_success, "Write failed (user={})".format(user)
+    assert read_successes, "Read failed (user={}): " \
+                           "MESSAGES={} " \
+                           "read_successes={}".format(user,
+                                                      kafka_client.MESSAGES,
+                                                      read_successes)

--- a/frameworks/kafka/tests/test_toggle_security.py
+++ b/frameworks/kafka/tests/test_toggle_security.py
@@ -115,7 +115,7 @@ def kafka_client(kerberos):
             "container": {
                 "type": "MESOS",
                 "docker": {
-                    "image": "elezar/kafka-client:latest",
+                    "image": "elezar/kafka-client:4b9c060",
                     "forcePullImage": True
                 },
                 "volumes": [

--- a/frameworks/kafka/tests/test_topics.py
+++ b/frameworks/kafka/tests/test_topics.py
@@ -61,7 +61,6 @@ def test_topic_partition_count(kafka_server: dict):
     assert len(topic_info['partitions']) == config.DEFAULT_PARTITION_COUNT
 
 
-
 @pytest.mark.sanity
 def test_topic_offsets_increase_with_writes(kafka_server: dict):
     package_name = kafka_server["package_name"]

--- a/frameworks/kafka/tests/test_utils.py
+++ b/frameworks/kafka/tests/test_utils.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import retrying
 

--- a/frameworks/kafka/tests/test_zookeeper_auth.py
+++ b/frameworks/kafka/tests/test_zookeeper_auth.py
@@ -2,22 +2,20 @@
 This module tests the interaction of Kafka with Zookeeper with authentication enabled
 """
 import logging
-import uuid
 import pytest
 
 import sdk_auth
 import sdk_cmd
 import sdk_hosts
 import sdk_install
-import sdk_marathon
 import sdk_security
 import sdk_utils
 
 from security import kerberos as krb5
 
 from tests import auth
+from tests import client
 from tests import config
-from tests import test_utils
 
 
 log = logging.getLogger(__name__)
@@ -58,7 +56,7 @@ def kerberos(configure_security):
 
 @pytest.fixture(scope='module')
 def zookeeper_server(kerberos):
-    service_kerberos_options = {
+    service_options = {
         "service": {
             "name": config.ZOOKEEPER_SERVICE_NAME,
             "security": {
@@ -68,7 +66,7 @@ def zookeeper_server(kerberos):
                         "hostname": kerberos.get_host(),
                         "port": int(kerberos.get_port())
                     },
-                    "realm": sdk_auth.REALM,
+                    "realm": kerberos.get_realm(),
                     "keytab_secret": kerberos.get_keytab_path(),
                 }
             }
@@ -79,12 +77,12 @@ def zookeeper_server(kerberos):
     zk_secret = "kakfa-zookeeper-secret"
 
     if sdk_utils.is_strict_mode():
-        service_kerberos_options = sdk_install.merge_dictionaries({
+        service_options = sdk_install.merge_dictionaries({
             'service': {
                 'service_account': zk_account,
                 'service_account_secret': zk_secret,
             }
-        }, service_kerberos_options)
+        }, service_options)
 
     try:
         sdk_install.uninstall(config.ZOOKEEPER_PACKAGE_NAME, config.ZOOKEEPER_SERVICE_NAME)
@@ -93,11 +91,11 @@ def zookeeper_server(kerberos):
             config.ZOOKEEPER_PACKAGE_NAME,
             config.ZOOKEEPER_SERVICE_NAME,
             config.ZOOKEEPER_TASK_COUNT,
-            additional_options=service_kerberos_options,
+            additional_options=service_options,
             timeout_seconds=30 * 60,
             insert_strict_options=False)
 
-        yield {**service_kerberos_options, **{"package_name": config.ZOOKEEPER_PACKAGE_NAME}}
+        yield {**service_options, **{"package_name": config.ZOOKEEPER_PACKAGE_NAME}}
 
     finally:
         sdk_install.uninstall(config.ZOOKEEPER_PACKAGE_NAME, config.ZOOKEEPER_SERVICE_NAME)
@@ -111,7 +109,7 @@ def kafka_server(kerberos, zookeeper_server):
                                     zookeeper_server["service"]["name"],
                                     "endpoint clientport", json=True)["dns"]
 
-    service_kerberos_options = {
+    service_options = {
         "service": {
             "name": config.SERVICE_NAME,
             "security": {
@@ -122,7 +120,7 @@ def kafka_server(kerberos, zookeeper_server):
                         "hostname": kerberos.get_host(),
                         "port": int(kerberos.get_port())
                     },
-                    "realm": sdk_auth.REALM,
+                    "realm": kerberos.get_realm(),
                     "keytab_secret": kerberos.get_keytab_path(),
                 }
             }
@@ -138,98 +136,43 @@ def kafka_server(kerberos, zookeeper_server):
             config.PACKAGE_NAME,
             config.SERVICE_NAME,
             config.DEFAULT_BROKER_COUNT,
-            additional_options=service_kerberos_options,
+            additional_options=service_options,
             timeout_seconds=30 * 60)
 
-        yield {**service_kerberos_options, **{"package_name": config.PACKAGE_NAME}}
+        yield {**service_options, **{"package_name": config.PACKAGE_NAME}}
     finally:
         sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
 
 
 @pytest.fixture(scope='module', autouse=True)
-def kafka_client(kerberos, kafka_server):
-
-    brokers = sdk_cmd.svc_cli(
-        kafka_server["package_name"],
-        kafka_server["service"]["name"],
-        "endpoint broker", json=True)["dns"]
-
+def kafka_client(kerberos):
     try:
-        client_id = "kafka-client"
-        client = {
-            "id": client_id,
-            "mem": 512,
-            "container": {
-                "type": "MESOS",
-                "docker": {
-                    "image": "elezar/kafka-client:latest",
-                    "forcePullImage": True
-                },
-                "volumes": [
-                    {
-                        "containerPath": "/tmp/kafkaconfig/kafka-client.keytab",
-                        "secret": "kafka_keytab"
-                    }
-                ]
-            },
-            "secrets": {
-                "kafka_keytab": {
-                    "source": kerberos.get_keytab_path(),
+        kafka_client = client.KafkaClient("kafka-client")
+        kafka_client.install(kerberos)
 
-                }
-            },
-            "networks": [
-                {
-                    "mode": "host"
-                }
-            ],
-            "env": {
-                "JVM_MaxHeapSize": "512",
-                "KAFKA_CLIENT_MODE": "test",
-                "KAFKA_TOPIC": "securetest",
-                "KAFKA_BROKER_LIST": ",".join(brokers)
-            }
-        }
-
-        sdk_marathon.install_app(client)
-        yield {**client, **{"brokers": list(map(lambda x: x.split(':')[0], brokers))}}
-
+        yield kafka_client
     finally:
-        sdk_marathon.destroy_app(client_id)
+        kafka_client.uninstall()
 
 
 @pytest.mark.dcos_min_version('1.10')
 @sdk_utils.dcos_ee_only
 @pytest.mark.zookeeper
 @pytest.mark.sanity
-def test_client_can_read_and_write(kafka_client, kafka_server, kerberos):
-    client_id = kafka_client["id"]
-
-    auth.wait_for_brokers(kafka_client["id"], kafka_client["brokers"])
+def test_client_can_read_and_write(kafka_client: client.KafkaClient, kafka_server, kerberos):
 
     topic_name = "authn.test"
     sdk_cmd.svc_cli(kafka_server["package_name"], kafka_server["service"]["name"],
                     "topic create {}".format(topic_name),
                     json=True)
 
-    test_utils.wait_for_topic(kafka_server["package_name"], kafka_server["service"]["name"], topic_name)
+    kafka_client.connect(kafka_server)
 
-    message = str(uuid.uuid4())
-
-    assert write_to_topic("client", client_id, topic_name, message, kerberos)
-
-    assert message in read_from_topic("client", client_id, topic_name, 1, kerberos)
-
-
-def write_to_topic(cn: str, task: str, topic: str, message: str, krb5: object) -> bool:
-
-    return auth.write_to_topic(cn, task, topic, message,
-                               auth.get_kerberos_client_properties(ssl_enabled=False),
-                               auth.setup_krb5_env(cn, task, krb5))
-
-
-def read_from_topic(cn: str, task: str, topic: str, message: str, krb5: object) -> str:
-
-    return auth.read_from_topic(cn, task, topic, message,
-                                auth.get_kerberos_client_properties(ssl_enabled=False),
-                                auth.setup_krb5_env(cn, task, krb5))
+    user = "client"
+    write_success, read_successes, _ = kafka_client.can_write_and_read(user, kafka_server, topic_name, kerberos)
+    assert write_success, "Write failed (user={})".format(user)
+    assert read_successes, "Read failed (user={}): " \
+                           "MESSAGES={} " \
+                           "read_successes={}".format(user,
+                                                      kafka_client.MESSAGES,
+                                                      read_successes)

--- a/frameworks/kafka/tests/test_zookeeper_authz.py
+++ b/frameworks/kafka/tests/test_zookeeper_authz.py
@@ -1,0 +1,297 @@
+"""
+This module tests the interaction of Kafka with Zookeeper with authorization enabled
+"""
+import logging
+import pytest
+
+import sdk_auth
+import sdk_cmd
+import sdk_hosts
+import sdk_install
+import sdk_security
+import sdk_utils
+
+from security import kerberos as krb5
+
+from tests import auth
+from tests import client
+from tests import config
+
+
+log = logging.getLogger(__name__)
+
+
+def get_zookeeper_principals(service_name: str, realm: str) -> list:
+    primaries = ["zookeeper", ]
+
+    tasks = [
+        "zookeeper-0-server",
+        "zookeeper-1-server",
+        "zookeeper-2-server",
+    ]
+    instances = map(lambda task: sdk_hosts.autoip_host(service_name, task), tasks)
+
+    principals = krb5.generate_principal_list(primaries, instances, realm)
+    return principals
+
+
+@pytest.fixture(scope='module', autouse=True)
+def kerberos(configure_security):
+    try:
+        kerberos_env = sdk_auth.KerberosEnvironment()
+
+        principals = auth.get_service_principals(config.SERVICE_NAME,
+                                                 kerberos_env.get_realm())
+        principals.extend(get_zookeeper_principals(config.ZOOKEEPER_SERVICE_NAME,
+                                                   kerberos_env.get_realm()))
+
+        kerberos_env.add_principals(principals)
+        kerberos_env.finalize()
+
+        yield kerberos_env
+
+    finally:
+        kerberos_env.cleanup()
+
+
+@pytest.fixture(scope='module')
+def zookeeper_server(kerberos):
+    service_options = {
+        "service": {
+            "name": config.ZOOKEEPER_SERVICE_NAME,
+            "security": {
+                "kerberos": {
+                    "enabled": True,
+                    "kdc": {
+                        "hostname": kerberos.get_host(),
+                        "port": int(kerberos.get_port())
+                    },
+                    "realm": kerberos.get_realm(),
+                    "keytab_secret": kerberos.get_keytab_path(),
+                }
+            }
+        }
+    }
+
+    zk_account = "kafka-zookeeper-service-account"
+    zk_secret = "kakfa-zookeeper-secret"
+
+    if sdk_utils.is_strict_mode():
+        service_options = sdk_install.merge_dictionaries({
+            'service': {
+                'service_account': zk_account,
+                'service_account_secret': zk_secret,
+            }
+        }, service_options)
+
+    try:
+        sdk_install.uninstall(config.ZOOKEEPER_PACKAGE_NAME, config.ZOOKEEPER_SERVICE_NAME)
+        sdk_security.setup_security(config.ZOOKEEPER_SERVICE_NAME, zk_account, zk_secret)
+        sdk_install.install(
+            config.ZOOKEEPER_PACKAGE_NAME,
+            config.ZOOKEEPER_SERVICE_NAME,
+            config.ZOOKEEPER_TASK_COUNT,
+            additional_options=service_options,
+            timeout_seconds=30 * 60,
+            insert_strict_options=False)
+
+        yield {**service_options, **{"package_name": config.ZOOKEEPER_PACKAGE_NAME}}
+
+    finally:
+        sdk_install.uninstall(config.ZOOKEEPER_PACKAGE_NAME, config.ZOOKEEPER_SERVICE_NAME)
+
+
+@pytest.fixture(scope='module', autouse=True)
+def kafka_client(kerberos):
+    try:
+        kafka_client = client.KafkaClient("kafka-client")
+        kafka_client.install(kerberos)
+
+        yield kafka_client
+    finally:
+        kafka_client.uninstall()
+
+
+@pytest.mark.dcos_min_version('1.10')
+@sdk_utils.dcos_ee_only
+@pytest.mark.sanity
+def test_authz_acls_required(kafka_client: client.KafkaClient, zookeeper_server, kerberos):
+    try:
+        zookeeper_dns = sdk_cmd.svc_cli(zookeeper_server["package_name"],
+                                        zookeeper_server["service"]["name"],
+                                        "endpoint clientport", json=True)["dns"]
+
+        sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
+        service_options = {
+            "service": {
+                "name": config.SERVICE_NAME,
+                "security": {
+                    "kerberos": {
+                        "enabled": True,
+                        "enabled_for_zookeeper": True,
+                        "kdc": {
+                            "hostname": kerberos.get_host(),
+                            "port": int(kerberos.get_port())
+                        },
+                        "realm": kerberos.get_realm(),
+                        "keytab_secret": kerberos.get_keytab_path(),
+                    },
+                    "authorization": {
+                        "enabled": True,
+                        "super_users": "User:{}".format("super")
+                    }
+                }
+            },
+            "kafka": {
+                "kafka_zookeeper_uri": ",".join(zookeeper_dns)
+            }
+        }
+        config.install(
+            config.PACKAGE_NAME,
+            config.SERVICE_NAME,
+            config.DEFAULT_BROKER_COUNT,
+            additional_options=service_options)
+
+        kafka_server = {**service_options, **{"package_name": config.PACKAGE_NAME}}
+
+        topic_name = "authz.test"
+        sdk_cmd.svc_cli(kafka_server["package_name"], kafka_server["service"]["name"],
+                        "topic create {}".format(topic_name),
+                        json=True)
+
+        kafka_client.connect(kafka_server)
+
+        # Clear the ACLs
+        kafka_client.remove_acls("authorized", kafka_server, topic_name)
+
+        # Since no ACLs are specified, only the super user can read and write
+        for user in ["super", ]:
+            log.info("Checking write / read permissions for user=%s", user)
+            write_success, read_successes, _ = kafka_client.can_write_and_read(user, kafka_server, topic_name, kerberos)
+            assert write_success, "Write failed (user={})".format(user)
+            assert read_successes, "Read failed (user={}): " \
+                                   "MESSAGES={} " \
+                                   "read_successes={}".format(user,
+                                                              kafka_client.MESSAGES,
+                                                              read_successes)
+
+        for user in ["authorized", "unauthorized", ]:
+            log.info("Checking lack of write / read permissions for user=%s", user)
+            write_success, _, read_messages = kafka_client.can_write_and_read(user, kafka_server, topic_name, kerberos)
+            assert not write_success, "Write not expected to succeed (user={})".format(user)
+            assert auth.is_not_authorized(read_messages), "Unauthorized expected (user={}".format(user)
+
+        log.info("Writing and reading: Adding acl for authorized user")
+        kafka_client.add_acls("authorized", kafka_server, topic_name)
+
+        # After adding ACLs the authorized user and super user should still have access to the topic.
+        for user in ["authorized", "super"]:
+            log.info("Checking write / read permissions for user=%s", user)
+            write_success, read_successes, _ = kafka_client.can_write_and_read(user, kafka_server, topic_name, kerberos)
+            assert write_success, "Write failed (user={})".format(user)
+            assert read_successes, "Read failed (user={}): " \
+                                   "MESSAGES={} " \
+                                   "read_successes={}".format(user,
+                                                              kafka_client.MESSAGES,
+                                                              read_successes)
+
+        for user in ["unauthorized", ]:
+            log.info("Checking lack of write / read permissions for user=%s", user)
+            write_success, _, read_messages = kafka_client.can_write_and_read(user, kafka_server, topic_name, kerberos)
+            assert not write_success, "Write not expected to succeed (user={})".format(user)
+            assert auth.is_not_authorized(read_messages), "Unauthorized expected (user={}".format(user)
+
+    finally:
+        sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
+
+
+@pytest.mark.dcos_min_version('1.10')
+@pytest.mark.ee_only
+@pytest.mark.sanity
+def test_authz_acls_not_required(kafka_client: client.KafkaClient, zookeeper_server, kerberos):
+    try:
+        zookeeper_dns = sdk_cmd.svc_cli(zookeeper_server["package_name"],
+                                        zookeeper_server["service"]["name"],
+                                        "endpoint clientport", json=True)["dns"]
+
+        sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
+        service_options = {
+            "service": {
+                "name": config.SERVICE_NAME,
+                "security": {
+                    "kerberos": {
+                        "enabled": True,
+                        "enabled_for_zookeeper": True,
+                        "kdc": {
+                            "hostname": kerberos.get_host(),
+                            "port": int(kerberos.get_port())
+                        },
+                        "realm": kerberos.get_realm(),
+                        "keytab_secret": kerberos.get_keytab_path(),
+                    },
+                    "authorization": {
+                        "enabled": True,
+                        "super_users": "User:{}".format("super"),
+                        "allow_everyone_if_no_acl_found": True
+                    }
+                }
+            },
+            "kafka": {
+                "kafka_zookeeper_uri": ",".join(zookeeper_dns)
+            }
+        }
+
+        config.install(
+            config.PACKAGE_NAME,
+            config.SERVICE_NAME,
+            config.DEFAULT_BROKER_COUNT,
+            additional_options=service_options)
+
+        kafka_server = {**service_options, **{"package_name": config.PACKAGE_NAME}}
+
+        topic_name = "authz.test"
+        sdk_cmd.svc_cli(kafka_server["package_name"], kafka_server["service"]["name"],
+                        "topic create {}".format(topic_name),
+                        json=True)
+
+        kafka_client.connect(kafka_server)
+
+        # Clear the ACLs
+        kafka_client.remove_acls("authorized", kafka_server, topic_name)
+
+        # Since no ACLs are specified, all users can read and write.
+        for user in ["authorized", "unauthorized", "super", ]:
+            log.info("Checking write / read permissions for user=%s", user)
+            write_success, read_successes, _ = kafka_client.can_write_and_read(user, kafka_server, topic_name, kerberos)
+            assert write_success, "Write failed (user={})".format(user)
+            assert read_successes, "Read failed (user={}): " \
+                                   "MESSAGES={} " \
+                                   "read_successes={}".format(user,
+                                                              kafka_client.MESSAGES,
+                                                              read_successes)
+
+        log.info("Writing and reading: Adding acl for authorized user")
+        kafka_client.add_acls("authorized", kafka_server, topic_name)
+
+        # After adding ACLs the authorized user and super user should still have access to the topic.
+        for user in ["authorized", "super", ]:
+            log.info("Checking write / read permissions for user=%s", user)
+            write_success, read_successes, _ = kafka_client.can_write_and_read(user, kafka_server, topic_name, kerberos)
+            assert write_success, "Write failed (user={})".format(user)
+            assert read_successes, "Read failed (user={}): " \
+                                   "MESSAGES={} " \
+                                   "read_successes={}".format(user,
+                                                              kafka_client.MESSAGES,
+                                                              read_successes)
+
+        for user in ["unauthorized", ]:
+            log.info("Checking lack of write / read permissions for user=%s", user)
+            write_success, _, read_messages = kafka_client.can_write_and_read(user,
+                                                                              kafka_server,
+                                                                              topic_name,
+                                                                              kerberos)
+            assert not write_success, "Write not expected to succeed (user={})".format(user)
+            assert auth.is_not_authorized(read_messages), "Unauthorized expected (user={}".format(user)
+
+    finally:
+        sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)

--- a/frameworks/kafka/tests/topics.py
+++ b/frameworks/kafka/tests/topics.py
@@ -24,7 +24,8 @@ def remove_acls(user: str, task: str, topic: str, zookeeper_endpoint: str, env_s
     _remove_role_acls(["--consumer", "--group=*"], user, task, topic, zookeeper_endpoint, env_str)
 
 
-def _modify_role_acls(action: str, roles: list, user: str, task: str, topic: str, zookeeper_endpoint: str, env_str: str=None):
+def _modify_role_acls(action: str, roles: list, user: str, task: str, topic: str,
+                      zookeeper_endpoint: str, env_str: str=None) -> tuple:
 
     if not action.startswith("--"):
         action = "--{}".format(action)
@@ -45,11 +46,13 @@ def _modify_role_acls(action: str, roles: list, user: str, task: str, topic: str
     return output
 
 
-def _add_role_acls(roles: list, user: str, task: str, topic: str, zookeeper_endpoint: str, env_str: str=None):
+def _add_role_acls(roles: list, user: str, task: str, topic: str,
+                   zookeeper_endpoint: str, env_str: str=None) -> tuple:
     return _modify_role_acls("add", roles, user, task, topic, zookeeper_endpoint, env_str)
 
 
-def _remove_role_acls(roles: list, user: str, task: str, topic: str, zookeeper_endpoint: str, env_str: str=None):
+def _remove_role_acls(roles: list, user: str, task: str, topic: str,
+                      zookeeper_endpoint: str, env_str: str=None) -> tuple:
     return _modify_role_acls("remove", roles, user, task, topic, zookeeper_endpoint, env_str)
 
 

--- a/frameworks/kafka/tests/topics.py
+++ b/frameworks/kafka/tests/topics.py
@@ -2,6 +2,7 @@ import logging
 
 import sdk_cmd
 
+from tests import auth
 
 LOG = logging.getLogger(__name__)
 
@@ -11,21 +12,21 @@ def add_acls(user: str, task: str, topic: str, zookeeper_endpoint: str, env_str=
     Add Porducer and Consumer ACLs for the specifed user and topic
     """
 
-    _add_role_acls("producer", user, task, topic, zookeeper_endpoint, env_str)
-    _add_role_acls("consumer --group=*", user, task, topic, zookeeper_endpoint, env_str)
+    _add_role_acls(["--producer", ], user, task, topic, zookeeper_endpoint, env_str)
+    _add_role_acls(["--consumer", "--group=*"], user, task, topic, zookeeper_endpoint, env_str)
 
 
-def _add_role_acls(role: str, user: str, task: str, topic: str, zookeeper_endpoint: str, env_str=None):
-    cmd = "bash -c \"{setup_env}kafka-acls \
-        --topic {topic_name} \
-        --authorizer-properties zookeeper.connect={zookeeper_endpoint} \
-        --add \
-        --allow-principal User:{user} \
-        --{role}\"".format(setup_env="{}  && ".format(env_str) if env_str else "",
-                                                     topic_name=topic,
-                                                     zookeeper_endpoint=zookeeper_endpoint,
-                                                     user=user,
-                                                     role=role)
+def _add_role_acls(roles: list, user: str, task: str, topic: str, zookeeper_endpoint: str, env_str: str=None):
+
+    cmd_list = ["kafka-acls",
+                "--topic", topic,
+                "--authorizer-properties", "zookeeper.connect={}".format(zookeeper_endpoint),
+                "--add",
+                "--allow-principal", "User:{}".format(user), ]
+    cmd_list.extend(roles)
+
+    cmd = auth.get_bash_command(" ".join(cmd_list), env_str)
+
     LOG.info("Running: %s", cmd)
     output = sdk_cmd.task_exec(task, cmd)
     LOG.info(output)


### PR DESCRIPTION
This PR extends the AuthZ tests for Kafka and includes:

* Adds the same authz tests that exist for SSL auth to Kerberos auth.
* Adds the same authz tests that exist for SSL auth to Kerberos auth with a custom Kerberized ZooKeeper
* Add the same authz tests that exist for SSL auth to SSL-Kerberos auth

It also: 
* applies some minor flake8 corrections to the kafka tests.
* Correctly replaces the `wait_for_brokers` function with `sdk_cmd.resolve_hosts` (see #2412)