### PR TITLE
[INFINITY-2971][INFINITY-3425] improve kafka authz test coverage (#2419)

### DIFF
--- a/frameworks/kafka/src/main/dist/server.properties.mustache
+++ b/frameworks/kafka/src/main/dist/server.properties.mustache
@@ -92,9 +92,11 @@ socket.request.max.bytes={{KAFKA_SOCKET_REQUEST_MAX_BYTES}}
 authorizer.class.name=kafka.security.auth.SimpleAclAuthorizer
 super.users={{SETUP_HELPER_SUPER_USERS}}
 allow.everyone.if.no.acl.found={{SECURITY_AUTHORIZATION_ALLOW_EVERYONE_IF_NO_ACL_FOUND}}
+{{^SECURITY_KERBEROS_ENABLED}}
 {{#SECURITY_SSL_AUTHENTICATION_ENABLED}}
 principal.builder.class=de.thmshmm.kafka.CustomPrincipalBuilder
 {{/SECURITY_SSL_AUTHENTICATION_ENABLED}}
+{{/SECURITY_KERBEROS_ENABLED}}
 {{/SECURITY_AUTHORIZATION_ENABLED}}
 
 ############################# Log Basics #############################

--- a/frameworks/kafka/tests/client.py
+++ b/frameworks/kafka/tests/client.py
@@ -1,0 +1,220 @@
+"""
+A collection of client utilites for Kafka.
+"""
+import logging
+import uuid
+
+import sdk_auth
+import sdk_cmd
+import sdk_install
+import sdk_marathon
+
+from tests import auth
+from tests import test_utils
+from tests import topics
+
+
+log = logging.getLogger(__name__)
+
+
+class KafkaService:
+    """
+    A light wrapper around a Kafka service installed as part of the integration tests.
+    """
+    def __init__(self, service_options: dict):
+        self._package_name = service_options["package_name"]
+        self._service_name = service_options["service"]["name"]
+
+    def get_zookeeper_connect(self) -> str:
+        return str(sdk_cmd.svc_cli(self._package_name, self._service_name,
+                   "endpoint zookeeper")).strip()
+
+    def get_brokers_endpoints(self, endpoint_name: str) -> list:
+        brokers = sdk_cmd.svc_cli(
+            self._package_name,
+            self._service_name,
+            "endpoint {}".format(endpoint_name), json=True)["dns"]
+
+        return brokers
+
+    def wait_for_topic(self, topic_name: str):
+        if not topic_name:
+            return True
+
+        test_utils.wait_for_topic(self._package_name, self._service_name, topic_name)
+
+        return True
+
+
+class KafkaClient:
+
+    def __init__(self, id: str):
+
+        self.id = id
+
+        self._is_kerberos = False
+        self._is_tls = False
+
+        self.reset()
+
+    def reset(self):
+        self.MESSAGES = []
+        self.brokers = None
+        self.topic_name = None
+
+    def get_id(self) -> str:
+        return self.id
+
+    @staticmethod
+    def _get_kerberos_options(kerberos: sdk_auth.KerberosEnvironment) -> dict:
+        options = {
+            "container": {
+                "volumes": [
+                    {
+                        "containerPath": "/tmp/kafkaconfig/kafka-client.keytab",
+                        "secret": "kafka_keytab"
+                    }
+                ]
+            },
+            "secrets": {
+                "kafka_keytab": {
+                    "source": kerberos.get_keytab_path(),
+
+                }
+            }
+        }
+
+        return options
+
+    def install(self, kerberos: sdk_auth.KerberosEnvironment=None) -> dict:
+        options = {
+            "id": self.id,
+            "mem": 512,
+            "container": {
+                "type": "MESOS",
+                "docker": {
+                    "image": "elezar/kafka-client:4b9c060",
+                    "forcePullImage": True
+                }
+            },
+            "networks": [
+                {
+                    "mode": "host"
+                }
+            ],
+            "env": {
+                "JVM_MaxHeapSize": "512",
+                "KAFKA_CLIENT_MODE": "test",
+                "KAFKA_TOPIC": "securetest"
+            }
+        }
+
+        if kerberos is not None:
+            self._is_kerberos = True
+            options = sdk_install.merge_dictionaries(options, self._get_kerberos_options(kerberos))
+
+        sdk_marathon.install_app(options)
+
+        return options
+
+    def uninstall(self):
+        sdk_marathon.destroy_app(self.id)
+
+    def _get_cli_settings(self, user: str, kerberos: sdk_auth.KerberosEnvironment):
+        properties = []
+        environment = None
+
+        if self._is_kerberos:
+            properties.extend(auth.get_kerberos_client_properties(ssl_enabled=self._is_tls))
+            environment = auth.setup_krb5_env(user, self.id, kerberos)
+
+        if self._is_tls:
+            properties.extend(auth.get_ssl_client_properties(user,
+                                                             has_kerberos=self._is_kerberos))
+
+        return properties, environment
+
+    def get_endpoint_name(self) -> str:
+        if self._is_tls:
+            return "broker-tls"
+
+        return "broker"
+
+    def wait_for(self, kafka_server: dict, topic_name: str) -> bool:
+        """
+        Wait for the service to be visible from a client perspective.
+        """
+        service = KafkaService(kafka_server)
+
+        if not self.brokers:
+            brokers_list = service.get_brokers_endpoints(self.get_endpoint_name())
+            broker_hosts = map(lambda b: b.split(":")[0], brokers_list)
+            brokers = ",".join(brokers_list)
+
+            if not sdk_cmd.resolve_hosts(self.id, broker_hosts, bootstrap_cmd='/opt/bootstrap'):
+                log.error("Failed to resolve brokers: %s", broker_hosts)
+                return False
+            self.brokers = brokers
+
+            return True
+
+        if self.topic_name != topic_name:
+            service.wait_for_topic(topic_name)
+            self.topic_name = topic_name
+
+        return True
+
+    def connect(self, kafka_server: dict) -> bool:
+        self.reset()
+        return self.wait_for(kafka_server, topic_name=None)
+
+    def can_write_and_read(self, user: str, kafka_server: dict,
+                           topic_name: str, krb5: sdk_auth.KerberosEnvironment) -> tuple:
+
+        if not self.wait_for(kafka_server, topic_name):
+            return False, [], []
+
+        write_success = self.write_to_topic(user, topic_name, self.brokers, krb5)
+        read_sucesses, read_messages = self.read_from_topic(user, topic_name, self.brokers, krb5)
+
+        return write_success, read_sucesses, read_messages
+
+    def read_from_topic(self, user: str, topic_name: str, brokers: str,
+                        krb5: sdk_auth.KerberosEnvironment) -> list:
+
+        properties, environment = self._get_cli_settings(user, krb5)
+        read_messages = auth.read_from_topic(user, self.id, topic_name, len(self.MESSAGES),
+                                             properties, environment, brokers)
+
+        read_success = map(lambda m: m in read_messages, self.MESSAGES)
+
+        return read_success, read_messages
+
+    def write_to_topic(self, user: str, topic_name: str, brokers: str,
+                       krb5: sdk_auth.KerberosEnvironment) -> bool:
+
+        # Generate a unique message:
+        message = str(uuid.uuid4())
+
+        properties, environment = self._get_cli_settings(user, krb5)
+        write_success = auth.write_to_topic(user, self.id, topic_name, message,
+                                            properties, environment, brokers)
+
+        if write_success:
+            self.MESSAGES.append(message)
+
+        return write_success
+
+    def add_acls(self, user: str, kafka_server: dict, topic_name: str):
+        service = KafkaService(kafka_server)
+
+        # TODO: If zookeeper has Kerberos enabled, then the environment should be changed
+        environment = None
+        topics.add_acls(user, self.id, topic_name, service.get_zookeeper_connect(), environment)
+
+    def remove_acls(self, user: str, kafka_server: dict, topic_name: str):
+        service = KafkaService(kafka_server)
+
+        # TODO: If zookeeper has Kerberos enabled, then the environment should be changed
+        environment = None
+        topics.remove_acls(user, self.id, topic_name, service.get_zookeeper_connect(), environment)

--- a/frameworks/kafka/tests/test_active_directory_auth.py
+++ b/frameworks/kafka/tests/test_active_directory_auth.py
@@ -1,4 +1,3 @@
-import os
 import logging
 import pytest
 import uuid

--- a/frameworks/kafka/tests/test_active_directory_auth.py
+++ b/frameworks/kafka/tests/test_active_directory_auth.py
@@ -85,7 +85,7 @@ def kafka_client(kerberos, kafka_server):
             "container": {
                 "type": "MESOS",
                 "docker": {
-                    "image": "elezar/kafka-client:latest",
+                    "image": "elezar/kafka-client:4b9c060",
                     "forcePullImage": True
                 },
                 "volumes": [

--- a/frameworks/kafka/tests/test_active_directory_zookeeper_auth.py
+++ b/frameworks/kafka/tests/test_active_directory_zookeeper_auth.py
@@ -126,7 +126,7 @@ def kafka_client(kerberos, kafka_server):
             "container": {
                 "type": "MESOS",
                 "docker": {
-                    "image": "elezar/kafka-client:latest",
+                    "image": "elezar/kafka-client:4b9c060",
                     "forcePullImage": True
                 },
                 "volumes": [

--- a/frameworks/kafka/tests/test_kerberos_auth.py
+++ b/frameworks/kafka/tests/test_kerberos_auth.py
@@ -1,17 +1,15 @@
 import logging
 import pytest
-import uuid
 
 import sdk_auth
 import sdk_cmd
 import sdk_install
-import sdk_marathon
-import sdk_utils
 import sdk_networks
+import sdk_utils
 
 from tests import auth
+from tests import client
 from tests import config
-from tests import test_utils
 
 
 log = logging.getLogger(__name__)
@@ -50,7 +48,7 @@ def kafka_server(kerberos):
                         "hostname": kerberos.get_host(),
                         "port": int(kerberos.get_port())
                     },
-                    "realm": sdk_auth.REALM,
+                    "realm": kerberos.get_realm(),
                     "keytab_secret": kerberos.get_keytab_path(),
                 }
             }
@@ -72,62 +70,23 @@ def kafka_server(kerberos):
 
 
 @pytest.fixture(scope='module', autouse=True)
-def kafka_client(kerberos, kafka_server):
-
-    brokers = sdk_cmd.svc_cli(
-        kafka_server["package_name"],
-        kafka_server["service"]["name"],
-        "endpoint broker", json=True)["dns"]
-
+def kafka_client(kerberos):
     try:
-        client_id = "kafka-client"
-        client = {
-            "id": client_id,
-            "mem": 512,
-            "container": {
-                "type": "MESOS",
-                "docker": {
-                    "image": "elezar/kafka-client:latest",
-                    "forcePullImage": True
-                },
-                "volumes": [
-                    {
-                        "containerPath": "/tmp/kafkaconfig/kafka-client.keytab",
-                        "secret": "kafka_keytab"
-                    }
-                ]
-            },
-            "secrets": {
-                "kafka_keytab": {
-                    "source": kerberos.get_keytab_path(),
+        kafka_client = client.KafkaClient("kafka-client")
+        kafka_client.install(kerberos)
 
-                }
-            },
-            "networks": [
-                {
-                    "mode": "host"
-                }
-            ],
-            "env": {
-                "JVM_MaxHeapSize": "512",
-                "KAFKA_CLIENT_MODE": "test",
-                "KAFKA_TOPIC": "securetest",
-                "KAFKA_BROKER_LIST": ",".join(brokers)
-            }
-        }
-
-        sdk_marathon.install_app(client)
-        yield {**client, **{"brokers": list(map(lambda x: x.split(':')[0], brokers))}}
-
+        yield kafka_client
     finally:
-        sdk_marathon.destroy_app(client_id)
+        kafka_client.uninstall()
 
 
 @pytest.mark.dcos_min_version('1.10')
 @sdk_utils.dcos_ee_only
 @pytest.mark.sanity
-def test_no_vip(kafka_client, kafka_server, kerberos):
-    endpoints = sdk_networks.get_and_test_endpoints(kafka_server["package_name"], kafka_server["service"]["name"], "broker", 2)
+def test_no_vip(kafka_server):
+    endpoints = sdk_networks.get_and_test_endpoints(kafka_server["package_name"],
+                                                    kafka_server["service"]["name"],
+                                                    "broker", 2)
     assert "vip" not in endpoints
 
 
@@ -135,33 +94,19 @@ def test_no_vip(kafka_client, kafka_server, kerberos):
 @sdk_utils.dcos_ee_only
 @pytest.mark.sanity
 def test_client_can_read_and_write(kafka_client, kafka_server, kerberos):
-    client_id = kafka_client["id"]
-
-    auth.wait_for_brokers(kafka_client["id"], kafka_client["brokers"])
 
     topic_name = "authn.test"
     sdk_cmd.svc_cli(kafka_server["package_name"], kafka_server["service"]["name"],
                     "topic create {}".format(topic_name),
                     json=True)
 
-    test_utils.wait_for_topic(kafka_server["package_name"], kafka_server["service"]["name"], topic_name)
+    kafka_client.connect(kafka_server)
+    user = "client"
 
-    message = str(uuid.uuid4())
-
-    assert write_to_topic("client", client_id, topic_name, message, kerberos)
-
-    assert message in read_from_topic("client", client_id, topic_name, 1, kerberos)
-
-
-def write_to_topic(cn: str, task: str, topic: str, message: str, krb5: object) -> bool:
-
-    return auth.write_to_topic(cn, task, topic, message,
-                               auth.get_kerberos_client_properties(ssl_enabled=False),
-                               auth.setup_krb5_env(cn, task, krb5))
-
-
-def read_from_topic(cn: str, task: str, topic: str, messages: int, krb5: object) -> str:
-
-    return auth.read_from_topic(cn, task, topic, messages,
-                                auth.get_kerberos_client_properties(ssl_enabled=False),
-                                auth.setup_krb5_env(cn, task, krb5))
+    write_success, read_successes, _ = kafka_client.can_write_and_read(user, kafka_server, topic_name, kerberos)
+    assert write_success, "Write failed (user={})".format(user)
+    assert read_successes, "Read failed (user={}): " \
+                           "MESSAGES={} " \
+                           "read_successes={}".format(user,
+                                                      kafka_client.MESSAGES,
+                                                      read_successes)

--- a/frameworks/kafka/tests/test_rack_awareness.py
+++ b/frameworks/kafka/tests/test_rack_awareness.py
@@ -3,7 +3,6 @@ import pytest
 import sdk_cmd
 import sdk_fault_domain
 import sdk_install
-import sdk_tasks
 import sdk_utils
 
 from tests import config, test_utils

--- a/frameworks/kafka/tests/test_rack_awareness.py
+++ b/frameworks/kafka/tests/test_rack_awareness.py
@@ -39,7 +39,7 @@ def test_zones_not_referenced_in_placement_constraints():
             'broker get {}'.format(broker_id),
             json=True)
 
-        assert broker_info.get('rack') == None
+        assert broker_info.get('rack') is None
 
     sdk_install.uninstall(config.PACKAGE_NAME, foldered_name)
 

--- a/frameworks/kafka/tests/test_sanity.py
+++ b/frameworks/kafka/tests/test_sanity.py
@@ -58,6 +58,7 @@ def test_mesos_v0_api():
 @pytest.mark.sanity
 def test_endpoints_address():
     foldered_name = sdk_utils.get_foldered_name(config.SERVICE_NAME)
+
     @retrying.retry(
         wait_fixed=1000,
         stop_max_delay=120*1000,
@@ -143,7 +144,7 @@ def test_broker_invalid():
         assert False, "Should have failed"
     except AssertionError as arg:
         raise arg
-    except:
+    except Exception as e:
         pass  # expected to fail
 
 

--- a/frameworks/kafka/tests/test_sanity.py
+++ b/frameworks/kafka/tests/test_sanity.py
@@ -180,7 +180,7 @@ def test_config_cli():
     assert len(configs) >= 1  # refrain from breaking this test if earlier tests did a config update
 
     assert sdk_cmd.svc_cli(config.PACKAGE_NAME, foldered_name,
-        'config show {}'.format(configs[0]), print_output=False) # noisy output
+                           'config show {}'.format(configs[0]), print_output=False)  # noisy output
     assert sdk_cmd.svc_cli(config.PACKAGE_NAME, foldered_name, 'config target', json=True)
     assert sdk_cmd.svc_cli(config.PACKAGE_NAME, foldered_name, 'config target_id', json=True)
 
@@ -192,14 +192,14 @@ def test_plan_cli():
     assert sdk_cmd.svc_cli(config.PACKAGE_NAME, foldered_name, 'plan list', json=True)
     assert sdk_cmd.svc_cli(config.PACKAGE_NAME, foldered_name, 'plan show {}'.format(config.DEFAULT_PLAN_NAME))
     assert sdk_cmd.svc_cli(config.PACKAGE_NAME, foldered_name,
-        'plan show --json {}'.format(config.DEFAULT_PLAN_NAME), json=True)
+                           'plan show --json {}'.format(config.DEFAULT_PLAN_NAME), json=True)
     assert sdk_cmd.svc_cli(config.PACKAGE_NAME, foldered_name,
-        'plan show {} --json'.format(config.DEFAULT_PLAN_NAME), json=True)
+                           'plan show {} --json'.format(config.DEFAULT_PLAN_NAME), json=True)
     assert sdk_cmd.svc_cli(config.PACKAGE_NAME, foldered_name, 'plan force-restart {}'.format(config.DEFAULT_PLAN_NAME))
     assert sdk_cmd.svc_cli(config.PACKAGE_NAME, foldered_name,
-        'plan interrupt {} {}'.format(config.DEFAULT_PLAN_NAME, config.DEFAULT_PHASE_NAME))
+                           'plan interrupt {} {}'.format(config.DEFAULT_PLAN_NAME, config.DEFAULT_PHASE_NAME))
     assert sdk_cmd.svc_cli(config.PACKAGE_NAME, foldered_name,
-        'plan continue {} {}'.format(config.DEFAULT_PLAN_NAME, config.DEFAULT_PHASE_NAME))
+                           'plan continue {} {}'.format(config.DEFAULT_PLAN_NAME, config.DEFAULT_PHASE_NAME))
 
 
 @pytest.mark.smoke
