### PR TITLE
Add updating md

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,12 +40,16 @@ RUN mkdir /root/.ssh
 RUN mkdir /build-tools
 ENV PATH /build-tools:$PATH
 
+COPY tools/distribution/init /build-tools/
 COPY tools/ci/* /build-tools/
 
 # Create a folder to store the distributed artefacts
 RUN mkdir /dcos-commons-dist
 
 ENV DCOS_COMMONS_DIST_ROOT /dcos-commons-dist
+
+COPY tools/distribution/* ${DCOS_COMMONS_DIST_ROOT}/
+
 COPY test.sh ${DCOS_COMMONS_DIST_ROOT}/
 COPY TESTING.md ${DCOS_COMMONS_DIST_ROOT}/
 

--- a/tools/distribution/UPDATING.md
+++ b/tools/distribution/UPDATING.md
@@ -1,0 +1,157 @@
+# Updating this repository
+
+This framework is built using the [DC/OS Commons SDK](https://github.com/mesosphere/dcos-commons), and in order to make use of new features in the SDK or consume bugfixes it should be updated regularly.
+
+The parts of the SDK consumed consist of:
+* The SDK Java libraries including:
+    * scheduler libraries
+    * executor libraries
+    * testing libraries
+* SDK artefacts including:
+    * The custom executor for use on DC/OS 1.9 clusters
+    * The `bootstrap` utility
+* CLI binaries for the three supported platforms
+* Build tooling
+* Testing utilities
+
+## Preparation
+
+If this repository has never been updated in this way, then the following changes may be required:
+
+### Check `build.gradle`
+
+Check that `build.gradle` in the project root contains the following dependencies in addition to any others required:
+```
+dependencies {
+    compile "mesosphere:scheduler:${dcosSDKVer}"
+    compile "mesosphere:executor:${dcosSDKVer}"
+    testCompile "mesosphere:testing:${dcosSDKVer}"
+}
+```
+as well as the following entry in the `ext` specification:
+```
+ext {
+    dcosSDKVer = "<CURRENT_SDK_VERSION>"
+}
+```
+(where `<CURRENT_SDK_VERSION>` represents a version string such as `0.30.1`)
+
+Older versions of `build.gradle` contained the following dependencies and no entry in the `ext` specification:
+* `compile "mesosphere:scheduler:<CURRENT_SDK_VERSION>"`
+* `compile "mesosphere:executor:<CURRENT_SDK_VERSION>"`
+* `testCompile "mesosphere:testing:<CURRENT_SDK_VERSION>"`
+
+Although this is supported in the current upgrade path, it is recommended that hese are changed to match the dependencies at the start of this section as this will result in a single line diff in the `build.gradle` file on update.
+
+### Check the `universe/resource.json` file
+
+#### URIs
+In order to facilitate upgrades, the `universe/resource.json` file should contain the following entries in the `"uris"` section:
+```json
+"uris": {
+    "...": "...",
+    "bootstrap-zip": "https://downloads.mesosphere.com/dcos-commons/artifacts/{{dcos-sdk-version}}/bootstrap.zip",
+    "executor-zip": "http://downloads.mesosphere.com/dcos-commons/artifacts/{{dcos-sdk-version}}/executor.zip",
+    "...": "..."
+}
+```
+Note the use of the `{{dcos-skd-version}}` mustache template to replace an explicit version specification.
+
+#### CLIs
+
+In addition, if no custom CLI command are required, the `"cli"` section in the `universe/resource.json` can be replaced by:
+```json
+"cli":{
+    "binaries":{
+      "darwin":{
+        "x86-64":{
+          "contentHash":[ { "algo":"sha256", "value":"{{sha256:dcos-service-cli-darwin@https://downloads.mesosphere.com/dcos-commons/artifacts/{{dcos-sdk-version}}/SHA256SUMS}}" } ],
+          "kind":"executable",
+          "url":"https://downloads.mesosphere.com/dcos-commons/artifacts/{{dcos-sdk-version}}/dcos-service-cli-darwin"
+        }
+      },
+      "linux":{
+        "x86-64":{
+          "contentHash":[ { "algo":"sha256", "value":"{{sha256:dcos-service-cli-linux@https://downloads.mesosphere.com/dcos-commons/artifacts/{{dcos-sdk-version}}/SHA256SUMS}}" } ],
+          "kind":"executable",
+          "url":"https://downloads.mesosphere.com/dcos-commons/artifacts/{{dcos-sdk-version}}/dcos-service-cli-linux"
+        }
+      },
+      "windows":{
+        "x86-64":{
+          "contentHash":[ { "algo":"sha256", "value":"{{sha256:dcos-service-cli.exe@https://downloads.mesosphere.com/dcos-commons/artifacts/{{dcos-sdk-version}}/SHA256SUMS}}" } ],
+          "kind":"executable",
+          "url":"https://downloads.mesosphere.com/dcos-commons/artifacts/{{dcos-sdk-version}}/dcos-service-cli.exe"
+        }
+      }
+    }
+  }
+```
+Meaning that the CLIs for the templated `{{dcos-sdk-version}}` are used directly instead of building these separately.
+
+## Updating
+
+### Clean the current working directory
+
+It is recommended that the update be performed in a **clean git repository**. Running the following commands should ensure this:
+
+**NOTE**: This is a destructive operation
+
+```bash
+$ git checkout -b update-sdk-version-to-<NEW_SDK_VERSION>
+$ git reset --hard HEAD
+$ git clean -fdx
+```
+
+Now running `git status should yield:
+```bash
+$ git status
+On branch update-sdk-version-to-<NEW_SDK_VERSION>
+nothing to commit, working tree clean
+```
+
+### Perform the update
+
+Assuming the `build.gradle` and `resource.json` files have been updated accordingly, the update to a specific version of the SDK can be performed as follows:
+```bash
+$ docker pull mesosphere/dcos-commons:latest
+$ docker run --rm -ti -v $(pwd):$(pwd) mesosphere/dcos-commons:latest init $(pwd) --update-sdk <NEW_SDK_VERSION>
+```
+
+Running a `git status` after this process should show something like:
+```bash
+$ git status
+On branch update-sdk-version-to-0.41.0
+Changes not staged for commit:
+  (use "git add <file>..." to update what will be committed)
+  (use "git checkout -- <file>..." to discard changes in working directory)
+
+	modified:   build.gradle
+	modified:   testing/sdk_auth.py
+	modified:   testing/sdk_cmd.py
+	modified:   testing/sdk_hosts.py
+	modified:   testing/sdk_install.py
+	modified:   testing/sdk_marathon.py
+	modified:   testing/sdk_repository.py
+	modified:   testing/sdk_security.py
+	modified:   testing/sdk_upgrade.py
+	modified:   testing/sdk_utils.py
+	modified:   testing/security/transport_encryption.py
+	modified:   tools/ci/init
+	modified:   tools/release_builder.py
+	modified:   tools/universe/package_builder.py
+	modified:   tools/universe/package_manager.py
+
+no changes added to commit (use "git add" and/or "git commit -a")
+```
+Note that the update procedure could also *delete* unneeded files.
+
+Check the differences in `build.gradle` and `tools/release_builder.py` to ensure that the `<NEW_SDK_VERSION>` is present in both files.
+
+Now add the changes to version control using the required git commants (`git add`, `git rm`).
+
+## Further steps
+
+* See the SDK release notes for any changes required when consuming the SKD.
+* If the build process is heavily customized, it may be that additional changes will be required to the `build.sh` file in the repo.
+* The API of the testing tools in `testing` could have changed, and any integration tests may need to be updted.

--- a/tools/distribution/UPDATING.md
+++ b/tools/distribution/UPDATING.md
@@ -154,4 +154,4 @@ Now add the changes to version control using the required git commants (`git add
 
 * See the SDK release notes for any changes required when consuming the SKD.
 * If the build process is heavily customized, it may be that additional changes will be required to the `build.sh` file in the repo.
-* The API of the testing tools in `testing` could have changed, and any integration tests may need to be updted.
+* The API of the testing tools in `testing` could have changed, and any integration tests may need to be updted. Run `git diff testing` to check for any relevant changes.

--- a/tools/distribution/init
+++ b/tools/distribution/init
@@ -118,7 +118,7 @@ def parse_args():
     parser = argparse.ArgumentParser(description="Init DC/OS test environment")
     parser.add_argument('output_path', type=str,
                         help='The absolute path where the testing tools should be created')
-    parser.add_argument("--update-sdk", nargs="?", type=str,
+    parser.add_argument("--update-sdk", type=str,
                         help="Update the SDK in the target framework.")
     return parser.parse_args()
 

--- a/tools/distribution/init
+++ b/tools/distribution/init
@@ -47,12 +47,20 @@ def copy_dist_file(filename: str, output_path: str):
     subprocess.check_output(["cp", source_file, output_path])
 
 
-def copy_dist_folder(folder: str, output_path: str):
+def copy_dist_folder(folder: str, output_path: str, exclude: list=[]):
     """Copy a distribution folder to the specified ouput path"""
     source_folder = os.path.join(DCOS_COMMONS_DIST_ROOT, folder.rstrip("/"))
 
     LOGGER.info("Copying %s to %s", source_folder, output_path)
-    subprocess.check_output(["rsync", "-avz", "--delete", source_folder, output_path])
+    cmd = ["rsync", "-avz", "--delete", ]
+
+    if exclude:
+        for e in exclude:
+            cmd.extend(["--exclude={}".format(e)])
+
+    cmd.extend([source_folder, output_path])
+
+    subprocess.check_output(cmd)
 
 
 def distribute_test_utils(output_path: str):
@@ -60,14 +68,17 @@ def distribute_test_utils(output_path: str):
 
     output_path = output_path.rstrip("/") + "/"
 
-    files = ["test.sh", "TESTING.md", "conftest.py", ]
+    files = ["conftest.py",
+             "test.sh",
+             "TESTING.md",
+             "UPDATING.md", ]
 
     for f in files:
         copy_dist_file(f, output_path)
 
-    folders = ["tools", "testing", ]
+    folders = [("tools", ["tools/ci", "tools/distribution"]), ("testing", []), ]
     for f in folders:
-        copy_dist_folder(f, output_path)
+        copy_dist_folder(f[0], output_path, f[1])
 
 
 def update_sdk(output_path: str, target_version: str):
@@ -100,12 +111,14 @@ def update_sdk(output_path: str, target_version: str):
                                       package_builder_contents)
     write_file(package_builder_path, package_builder_contents)
 
+    LOGGER.info("Updated to SDK version %s", target_version)
+
 
 def parse_args():
     parser = argparse.ArgumentParser(description="Init DC/OS test environment")
     parser.add_argument('output_path', type=str,
                         help='The absolute path where the testing tools should be created')
-    parser.add_argument("--update-sdk", nargs="?", type=str, const=get_sdk_version(),
+    parser.add_argument("--update-sdk", nargs="?", type=str,
                         help="Update the SDK in the target framework.")
     return parser.parse_args()
 


### PR DESCRIPTION
This PR adds some short documentation on updating non-mono-repo frameworks.

This was prompted by mesosphere/dcos-zookeeper#90 and will ensure that this is present in all future updated repositories.