@@ -216,9 +216,9 @@ def test_pod_cli():
     foldered_name = sdk_utils.get_foldered_name(config.SERVICE_NAME)
     assert sdk_cmd.svc_cli(config.PACKAGE_NAME, foldered_name, 'pod list', json=True)
     assert sdk_cmd.svc_cli(config.PACKAGE_NAME, foldered_name,
-        'pod status --json {}-0'.format(config.DEFAULT_POD_TYPE), json=True)
+                           'pod status --json {}-0'.format(config.DEFAULT_POD_TYPE), json=True)
     assert sdk_cmd.svc_cli(config.PACKAGE_NAME, foldered_name,
-        'pod info {}-0'.format(config.DEFAULT_POD_TYPE), print_output=False)  # noisy output
+                           'pod info {}-0'.format(config.DEFAULT_POD_TYPE), print_output=False)  # noisy output
 
 
 @pytest.mark.sanity

--- a/frameworks/kafka/tests/test_ssl_kerberos_auth.py
+++ b/frameworks/kafka/tests/test_ssl_kerberos_auth.py
@@ -1,11 +1,9 @@
 import logging
-import uuid
 import pytest
 
 import sdk_auth
 import sdk_cmd
 import sdk_install
-import sdk_marathon
 import sdk_utils
 
 
@@ -13,8 +11,8 @@ from security import transport_encryption
 
 
 from tests import auth
+from tests import client
 from tests import config
-from tests import test_utils
 
 
 log = logging.getLogger(__name__)
@@ -74,7 +72,7 @@ def kafka_server(kerberos, service_account):
                         "hostname": kerberos.get_host(),
                         "port": int(kerberos.get_port())
                     },
-                    "realm": sdk_auth.REALM,
+                    "realm": kerberos.get_realm(),
                     "keytab_secret": kerberos.get_keytab_path(),
                 },
                 "transport_encryption": {
@@ -99,103 +97,44 @@ def kafka_server(kerberos, service_account):
 
 
 @pytest.fixture(scope='module', autouse=True)
-def kafka_client(kerberos, kafka_server):
-
-    brokers = sdk_cmd.svc_cli(
-        kafka_server["package_name"],
-        kafka_server["service"]["name"],
-        "endpoint broker-tls", json=True)["dns"]
-
+def kafka_client(kerberos):
     try:
-        client_id = "kafka-client"
-        client = {
-            "id": client_id,
-            "mem": 512,
-            "user": "nobody",
-            "container": {
-                "type": "MESOS",
-                "docker": {
-                    "image": "elezar/kafka-client:latest",
-                    "forcePullImage": True
-                },
-                "volumes": [
-                    {
-                        "containerPath": "/tmp/kafkaconfig/kafka-client.keytab",
-                        "secret": "kafka_keytab"
-                    }
-                ]
-            },
-            "secrets": {
-                "kafka_keytab": {
-                    "source": kerberos.get_keytab_path(),
+        kafka_client = client.KafkaClient("kafka-client")
+        kafka_client.install(kerberos)
 
-                }
-            },
-            "networks": [
-                {
-                    "mode": "host"
-                }
-            ],
-            "env": {
-                "JVM_MaxHeapSize": "512",
-                "KAFKA_CLIENT_MODE": "test",
-                "KAFKA_TOPIC": "securetest",
-                "KAFKA_BROKER_LIST": ",".join(brokers)
-            }
-        }
-
-        sdk_marathon.install_app(client)
+        # TODO: This flag should be set correctly.
+        kafka_client._is_tls = True
 
         transport_encryption.create_tls_artifacts(
             cn="client",
-            task=client_id)
+            task=kafka_client.get_id())
 
-        broker_hosts = list(map(lambda x: x.split(':')[0], brokers))
-        yield {**client, **{"brokers": broker_hosts}}
-
+        yield kafka_client
     finally:
-        sdk_marathon.destroy_app(client_id)
+        kafka_client.uninstall()
 
 
 @pytest.mark.dcos_min_version('1.10')
 @sdk_utils.dcos_ee_only
 @pytest.mark.sanity
-def test_client_can_read_and_write(kafka_client, kafka_server, kerberos):
-    client_id = kafka_client["id"]
+def test_client_can_read_and_write(kafka_client: client.KafkaClient, kafka_server, kerberos):
 
-    auth.wait_for_brokers(kafka_client["id"], kafka_client["brokers"])
-
-    topic_name = "authn.test"
+    topic_name = "tls.topic"
     sdk_cmd.svc_cli(kafka_server["package_name"], kafka_server["service"]["name"],
                     "topic create {}".format(topic_name),
                     json=True)
 
-    test_utils.wait_for_topic(kafka_server["package_name"], kafka_server["service"]["name"], topic_name)
+    kafka_client.connect(kafka_server)
 
-    message = str(uuid.uuid4())
+    user = "client"
+    write_success, read_successes, _ = kafka_client.can_write_and_read(user,
+                                                                       kafka_server,
+                                                                       topic_name,
+                                                                       kerberos)
 
-    assert write_to_topic("client", client_id, topic_name, message, kerberos)
-
-    assert message in read_from_topic("client", client_id, topic_name, 1, kerberos)
-
-
-def get_client_properties(cn: str) -> str:
-    client_properties_lines = []
-    client_properties_lines.extend(auth.get_kerberos_client_properties(ssl_enabled=True))
-    client_properties_lines.extend(auth.get_ssl_client_properties(cn, True))
-
-    return client_properties_lines
-
-
-def write_to_topic(cn: str, task: str, topic: str, message: str, krb5: object) -> bool:
-
-    return auth.write_to_topic(cn, task, topic, message,
-                               get_client_properties(cn),
-                               environment=auth.setup_krb5_env(cn, task, krb5))
-
-
-def read_from_topic(cn: str, task: str, topic: str, messages: int, krb5: object) -> str:
-
-    return auth.read_from_topic(cn, task, topic, messages,
-                                get_client_properties(cn),
-                                environment=auth.setup_krb5_env(cn, task, krb5))
+    assert write_success, "Write failed (user={})".format(user)
+    assert read_successes, "Read failed (user={}): " \
+                           "MESSAGES={} " \
+                           "read_successes={}".format(user,
+                                                      kafka_client.MESSAGES,
+                                                      read_successes)

--- a/frameworks/kafka/tests/test_ssl_kerberos_authz.py
+++ b/frameworks/kafka/tests/test_ssl_kerberos_authz.py
@@ -73,16 +73,16 @@ def setup_principals(kafka_client: client.KafkaClient):
 
     transport_encryption.create_tls_artifacts(
         cn="client",
-        marathon_task=client_id)
+        task=client_id)
     transport_encryption.create_tls_artifacts(
         cn="authorized",
-        marathon_task=client_id)
+        task=client_id)
     transport_encryption.create_tls_artifacts(
         cn="unauthorized",
-        marathon_task=client_id)
+        task=client_id)
     transport_encryption.create_tls_artifacts(
         cn="super",
-        marathon_task=client_id)
+        task=client_id)
 
 
 @pytest.mark.dcos_min_version('1.10')

--- a/frameworks/kafka/tests/test_ssl_kerberos_authz.py
+++ b/frameworks/kafka/tests/test_ssl_kerberos_authz.py
@@ -1,15 +1,18 @@
 import logging
 import pytest
 
+import sdk_auth
 import sdk_cmd
 import sdk_install
 import sdk_utils
 
+
 from security import transport_encryption
 
+
+from tests import auth
 from tests import client
 from tests import config
-from tests import auth
 
 
 log = logging.getLogger(__name__)
@@ -35,10 +38,26 @@ def service_account(configure_security):
 
 
 @pytest.fixture(scope='module', autouse=True)
-def kafka_client():
+def kerberos(configure_security):
+    try:
+        kerberos_env = sdk_auth.KerberosEnvironment()
+
+        principals = auth.get_service_principals(config.SERVICE_NAME,
+                                                 kerberos_env.get_realm())
+        kerberos_env.add_principals(principals)
+        kerberos_env.finalize()
+
+        yield kerberos_env
+
+    finally:
+        kerberos_env.cleanup()
+
+
+@pytest.fixture(scope='module', autouse=True)
+def kafka_client(kerberos):
     try:
         kafka_client = client.KafkaClient("kafka-client")
-        kafka_client.install()
+        kafka_client.install(kerberos)
 
         # TODO: This flag should be set correctly.
         kafka_client._is_tls = True
@@ -53,23 +72,23 @@ def setup_principals(kafka_client: client.KafkaClient):
     client_id = kafka_client.get_id()
 
     transport_encryption.create_tls_artifacts(
-        cn="kafka-tester",
-        task=client_id)
+        cn="client",
+        marathon_task=client_id)
     transport_encryption.create_tls_artifacts(
         cn="authorized",
-        task=client_id)
+        marathon_task=client_id)
     transport_encryption.create_tls_artifacts(
         cn="unauthorized",
-        task=client_id)
+        marathon_task=client_id)
     transport_encryption.create_tls_artifacts(
         cn="super",
-        task=client_id)
+        marathon_task=client_id)
 
 
 @pytest.mark.dcos_min_version('1.10')
-@pytest.mark.ee_only
+@sdk_utils.dcos_ee_only
 @pytest.mark.sanity
-def test_authn_client_can_read_and_write(kafka_client: client.KafkaClient, service_account, setup_principals):
+def test_authz_acls_required(kafka_client: client.KafkaClient, kerberos, service_account, setup_principals):
     try:
         sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
         service_options = {
@@ -78,64 +97,16 @@ def test_authn_client_can_read_and_write(kafka_client: client.KafkaClient, servi
                 "service_account": service_account["name"],
                 "service_account_secret": service_account["secret"],
                 "security": {
-                    "transport_encryption": {
-                        "enabled": True
+                    "kerberos": {
+                        "enabled": True,
+                        "kdc": {
+                            "hostname": kerberos.get_host(),
+                            "port": int(kerberos.get_port())
+                        },
+                        "realm": kerberos.get_realm(),
+                        "keytab_secret": kerberos.get_keytab_path(),
                     },
-                    "ssl_authentication": {
-                        "enabled": True
-                    }
-                }
-            }
-        }
-        config.install(
-            config.PACKAGE_NAME,
-            config.SERVICE_NAME,
-            config.DEFAULT_BROKER_COUNT,
-            additional_options=service_options)
-
-        kafka_server = {**service_options, **{"package_name": config.PACKAGE_NAME}}
-
-        topic_name = "tls.topic"
-        sdk_cmd.svc_cli(kafka_server["package_name"], kafka_server["service"]["name"],
-                        "topic create {}".format(topic_name),
-                        json=True)
-
-        kafka_client.connect(kafka_server)
-
-        user = "kafka-tester"
-        write_success, read_successes, _ = kafka_client.can_write_and_read(user,
-                                                                           kafka_server,
-                                                                           topic_name,
-                                                                           None)
-
-        assert write_success, "Write failed (user={})".format(user)
-        assert read_successes, "Read failed (user={}): " \
-                               "MESSAGES={} " \
-                               "read_successes={}".format(user,
-                                                          kafka_client.MESSAGES,
-                                                          read_successes)
-
-    finally:
-        sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
-
-
-@pytest.mark.dcos_min_version('1.10')
-@pytest.mark.ee_only
-@pytest.mark.sanity
-def test_authz_acls_required(kafka_client: client.KafkaClient, service_account, setup_principals):
-
-    try:
-        sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
-        service_options = {
-            "service": {
-                "name": config.SERVICE_NAME,
-                "service_account": service_account["name"],
-                "service_account_secret": service_account["secret"],
-                "security": {
                     "transport_encryption": {
-                        "enabled": True
-                    },
-                    "ssl_authentication": {
                         "enabled": True
                     },
                     "authorization": {
@@ -160,10 +131,13 @@ def test_authz_acls_required(kafka_client: client.KafkaClient, service_account, 
 
         kafka_client.connect(kafka_server)
 
+        # Clear the ACLs
+        kafka_client.remove_acls("authorized", kafka_server, topic_name)
+
         # Since no ACLs are specified, only the super user can read and write
         for user in ["super", ]:
             log.info("Checking write / read permissions for user=%s", user)
-            write_success, read_successes, _ = kafka_client.can_write_and_read(user, kafka_server, topic_name, None)
+            write_success, read_successes, _ = kafka_client.can_write_and_read(user, kafka_server, topic_name, kerberos)
             assert write_success, "Write failed (user={})".format(user)
             assert read_successes, "Read failed (user={}): " \
                                    "MESSAGES={} " \
@@ -173,7 +147,7 @@ def test_authz_acls_required(kafka_client: client.KafkaClient, service_account, 
 
         for user in ["authorized", "unauthorized", ]:
             log.info("Checking lack of write / read permissions for user=%s", user)
-            write_success, _, read_messages = kafka_client.can_write_and_read(user, kafka_server, topic_name, None)
+            write_success, _, read_messages = kafka_client.can_write_and_read(user, kafka_server, topic_name, kerberos)
             assert not write_success, "Write not expected to succeed (user={})".format(user)
             assert auth.is_not_authorized(read_messages), "Unauthorized expected (user={}".format(user)
 
@@ -183,7 +157,7 @@ def test_authz_acls_required(kafka_client: client.KafkaClient, service_account, 
         # After adding ACLs the authorized user and super user should still have access to the topic.
         for user in ["authorized", "super"]:
             log.info("Checking write / read permissions for user=%s", user)
-            write_success, read_successes, _ = kafka_client.can_write_and_read(user, kafka_server, topic_name, None)
+            write_success, read_successes, _ = kafka_client.can_write_and_read(user, kafka_server, topic_name, kerberos)
             assert write_success, "Write failed (user={})".format(user)
             assert read_successes, "Read failed (user={}): " \
                                    "MESSAGES={} " \
@@ -193,7 +167,7 @@ def test_authz_acls_required(kafka_client: client.KafkaClient, service_account, 
 
         for user in ["unauthorized", ]:
             log.info("Checking lack of write / read permissions for user=%s", user)
-            write_success, _, read_messages = kafka_client.can_write_and_read(user, kafka_server, topic_name, None)
+            write_success, _, read_messages = kafka_client.can_write_and_read(user, kafka_server, topic_name, kerberos)
             assert not write_success, "Write not expected to succeed (user={})".format(user)
             assert auth.is_not_authorized(read_messages), "Unauthorized expected (user={}".format(user)
 
@@ -204,8 +178,7 @@ def test_authz_acls_required(kafka_client: client.KafkaClient, service_account, 
 @pytest.mark.dcos_min_version('1.10')
 @pytest.mark.ee_only
 @pytest.mark.sanity
-def test_authz_acls_not_required(kafka_client, service_account, setup_principals):
-
+def test_authz_acls_not_required(kafka_client: client.KafkaClient, kerberos, service_account, setup_principals):
     try:
         sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
         service_options = {
@@ -214,10 +187,16 @@ def test_authz_acls_not_required(kafka_client, service_account, setup_principals
                 "service_account": service_account["name"],
                 "service_account_secret": service_account["secret"],
                 "security": {
-                    "transport_encryption": {
-                        "enabled": True
+                    "kerberos": {
+                        "enabled": True,
+                        "kdc": {
+                            "hostname": kerberos.get_host(),
+                            "port": int(kerberos.get_port())
+                        },
+                        "realm": kerberos.get_realm(),
+                        "keytab_secret": kerberos.get_keytab_path(),
                     },
-                    "ssl_authentication": {
+                    "transport_encryption": {
                         "enabled": True
                     },
                     "authorization": {
@@ -228,6 +207,7 @@ def test_authz_acls_not_required(kafka_client, service_account, setup_principals
                 }
             }
         }
+
         config.install(
             config.PACKAGE_NAME,
             config.SERVICE_NAME,
@@ -243,10 +223,13 @@ def test_authz_acls_not_required(kafka_client, service_account, setup_principals
 
         kafka_client.connect(kafka_server)
 
+        # Clear the ACLs
+        kafka_client.remove_acls("authorized", kafka_server, topic_name)
+
         # Since no ACLs are specified, all users can read and write.
         for user in ["authorized", "unauthorized", "super", ]:
             log.info("Checking write / read permissions for user=%s", user)
-            write_success, read_successes, _ = kafka_client.can_write_and_read(user, kafka_server, topic_name, None)
+            write_success, read_successes, _ = kafka_client.can_write_and_read(user, kafka_server, topic_name, kerberos)
             assert write_success, "Write failed (user={})".format(user)
             assert read_successes, "Read failed (user={}): " \
                                    "MESSAGES={} " \
@@ -260,7 +243,7 @@ def test_authz_acls_not_required(kafka_client, service_account, setup_principals
         # After adding ACLs the authorized user and super user should still have access to the topic.
         for user in ["authorized", "super", ]:
             log.info("Checking write / read permissions for user=%s", user)
-            write_success, read_successes, _ = kafka_client.can_write_and_read(user, kafka_server, topic_name, None)
+            write_success, read_successes, _ = kafka_client.can_write_and_read(user, kafka_server, topic_name, kerberos)
             assert write_success, "Write failed (user={})".format(user)
             assert read_successes, "Read failed (user={}): " \
                                    "MESSAGES={} " \
@@ -273,23 +256,9 @@ def test_authz_acls_not_required(kafka_client, service_account, setup_principals
             write_success, _, read_messages = kafka_client.can_write_and_read(user,
                                                                               kafka_server,
                                                                               topic_name,
-                                                                              None)
+                                                                              kerberos)
             assert not write_success, "Write not expected to succeed (user={})".format(user)
             assert auth.is_not_authorized(read_messages), "Unauthorized expected (user={}".format(user)
 
     finally:
         sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
-
-
-def write_to_topic(cn: str, task: str, topic: str, message: str) -> bool:
-
-    return auth.write_to_topic(cn, task, topic, message,
-                               auth.get_ssl_client_properties(cn, False),
-                               environment=None)
-
-
-def read_from_topic(cn: str, task: str, topic: str, messages: int) -> str:
-
-    return auth.read_from_topic(cn, task, topic, messages,
-                                auth.get_ssl_client_properties(cn, False),
-                                environment=None)

--- a/frameworks/kafka/tests/test_ssl_kerberos_custom_domain_auth.py
+++ b/frameworks/kafka/tests/test_ssl_kerberos_custom_domain_auth.py
@@ -1,21 +1,17 @@
 import logging
-import uuid
 import pytest
 
 import sdk_auth
 import sdk_cmd
 import sdk_hosts
 import sdk_install
-import sdk_marathon
 import sdk_utils
-
 
 from security import transport_encryption
 
-
 from tests import auth
+from tests import client
 from tests import config
-from tests import test_utils
 
 
 log = logging.getLogger(__name__)
@@ -77,7 +73,7 @@ def kafka_server(kerberos, service_account):
                         "hostname": kerberos.get_host(),
                         "port": int(kerberos.get_port())
                     },
-                    "realm": sdk_auth.REALM,
+                    "realm": kerberos.get_realm(),
                     "keytab_secret": kerberos.get_keytab_path(),
                 },
                 "transport_encryption": {
@@ -102,103 +98,44 @@ def kafka_server(kerberos, service_account):
 
 
 @pytest.fixture(scope='module', autouse=True)
-def kafka_client(kerberos, kafka_server):
-
-    brokers = sdk_cmd.svc_cli(
-        kafka_server["package_name"],
-        kafka_server["service"]["name"],
-        "endpoint broker-tls", json=True)["dns"]
-
+def kafka_client(kerberos):
     try:
-        client_id = "kafka-client"
-        client = {
-            "id": client_id,
-            "mem": 512,
-            "user": "nobody",
-            "container": {
-                "type": "MESOS",
-                "docker": {
-                    "image": "elezar/kafka-client:latest",
-                    "forcePullImage": True
-                },
-                "volumes": [
-                    {
-                        "containerPath": "/tmp/kafkaconfig/kafka-client.keytab",
-                        "secret": "kafka_keytab"
-                    }
-                ]
-            },
-            "secrets": {
-                "kafka_keytab": {
-                    "source": kerberos.get_keytab_path(),
+        kafka_client = client.KafkaClient("kafka-client")
+        kafka_client.install(kerberos)
 
-                }
-            },
-            "networks": [
-                {
-                    "mode": "host"
-                }
-            ],
-            "env": {
-                "JVM_MaxHeapSize": "512",
-                "KAFKA_CLIENT_MODE": "test",
-                "KAFKA_TOPIC": "securetest",
-                "KAFKA_BROKER_LIST": ",".join(brokers)
-            }
-        }
-
-        sdk_marathon.install_app(client)
+        # TODO: This flag should be set correctly.
+        kafka_client._is_tls = True
 
         transport_encryption.create_tls_artifacts(
             cn="client",
-            task=client_id)
+            task=kafka_client.get_id())
 
-        broker_hosts = list(map(lambda x: x.split(':')[0], brokers))
-        yield {**client, **{"brokers": broker_hosts}}
-
+        yield kafka_client
     finally:
-        sdk_marathon.destroy_app(client_id)
+        kafka_client.uninstall()
 
 
 @pytest.mark.dcos_min_version('1.10')
 @sdk_utils.dcos_ee_only
 @pytest.mark.sanity
-def test_client_can_read_and_write(kafka_client, kafka_server, kerberos):
-    client_id = kafka_client["id"]
-
-    auth.wait_for_brokers(kafka_client["id"], kafka_client["brokers"])
+def test_client_can_read_and_write(kafka_client: client.KafkaClient, kafka_server, kerberos):
 
     topic_name = "authn.test"
     sdk_cmd.svc_cli(kafka_server["package_name"], kafka_server["service"]["name"],
                     "topic create {}".format(topic_name),
                     json=True)
 
-    test_utils.wait_for_topic(kafka_server["package_name"], kafka_server["service"]["name"], topic_name)
+    kafka_client.connect(kafka_server)
 
-    message = str(uuid.uuid4())
+    user = "client"
+    write_success, read_successes, _ = kafka_client.can_write_and_read(user,
+                                                                       kafka_server,
+                                                                       topic_name,
+                                                                       kerberos)
 
-    assert write_to_topic("client", client_id, topic_name, message, kerberos)
-
-    assert message in read_from_topic("client", client_id, topic_name, 1, kerberos)
-
-
-def get_client_properties(cn: str) -> str:
-    client_properties_lines = []
-    client_properties_lines.extend(auth.get_kerberos_client_properties(ssl_enabled=True))
-    client_properties_lines.extend(auth.get_ssl_client_properties(cn, True))
-
-    return client_properties_lines
-
-
-def write_to_topic(cn: str, task: str, topic: str, message: str, krb5: object) -> bool:
-
-    return auth.write_to_topic(cn, task, topic, message,
-                               get_client_properties(cn),
-                               environment=auth.setup_krb5_env(cn, task, krb5))
-
-
-def read_from_topic(cn: str, task: str, topic: str, messages: int, krb5: object) -> str:
-
-    return auth.read_from_topic(cn, task, topic, messages,
-                                get_client_properties(cn),
-                                environment=auth.setup_krb5_env(cn, task, krb5))
+    assert write_success, "Write failed (user={})".format(user)
+    assert read_successes, "Read failed (user={}): " \
+                           "MESSAGES={} " \
+                           "read_successes={}".format(user,
+                                                      kafka_client.MESSAGES,
+                                                      read_successes)

--- a/frameworks/kafka/tests/test_toggle_security.py
+++ b/frameworks/kafka/tests/test_toggle_security.py
@@ -115,7 +115,7 @@ def kafka_client(kerberos):
             "container": {
                 "type": "MESOS",
                 "docker": {
-                    "image": "elezar/kafka-client:latest",
+                    "image": "elezar/kafka-client:4b9c060",
                     "forcePullImage": True
                 },
                 "volumes": [

--- a/frameworks/kafka/tests/test_topics.py
+++ b/frameworks/kafka/tests/test_topics.py
@@ -61,7 +61,6 @@ def test_topic_partition_count(kafka_server: dict):
     assert len(topic_info['partitions']) == config.DEFAULT_PARTITION_COUNT
 
 
-
 @pytest.mark.sanity
 def test_topic_offsets_increase_with_writes(kafka_server: dict):
     package_name = kafka_server["package_name"]

--- a/frameworks/kafka/tests/test_utils.py
+++ b/frameworks/kafka/tests/test_utils.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import retrying
 

--- a/frameworks/kafka/tests/test_zookeeper_auth.py
+++ b/frameworks/kafka/tests/test_zookeeper_auth.py
@@ -2,22 +2,20 @@
 This module tests the interaction of Kafka with Zookeeper with authentication enabled
 """
 import logging
-import uuid
 import pytest
 
 import sdk_auth
 import sdk_cmd
 import sdk_hosts
 import sdk_install
-import sdk_marathon
 import sdk_security
 import sdk_utils
 
 from security import kerberos as krb5
 
 from tests import auth
+from tests import client
 from tests import config
-from tests import test_utils
 
 
 log = logging.getLogger(__name__)
@@ -58,7 +56,7 @@ def kerberos(configure_security):
 
 @pytest.fixture(scope='module')
 def zookeeper_server(kerberos):
-    service_kerberos_options = {
+    service_options = {
         "service": {
             "name": config.ZOOKEEPER_SERVICE_NAME,
             "security": {
@@ -68,7 +66,7 @@ def zookeeper_server(kerberos):
                         "hostname": kerberos.get_host(),
                         "port": int(kerberos.get_port())
                     },
-                    "realm": sdk_auth.REALM,
+                    "realm": kerberos.get_realm(),
                     "keytab_secret": kerberos.get_keytab_path(),
                 }
             }
@@ -79,12 +77,12 @@ def zookeeper_server(kerberos):
     zk_secret = "kakfa-zookeeper-secret"
 
     if sdk_utils.is_strict_mode():
-        service_kerberos_options = sdk_install.merge_dictionaries({
+        service_options = sdk_install.merge_dictionaries({
             'service': {
                 'service_account': zk_account,
                 'service_account_secret': zk_secret,
             }
-        }, service_kerberos_options)
+        }, service_options)
 
     try:
         sdk_install.uninstall(config.ZOOKEEPER_PACKAGE_NAME, config.ZOOKEEPER_SERVICE_NAME)
@@ -93,11 +91,11 @@ def zookeeper_server(kerberos):
             config.ZOOKEEPER_PACKAGE_NAME,
             config.ZOOKEEPER_SERVICE_NAME,
             config.ZOOKEEPER_TASK_COUNT,
-            additional_options=service_kerberos_options,
+            additional_options=service_options,
             timeout_seconds=30 * 60,
             insert_strict_options=False)
 
-        yield {**service_kerberos_options, **{"package_name": config.ZOOKEEPER_PACKAGE_NAME}}
+        yield {**service_options, **{"package_name": config.ZOOKEEPER_PACKAGE_NAME}}
 
     finally:
         sdk_install.uninstall(config.ZOOKEEPER_PACKAGE_NAME, config.ZOOKEEPER_SERVICE_NAME)
@@ -111,7 +109,7 @@ def kafka_server(kerberos, zookeeper_server):
                                     zookeeper_server["service"]["name"],
                                     "endpoint clientport", json=True)["dns"]
 
-    service_kerberos_options = {
+    service_options = {
         "service": {
             "name": config.SERVICE_NAME,
             "security": {
@@ -122,7 +120,7 @@ def kafka_server(kerberos, zookeeper_server):
                         "hostname": kerberos.get_host(),
                         "port": int(kerberos.get_port())
                     },
-                    "realm": sdk_auth.REALM,
+                    "realm": kerberos.get_realm(),
                     "keytab_secret": kerberos.get_keytab_path(),
                 }
             }
@@ -138,98 +136,43 @@ def kafka_server(kerberos, zookeeper_server):
             config.PACKAGE_NAME,
             config.SERVICE_NAME,
             config.DEFAULT_BROKER_COUNT,
-            additional_options=service_kerberos_options,
+            additional_options=service_options,
             timeout_seconds=30 * 60)
 
-        yield {**service_kerberos_options, **{"package_name": config.PACKAGE_NAME}}
+        yield {**service_options, **{"package_name": config.PACKAGE_NAME}}
     finally:
         sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
 
 
 @pytest.fixture(scope='module', autouse=True)
-def kafka_client(kerberos, kafka_server):
-
-    brokers = sdk_cmd.svc_cli(
-        kafka_server["package_name"],
-        kafka_server["service"]["name"],
-        "endpoint broker", json=True)["dns"]
-
+def kafka_client(kerberos):
     try:
-        client_id = "kafka-client"
-        client = {
-            "id": client_id,
-            "mem": 512,
-            "container": {
-                "type": "MESOS",
-                "docker": {
-                    "image": "elezar/kafka-client:latest",
-                    "forcePullImage": True
-                },
-                "volumes": [
-                    {
-                        "containerPath": "/tmp/kafkaconfig/kafka-client.keytab",
-                        "secret": "kafka_keytab"
-                    }
-                ]
-            },
-            "secrets": {
-                "kafka_keytab": {
-                    "source": kerberos.get_keytab_path(),
+        kafka_client = client.KafkaClient("kafka-client")
+        kafka_client.install(kerberos)
 
-                }
-            },
-            "networks": [
-                {
-                    "mode": "host"
-                }
-            ],
-            "env": {
-                "JVM_MaxHeapSize": "512",
-                "KAFKA_CLIENT_MODE": "test",
-                "KAFKA_TOPIC": "securetest",
-                "KAFKA_BROKER_LIST": ",".join(brokers)
-            }
-        }
-
-        sdk_marathon.install_app(client)
-        yield {**client, **{"brokers": list(map(lambda x: x.split(':')[0], brokers))}}
-
+        yield kafka_client
     finally:
-        sdk_marathon.destroy_app(client_id)
+        kafka_client.uninstall()
 
 
 @pytest.mark.dcos_min_version('1.10')
 @sdk_utils.dcos_ee_only
 @pytest.mark.zookeeper
 @pytest.mark.sanity
-def test_client_can_read_and_write(kafka_client, kafka_server, kerberos):
-    client_id = kafka_client["id"]
-
-    auth.wait_for_brokers(kafka_client["id"], kafka_client["brokers"])
+def test_client_can_read_and_write(kafka_client: client.KafkaClient, kafka_server, kerberos):
 
     topic_name = "authn.test"
     sdk_cmd.svc_cli(kafka_server["package_name"], kafka_server["service"]["name"],
                     "topic create {}".format(topic_name),
                     json=True)
 
-    test_utils.wait_for_topic(kafka_server["package_name"], kafka_server["service"]["name"], topic_name)
+    kafka_client.connect(kafka_server)
 
-    message = str(uuid.uuid4())
-
-    assert write_to_topic("client", client_id, topic_name, message, kerberos)
-
-    assert message in read_from_topic("client", client_id, topic_name, 1, kerberos)
-
-
-def write_to_topic(cn: str, task: str, topic: str, message: str, krb5: object) -> bool:
-
-    return auth.write_to_topic(cn, task, topic, message,
-                               auth.get_kerberos_client_properties(ssl_enabled=False),
-                               auth.setup_krb5_env(cn, task, krb5))
-
-
-def read_from_topic(cn: str, task: str, topic: str, message: str, krb5: object) -> str:
-
-    return auth.read_from_topic(cn, task, topic, message,
-                                auth.get_kerberos_client_properties(ssl_enabled=False),
-                                auth.setup_krb5_env(cn, task, krb5))
+    user = "client"
+    write_success, read_successes, _ = kafka_client.can_write_and_read(user, kafka_server, topic_name, kerberos)
+    assert write_success, "Write failed (user={})".format(user)
+    assert read_successes, "Read failed (user={}): " \
+                           "MESSAGES={} " \
+                           "read_successes={}".format(user,
+                                                      kafka_client.MESSAGES,
+                                                      read_successes)

--- a/frameworks/kafka/tests/test_zookeeper_authz.py
+++ b/frameworks/kafka/tests/test_zookeeper_authz.py
@@ -1,148 +1,149 @@
+"""
+This module tests the interaction of Kafka with Zookeeper with authorization enabled
+"""
 import logging
 import pytest
 
+import sdk_auth
 import sdk_cmd
+import sdk_hosts
 import sdk_install
+import sdk_security
 import sdk_utils
 
-from security import transport_encryption
+from security import kerberos as krb5
 
+from tests import auth
 from tests import client
 from tests import config
-from tests import auth
 
 
 log = logging.getLogger(__name__)
 
 
-pytestmark = pytest.mark.skipif(sdk_utils.is_open_dcos(),
-                                reason='Feature only supported in DC/OS EE')
+def get_zookeeper_principals(service_name: str, realm: str) -> list:
+    primaries = ["zookeeper", ]
+
+    tasks = [
+        "zookeeper-0-server",
+        "zookeeper-1-server",
+        "zookeeper-2-server",
+    ]
+    instances = map(lambda task: sdk_hosts.autoip_host(service_name, task), tasks)
+
+    principals = krb5.generate_principal_list(primaries, instances, realm)
+    return principals
 
 
 @pytest.fixture(scope='module', autouse=True)
-def service_account(configure_security):
-    """
-    Sets up a service account for use with TLS.
-    """
+def kerberos(configure_security):
     try:
-        name = config.SERVICE_NAME
-        service_account_info = transport_encryption.setup_service_account(name)
+        kerberos_env = sdk_auth.KerberosEnvironment()
 
-        yield service_account_info
+        principals = auth.get_service_principals(config.SERVICE_NAME,
+                                                 kerberos_env.get_realm())
+        principals.extend(get_zookeeper_principals(config.ZOOKEEPER_SERVICE_NAME,
+                                                   kerberos_env.get_realm()))
+
+        kerberos_env.add_principals(principals)
+        kerberos_env.finalize()
+
+        yield kerberos_env
+
     finally:
-        transport_encryption.cleanup_service_account(config.SERVICE_NAME,
-                                                     service_account_info)
+        kerberos_env.cleanup()
+
+
+@pytest.fixture(scope='module')
+def zookeeper_server(kerberos):
+    service_options = {
+        "service": {
+            "name": config.ZOOKEEPER_SERVICE_NAME,
+            "security": {
+                "kerberos": {
+                    "enabled": True,
+                    "kdc": {
+                        "hostname": kerberos.get_host(),
+                        "port": int(kerberos.get_port())
+                    },
+                    "realm": kerberos.get_realm(),
+                    "keytab_secret": kerberos.get_keytab_path(),
+                }
+            }
+        }
+    }
+
+    zk_account = "kafka-zookeeper-service-account"
+    zk_secret = "kakfa-zookeeper-secret"
+
+    if sdk_utils.is_strict_mode():
+        service_options = sdk_install.merge_dictionaries({
+            'service': {
+                'service_account': zk_account,
+                'service_account_secret': zk_secret,
+            }
+        }, service_options)
+
+    try:
+        sdk_install.uninstall(config.ZOOKEEPER_PACKAGE_NAME, config.ZOOKEEPER_SERVICE_NAME)
+        sdk_security.setup_security(config.ZOOKEEPER_SERVICE_NAME, zk_account, zk_secret)
+        sdk_install.install(
+            config.ZOOKEEPER_PACKAGE_NAME,
+            config.ZOOKEEPER_SERVICE_NAME,
+            config.ZOOKEEPER_TASK_COUNT,
+            additional_options=service_options,
+            timeout_seconds=30 * 60,
+            insert_strict_options=False)
+
+        yield {**service_options, **{"package_name": config.ZOOKEEPER_PACKAGE_NAME}}
+
+    finally:
+        sdk_install.uninstall(config.ZOOKEEPER_PACKAGE_NAME, config.ZOOKEEPER_SERVICE_NAME)
 
 
 @pytest.fixture(scope='module', autouse=True)
-def kafka_client():
+def kafka_client(kerberos):
     try:
         kafka_client = client.KafkaClient("kafka-client")
-        kafka_client.install()
-
-        # TODO: This flag should be set correctly.
-        kafka_client._is_tls = True
+        kafka_client.install(kerberos)
 
         yield kafka_client
     finally:
         kafka_client.uninstall()
 
 
-@pytest.fixture(scope='module', autouse=True)
-def setup_principals(kafka_client: client.KafkaClient):
-    client_id = kafka_client.get_id()
-
-    transport_encryption.create_tls_artifacts(
-        cn="kafka-tester",
-        task=client_id)
-    transport_encryption.create_tls_artifacts(
-        cn="authorized",
-        task=client_id)
-    transport_encryption.create_tls_artifacts(
-        cn="unauthorized",
-        task=client_id)
-    transport_encryption.create_tls_artifacts(
-        cn="super",
-        task=client_id)
-
-
 @pytest.mark.dcos_min_version('1.10')
-@pytest.mark.ee_only
+@sdk_utils.dcos_ee_only
 @pytest.mark.sanity
-def test_authn_client_can_read_and_write(kafka_client: client.KafkaClient, service_account, setup_principals):
+def test_authz_acls_required(kafka_client: client.KafkaClient, zookeeper_server, kerberos):
     try:
+        zookeeper_dns = sdk_cmd.svc_cli(zookeeper_server["package_name"],
+                                        zookeeper_server["service"]["name"],
+                                        "endpoint clientport", json=True)["dns"]
+
         sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
         service_options = {
             "service": {
                 "name": config.SERVICE_NAME,
-                "service_account": service_account["name"],
-                "service_account_secret": service_account["secret"],
                 "security": {
-                    "transport_encryption": {
-                        "enabled": True
-                    },
-                    "ssl_authentication": {
-                        "enabled": True
-                    }
-                }
-            }
-        }
-        config.install(
-            config.PACKAGE_NAME,
-            config.SERVICE_NAME,
-            config.DEFAULT_BROKER_COUNT,
-            additional_options=service_options)
-
-        kafka_server = {**service_options, **{"package_name": config.PACKAGE_NAME}}
-
-        topic_name = "tls.topic"
-        sdk_cmd.svc_cli(kafka_server["package_name"], kafka_server["service"]["name"],
-                        "topic create {}".format(topic_name),
-                        json=True)
-
-        kafka_client.connect(kafka_server)
-
-        user = "kafka-tester"
-        write_success, read_successes, _ = kafka_client.can_write_and_read(user,
-                                                                           kafka_server,
-                                                                           topic_name,
-                                                                           None)
-
-        assert write_success, "Write failed (user={})".format(user)
-        assert read_successes, "Read failed (user={}): " \
-                               "MESSAGES={} " \
-                               "read_successes={}".format(user,
-                                                          kafka_client.MESSAGES,
-                                                          read_successes)
-
-    finally:
-        sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
-
-
-@pytest.mark.dcos_min_version('1.10')
-@pytest.mark.ee_only
-@pytest.mark.sanity
-def test_authz_acls_required(kafka_client: client.KafkaClient, service_account, setup_principals):
-
-    try:
-        sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
-        service_options = {
-            "service": {
-                "name": config.SERVICE_NAME,
-                "service_account": service_account["name"],
-                "service_account_secret": service_account["secret"],
-                "security": {
-                    "transport_encryption": {
-                        "enabled": True
-                    },
-                    "ssl_authentication": {
-                        "enabled": True
+                    "kerberos": {
+                        "enabled": True,
+                        "enabled_for_zookeeper": True,
+                        "kdc": {
+                            "hostname": kerberos.get_host(),
+                            "port": int(kerberos.get_port())
+                        },
+                        "realm": kerberos.get_realm(),
+                        "keytab_secret": kerberos.get_keytab_path(),
                     },
                     "authorization": {
                         "enabled": True,
                         "super_users": "User:{}".format("super")
                     }
                 }
+            },
+            "kafka": {
+                "kafka_zookeeper_uri": ",".join(zookeeper_dns)
             }
         }
         config.install(
@@ -160,10 +161,13 @@ def test_authz_acls_required(kafka_client: client.KafkaClient, service_account, 
 
         kafka_client.connect(kafka_server)
 
+        # Clear the ACLs
+        kafka_client.remove_acls("authorized", kafka_server, topic_name)
+
         # Since no ACLs are specified, only the super user can read and write
         for user in ["super", ]:
             log.info("Checking write / read permissions for user=%s", user)
-            write_success, read_successes, _ = kafka_client.can_write_and_read(user, kafka_server, topic_name, None)
+            write_success, read_successes, _ = kafka_client.can_write_and_read(user, kafka_server, topic_name, kerberos)
             assert write_success, "Write failed (user={})".format(user)
             assert read_successes, "Read failed (user={}): " \
                                    "MESSAGES={} " \
@@ -173,7 +177,7 @@ def test_authz_acls_required(kafka_client: client.KafkaClient, service_account, 
 
         for user in ["authorized", "unauthorized", ]:
             log.info("Checking lack of write / read permissions for user=%s", user)
-            write_success, _, read_messages = kafka_client.can_write_and_read(user, kafka_server, topic_name, None)
+            write_success, _, read_messages = kafka_client.can_write_and_read(user, kafka_server, topic_name, kerberos)
             assert not write_success, "Write not expected to succeed (user={})".format(user)
             assert auth.is_not_authorized(read_messages), "Unauthorized expected (user={}".format(user)
 
@@ -183,7 +187,7 @@ def test_authz_acls_required(kafka_client: client.KafkaClient, service_account, 
         # After adding ACLs the authorized user and super user should still have access to the topic.
         for user in ["authorized", "super"]:
             log.info("Checking write / read permissions for user=%s", user)
-            write_success, read_successes, _ = kafka_client.can_write_and_read(user, kafka_server, topic_name, None)
+            write_success, read_successes, _ = kafka_client.can_write_and_read(user, kafka_server, topic_name, kerberos)
             assert write_success, "Write failed (user={})".format(user)
             assert read_successes, "Read failed (user={}): " \
                                    "MESSAGES={} " \
@@ -193,7 +197,7 @@ def test_authz_acls_required(kafka_client: client.KafkaClient, service_account, 
 
         for user in ["unauthorized", ]:
             log.info("Checking lack of write / read permissions for user=%s", user)
-            write_success, _, read_messages = kafka_client.can_write_and_read(user, kafka_server, topic_name, None)
+            write_success, _, read_messages = kafka_client.can_write_and_read(user, kafka_server, topic_name, kerberos)
             assert not write_success, "Write not expected to succeed (user={})".format(user)
             assert auth.is_not_authorized(read_messages), "Unauthorized expected (user={}".format(user)
 
@@ -204,21 +208,26 @@ def test_authz_acls_required(kafka_client: client.KafkaClient, service_account, 
 @pytest.mark.dcos_min_version('1.10')
 @pytest.mark.ee_only
 @pytest.mark.sanity
-def test_authz_acls_not_required(kafka_client, service_account, setup_principals):
-
+def test_authz_acls_not_required(kafka_client: client.KafkaClient, zookeeper_server, kerberos):
     try:
+        zookeeper_dns = sdk_cmd.svc_cli(zookeeper_server["package_name"],
+                                        zookeeper_server["service"]["name"],
+                                        "endpoint clientport", json=True)["dns"]
+
         sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
         service_options = {
             "service": {
                 "name": config.SERVICE_NAME,
-                "service_account": service_account["name"],
-                "service_account_secret": service_account["secret"],
                 "security": {
-                    "transport_encryption": {
-                        "enabled": True
-                    },
-                    "ssl_authentication": {
-                        "enabled": True
+                    "kerberos": {
+                        "enabled": True,
+                        "enabled_for_zookeeper": True,
+                        "kdc": {
+                            "hostname": kerberos.get_host(),
+                            "port": int(kerberos.get_port())
+                        },
+                        "realm": kerberos.get_realm(),
+                        "keytab_secret": kerberos.get_keytab_path(),
                     },
                     "authorization": {
                         "enabled": True,
@@ -226,8 +235,12 @@ def test_authz_acls_not_required(kafka_client, service_account, setup_principals
                         "allow_everyone_if_no_acl_found": True
                     }
                 }
+            },
+            "kafka": {
+                "kafka_zookeeper_uri": ",".join(zookeeper_dns)
             }
         }
+
         config.install(
             config.PACKAGE_NAME,
             config.SERVICE_NAME,
@@ -243,10 +256,13 @@ def test_authz_acls_not_required(kafka_client, service_account, setup_principals
 
         kafka_client.connect(kafka_server)
 
+        # Clear the ACLs
+        kafka_client.remove_acls("authorized", kafka_server, topic_name)
+
         # Since no ACLs are specified, all users can read and write.
         for user in ["authorized", "unauthorized", "super", ]:
             log.info("Checking write / read permissions for user=%s", user)
-            write_success, read_successes, _ = kafka_client.can_write_and_read(user, kafka_server, topic_name, None)
+            write_success, read_successes, _ = kafka_client.can_write_and_read(user, kafka_server, topic_name, kerberos)
             assert write_success, "Write failed (user={})".format(user)
             assert read_successes, "Read failed (user={}): " \
                                    "MESSAGES={} " \
@@ -260,7 +276,7 @@ def test_authz_acls_not_required(kafka_client, service_account, setup_principals
         # After adding ACLs the authorized user and super user should still have access to the topic.
         for user in ["authorized", "super", ]:
             log.info("Checking write / read permissions for user=%s", user)
-            write_success, read_successes, _ = kafka_client.can_write_and_read(user, kafka_server, topic_name, None)
+            write_success, read_successes, _ = kafka_client.can_write_and_read(user, kafka_server, topic_name, kerberos)
             assert write_success, "Write failed (user={})".format(user)
             assert read_successes, "Read failed (user={}): " \
                                    "MESSAGES={} " \
@@ -273,23 +289,9 @@ def test_authz_acls_not_required(kafka_client, service_account, setup_principals
             write_success, _, read_messages = kafka_client.can_write_and_read(user,
                                                                               kafka_server,
                                                                               topic_name,
-                                                                              None)
+                                                                              kerberos)
             assert not write_success, "Write not expected to succeed (user={})".format(user)
             assert auth.is_not_authorized(read_messages), "Unauthorized expected (user={}".format(user)
 
     finally:
         sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
-
-
-def write_to_topic(cn: str, task: str, topic: str, message: str) -> bool:
-
-    return auth.write_to_topic(cn, task, topic, message,
-                               auth.get_ssl_client_properties(cn, False),
-                               environment=None)
-
-
-def read_from_topic(cn: str, task: str, topic: str, messages: int) -> str:
-
-    return auth.read_from_topic(cn, task, topic, messages,
-                                auth.get_ssl_client_properties(cn, False),
-                                environment=None)

--- a/frameworks/kafka/tests/topics.py
+++ b/frameworks/kafka/tests/topics.py
@@ -2,33 +2,58 @@ import logging
 
 import sdk_cmd
 
+from tests import auth
 
 LOG = logging.getLogger(__name__)
 
 
-def add_acls(user: str, task: str, topic: str, zookeeper_endpoint: str, env_str=None):
+def add_acls(user: str, marathon_task: str, topic: str, zookeeper_endpoint: str, env_str=None):
     """
-    Add Porducer and Consumer ACLs for the specifed user and topic
+    Add Producer and Consumer ACLs for the specifed user and topic
     """
 
-    _add_role_acls("producer", user, task, topic, zookeeper_endpoint, env_str)
-    _add_role_acls("consumer --group=*", user, task, topic, zookeeper_endpoint, env_str)
+    _add_role_acls(["--producer", ], user, marathon_task, topic, zookeeper_endpoint, env_str)
+    _add_role_acls(["--consumer", "--group=*"], user, marathon_task, topic, zookeeper_endpoint, env_str)
 
 
-def _add_role_acls(role: str, user: str, task: str, topic: str, zookeeper_endpoint: str, env_str=None):
-    cmd = "bash -c \"{setup_env}kafka-acls \
-        --topic {topic_name} \
-        --authorizer-properties zookeeper.connect={zookeeper_endpoint} \
-        --add \
-        --allow-principal User:{user} \
-        --{role}\"".format(setup_env="{}  && ".format(env_str) if env_str else "",
-                                                     topic_name=topic,
-                                                     zookeeper_endpoint=zookeeper_endpoint,
-                                                     user=user,
-                                                     role=role)
+def remove_acls(user: str, marathon_task: str, topic: str, zookeeper_endpoint: str, env_str=None):
+    """
+    Remove Producer and Consumer ACLs for the specifed user and topic
+    """
+    _remove_role_acls(["--producer", ], user, marathon_task, topic, zookeeper_endpoint, env_str)
+    _remove_role_acls(["--consumer", "--group=*"], user, marathon_task, topic, zookeeper_endpoint, env_str)
+
+
+def _modify_role_acls(action: str, roles: list, user: str, marathon_task: str, topic: str,
+                      zookeeper_endpoint: str, env_str: str=None) -> tuple:
+
+    if not action.startswith("--"):
+        action = "--{}".format(action)
+
+    cmd_list = ["kafka-acls",
+                "--topic", topic,
+                "--authorizer-properties", "zookeeper.connect={}".format(zookeeper_endpoint),
+                action, "--force",
+                "--allow-principal", "User:{}".format(user), ]
+    cmd_list.extend(roles)
+
+    cmd = auth.get_bash_command(" ".join(cmd_list), env_str)
+
     LOG.info("Running: %s", cmd)
-    output = sdk_cmd.task_exec(task, cmd)
+    output = sdk_cmd.task_exec(marathon_task, cmd)
     LOG.info(output)
+
+    return output
+
+
+def _add_role_acls(roles: list, user: str, marathon_task: str, topic: str,
+                   zookeeper_endpoint: str, env_str: str=None) -> tuple:
+    return _modify_role_acls("add", roles, user, marathon_task, topic, zookeeper_endpoint, env_str)
+
+
+def _remove_role_acls(roles: list, user: str, marathon_task: str, topic: str,
+                      zookeeper_endpoint: str, env_str: str=None) -> tuple:
+    return _modify_role_acls("remove", roles, user, marathon_task, topic, zookeeper_endpoint, env_str)
 
 
 def filter_empty_offsets(offsets: list, additional: list=[]) -> list:


### PR DESCRIPTION
Backport of #2419 

* RELEASE_NOTES: INFINITY-3425: Fix a bug where Kafka authz was using SSL principals instead of Kerberos principals as documented when both transport encryption and Kerberos were enabled.

* Address flake8 issues.

* Refactor acls script to use get_bash_command.

* Add a KafkaClient class for testing and use this in an authz test.

* Use KafkaClient for existing authz test.

* Add connect method that resets client state.

* Use the client for the ssl authz tests.

* Switch ZK auth tests to KafkaClient.

* Call kerberos.get_realm() instead of accessing sdk_auth.REALM directly.

* Use KafkaClient in test_kerberos_auth.

* Add function to remove acls and apply `--force` to skip prompt

* Add Kafka authz test using Zookeeper.

* Minor code formatting

* Use KafkaClient in ssl-kerberos tests

* Add ssl-kerberos Authz tests

* Properly supply TLS options

* Only use principal builder if Kerberos is NOT enabled

* Use versioned Kafka client.

* Use KafkaClient in custom_domain test.