### PR TITLE
INFINITY-3406 Break out Framework vs Scheduler config handling

### DIFF
--- a/frameworks/cassandra/src/main/java/com/mesosphere/sdk/cassandra/scheduler/Main.java
+++ b/frameworks/cassandra/src/main/java/com/mesosphere/sdk/cassandra/scheduler/Main.java
@@ -29,9 +29,7 @@ public class Main {
     }
 
     private static SchedulerBuilder createSchedulerBuilder(File yamlSpecFile) throws Exception {
-        Map<String, String> env = new HashMap<>(System.getenv());
-        env.put("ALLOW_REGION_AWARENESS", "true");
-        SchedulerConfig schedulerConfig = SchedulerConfig.fromMap(env);
+        SchedulerConfig schedulerConfig = SchedulerConfig.fromEnv();
         RawServiceSpec rawServiceSpec = RawServiceSpec.newBuilder(yamlSpecFile).build();
         List<String> localSeeds = CassandraSeedUtils.getLocalSeeds(rawServiceSpec.getName(), schedulerConfig);
 

--- a/frameworks/elastic/src/main/java/com/mesosphere/sdk/elastic/scheduler/Main.java
+++ b/frameworks/elastic/src/main/java/com/mesosphere/sdk/elastic/scheduler/Main.java
@@ -8,8 +8,6 @@ import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Base64;
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * Main entry point for the Scheduler.
@@ -28,15 +26,11 @@ public class Main {
 
     private static SchedulerBuilder createSchedulerBuilder(File yamlSpecFile) throws Exception {
         RawServiceSpec rawServiceSpec = RawServiceSpec.newBuilder(yamlSpecFile).build();
-
-        Map<String, String> env = new HashMap<>(System.getenv());
-        env.put("ALLOW_REGION_AWARENESS", "true");
-        SchedulerConfig schedulerConfig = SchedulerConfig.fromMap(env);
+        SchedulerConfig schedulerConfig = SchedulerConfig.fromEnv();
 
         // Modify pod environments in two ways:
         // 1) Elastic is unhappy if cluster.name contains slashes. Replace any slashes with double-underscores.
         // 2) Base64 decode the custom YAML block.
-
         DefaultServiceSpec.Generator serviceSpecGenerator =
                 DefaultServiceSpec.newGenerator(
                         rawServiceSpec, schedulerConfig, yamlSpecFile.getParentFile())

--- a/frameworks/hdfs/src/main/java/com/mesosphere/sdk/hdfs/scheduler/Main.java
+++ b/frameworks/hdfs/src/main/java/com/mesosphere/sdk/hdfs/scheduler/Main.java
@@ -54,12 +54,8 @@ public class Main {
         RawServiceSpec rawServiceSpec = RawServiceSpec.newBuilder(yamlSpecFile).build();
         File configDir = yamlSpecFile.getParentFile();
 
-        Map<String, String> env = new HashMap<>(System.getenv());
-        env.put("ALLOW_REGION_AWARENESS", "true");
-        SchedulerConfig schedulerConfig = SchedulerConfig.fromMap(env);
-
+        SchedulerConfig schedulerConfig = SchedulerConfig.fromEnv();
         DefaultServiceSpec serviceSpec = DefaultServiceSpec.newGenerator(rawServiceSpec, schedulerConfig, configDir)
-
                 // Used by 'zkfc' and 'zkfc-format' tasks within this pod:
                 .setPodEnv("name", SERVICE_ZK_ROOT_TASKENV, CuratorUtils.getServiceRootPath(rawServiceSpec.getName()))
                 .setAllPodsEnv(DECODED_AUTH_TO_LOCAL,

--- a/frameworks/helloworld/build.gradle
+++ b/frameworks/helloworld/build.gradle
@@ -13,12 +13,6 @@ repositories {
     }
 }
 
-ext {
-    junitVer = "4.12"
-    systemRulesVer = "1.16.0"
-    mockitoVer = "1.9.5"
-}
-
 dependencies {
     compile project(":scheduler")
     testCompile project(":testing")

--- a/frameworks/helloworld/src/main/java/com/mesosphere/sdk/helloworld/scheduler/Main.java
+++ b/frameworks/helloworld/src/main/java/com/mesosphere/sdk/helloworld/scheduler/Main.java
@@ -37,8 +37,7 @@ public class Main {
         switch (scenario) {
             case Java:
                 // Create a sample config in Java
-                runner = SchedulerRunner.fromServiceSpec(
-                        createSampleServiceSpec(schedulerConfig), schedulerConfig);
+                runner = SchedulerRunner.fromServiceSpec(createSampleServiceSpec(schedulerConfig), schedulerConfig);
                 break;
             case YAML:
                 // Read config from provided file, and assume any config templates

--- a/frameworks/helloworld/src/test/java/com/mesosphere/sdk/helloworld/scheduler/SchedulerRestartServiceTest.java
+++ b/frameworks/helloworld/src/test/java/com/mesosphere/sdk/helloworld/scheduler/SchedulerRestartServiceTest.java
@@ -42,9 +42,8 @@ public class SchedulerRestartServiceTest {
     }
 
 
-    private void testTaskWithReadinessCheckHasStatus(int readinessCheckStatusCode,
-                                                     Status expectedStatus,
-                                                     boolean useDefaultExecutor) throws Exception {
+    private void testTaskWithReadinessCheckHasStatus(
+            int readinessCheckStatusCode, Status expectedStatus, boolean useDefaultExecutor) throws Exception {
         Collection<SimulationTick> ticks = new ArrayList<>();
 
         ticks.add(Send.register());

--- a/frameworks/kafka/build.sh
+++ b/frameworks/kafka/build.sh
@@ -13,7 +13,7 @@ source $FRAMEWORK_DIR/versions.sh
 # Kafka skips the default CLI build because we're building our own below.
 CLI_DIR="disable" $REPO_ROOT_DIR/build.sh -b
 
-# Build/test scheduler.zip/CLIs/setup-helper.zip
+# Build/test scheduler.zip, CLIs, setup-helper.zip
 ${REPO_ROOT_DIR}/gradlew -p ${FRAMEWORK_DIR} check distZip
 $FRAMEWORK_DIR/cli/build.sh
 $FRAMEWORK_DIR/setup-helper/build.sh

--- a/sdk/common/src/main/java/com/mesosphere/sdk/offer/CommonIdUtils.java
+++ b/sdk/common/src/main/java/com/mesosphere/sdk/offer/CommonIdUtils.java
@@ -180,7 +180,7 @@ public class CommonIdUtils {
     }
 
     /**
-     * Extracts either the service name or task name from the provided {@code id} string
+     * Extracts either the service name or task name from the provided {@code id} string.
      *
      * @param id the string to extract from
      * @param serviceName whether to return a service name ({@code true}) or task name ({@code false})

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/config/validate/PodSpecsCannotUseUnsupportedFeatures.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/config/validate/PodSpecsCannotUseUnsupportedFeatures.java
@@ -31,7 +31,7 @@ public class PodSpecsCannotUseUnsupportedFeatures implements ConfigValidator<Ser
 
         for (PodSpec podSpec : newConfig.getPods()) {
             if (!supportsGpus && podRequestsGpuResources(podSpec)) {
-                errors.add(ConfigValidationError.valueError("pod:" + podSpec.getType(), "gpus",
+                errors.add(ConfigValidationError.valueError("pod:" + podSpec.getType(), Constants.GPUS_RESOURCE_TYPE,
                         "This DC/OS cluster does not support GPU resources"));
             }
 
@@ -64,12 +64,7 @@ public class PodSpecsCannotUseUnsupportedFeatures implements ConfigValidator<Ser
     }
 
     public static boolean serviceRequestsGpuResources(ServiceSpec serviceSpec) {
-        for (PodSpec podSpec : serviceSpec.getPods()) {
-            if (podRequestsGpuResources(podSpec)) {
-                return true;
-            }
-        }
-        return false;
+        return serviceSpec.getPods().stream().anyMatch(podSpec -> podRequestsGpuResources(podSpec));
     }
 
     private static boolean podRequestsGpuResources(PodSpec podSpec) {
@@ -80,7 +75,7 @@ public class PodSpecsCannotUseUnsupportedFeatures implements ConfigValidator<Ser
         }
         return podSpec.getTasks().stream()
                 .flatMap(taskSpec -> taskSpec.getResourceSet().getResources().stream())
-                .anyMatch(resourceSpec -> resourceSpec.getName().equals("gpus")
+                .anyMatch(resourceSpec -> resourceSpec.getName().equals(Constants.GPUS_RESOURCE_TYPE)
                         && resourceSpec.getValue().getScalar().getValue() >= 1);
     }
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/curator/CuratorUtils.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/curator/CuratorUtils.java
@@ -60,6 +60,7 @@ public class CuratorUtils {
         return new ExponentialBackoffRetry(
                 CuratorUtils.DEFAULT_CURATOR_POLL_DELAY_MS, CuratorUtils.DEFAULT_CURATOR_MAX_RETRIES);
     }
+
     /**
      * Compares the service name to the previously stored name in zookeeper, or creates a new node containing this data
      * if it isn't already present. This is useful for two situations where foldered service names may be confused with

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/dcos/Capabilities.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/dcos/Capabilities.java
@@ -3,7 +3,6 @@ package com.mesosphere.sdk.dcos;
 import com.google.common.annotations.VisibleForTesting;
 import com.mesosphere.sdk.dcos.clients.DcosVersionClient;
 import com.mesosphere.sdk.offer.LoggingUtils;
-import com.mesosphere.sdk.scheduler.SchedulerConfig;
 import org.slf4j.Logger;
 
 import java.io.IOException;
@@ -100,15 +99,10 @@ public class Capabilities {
         return hasOrExceedsVersion(1, 11);
     }
 
-    public boolean supportsRegionAwareness() {
-        // This feature is in BETA for 1.11, so requires explicit opt-in by end-users.
-        return SchedulerConfig.fromEnv().isregionAwarenessEnabled() && hasOrExceedsVersion(1, 11);
-    }
-
     public boolean supportsDomains() {
         // A given DC/OS cluster may or may not have domain information available in Offers.  This information is
-        // dependent upon the cluster operator and is unknown to the scheduler.  However it is only possible that
-        // domain information be present in DC/OS 1.11+ clusters.
+        // dependent upon the cluster operator and is unknown to the scheduler.  However domain information is only
+        // present on DC/OS 1.11+ clusters.
         return hasOrExceedsVersion(1, 11);
     }
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/framework/EnvStore.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/framework/EnvStore.java
@@ -1,0 +1,167 @@
+package com.mesosphere.sdk.framework;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.google.common.base.Joiner;
+import com.google.common.base.Splitter;
+
+/**
+ * Utility class for grabbing values from a mapping of flag values (typically the process env).
+ */
+public class EnvStore {
+    /**
+     * Exception which is thrown when failing to retrieve or parse a given flag value.
+     */
+    public static class ConfigException extends RuntimeException {
+
+        /**
+         * A machine-accessible error type.
+         */
+        public enum Type {
+            UNKNOWN,
+            NOT_FOUND,
+            INVALID_VALUE
+        }
+
+        private static ConfigException notFound(String message) {
+            return new ConfigException(Type.NOT_FOUND, message);
+        }
+
+        private static ConfigException invalidValue(String message) {
+            return new ConfigException(Type.INVALID_VALUE, message);
+        }
+
+        private final Type type;
+
+        private ConfigException(Type type, String message) {
+            super(message);
+            this.type = type;
+        }
+
+        public Type getType() {
+            return type;
+        }
+
+        @Override
+        public String getMessage() {
+            return String.format("%s (errtype: %s)", super.getMessage(), type);
+        }
+    }
+
+    private final Map<String, String> envMap;
+
+    public static EnvStore fromEnv() {
+        return new EnvStore(System.getenv());
+    }
+
+    public static EnvStore fromMap(Map<String, String> envMap) {
+        return new EnvStore(envMap);
+    }
+
+    EnvStore(Map<String, String> envMap) {
+        this.envMap = new HashMap<>(envMap);
+    }
+
+    public int getOptionalInt(String envKey, int defaultValue) {
+        return toInt(envKey, getOptional(envKey, String.valueOf(defaultValue)));
+    }
+
+    public long getOptionalLong(String envKey, long defaultValue) {
+        return toLong(envKey, getOptional(envKey, String.valueOf(defaultValue)));
+    }
+
+    /**
+     * List of comma-separated strings. Any whitespace is cleaned up automatically.
+     */
+    public List<String> getOptionalStringList(String envKey, List<String> defaultValue) {
+        return toStringList(envKey, getOptional(envKey, Joiner.on(',').join(defaultValue)));
+    }
+
+    public boolean getOptionalBoolean(String envKey, boolean defaultValue) {
+        return toBoolean(envKey, getOptional(envKey, String.valueOf(defaultValue)));
+    }
+
+    public int getRequiredInt(String envKey) {
+        return toInt(envKey, getRequired(envKey));
+    }
+
+    public long getRequiredLong(String envKey) {
+        return toLong(envKey, getRequired(envKey));
+    }
+
+    public String getOptional(String envKey, String defaultValue) {
+        String value = envMap.get(envKey);
+        return (value == null) ? defaultValue : value;
+    }
+
+    public String getRequired(String envKey) {
+        String value = envMap.get(envKey);
+        if (value == null) {
+            throw ConfigException.notFound(String.format("Missing required environment variable: %s", envKey));
+        }
+        return value;
+    }
+
+    public boolean isPresent(String envKey) {
+        return envMap.containsKey(envKey);
+    }
+
+    /**
+     * If the value cannot be parsed as an int, this points to the source envKey, and ensures that
+     * {@link SchedulerConfig} calls only throw {@link ConfigException}.
+     */
+    private static int toInt(String envKey, String envVal) {
+        try {
+            return Integer.parseInt(envVal);
+        } catch (NumberFormatException e) {
+            throw ConfigException.invalidValue(String.format(
+                    "Failed to parse configured environment variable '%s' as an integer: %s", envKey, envVal));
+        }
+    }
+
+    /**
+     * If the value cannot be parsed as a long, this points to the source envKey, and ensures that
+     * {@link SchedulerConfig} calls only throw {@link ConfigException}.
+     */
+    private static long toLong(String envKey, String envVal) {
+        try {
+            return Long.parseLong(envVal);
+        } catch (NumberFormatException e) {
+            throw ConfigException.invalidValue(String.format(
+                    "Failed to parse configured environment variable '%s' as a long integer: %s", envKey, envVal));
+        }
+    }
+
+    private static boolean toBoolean(String envKey, String envVal) {
+        if (envVal.trim().isEmpty()) {
+            // Treat empty or whitespace-only envvar as false
+            return false;
+        }
+        switch (envVal.trim().charAt(0)) {
+        case 't':
+        case 'T':
+        case 'y':
+        case 'Y':
+            // true: "[tT]rue" and "[yY]es"
+            return true;
+        case 'f':
+        case 'F':
+        case 'n':
+        case 'N':
+            // false: "[fF]alse" and "[nN]o"
+            return false;
+        default:
+            throw ConfigException.invalidValue(String.format(
+                    "Failed to parse configured environment variable '%s' as a boolean: %s", envKey, envVal));
+        }
+    }
+
+    private static List<String> toStringList(String envKey, String envVal) {
+        return Splitter.on(',')
+                .trimResults()
+                .omitEmptyStrings()
+                .splitToList(envVal);
+    }
+}

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/framework/FrameworkConfig.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/framework/FrameworkConfig.java
@@ -1,0 +1,239 @@
+package com.mesosphere.sdk.framework;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.google.common.collect.ImmutableList;
+import com.mesosphere.sdk.dcos.DcosConstants;
+import com.mesosphere.sdk.offer.Constants;
+import com.mesosphere.sdk.scheduler.SchedulerUtils;
+import com.mesosphere.sdk.specification.ServiceSpec;
+import com.mesosphere.sdk.specification.yaml.RawServiceSpec;
+
+/**
+ * This class encapsulates global Framework settings retrieved from the environment, or from a ServiceSpec in the case
+ * of a single-Service Framework. Presented as a non-static object to simplify scheduler tests, and to make it painfully
+ * obvious when global settings are being used in awkward places.
+ */
+public class FrameworkConfig {
+
+    private static final String DEFAULT_ROLE_SUFFIX = "-role";
+    private static final String DEFAULT_PRINCIPAL_SUFFIX = "-principal";
+
+    private final String frameworkName;
+    private final String principal;
+    private final String user;
+    private final String zookeeperHostPort;
+    private final ImmutableList<String> preReservedRoles;
+    private final String role;
+    private final String webUrl;
+
+    /**
+     * @param frameworkName name to use for ZK and for registering the framework, in single-service schedulers this
+     *                      is the service name
+     * @param principal the principal to use when registering the framework
+     * @param user the username to use when registering the framework
+     * @param zookeeperHostPort ZK connection string of the form "master.mesos:2181"
+     * @param preReservedRoles list of pre-reserved parent roles to register for (in addition to the base role)
+     * @param role base mesos role
+     * @param webUrl optional URL to advertise in framework info, or empty string
+     */
+    public FrameworkConfig(
+            String frameworkName,
+            String role,
+            String principal,
+            String user,
+            String zookeeperHostPort,
+            Collection<String> preReservedRoles,
+            String webUrl) {
+        this.frameworkName = frameworkName;
+        this.role = role;
+        this.principal = principal;
+        this.user = user;
+        this.zookeeperHostPort = zookeeperHostPort;
+        this.preReservedRoles = ImmutableList.copyOf(preReservedRoles);
+        this.webUrl = webUrl;
+    }
+
+    /**
+     * Creates a {@link FrameworkConfig} instance based off the contents of the provided {@link RawServiceSpec}.
+     */
+    public static FrameworkConfig fromRawServiceSpec(RawServiceSpec rawServiceSpec) {
+        String serviceRole = getServiceRole(rawServiceSpec.getName());
+        return new FrameworkConfig(
+                rawServiceSpec.getName(),
+                serviceRole,
+                getServicePrincipal(rawServiceSpec, rawServiceSpec.getName()),
+                getUser(rawServiceSpec),
+                getZkHostPort(rawServiceSpec),
+                getFrameworkPreReservedRoles(serviceRole, rawServiceSpec.getPods().values().stream()
+                        .map(pod -> pod.getPreReservedRole())
+                        .collect(Collectors.toList())),
+                rawServiceSpec.getWebUrl());
+    }
+
+    /**
+     * Creates a {@link FrameworkConfig} instance based off the contents of the provided {@link ServiceSpec}.
+     */
+    public static FrameworkConfig fromServiceSpec(ServiceSpec serviceSpec) {
+        return new FrameworkConfig(
+                serviceSpec.getName(),
+                serviceSpec.getRole(),
+                serviceSpec.getPrincipal(),
+                serviceSpec.getUser(),
+                serviceSpec.getZookeeperConnection(),
+                getFrameworkPreReservedRoles(serviceSpec.getRole(), serviceSpec.getPods().stream()
+                        .map(pod -> pod.getPreReservedRole())
+                        .collect(Collectors.toList())),
+                serviceSpec.getWebUrl());
+    }
+
+    /**
+     * Creates a {@link FrameworkConfig} instance based off the provided process environment. This is used when no
+     * single {@link ServiceSpec} is applicable (multi-service mode).
+     */
+    public static FrameworkConfig fromEnvStore(EnvStore envStore) {
+        // The only required value is FRAMEWORK_NAME.
+        String frameworkName = envStore.getRequired("FRAMEWORK_NAME");
+        return new FrameworkConfig(
+                frameworkName,
+                getServiceRole(frameworkName),
+                envStore.getOptional("FRAMEWORK_PRINCIPAL", frameworkName + DEFAULT_PRINCIPAL_SUFFIX),
+                envStore.getOptional("FRAMEWORK_USER", DcosConstants.DEFAULT_SERVICE_USER),
+                envStore.getOptional("FRAMEWORK_ZOOKEEPER", DcosConstants.MESOS_MASTER_ZK_CONNECTION_STRING),
+                envStore.getOptionalStringList("FRAMEWORK_PRERESERVED_ROLES", Collections.emptyList()),
+                envStore.getOptional("FRAMEWORK_WEB_URL", ""));
+    }
+
+    /**
+     * Returns the framework name to use with Mesos. When running a single service, this is equal to the service name.
+     */
+    public String getFrameworkName() {
+        return frameworkName;
+    }
+
+    /**
+     * Returns the principal to use in resource reservations.
+     */
+    public String getPrincipal() {
+        return principal;
+    }
+
+    /**
+     * Returns the user to run tasks as.
+     */
+    public String getUser() {
+        return user;
+    }
+
+    /**
+     * Returns the zookeeper endpoint to use for state storage, of the form "hostname:port".
+     */
+    public String getZookeeperHostPort() {
+        return zookeeperHostPort;
+    }
+
+    /**
+     * Returns the list of pre-reserved roles as they should be provided to Mesos with the main role included.
+     */
+    public ImmutableList<String> getPreReservedRoles() {
+        return preReservedRoles;
+    }
+
+    /**
+     * Returns the 'main' role to register as.
+     */
+    public String getRole() {
+        return role;
+    }
+
+    /**
+     * Returns the union of the pre-reserved roles and the main role.
+     */
+    public Set<String> getAllResourceRoles() {
+        Set<String> roles = new HashSet<>(preReservedRoles);
+        roles.add(role);
+        return roles;
+    }
+
+    /**
+     * Returns the web URL to specify when registering with Mesos.
+     */
+    public String getWebUrl() {
+        return webUrl;
+    }
+
+    /**
+     * Returns the configured Mesos role to use for running the service, based on the service name.
+     * Unlike the Mesos principal and pre-reserved roles, this value cannot be configured directly via the YAML schema.
+     *
+     * For example: /path/to/kafka => path__to__kafka-role
+     */
+    private static String getServiceRole(String frameworkName) {
+        // Use <svcname>-role (or throw if svcname is missing)
+
+        // If the service name has a leading slash (due to folders), omit that leading slash from the role.
+        // This is done with the reasoning that "/path/to/kafka" and "path/to/kafka" should be equivalent.
+
+        // Slashes are currently banned from roles by as of mesos commit e0d8cc7c. Sounds like they will be allowed
+        // again in 1.4 when hierarchical roles are supported.
+        return SchedulerUtils.withEscapedSlashes(frameworkName) + DEFAULT_ROLE_SUFFIX;
+    }
+
+    /**
+     * Returns the configured Mesos principal to use for running the service.
+     */
+    private static String getServicePrincipal(RawServiceSpec rawServiceSpec, String frameworkName) {
+        // If the svc.yml explicitly provided a principal, use that
+        if (rawServiceSpec.getScheduler() != null
+                && !StringUtils.isEmpty(rawServiceSpec.getScheduler().getPrincipal())) {
+            return rawServiceSpec.getScheduler().getPrincipal();
+        }
+        // Fallback: Use <fwkname>-principal
+        return frameworkName + DEFAULT_PRINCIPAL_SUFFIX;
+    }
+
+    /**
+     * Returns the configured {@code hostname:port} to use for state storage at the scheduler.
+     */
+    private static String getZkHostPort(RawServiceSpec rawServiceSpec) {
+        // If the svc.yml explicitly provided a zk host:port, use that
+        if (rawServiceSpec.getScheduler() != null
+                && !StringUtils.isEmpty(rawServiceSpec.getScheduler().getZookeeper())) {
+            return rawServiceSpec.getScheduler().getZookeeper();
+        }
+        // Fallback: Use the default host:port
+        return DcosConstants.MESOS_MASTER_ZK_CONNECTION_STRING;
+    }
+
+    /**
+     * Returns the configured user to use for running the service pods.
+     */
+    private static String getUser(RawServiceSpec rawServiceSpec) {
+        // If the svc.yml explicitly provided a service user, use that
+        if (rawServiceSpec.getScheduler() != null && !StringUtils.isEmpty(rawServiceSpec.getScheduler().getUser())) {
+            return rawServiceSpec.getScheduler().getUser();
+        }
+
+        // Fallback: Use the default scheduler user
+        return DcosConstants.DEFAULT_SERVICE_USER;
+    }
+
+    /**
+     * Maps the provided per-pod pre-reserved roles to a set of namespaced roles which should be registered with Mesos.
+     *
+     * For example, ["slave_public", "*", "*"] => ["mysvc-role/slave_public"]
+     */
+    private static Collection<String> getFrameworkPreReservedRoles(
+            String frameworkRole, Collection<String> podSpecPreReservedRoles) {
+        return podSpecPreReservedRoles.stream()
+                .filter(r -> !r.equals(Constants.ANY_ROLE))
+                .map(r -> r + "/" + frameworkRole)
+                .collect(Collectors.toList());
+    }
+}

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/framework/FrameworkRunner.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/framework/FrameworkRunner.java
@@ -1,0 +1,93 @@
+package com.mesosphere.sdk.framework;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.mesosphere.sdk.dcos.Capabilities;
+import com.mesosphere.sdk.offer.Constants;
+import com.mesosphere.sdk.scheduler.AbstractScheduler;
+import com.mesosphere.sdk.scheduler.plan.DefaultPlan;
+import com.mesosphere.sdk.scheduler.plan.Plan;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.mesos.Protos;
+import java.util.*;
+
+/**
+ * Class which sets up and executes the correct {@link AbstractScheduler} instance.
+ *
+ * TODO(nickbp): Once *Scheduler is broken up, this will run the Mesos framework thread.
+ */
+public class FrameworkRunner {
+    private static final int TWO_WEEK_SEC = 2 * 7 * 24 * 60 * 60;
+
+    /**
+     * Empty complete deploy plan to be used if the scheduler is uninstalling and was launched in a finished state.
+     */
+    @VisibleForTesting
+    static final Plan EMPTY_DEPLOY_PLAN = new DefaultPlan(Constants.DEPLOY_PLAN_NAME, Collections.emptyList());
+
+    private final FrameworkConfig frameworkConfig;
+    private final boolean usingGpus;
+    private final boolean usingRegions;
+
+    /**
+     * Creates a new instance and does some internal initialization.
+     *
+     * @param frameworkConfig settings to use for registering the framework
+     */
+    public FrameworkRunner(
+            FrameworkConfig frameworkConfig,
+            boolean usingGpus,
+            boolean usingRegions) {
+        this.frameworkConfig = frameworkConfig;
+        this.usingGpus = usingGpus;
+        this.usingRegions = usingRegions;
+    }
+
+    public Protos.FrameworkInfo getFrameworkInfo(Optional<Protos.FrameworkID> frameworkId) {
+        Protos.FrameworkInfo.Builder fwkInfoBuilder = Protos.FrameworkInfo.newBuilder()
+                .setName(frameworkConfig.getFrameworkName())
+                .setPrincipal(frameworkConfig.getPrincipal())
+                .setUser(frameworkConfig.getUser())
+                .setFailoverTimeout(TWO_WEEK_SEC)
+                .setCheckpoint(true);
+
+        // The framework ID is not available when we're being started for the first time.
+        frameworkId.ifPresent(fwkInfoBuilder::setId);
+
+        if (frameworkConfig.getPreReservedRoles().isEmpty()) {
+            setRole(fwkInfoBuilder, frameworkConfig.getRole());
+        } else {
+            fwkInfoBuilder.addCapabilitiesBuilder()
+                    .setType(Protos.FrameworkInfo.Capability.Type.MULTI_ROLE);
+            fwkInfoBuilder
+                    .addRoles(frameworkConfig.getRole())
+                    .addAllRoles(frameworkConfig.getPreReservedRoles());
+        }
+
+        if (!StringUtils.isEmpty(frameworkConfig.getWebUrl())) {
+            fwkInfoBuilder.setWebuiUrl(frameworkConfig.getWebUrl());
+        }
+
+        Capabilities capabilities = Capabilities.getInstance();
+        if (usingGpus && capabilities.supportsGpuResource()) {
+            fwkInfoBuilder.addCapabilitiesBuilder()
+                    .setType(Protos.FrameworkInfo.Capability.Type.GPU_RESOURCES);
+        }
+        if (capabilities.supportsPreReservedResources()) {
+            fwkInfoBuilder.addCapabilitiesBuilder()
+                    .setType(Protos.FrameworkInfo.Capability.Type.RESERVATION_REFINEMENT);
+        }
+
+        // Only enable if opted-in by the developer or user.
+        if (usingRegions && capabilities.supportsDomains()) {
+            fwkInfoBuilder.addCapabilitiesBuilder()
+                    .setType(Protos.FrameworkInfo.Capability.Type.REGION_AWARE);
+        }
+
+        return fwkInfoBuilder.build();
+    }
+
+    @SuppressWarnings("deprecation") // mute warning for FrameworkInfo.setRole()
+    private static void setRole(Protos.FrameworkInfo.Builder fwkInfoBuilder, String role) {
+        fwkInfoBuilder.setRole(role);
+    }
+}

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/Constants.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/Constants.java
@@ -29,7 +29,8 @@ public class Constants {
     public static final String CPUS_RESOURCE_TYPE = "cpus";
     /** The name used for memory resources. */
     public static final String MEMORY_RESOURCE_TYPE = "mem";
-
+    /** The name used for GPU resources. */
+    public static final String GPUS_RESOURCE_TYPE = "gpus";
 
     /**
      * The amount of additional CPU to require for the default executor.
@@ -71,7 +72,7 @@ public class Constants {
      * This may be overridden by manually constructing the {@link com.mesosphere.sdk.specification.NamedVIPSpec} or
      * {@link com.mesosphere.sdk.specification.PortSpec}.
      *
-     * As of this writing, this setting is only used by {@link com.mesosphere.sdk.http.EndpointsResource} for
+     * As of this writing, this setting is only used by {@link com.mesosphere.sdk.http.endpoints.EndpointsResource} for
      * determining what ports to advertise, where {@code EXTERNAL} means advertise and non-{@code EXTERNAL} means don't
      * advertise. According to the networking team this isn't currently used by DC/OS itself (as of 1.10).
      */

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/MesosResourcePool.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/MesosResourcePool.java
@@ -216,8 +216,8 @@ public class MesosResourcePool {
     private void freeMergedResource(MesosResource mesosResource) {
         if (mesosResource.getResourceId().isPresent()) {
             dynamicallyReservedPoolByResourceId.remove(mesosResource.getResourceId().get());
-            LOGGER.info("Freed resource: {}", !dynamicallyReservedPoolByResourceId
-                    .containsKey(mesosResource.getResourceId().get()));
+            LOGGER.info("Freed resource: {}",
+                    !dynamicallyReservedPoolByResourceId.containsKey(mesosResource.getResourceId().get()));
         }
 
         String previousRole = mesosResource.getPreviousRole();

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/ResourceBuilder.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/ResourceBuilder.java
@@ -67,12 +67,12 @@ public class ResourceBuilder {
             return fromSpec(
                     getResourceSpec(resource),
                     ResourceUtils.getResourceId(resource),
-                    ResourceUtils.getResourceNamespace(resource));
+                    ResourceUtils.getNamespace(resource));
         } else {
             return fromSpec(
                     getVolumeSpec(resource),
                     ResourceUtils.getResourceId(resource),
-                    ResourceUtils.getResourceNamespace(resource),
+                    ResourceUtils.getNamespace(resource),
                     ResourceUtils.getPersistenceId(resource),
                     ResourceUtils.getSourceRoot(resource));
         }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluationUtils.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluationUtils.java
@@ -71,14 +71,14 @@ class OfferEvaluationUtils {
         MesosResource mesosResource = mesosResourceOptional.get();
 
         if (ValueUtils.equal(mesosResource.getValue(), resourceSpec.getValue())) {
-            LOGGER.info("Resource '{}' matches required value: {}",
+            LOGGER.info("Resource '{}' matches required value: {} {}",
                     resourceSpec.getName(),
                     TextFormat.shortDebugString(mesosResource.getValue()),
-                    TextFormat.shortDebugString(resourceSpec.getValue()));
+                    TextFormat.shortDebugString(resourceSpec.getValue()),
+                    resourceId.isPresent() ? "(previously reserved)" : "(requires RESERVE operation)");
 
             if (!resourceId.isPresent()) {
                 // Initial reservation of resources
-                LOGGER.info("Resource '{}' requires a RESERVE operation", resourceSpec.getName());
                 Protos.Resource resource = ResourceBuilder.fromSpec(resourceSpec, resourceId, resourceNamespace)
                         .setMesosResource(mesosResource)
                         .build();
@@ -158,8 +158,8 @@ class OfferEvaluationUtils {
                         ResourceUtils.getResourceId(resource).get());
             } else {
                 Protos.Value unreserve = ValueUtils.subtract(mesosResource.getValue(), resourceSpec.getValue());
-                LOGGER.info(
-                        "Reservation for resource '{}' needs decreasing from current {} to required {} subtract: {})",
+                LOGGER.info("Reservation for resource '{}' needs decreasing from current {} to required {} " +
+                        "(subtract: {})",
                         resourceSpec.getName(),
                         TextFormat.shortDebugString(mesosResource.getValue()),
                         TextFormat.shortDebugString(resourceSpec.getValue()),

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluator.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluator.java
@@ -82,8 +82,7 @@ public class OfferEvaluator {
             Protos.Offer offer = offers.get(i);
 
             MesosResourcePool resourcePool = new MesosResourcePool(
-                    offer,
-                    OfferEvaluationUtils.getRole(podInstanceRequirement.getPodInstance().getPod()));
+                    offer, OfferEvaluationUtils.getRole(podInstanceRequirement.getPodInstance().getPod()));
 
             Map<TaskSpec, GoalStateOverride> overrideMap = new HashMap<>();
             for (TaskSpec taskSpec : podInstanceRequirement.getPodInstance().getPod().getTasks()) {

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/ExactMatcher.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/ExactMatcher.java
@@ -22,7 +22,6 @@ public class ExactMatcher implements StringMatcher {
     }
 
     private String str;
-    private static final Double epsilon = 0.0001;
     private static final DecimalFormat format = new DecimalFormat("0.###");
 
     @JsonCreator

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/AbstractScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/AbstractScheduler.java
@@ -35,6 +35,7 @@ public abstract class AbstractScheduler {
 
     protected final Protos.FrameworkInfo frameworkInfo;
     protected final FrameworkStore frameworkStore;
+    protected final ServiceSpec serviceSpec;
     protected final StateStore stateStore;
     protected final ConfigStore<ServiceSpec> configStore;
     protected final SchedulerConfig schedulerConfig;
@@ -69,16 +70,25 @@ public abstract class AbstractScheduler {
     protected AbstractScheduler(
             Protos.FrameworkInfo frameworkInfo,
             FrameworkStore frameworkStore,
+            ServiceSpec serviceSpec,
             StateStore stateStore,
             ConfigStore<ServiceSpec> configStore,
             SchedulerConfig schedulerConfig,
             Optional<PlanCustomizer> planCustomizer) {
         this.frameworkInfo = frameworkInfo;
         this.frameworkStore = frameworkStore;
+        this.serviceSpec = serviceSpec;
         this.stateStore = stateStore;
         this.configStore = configStore;
         this.schedulerConfig = schedulerConfig;
         this.planCustomizer = planCustomizer;
+    }
+
+    /**
+     * Returns the service spec for this service.
+     */
+    public ServiceSpec getServiceSpec() {
+        return serviceSpec;
     }
 
     /**

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/DefaultScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/DefaultScheduler.java
@@ -83,7 +83,7 @@ public class DefaultScheduler extends AbstractScheduler {
             ConfigStore<ServiceSpec> configStore,
             ArtifactQueries.TemplateUrlFactory templateUrlFactory,
             Map<String, EndpointProducer> customEndpointProducers) throws ConfigStoreException {
-        super(frameworkInfo, frameworkStore, stateStore, configStore, schedulerConfig, planCustomizer);
+        super(frameworkInfo, frameworkStore, serviceSpec, stateStore, configStore, schedulerConfig, planCustomizer);
         this.planCoordinator = planCoordinator;
         this.offerAccepter = getOfferAccepter(stateStore, serviceSpec, planCoordinator);
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerBuilder.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerBuilder.java
@@ -9,6 +9,8 @@ import com.mesosphere.sdk.config.validate.DefaultConfigValidators;
 import com.mesosphere.sdk.config.validate.PodSpecsCannotUseUnsupportedFeatures;
 import com.mesosphere.sdk.curator.CuratorPersister;
 import com.mesosphere.sdk.dcos.Capabilities;
+import com.mesosphere.sdk.framework.FrameworkConfig;
+import com.mesosphere.sdk.framework.FrameworkRunner;
 import com.mesosphere.sdk.http.endpoints.ArtifactResource;
 import com.mesosphere.sdk.http.queries.ArtifactQueries;
 import com.mesosphere.sdk.http.types.EndpointProducer;
@@ -44,7 +46,6 @@ import com.mesosphere.sdk.storage.Persister;
 import com.mesosphere.sdk.storage.PersisterCache;
 import com.mesosphere.sdk.storage.PersisterException;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.mesos.Protos;
 import org.slf4j.Logger;
 
@@ -58,9 +59,8 @@ import java.util.stream.Collectors;
 public class SchedulerBuilder {
 
     private final Logger logger;
-    private static final int TWO_WEEK_SEC = 2 * 7 * 24 * 60 * 60;
 
-    private ServiceSpec serviceSpec;
+    private final ServiceSpec originalServiceSpec;
     private final SchedulerConfig schedulerConfig;
     private final Persister persister;
 
@@ -72,6 +72,7 @@ public class SchedulerBuilder {
     private RecoveryPlanOverriderFactory recoveryPlanOverriderFactory;
     private PlanCustomizer planCustomizer;
     private Optional<String> namespace = Optional.empty();
+    private boolean regionAwarenessEnabled = false;
     private Optional<ArtifactQueries.TemplateUrlFactory> templateUrlFactory = Optional.empty();
 
     SchedulerBuilder(ServiceSpec serviceSpec, SchedulerConfig schedulerConfig) throws PersisterException {
@@ -87,7 +88,7 @@ public class SchedulerBuilder {
         // NOTE: we specifically avoid accessing the provided persister before build() is called.
         // This is to ensure that upstream has a chance to e.g. lock it via CuratorLocker.
         this.logger = LoggingUtils.getLogger(getClass(), serviceSpec.getName());
-        this.serviceSpec = serviceSpec;
+        this.originalServiceSpec = serviceSpec;
         this.schedulerConfig = schedulerConfig;
         this.persister = persister;
     }
@@ -96,7 +97,7 @@ public class SchedulerBuilder {
      * Returns the {@link ServiceSpec} which was provided via the constructor.
      */
     public ServiceSpec getServiceSpec() {
-        return serviceSpec;
+        return originalServiceSpec;
     }
 
     /**
@@ -112,6 +113,14 @@ public class SchedulerBuilder {
      */
     public Persister getPersister() {
         return persister;
+    }
+
+    /**
+     * Returns whether the developer has enabled region awareness for this service, either via
+     * {@link #withSingleRegionConstraint()} or via the scheduler process environment.
+     */
+    public boolean isRegionAwarenessEnabled() {
+        return regionAwarenessEnabled || schedulerConfig.isRegionAwarenessEnabled();
     }
 
     /**
@@ -181,42 +190,8 @@ public class SchedulerBuilder {
      * Configures the resulting scheduler instance with a region constraint.
      */
     public SchedulerBuilder withSingleRegionConstraint() {
-         if (!Capabilities.getInstance().supportsDomains()) {
-             // If this is an older version of DC/OS that doesn't support multi-region deployments, this is a noop.
-             return this;
-         }
-
-         Optional<String> schedulerRegion = schedulerConfig.getSchedulerRegion();
-         PlacementRule regionRule = getRegionRule(schedulerRegion);
-
-         List<PodSpec> updatedPodSpecs = serviceSpec.getPods().stream()
-                 .map(p -> podWithPlacementRule(p, regionRule))
-                 .collect(Collectors.toList());
-
-         DefaultServiceSpec.Builder builder = DefaultServiceSpec.newBuilder(serviceSpec).pods(updatedPodSpecs);
-         if (schedulerRegion.isPresent()) {
-             builder.region(schedulerRegion.get());
-         }
-         serviceSpec = builder.build();
-
-         return this;
-    }
-
-    @VisibleForTesting
-    static PlacementRule getRegionRule(Optional<String> schedulerRegion) {
-        if (!schedulerRegion.isPresent()) {
-            return new IsLocalRegionRule();
-        }
-
-        return RegionRuleFactory.getInstance().require(ExactMatcher.create(schedulerRegion.get()));
-    }
-
-    private static PodSpec podWithPlacementRule(PodSpec podSpec, PlacementRule placementRule) {
-        if (podSpec.getPlacementRule().isPresent()) {
-            placementRule = new AndRule(placementRule, podSpec.getPlacementRule().get());
-        }
-
-        return DefaultPodSpec.newBuilder(podSpec).placementRule(placementRule).build();
+        this.regionAwarenessEnabled = true;
+        return this;
     }
 
     /**
@@ -246,6 +221,56 @@ public class SchedulerBuilder {
      * @throws IllegalArgumentException if validating the provided configuration failed
      */
     public AbstractScheduler build() {
+        // If region awareness is enabled (via java bit or via env) and the cluster supports it, update the ServiceSpec
+        // to include region constraints.
+        final ServiceSpec serviceSpec;
+        if (Capabilities.getInstance().supportsDomains()) {
+            // This cluster supports domains. We need to update pod placement with region configuration, for any pods
+            // that weren't already configured by the developer (expected to be rare, but possible).
+
+            // Whether region awareness is enabled for the service (via env or via java).
+            boolean regionAwarenessEnabled = isRegionAwarenessEnabled();
+            // A region to target, as specified in env, if any.
+            Optional<String> schedulerRegion = schedulerConfig.getSchedulerRegion();
+
+            // Target the specified region, or use the local region.
+            // Local region is determined at framework registration, see IsLocalRegionRule.setLocalDomain().
+            final PlacementRule placementRuleToAdd;
+            if (regionAwarenessEnabled && schedulerRegion.isPresent()) {
+                logger.info("Updating pods with placement rule for region={}", schedulerRegion.get());
+                placementRuleToAdd =
+                        RegionRuleFactory.getInstance().require(ExactMatcher.create(schedulerRegion.get()));
+            } else {
+                logger.info("Updating pods with local region placement rule: region awareness={}, scheduler region={}",
+                        regionAwarenessEnabled, schedulerRegion);
+                placementRuleToAdd = new IsLocalRegionRule();
+            }
+
+            List<PodSpec> updatedPodSpecs = new ArrayList<>();
+            for (PodSpec podSpec : originalServiceSpec.getPods()) {
+                if (PlacementUtils.placementRuleReferencesRegion(podSpec)) {
+                    // Pod already has a region constraint (specified by developer?). Leave it as-is.
+                    logger.info("Pod {} already has a region rule defined, leaving as-is", podSpec.getType());
+                    updatedPodSpecs.add(podSpec);
+                } else {
+                    // Combine the new rule with any existing rules:
+                    PlacementRule mergedRule = podSpec.getPlacementRule().isPresent()
+                            ? new AndRule(placementRuleToAdd, podSpec.getPlacementRule().get())
+                            : placementRuleToAdd;
+                    updatedPodSpecs.add(DefaultPodSpec.newBuilder(podSpec).placementRule(mergedRule).build());
+                }
+            }
+
+            DefaultServiceSpec.Builder builder =
+                    DefaultServiceSpec.newBuilder(originalServiceSpec).pods(updatedPodSpecs);
+            if (schedulerRegion.isPresent()) {
+                builder.region(schedulerRegion.get());
+            }
+            serviceSpec = builder.build();
+        } else {
+            serviceSpec = originalServiceSpec;
+        }
+
         // NOTE: we specifically avoid accessing the provided persister before build() is called.
         // This is to ensure that upstream has a chance to e.g. lock it via CuratorLocker.
 
@@ -257,7 +282,11 @@ public class SchedulerBuilder {
         ConfigStore<ServiceSpec> configStore = new ConfigStore<>(
                 DefaultServiceSpec.getConfigurationFactory(serviceSpec), persister, namespaceStr);
 
-        Protos.FrameworkInfo frameworkInfo = getFrameworkInfo(serviceSpec, frameworkStore);
+        Protos.FrameworkInfo frameworkInfo = new FrameworkRunner(
+                FrameworkConfig.fromServiceSpec(serviceSpec),
+                PodSpecsCannotUseUnsupportedFeatures.serviceRequestsGpuResources(serviceSpec),
+                isRegionAwarenessEnabled())
+                .getFrameworkInfo(frameworkStore.fetchFrameworkId());
 
         if (schedulerConfig.isUninstallEnabled()) {
             // FRAMEWORK UNINSTALL: The scheduler and all its service(s) are being uninstalled. Launch this service in
@@ -297,7 +326,7 @@ public class SchedulerBuilder {
         }
 
         try {
-            return getDefaultScheduler(frameworkInfo, frameworkStore, stateStore, configStore);
+            return getDefaultScheduler(serviceSpec, frameworkInfo, frameworkStore, stateStore, configStore);
         } catch (ConfigStoreException e) {
             logger.error("Failed to construct scheduler.", e);
             SchedulerUtils.hardExit(SchedulerErrorCode.INITIALIZATION_FAILURE);
@@ -312,6 +341,7 @@ public class SchedulerBuilder {
      * @throws IllegalArgumentException if config validation failed when updating the target config.
      */
     private DefaultScheduler getDefaultScheduler(
+            ServiceSpec serviceSpec,
             Protos.FrameworkInfo frameworkInfo,
             FrameworkStore frameworkStore,
             StateStore stateStore,
@@ -337,11 +367,6 @@ public class SchedulerBuilder {
                 logger.info("Unable to retrieve last configuration. Assuming that no prior deployment has completed");
             }
         }
-
-        List<PodSpec> pods = serviceSpec.getPods().stream()
-                .map(podSpec -> updatePodPlacement(podSpec))
-                .collect(Collectors.toList());
-        serviceSpec = DefaultServiceSpec.newBuilder(serviceSpec).pods(pods).build();
 
         // Update/validate config as needed to reflect the new service spec:
         Collection<ConfigValidator<ServiceSpec>> configValidators = new ArrayList<>();
@@ -380,11 +405,12 @@ public class SchedulerBuilder {
         PlanManager deploymentPlanManager =
                 DefaultPlanManager.createProceeding(getDeployPlan(plans).get());
         PlanManager recoveryPlanManager = getRecoveryPlanManager(
+                serviceSpec,
                 Optional.ofNullable(recoveryPlanOverriderFactory),
                 stateStore,
                 configStore,
                 plans);
-        Optional<PlanManager> decommissionPlanManager = getDecommissionPlanManager(stateStore);
+        Optional<PlanManager> decommissionPlanManager = getDecommissionPlanManager(serviceSpec, stateStore);
         PlanCoordinator planCoordinator = buildPlanCoordinator(
                 serviceSpec.getName(),
                 deploymentPlanManager,
@@ -408,6 +434,7 @@ public class SchedulerBuilder {
     }
 
     private PlanManager getRecoveryPlanManager(
+            ServiceSpec serviceSpec,
             Optional<RecoveryPlanOverriderFactory> recoveryOverriderFactory,
             StateStore stateStore,
             ConfigStore<ServiceSpec> configStore,
@@ -441,7 +468,7 @@ public class SchedulerBuilder {
                 overrideRecoveryPlanManagers);
     }
 
-    private Optional<PlanManager> getDecommissionPlanManager(StateStore stateStore) {
+    private static Optional<PlanManager> getDecommissionPlanManager(ServiceSpec serviceSpec, StateStore stateStore) {
         DecommissionPlanFactory decommissionPlanFactory = new DecommissionPlanFactory(serviceSpec, stateStore);
         Optional<Plan> decommissionPlan = decommissionPlanFactory.getPlan();
         if (decommissionPlan.isPresent()) {
@@ -476,29 +503,6 @@ public class SchedulerBuilder {
                 .collect(Collectors.toList()));
 
         return new DefaultPlanCoordinator(planManagers);
-    }
-
-    /**
-     * Update pods with appropriate placement constraints to enforce user REGION intent.
-     * If a pod's placement rules do not explicitly reference a REGION the assumption should be that
-     * the user intends that a pod be restriced to the local REGION.
-     *
-     * @param podSpec The {@link PodSpec} whose placement rule will be updated to enforce appropriate region placement.
-     * @return The updated {@link PodSpec}
-     */
-    static PodSpec updatePodPlacement(PodSpec podSpec) {
-        if (!Capabilities.getInstance().supportsDomains() || PlacementUtils.placementRuleReferencesRegion(podSpec)) {
-            return podSpec;
-        }
-
-        PlacementRule rule;
-        if (podSpec.getPlacementRule().isPresent()) {
-            rule = new AndRule(new IsLocalRegionRule(), podSpec.getPlacementRule().get());
-        } else {
-            rule = new IsLocalRegionRule();
-        }
-
-        return DefaultPodSpec.newBuilder(podSpec).placementRule(rule).build();
     }
 
     /**
@@ -638,60 +642,4 @@ public class SchedulerBuilder {
             throw new IllegalStateException(e);
         }
     }
-
-    private static Protos.FrameworkInfo getFrameworkInfo(ServiceSpec serviceSpec, FrameworkStore frameworkStore) {
-        Protos.FrameworkInfo.Builder fwkInfoBuilder = Protos.FrameworkInfo.newBuilder()
-                .setName(serviceSpec.getName())
-                .setPrincipal(serviceSpec.getPrincipal())
-                .setFailoverTimeout(TWO_WEEK_SEC)
-                .setUser(serviceSpec.getUser())
-                .setCheckpoint(true);
-
-        setRoles(fwkInfoBuilder, serviceSpec);
-
-        // The framework ID is not available when we're being started for the first time.
-        Optional<Protos.FrameworkID> optionalFrameworkId = frameworkStore.fetchFrameworkId();
-        optionalFrameworkId.ifPresent(fwkInfoBuilder::setId);
-
-        if (!StringUtils.isEmpty(serviceSpec.getWebUrl())) {
-            fwkInfoBuilder.setWebuiUrl(serviceSpec.getWebUrl());
-        }
-
-        if (Capabilities.getInstance().supportsGpuResource()
-                && PodSpecsCannotUseUnsupportedFeatures.serviceRequestsGpuResources(serviceSpec)) {
-            fwkInfoBuilder.addCapabilities(Protos.FrameworkInfo.Capability.newBuilder()
-                    .setType(Protos.FrameworkInfo.Capability.Type.GPU_RESOURCES));
-        }
-
-        if (Capabilities.getInstance().supportsPreReservedResources()) {
-            fwkInfoBuilder.addCapabilities(Protos.FrameworkInfo.Capability.newBuilder()
-                    .setType(Protos.FrameworkInfo.Capability.Type.RESERVATION_REFINEMENT));
-        }
-
-        if (Capabilities.getInstance().supportsRegionAwareness()) {
-            fwkInfoBuilder.addCapabilities(Protos.FrameworkInfo.Capability.newBuilder()
-                    .setType(Protos.FrameworkInfo.Capability.Type.REGION_AWARE));
-        }
-
-        return fwkInfoBuilder.build();
-    }
-
-    @SuppressWarnings("deprecation") // mute warning for FrameworkInfo.setRole()
-    private static void setRoles(Protos.FrameworkInfo.Builder fwkInfoBuilder, ServiceSpec serviceSpec) {
-        List<String> preReservedRoles =
-                serviceSpec.getPods().stream()
-                        .filter(podSpec -> !podSpec.getPreReservedRole().equals(Constants.ANY_ROLE))
-                        .map(podSpec -> podSpec.getPreReservedRole() + "/" + serviceSpec.getRole())
-                        .collect(Collectors.toList());
-        if (preReservedRoles.isEmpty()) {
-            fwkInfoBuilder.setRole(serviceSpec.getRole());
-        } else {
-            fwkInfoBuilder.addCapabilities(Protos.FrameworkInfo.Capability.newBuilder()
-                    .setType(Protos.FrameworkInfo.Capability.Type.MULTI_ROLE));
-            fwkInfoBuilder.addRoles(serviceSpec.getRole());
-            fwkInfoBuilder.addAllRoles(preReservedRoles);
-        }
-    }
-
-
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerUtils.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerUtils.java
@@ -1,46 +1,21 @@
 package com.mesosphere.sdk.scheduler;
 
-import com.mesosphere.sdk.dcos.DcosConstants;
-import com.mesosphere.sdk.scheduler.plan.Plan;
-import com.mesosphere.sdk.specification.yaml.RawServiceSpec;
 import com.mesosphere.sdk.storage.PersisterUtils;
-import org.apache.commons.lang3.StringUtils;
-
-import java.util.Collection;
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * This class provides utilities common to the construction and operation of Mesos Schedulers.
  */
 public class SchedulerUtils {
-    private static final String DEFAULT_ROLE_SUFFIX = "-role";
-    private static final String DEFAULT_PRINCIPAL_SUFFIX = "-principal";
-
-    /** Reasonable zk host on DC/OS systems. */
-    private static final String DEFAULT_ZK_HOST_PORT = "master.mesos:2181";
 
     /**
      * Escape sequence to use for slashes in service names. Slashes are used in DC/OS for folders, and we don't want to
      * confuse ZK with those.
      */
-    private static final String FRAMEWORK_NAME_SLASH_ESCAPE = "__";
+    private static final String SLASH_REPLACEMENT = "__";
 
     /**
-     * Returns the configured service name (aka framework name) to use for running the service.
-     *
-     * @throws IllegalArgumentException if no service name could be found
-     */
-    public static String getServiceName(RawServiceSpec rawServiceSpec) {
-        if (!StringUtils.isEmpty(rawServiceSpec.getName())) {
-            return rawServiceSpec.getName();
-        }
-        throw new IllegalStateException("Missing required 'name' in Service Spec");
-    }
-
-    /**
-     * Removes any slashes from the provided framework name and replaces them with double underscores.
+     * Removes any slashes from the provided name and replaces them with double underscores. Any leading slash is
+     * removed entirely. This is useful for sanitizing framework names, framework roles, and curator paths.
      *
      * For example:
      * <ul>
@@ -49,76 +24,21 @@ public class SchedulerUtils {
      * <li>path__to__kafka => EXCEPTION</li>
      * </ul>
      *
-     * @throws IllegalArgumentException if the provided framework name already contains double underscores
+     * @throws IllegalArgumentException if the provided name already contains double underscores
      */
-    public static String withEscapedSlashes(String frameworkName) {
-        if (frameworkName.contains(FRAMEWORK_NAME_SLASH_ESCAPE)) {
-            throw new IllegalArgumentException("Service names may not contain double underscores: " + frameworkName);
+    public static String withEscapedSlashes(String name) {
+        if (name.contains(SLASH_REPLACEMENT)) {
+            throw new IllegalArgumentException("Service names may not contain double underscores: " + name);
         }
 
-        if (frameworkName.startsWith(PersisterUtils.PATH_DELIM_STR)) {
+        if (name.startsWith(PersisterUtils.PATH_DELIM_STR)) {
             // Trim any leading slash
-            frameworkName = frameworkName.substring(PersisterUtils.PATH_DELIM_STR.length());
+            name = name.substring(PersisterUtils.PATH_DELIM_STR.length());
         }
+
         // Replace any other slashes (e.g. from folder support) with double underscores:
-        frameworkName = frameworkName.replace(PersisterUtils.PATH_DELIM_STR, FRAMEWORK_NAME_SLASH_ESCAPE);
-        return frameworkName;
-    }
-
-    /**
-     * Returns the configured Mesos role to use for running the service.
-     *
-     * For example: /path/to/kafka => path__to__kafka-role
-     */
-    public static String getServiceRole(RawServiceSpec rawServiceSpec) {
-        // Use <svcname>-role (or throw if svcname is missing)
-
-        // If the service name has a leading slash (due to folders), omit that leading slash from the role.
-        // This is done with the reasoning that "/path/to/kafka" and "path/to/kafka" should be equivalent.
-
-        // Slashes are currently banned from roles by as of mesos commit e0d8cc7c. Sounds like they will be allowed
-        // again in 1.4 when hierarchical roles are supported.
-        //TODO(nickbp): Revisit use of slashes here, as they're needed for hierarchical roles.
-        return withEscapedSlashes(getServiceName(rawServiceSpec)) + DEFAULT_ROLE_SUFFIX;
-    }
-
-    /**
-     * Returns the configured Mesos principal to use for running the service.
-     */
-    public static String getServicePrincipal(RawServiceSpec rawServiceSpec) {
-        // If the svc.yml explicitly provided a principal, use that
-        if (rawServiceSpec.getScheduler() != null
-                && !StringUtils.isEmpty(rawServiceSpec.getScheduler().getPrincipal())) {
-            return rawServiceSpec.getScheduler().getPrincipal();
-        }
-        // Fallback: Use <svcname>-principal (or throw if svcname is missing)
-        return getServiceName(rawServiceSpec) + DEFAULT_PRINCIPAL_SUFFIX;
-    }
-
-    /**
-     * Returns the configured {@code hostname:port} to use for state storage at the scheduler.
-     */
-    public static String getZkHost(RawServiceSpec rawServiceSpec, SchedulerConfig schedulerConfig) {
-        // If the svc.yml explicitly provided a zk host:port, use that
-        if (rawServiceSpec.getScheduler() != null
-                && !StringUtils.isEmpty(rawServiceSpec.getScheduler().getZookeeper())) {
-            return rawServiceSpec.getScheduler().getZookeeper();
-        }
-        // Fallback: Use the default host:port
-        return DEFAULT_ZK_HOST_PORT;
-    }
-
-    /**
-     * Returns the configured user to use for running the scheduler.
-     */
-    public static String getUser(RawServiceSpec rawServiceSpec) {
-        // If the svc.yml explicitly provided a service user, use that
-        if (rawServiceSpec.getScheduler() != null && !StringUtils.isEmpty(rawServiceSpec.getScheduler().getUser())) {
-            return rawServiceSpec.getScheduler().getUser();
-        }
-
-        // Fallback: Use the default scheduler user
-        return DcosConstants.DEFAULT_SERVICE_USER;
+        name = name.replace(PersisterUtils.PATH_DELIM_STR, SLASH_REPLACEMENT);
+        return name;
     }
 
     /**
@@ -126,21 +46,10 @@ public class SchedulerUtils {
      */
     @SuppressWarnings("DM_EXIT")
     public static void hardExit(SchedulerErrorCode errorCode) {
-        String message = String.format("Scheduler exiting immediately with code: %d", errorCode.getValue());
+        String message =
+                String.format("Scheduler exiting immediately with code: %s[%d]", errorCode, errorCode.getValue());
         System.err.println(message);
         System.out.println(message);
         System.exit(errorCode.getValue());
-    }
-
-    static Optional<Plan> getDeployPlan(Collection<Plan> plans) {
-        List<Plan> deployPlans = plans.stream().filter(Plan::isDeployPlan).collect(Collectors.toList());
-
-        if (deployPlans.size() == 1) {
-            return Optional.of(deployPlans.get(0));
-        } else if (deployPlans.size() == 0) {
-            return Optional.empty();
-        } else {
-            throw new IllegalStateException(String.format("Found multiple deploy plans: %s", deployPlans));
-        }
     }
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/uninstall/UninstallScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/uninstall/UninstallScheduler.java
@@ -68,7 +68,7 @@ public class UninstallScheduler extends AbstractScheduler {
             SchedulerConfig schedulerConfig,
             Optional<PlanCustomizer> planCustomizer,
             Optional<SecretsClient> customSecretsClientForTests) {
-        super(frameworkInfo, frameworkStore, stateStore, configStore, schedulerConfig, planCustomizer);
+        super(frameworkInfo, frameworkStore, serviceSpec, stateStore, configStore, schedulerConfig, planCustomizer);
         this.secretsClient = customSecretsClientForTests;
 
         Plan plan = new UninstallPlanBuilder(

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/ServiceSpec.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/ServiceSpec.java
@@ -19,8 +19,11 @@ public interface ServiceSpec extends Configuration {
     @JsonProperty("principal")
     String getPrincipal();
 
-    @JsonProperty("pod-specs")
-    List<PodSpec> getPods();
+    @JsonProperty("user")
+    String getUser();
+
+    @JsonProperty("region")
+    Optional<String> getRegion();
 
     @JsonProperty("web-url")
     String getWebUrl();
@@ -31,9 +34,6 @@ public interface ServiceSpec extends Configuration {
     @JsonProperty("replacement-failure-policy")
     Optional<ReplacementFailurePolicy> getReplacementFailurePolicy();
 
-    @JsonProperty("user")
-    String getUser();
-
-    @JsonProperty("region")
-    Optional<String> getRegion();
+    @JsonProperty("pod-specs")
+    List<PodSpec> getPods();
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/validation/ZoneValidator.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/validation/ZoneValidator.java
@@ -17,6 +17,11 @@ import java.util.stream.Collectors;
  * 3. false --> false
  */
 public class ZoneValidator {
+
+    private ZoneValidator() {
+        // do not instantiate
+    }
+
     public static Collection<ConfigValidationError> validate(
             Optional<ServiceSpec> oldConfig,
             ServiceSpec newConfig,

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/RawServiceSpec.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/RawServiceSpec.java
@@ -2,7 +2,9 @@ package com.mesosphere.sdk.specification.yaml;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.google.common.annotations.VisibleForTesting;
@@ -25,17 +27,24 @@ import org.slf4j.Logger;
 public class RawServiceSpec {
     private static final Logger LOGGER = LoggingUtils.getLogger(RawServiceSpec.class);
     private static final ObjectMapper YAML_MAPPER = new ObjectMapper(new YAMLFactory());
+    static {
+        // If the user provides duplicate fields (e.g. 'count' twice), throw an error instead of silently dropping data:
+        YAML_MAPPER.enable(JsonParser.Feature.STRICT_DUPLICATE_DETECTION);
+    }
 
     /**
-     * Handles rendering of {@link RawServiceSpec}s based on the Scheduler's environment variables.
+     * Generates a {@link RawServiceSpec} object representation from the provided plain YAML content.
+     * Mustache handling is not done here. For that you need {@link #newBuilder(File)}.
+     */
+    public static RawServiceSpec fromBytes(byte[] yamlContent)
+            throws JsonParseException, JsonMappingException, IOException {
+        return YAML_MAPPER.readValue(yamlContent, RawServiceSpec.class);
+    }
+
+    /**
+     * Handles mustache rendering of {@link RawServiceSpec}s based on the Scheduler's environment variables.
      */
     public static class Builder {
-
-        static {
-            // If the user provides duplicate fields (e.g. 'count' twice), throw an error instead of silently dropping
-            // data:
-            YAML_MAPPER.enable(JsonParser.Feature.STRICT_DUPLICATE_DETECTION);
-        }
 
         private final File pathToYamlTemplate;
         private Map<String, String> env;
@@ -69,7 +78,7 @@ public class RawServiceSpec {
                     missingValues);
             LOGGER.info("Rendered ServiceSpec from {}:\nMissing template values: {}\n{}",
                     pathToYamlTemplate.getAbsolutePath(), missingValues, yamlWithEnv);
-            return YAML_MAPPER.readValue(yamlWithEnv.getBytes(StandardCharsets.UTF_8), RawServiceSpec.class);
+            return fromBytes(yamlWithEnv.getBytes(StandardCharsets.UTF_8));
         }
     }
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/TemplateUtils.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/TemplateUtils.java
@@ -62,6 +62,7 @@ public class TemplateUtils {
      * Renders a given Mustache template using the provided value map, returning any template parameters which weren't
      * present in the map.
      *
+     * @param templateName descriptive name of template to show in logs
      * @param templateContent String representation of template
      * @param values Map of values to be inserted into the template
      * @param missingValues List where missing value entries will be added for any template params in

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/YAMLToInternalMappers.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/YAMLToInternalMappers.java
@@ -2,6 +2,8 @@ package com.mesosphere.sdk.specification.yaml;
 
 import com.google.common.base.Strings;
 import com.mesosphere.sdk.dcos.DcosConstants;
+import com.mesosphere.sdk.framework.FrameworkConfig;
+
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -13,7 +15,6 @@ import com.mesosphere.sdk.offer.evaluate.placement.MarathonConstraintParser;
 import com.mesosphere.sdk.offer.evaluate.placement.PassthroughRule;
 import com.mesosphere.sdk.offer.evaluate.placement.PlacementRule;
 import com.mesosphere.sdk.scheduler.SchedulerConfig;
-import com.mesosphere.sdk.scheduler.SchedulerUtils;
 import com.mesosphere.sdk.specification.*;
 import org.apache.mesos.Protos;
 
@@ -56,27 +57,47 @@ public class YAMLToInternalMappers {
      */
     public static DefaultServiceSpec convertServiceSpec(
             RawServiceSpec rawServiceSpec,
+            FrameworkConfig frameworkConfig,
             SchedulerConfig schedulerConfig,
             TaskEnvRouter taskEnvRouter,
             ConfigTemplateReader configTemplateReader) throws Exception {
-        verifyDistinctDiscoveryPrefixes(rawServiceSpec.getPods().values());
-        verifyDistinctEndpointNames(rawServiceSpec.getPods().values());
+        if (StringUtils.isEmpty(rawServiceSpec.getName())) {
+            throw new IllegalStateException("Missing required 'name' in Service Spec");
+        }
+        return convertServiceSpec(
+                rawServiceSpec.getName(),
+                rawServiceSpec.getPods(),
+                frameworkConfig,
+                schedulerConfig,
+                taskEnvRouter,
+                configTemplateReader);
+    }
 
-        String role = SchedulerUtils.getServiceRole(rawServiceSpec);
-        String principal = SchedulerUtils.getServicePrincipal(rawServiceSpec);
-        String user = SchedulerUtils.getUser(rawServiceSpec);
+    /**
+     * Note: We make it very explicit here that many fields from the {@link RawServiceSpec} should not be read directly.
+     * Instead we should go to the {@link FrameworkConfig} for those values. This is because they may be different in
+     * the case of a multi-service scheduler.
+     */
+    private static DefaultServiceSpec convertServiceSpec(
+            String serviceName,
+            LinkedHashMap<String, RawPod> rawPods,
+            FrameworkConfig frameworkConfig,
+            SchedulerConfig schedulerConfig,
+            TaskEnvRouter taskEnvRouter,
+            ConfigTemplateReader configTemplateReader) throws Exception {
+        verifyDistinctDiscoveryPrefixes(rawPods.values());
+        verifyDistinctEndpointNames(rawPods.values());
 
         DefaultServiceSpec.Builder builder = DefaultServiceSpec.newBuilder()
-                .name(SchedulerUtils.getServiceName(rawServiceSpec))
-                .role(role)
-                .principal(principal)
-                .zookeeperConnection(SchedulerUtils.getZkHost(rawServiceSpec, schedulerConfig))
-                .webUrl(rawServiceSpec.getWebUrl())
-                .user(user);
+                .name(serviceName)
+                .role(frameworkConfig.getRole())
+                .principal(frameworkConfig.getPrincipal())
+                .zookeeperConnection(frameworkConfig.getZookeeperHostPort())
+                .webUrl(frameworkConfig.getWebUrl())
+                .user(frameworkConfig.getUser());
 
         // Add all pods
         List<PodSpec> pods = new ArrayList<>();
-        final LinkedHashMap<String, RawPod> rawPods = rawServiceSpec.getPods();
         for (Map.Entry<String, RawPod> entry : rawPods.entrySet()) {
             String podName = entry.getKey();
             RawPod rawPod = entry.getValue();
@@ -85,10 +106,10 @@ public class YAMLToInternalMappers {
                     configTemplateReader,
                     podName,
                     taskEnvRouter.getConfig(podName),
-                    getRole(rawPod.getPreReservedRole(), role),
-                    principal,
+                    getPodRole(rawPod.getPreReservedRole(), frameworkConfig.getRole()),
+                    frameworkConfig.getPrincipal(),
                     schedulerConfig.getExecutorURI(),
-                    user));
+                    frameworkConfig.getUser()));
 
         }
         builder.pods(pods);
@@ -614,7 +635,7 @@ public class YAMLToInternalMappers {
      * @param role The role of the service
      * @return The final role which refined resources should use
      */
-    private static String getRole(String preReservedRole, String role) {
+    private static String getPodRole(String preReservedRole, String role) {
         if (preReservedRole == null || preReservedRole.equals(Constants.ANY_ROLE)) {
             return role;
         } else {

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/dcos/CapabilitiesTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/dcos/CapabilitiesTest.java
@@ -1,21 +1,12 @@
 package com.mesosphere.sdk.dcos;
 
 import org.junit.*;
-import org.junit.contrib.java.lang.system.EnvironmentVariables;
-
 import java.io.IOException;
 
 /**
  * Tests for the {@link Capabilities} class
  */
 public class CapabilitiesTest {
-    @Rule
-    public final EnvironmentVariables environmentVariables = new EnvironmentVariables();
-
-    @Before
-    public void beforeEach() {
-        environmentVariables.set("ALLOW_REGION_AWARENESS", null);
-    }
 
     @Test
     public void test_090() throws IOException {
@@ -24,13 +15,7 @@ public class CapabilitiesTest {
         Assert.assertFalse(capabilities.supportsRLimits());
 
         // Region awareness
-        Assert.assertFalse(capabilities.supportsRegionAwareness());
-        environmentVariables.set("ALLOW_REGION_AWARENESS", "true");
-        Assert.assertFalse(capabilities.supportsRegionAwareness());
-        environmentVariables.set("ALLOW_REGION_AWARENESS", "false");
-        Assert.assertFalse(capabilities.supportsRegionAwareness());
-        environmentVariables.set("ALLOW_REGION_AWARENESS", null);
-        Assert.assertFalse(capabilities.supportsRegionAwareness());
+        Assert.assertFalse(capabilities.supportsDomains());
     }
 
     @Test
@@ -40,13 +25,7 @@ public class CapabilitiesTest {
         Assert.assertFalse(capabilities.supportsRLimits());
 
         // Region awareness
-        Assert.assertFalse(capabilities.supportsRegionAwareness());
-        environmentVariables.set("ALLOW_REGION_AWARENESS", "true");
-        Assert.assertFalse(capabilities.supportsRegionAwareness());
-        environmentVariables.set("ALLOW_REGION_AWARENESS", "false");
-        Assert.assertFalse(capabilities.supportsRegionAwareness());
-        environmentVariables.set("ALLOW_REGION_AWARENESS", null);
-        Assert.assertFalse(capabilities.supportsRegionAwareness());
+        Assert.assertFalse(capabilities.supportsDomains());
     }
 
     @Test
@@ -56,13 +35,7 @@ public class CapabilitiesTest {
         Assert.assertFalse(capabilities.supportsRLimits());
 
         // Region awareness
-        Assert.assertFalse(capabilities.supportsRegionAwareness());
-        environmentVariables.set("ALLOW_REGION_AWARENESS", "true");
-        Assert.assertFalse(capabilities.supportsRegionAwareness());
-        environmentVariables.set("ALLOW_REGION_AWARENESS", "false");
-        Assert.assertFalse(capabilities.supportsRegionAwareness());
-        environmentVariables.set("ALLOW_REGION_AWARENESS", null);
-        Assert.assertFalse(capabilities.supportsRegionAwareness());
+        Assert.assertFalse(capabilities.supportsDomains());
     }
 
     @Test
@@ -73,13 +46,7 @@ public class CapabilitiesTest {
         Assert.assertTrue(capabilities.supportsEnvBasedSecretsDirectiveLabel());
 
         // Region awareness
-        Assert.assertFalse(capabilities.supportsRegionAwareness());
-        environmentVariables.set("ALLOW_REGION_AWARENESS", "true");
-        Assert.assertFalse(capabilities.supportsRegionAwareness());
-        environmentVariables.set("ALLOW_REGION_AWARENESS", "false");
-        Assert.assertFalse(capabilities.supportsRegionAwareness());
-        environmentVariables.set("ALLOW_REGION_AWARENESS", null);
-        Assert.assertFalse(capabilities.supportsRegionAwareness());
+        Assert.assertFalse(capabilities.supportsDomains());
     }
 
     @Test
@@ -90,13 +57,7 @@ public class CapabilitiesTest {
         Assert.assertTrue(capabilities.supportsEnvBasedSecretsDirectiveLabel());
 
         // Region awareness
-        Assert.assertFalse(capabilities.supportsRegionAwareness());
-        environmentVariables.set("ALLOW_REGION_AWARENESS", "true");
-        Assert.assertFalse(capabilities.supportsRegionAwareness());
-        environmentVariables.set("ALLOW_REGION_AWARENESS", "false");
-        Assert.assertFalse(capabilities.supportsRegionAwareness());
-        environmentVariables.set("ALLOW_REGION_AWARENESS", null);
-        Assert.assertFalse(capabilities.supportsRegionAwareness());
+        Assert.assertFalse(capabilities.supportsDomains());
     }
 
     @Test
@@ -105,19 +66,14 @@ public class CapabilitiesTest {
         Assert.assertTrue(capabilities.supportsNamedVips());
         Assert.assertTrue(capabilities.supportsGpuResource());
         Assert.assertTrue(capabilities.supportsRLimits());
-        //Secrets
+
+        // Secrets
         Assert.assertTrue(capabilities.supportsEnvBasedSecretsDirectiveLabel());
         Assert.assertFalse(capabilities.supportsEnvBasedSecretsProtobuf());
         Assert.assertFalse(capabilities.supportsFileBasedSecrets());
 
         // Region awareness
-        Assert.assertFalse(capabilities.supportsRegionAwareness());
-        environmentVariables.set("ALLOW_REGION_AWARENESS", "true");
-        Assert.assertFalse(capabilities.supportsRegionAwareness());
-        environmentVariables.set("ALLOW_REGION_AWARENESS", "false");
-        Assert.assertFalse(capabilities.supportsRegionAwareness());
-        environmentVariables.set("ALLOW_REGION_AWARENESS", null);
-        Assert.assertFalse(capabilities.supportsRegionAwareness());
+        Assert.assertFalse(capabilities.supportsDomains());
     }
 
     @Test
@@ -126,19 +82,14 @@ public class CapabilitiesTest {
         Assert.assertTrue(capabilities.supportsNamedVips());
         Assert.assertTrue(capabilities.supportsGpuResource());
         Assert.assertTrue(capabilities.supportsRLimits());
-        //Secrets
+
+        // Secrets
         Assert.assertTrue(capabilities.supportsEnvBasedSecretsDirectiveLabel());
         Assert.assertFalse(capabilities.supportsEnvBasedSecretsProtobuf());
         Assert.assertFalse(capabilities.supportsFileBasedSecrets());
 
         // Region awareness
-        Assert.assertFalse(capabilities.supportsRegionAwareness());
-        environmentVariables.set("ALLOW_REGION_AWARENESS", "true");
-        Assert.assertFalse(capabilities.supportsRegionAwareness());
-        environmentVariables.set("ALLOW_REGION_AWARENESS", "false");
-        Assert.assertFalse(capabilities.supportsRegionAwareness());
-        environmentVariables.set("ALLOW_REGION_AWARENESS", null);
-        Assert.assertFalse(capabilities.supportsRegionAwareness());
+        Assert.assertFalse(capabilities.supportsDomains());
     }
 
     @Test
@@ -155,13 +106,7 @@ public class CapabilitiesTest {
         Assert.assertFalse(capabilities.supportsV1APIByDefault());
 
         // Region awareness
-        Assert.assertFalse(capabilities.supportsRegionAwareness());
-        environmentVariables.set("ALLOW_REGION_AWARENESS", "true");
-        Assert.assertFalse(capabilities.supportsRegionAwareness());
-        environmentVariables.set("ALLOW_REGION_AWARENESS", "false");
-        Assert.assertFalse(capabilities.supportsRegionAwareness());
-        environmentVariables.set("ALLOW_REGION_AWARENESS", null);
-        Assert.assertFalse(capabilities.supportsRegionAwareness());
+        Assert.assertFalse(capabilities.supportsDomains());
     }
 
     @Test
@@ -170,6 +115,7 @@ public class CapabilitiesTest {
         Assert.assertTrue(capabilities.supportsNamedVips());
         Assert.assertTrue(capabilities.supportsGpuResource());
         Assert.assertTrue(capabilities.supportsRLimits());
+
         // Secrets
         Assert.assertTrue(capabilities.supportsEnvBasedSecretsDirectiveLabel());
         Assert.assertTrue(capabilities.supportsEnvBasedSecretsProtobuf());
@@ -178,13 +124,7 @@ public class CapabilitiesTest {
         Assert.assertFalse(capabilities.supportsV1APIByDefault());
 
         // Region awareness
-        Assert.assertFalse(capabilities.supportsRegionAwareness());
-        environmentVariables.set("ALLOW_REGION_AWARENESS", "true");
-        Assert.assertFalse(capabilities.supportsRegionAwareness());
-        environmentVariables.set("ALLOW_REGION_AWARENESS", "false");
-        Assert.assertFalse(capabilities.supportsRegionAwareness());
-        environmentVariables.set("ALLOW_REGION_AWARENESS", null);
-        Assert.assertFalse(capabilities.supportsRegionAwareness());
+        Assert.assertFalse(capabilities.supportsDomains());
     }
 
     @Test
@@ -193,6 +133,7 @@ public class CapabilitiesTest {
         Assert.assertTrue(capabilities.supportsNamedVips());
         Assert.assertTrue(capabilities.supportsGpuResource());
         Assert.assertTrue(capabilities.supportsRLimits());
+
         // Secrets
         Assert.assertTrue(capabilities.supportsEnvBasedSecretsDirectiveLabel());
         Assert.assertTrue(capabilities.supportsEnvBasedSecretsProtobuf());
@@ -201,13 +142,7 @@ public class CapabilitiesTest {
         Assert.assertTrue(capabilities.supportsV1APIByDefault());
 
         // Region awareness
-        Assert.assertFalse(capabilities.supportsRegionAwareness());
-        environmentVariables.set("ALLOW_REGION_AWARENESS", "true");
-        Assert.assertTrue(capabilities.supportsRegionAwareness());
-        environmentVariables.set("ALLOW_REGION_AWARENESS", "false");
-        Assert.assertFalse(capabilities.supportsRegionAwareness());
-        environmentVariables.set("ALLOW_REGION_AWARENESS", null);
-        Assert.assertFalse(capabilities.supportsRegionAwareness());
+        Assert.assertTrue(capabilities.supportsDomains());
     }
 
     @Test
@@ -216,6 +151,7 @@ public class CapabilitiesTest {
         Assert.assertTrue(capabilities.supportsNamedVips());
         Assert.assertTrue(capabilities.supportsGpuResource());
         Assert.assertTrue(capabilities.supportsRLimits());
+
         // Secrets
         Assert.assertTrue(capabilities.supportsEnvBasedSecretsDirectiveLabel());
         Assert.assertTrue(capabilities.supportsEnvBasedSecretsProtobuf());
@@ -224,13 +160,7 @@ public class CapabilitiesTest {
         Assert.assertTrue(capabilities.supportsV1APIByDefault());
 
         // Region awareness
-        Assert.assertFalse(capabilities.supportsRegionAwareness());
-        environmentVariables.set("ALLOW_REGION_AWARENESS", "true");
-        Assert.assertTrue(capabilities.supportsRegionAwareness());
-        environmentVariables.set("ALLOW_REGION_AWARENESS", "false");
-        Assert.assertFalse(capabilities.supportsRegionAwareness());
-        environmentVariables.set("ALLOW_REGION_AWARENESS", null);
-        Assert.assertFalse(capabilities.supportsRegionAwareness());
+        Assert.assertTrue(capabilities.supportsDomains());
     }
 
     @Test
@@ -239,19 +169,14 @@ public class CapabilitiesTest {
         Assert.assertTrue(capabilities.supportsNamedVips());
         Assert.assertTrue(capabilities.supportsGpuResource());
         Assert.assertTrue(capabilities.supportsRLimits());
+
         // Secrets
         Assert.assertTrue(capabilities.supportsEnvBasedSecretsDirectiveLabel());
         Assert.assertTrue(capabilities.supportsEnvBasedSecretsProtobuf());
         Assert.assertTrue(capabilities.supportsFileBasedSecrets());
 
         // Region awareness
-        Assert.assertFalse(capabilities.supportsRegionAwareness());
-        environmentVariables.set("ALLOW_REGION_AWARENESS", "true");
-        Assert.assertTrue(capabilities.supportsRegionAwareness());
-        environmentVariables.set("ALLOW_REGION_AWARENESS", "false");
-        Assert.assertFalse(capabilities.supportsRegionAwareness());
-        environmentVariables.set("ALLOW_REGION_AWARENESS", null);
-        Assert.assertFalse(capabilities.supportsRegionAwareness());
+        Assert.assertTrue(capabilities.supportsDomains());
     }
 
     @Test
@@ -266,16 +191,10 @@ public class CapabilitiesTest {
         Assert.assertTrue(capabilities.supportsFileBasedSecrets());
 
         // Region awareness
-        Assert.assertFalse(capabilities.supportsRegionAwareness());
-        environmentVariables.set("ALLOW_REGION_AWARENESS", "true");
-        Assert.assertTrue(capabilities.supportsRegionAwareness());
-        environmentVariables.set("ALLOW_REGION_AWARENESS", "false");
-        Assert.assertFalse(capabilities.supportsRegionAwareness());
-        environmentVariables.set("ALLOW_REGION_AWARENESS", null);
-        Assert.assertFalse(capabilities.supportsRegionAwareness());
+        Assert.assertTrue(capabilities.supportsDomains());
     }
 
-    private Capabilities testCapabilities(String version) throws IOException {
+    private static Capabilities testCapabilities(String version) throws IOException {
         return new Capabilities(new DcosVersion(version));
     }
 }

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/framework/FrameworkRunnerTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/framework/FrameworkRunnerTest.java
@@ -1,0 +1,140 @@
+package com.mesosphere.sdk.framework;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import org.apache.mesos.Protos;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import com.mesosphere.sdk.dcos.Capabilities;
+import com.mesosphere.sdk.dcos.DcosConstants;
+import com.mesosphere.sdk.offer.Constants;
+import com.mesosphere.sdk.scheduler.SchedulerConfig;
+import com.mesosphere.sdk.scheduler.plan.Status;
+import com.mesosphere.sdk.storage.Persister;
+import com.mesosphere.sdk.testutils.TestConstants;
+
+import static org.mockito.Mockito.*;
+
+public class FrameworkRunnerTest {
+
+    @Mock private SchedulerConfig mockSchedulerConfig;
+    @Mock private Capabilities mockCapabilities;
+    @Mock private Persister mockPersister;
+
+    @Before
+    public void beforeEach() {
+        MockitoAnnotations.initMocks(this);
+        Capabilities.overrideCapabilities(mockCapabilities);
+    }
+
+    @Test
+    public void testEmptyDeployPlan() {
+        // Sanity check...
+        Assert.assertEquals(Constants.DEPLOY_PLAN_NAME, FrameworkRunner.EMPTY_DEPLOY_PLAN.getName());
+        Assert.assertEquals(Status.COMPLETE, FrameworkRunner.EMPTY_DEPLOY_PLAN.getStatus());
+        Assert.assertTrue(FrameworkRunner.EMPTY_DEPLOY_PLAN.getChildren().isEmpty());
+    }
+
+    @Test
+    public void testMinimalFrameworkInfoInitial() {
+        EnvStore envStore = EnvStore.fromMap(getMinimalMap());
+        FrameworkConfig frameworkConfig = FrameworkConfig.fromEnvStore(envStore);
+
+        FrameworkRunner runner = new FrameworkRunner(frameworkConfig, false, false);
+
+        Protos.FrameworkInfo info = runner.getFrameworkInfo(Optional.empty());
+        Assert.assertEquals("/path/to/test-service", info.getName());
+        Assert.assertEquals(DcosConstants.DEFAULT_SERVICE_USER, info.getUser());
+        Assert.assertEquals(1209600, info.getFailoverTimeout(), 0.1);
+        Assert.assertTrue(info.getCheckpoint());
+        Assert.assertEquals("/path/to/test-service-principal", info.getPrincipal());
+        Assert.assertFalse(info.hasId());
+        checkRole(Optional.of("path__to__test-service-role"), info);
+        Assert.assertEquals(0, info.getRolesCount());
+        Assert.assertEquals(0, info.getCapabilitiesCount());
+        Assert.assertFalse(info.hasWebuiUrl());
+    }
+
+    @Test
+    public void testMinimalFrameworkInfoRelaunch() {
+        EnvStore envStore = EnvStore.fromMap(getMinimalMap());
+        FrameworkConfig frameworkConfig = FrameworkConfig.fromEnvStore(envStore);
+
+        FrameworkRunner runner = new FrameworkRunner(frameworkConfig, false, false);
+
+        Protos.FrameworkInfo info = runner.getFrameworkInfo(Optional.of(TestConstants.FRAMEWORK_ID));
+        Assert.assertEquals("/path/to/test-service", info.getName());
+        Assert.assertEquals(DcosConstants.DEFAULT_SERVICE_USER, info.getUser());
+        Assert.assertEquals(1209600, info.getFailoverTimeout(), 0.1);
+        Assert.assertTrue(info.getCheckpoint());
+        Assert.assertEquals("/path/to/test-service-principal", info.getPrincipal());
+        Assert.assertEquals(TestConstants.FRAMEWORK_ID, info.getId());
+        checkRole(Optional.of("path__to__test-service-role"), info);
+        Assert.assertEquals(0, info.getRolesCount());
+        Assert.assertEquals(0, info.getCapabilitiesCount());
+        Assert.assertFalse(info.hasWebuiUrl());
+    }
+
+    @Test
+    public void testExhaustiveFrameworkInfo() {
+        Map<String, String> env = getMinimalMap();
+        env.put("FRAMEWORK_PRINCIPAL", "custom-principal");
+        env.put("FRAMEWORK_USER", "custom-user");
+        env.put("FRAMEWORK_PRERESERVED_ROLES", "role1,role2,role3");
+        env.put("FRAMEWORK_WEB_URL", "custom-url");
+        EnvStore envStore = EnvStore.fromMap(env);
+        FrameworkConfig frameworkConfig = FrameworkConfig.fromEnvStore(envStore);
+
+        when(mockCapabilities.supportsGpuResource()).thenReturn(true);
+        when(mockCapabilities.supportsPreReservedResources()).thenReturn(true);
+        when(mockCapabilities.supportsDomains()).thenReturn(true);
+        when(mockCapabilities.supportsGpuResource()).thenReturn(true);
+
+        FrameworkRunner runner = new FrameworkRunner( frameworkConfig, true, true);
+        Protos.FrameworkInfo info = runner.getFrameworkInfo(Optional.of(TestConstants.FRAMEWORK_ID));
+        Assert.assertEquals("/path/to/test-service", info.getName());
+        Assert.assertEquals("custom-user", info.getUser());
+        Assert.assertEquals(1209600, info.getFailoverTimeout(), 0.1);
+        Assert.assertTrue(info.getCheckpoint());
+        Assert.assertEquals("custom-principal", info.getPrincipal());
+        Assert.assertEquals(TestConstants.FRAMEWORK_ID, info.getId());
+        checkRole(Optional.empty(), info);
+        Assert.assertEquals(Arrays.asList("path__to__test-service-role", "role1", "role2", "role3"), info.getRolesList());
+        Assert.assertEquals(Arrays.asList(
+                getCapability(Protos.FrameworkInfo.Capability.Type.MULTI_ROLE),
+                getCapability(Protos.FrameworkInfo.Capability.Type.GPU_RESOURCES),
+                getCapability(Protos.FrameworkInfo.Capability.Type.RESERVATION_REFINEMENT),
+                getCapability(Protos.FrameworkInfo.Capability.Type.REGION_AWARE)), info.getCapabilitiesList());
+        Assert.assertEquals("custom-url", info.getWebuiUrl());
+    }
+
+    private static Protos.FrameworkInfo.Capability getCapability(Protos.FrameworkInfo.Capability.Type type) {
+        return Protos.FrameworkInfo.Capability.newBuilder().setType(type).build();
+    }
+
+    @SuppressWarnings("deprecation")
+    private static void checkRole(Optional<String> expectedRole, Protos.FrameworkInfo info) {
+        if (expectedRole.isPresent()) {
+            Assert.assertEquals(info.getRole(), expectedRole.get());
+        } else {
+            Assert.assertFalse(info.hasRole());
+        }
+    }
+
+    private static Map<String, String> getMinimalMap() {
+        Map<String, String> map = new HashMap<>();
+        map.put("FRAMEWORK_NAME", "/path/to/test-service");
+        // Required by SchedulerConfig:
+        map.put("PACKAGE_NAME", "test-package");
+        map.put("PACKAGE_VERSION", "1.5");
+        map.put("PACKAGE_BUILD_TIME_EPOCH_MS", "1234567890");
+        return map;
+    }
+}

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/http/queries/EndpointsQueriesTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/http/queries/EndpointsQueriesTest.java
@@ -175,7 +175,8 @@ public class EndpointsQueriesTest {
     @SuppressWarnings("PMD.AvoidUsingHardCodedIP")
     private void testEndpoint(String expectedHostname) throws ConfigStoreException {
         when(mockStateStore.fetchTasks()).thenReturn(TASK_INFOS);
-        Response response = EndpointsQueries.getEndpoint(mockStateStore, SERVICE_NAME, CUSTOM_ENDPOINTS, "porta", SchedulerConfigTestUtils.getTestSchedulerConfig());
+        Response response = EndpointsQueries.getEndpoint(
+                mockStateStore, SERVICE_NAME, CUSTOM_ENDPOINTS, "porta", SchedulerConfigTestUtils.getTestSchedulerConfig());
         assertEquals(200, response.getStatus());
         JSONObject json = new JSONObject((String) response.getEntity());
         assertEquals(json.toString(), 3, json.length());
@@ -314,7 +315,8 @@ public class EndpointsQueriesTest {
     @Test
     public void testGetOneCustomEndpoint() throws ConfigStoreException {
         when(mockStateStore.fetchTasks()).thenReturn(TASK_INFOS);
-        Response response = EndpointsQueries.getEndpoint(mockStateStore, SERVICE_NAME, CUSTOM_ENDPOINTS, CUSTOM_KEY, SchedulerConfigTestUtils.getTestSchedulerConfig());
+        Response response = EndpointsQueries.getEndpoint(
+                mockStateStore, SERVICE_NAME, CUSTOM_ENDPOINTS, CUSTOM_KEY, SchedulerConfigTestUtils.getTestSchedulerConfig());
         assertEquals(200, response.getStatus());
         assertEquals(CUSTOM_VALUE, response.getEntity());
     }

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/ResourceBuilderTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/ResourceBuilderTest.java
@@ -404,10 +404,8 @@ public class ResourceBuilderTest extends DefaultCapabilitiesTestSuite {
                 Constants.ANY_ROLE,
                 TestConstants.PRINCIPAL);
         Optional<String> resourceId = Optional.of(UUID.randomUUID().toString());
-        Protos.Resource originalResource =
-                ResourceBuilder.fromSpec(resourceSpec, resourceId, namespace).build();
-        Protos.Resource reconstructedResource =
-                ResourceBuilder.fromExistingResource(originalResource).build();
+        Protos.Resource originalResource = ResourceBuilder.fromSpec(resourceSpec, resourceId, namespace).build();
+        Protos.Resource reconstructedResource = ResourceBuilder.fromExistingResource(originalResource).build();
 
         Assert.assertEquals(originalResource, reconstructedResource);
     }
@@ -443,8 +441,7 @@ public class ResourceBuilderTest extends DefaultCapabilitiesTestSuite {
                 persistenceId,
                 Optional.empty())
                 .build();
-        Protos.Resource reconstructedResource =
-                ResourceBuilder.fromExistingResource(originalResource).build();
+        Protos.Resource reconstructedResource = ResourceBuilder.fromExistingResource(originalResource).build();
 
         Assert.assertEquals(originalResource, reconstructedResource);
     }
@@ -481,8 +478,7 @@ public class ResourceBuilderTest extends DefaultCapabilitiesTestSuite {
                 persistenceId,
                 sourceRoot)
                 .build();
-        Protos.Resource reconstructedResource =
-                ResourceBuilder.fromExistingResource(originalResource).build();
+        Protos.Resource reconstructedResource = ResourceBuilder.fromExistingResource(originalResource).build();
 
         Assert.assertEquals(originalResource, reconstructedResource);
     }

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/LaunchEvaluationStageTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/LaunchEvaluationStageTest.java
@@ -46,8 +46,8 @@ public class LaunchEvaluationStageTest extends DefaultCapabilitiesTestSuite {
 
     @Test
     public void isPassing() {
-        EvaluationOutcome outcome = stage.evaluate(new MesosResourcePool(offer, Optional.of(Constants.ANY_ROLE)),
-                podInfoBuilder);
+        EvaluationOutcome outcome = stage.evaluate(
+                new MesosResourcePool(offer, Optional.of(Constants.ANY_ROLE)), podInfoBuilder);
         Assert.assertTrue(outcome.isPassing());
     }
 

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/NamedVIPEvaluationStageTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/NamedVIPEvaluationStageTest.java
@@ -33,8 +33,7 @@ public class NamedVIPEvaluationStageTest extends DefaultCapabilitiesTestSuite {
         // Evaluate stage
         NamedVIPEvaluationStage vipEvaluationStage = getEvaluationStageOnNetwork(10000, Optional.empty(), Optional.empty());
         EvaluationOutcome outcome = vipEvaluationStage.evaluate(
-                new MesosResourcePool(offer, Optional.of(Constants.ANY_ROLE)),
-                podInfoBuilder);
+                new MesosResourcePool(offer, Optional.of(Constants.ANY_ROLE)), podInfoBuilder);
         Assert.assertTrue(outcome.isPassing());
 
         Protos.DiscoveryInfo discoveryInfo = podInfoBuilder.getTaskBuilder(TestConstants.TASK_NAME).getDiscovery();
@@ -68,8 +67,7 @@ public class NamedVIPEvaluationStageTest extends DefaultCapabilitiesTestSuite {
                 containerPort, Optional.empty(), Optional.of(overlayNetwork));
 
         EvaluationOutcome outcome = vipEvaluationStage.evaluate(
-                new MesosResourcePool(offer, Optional.of(Constants.ANY_ROLE)),
-                podInfoBuilder);
+                new MesosResourcePool(offer, Optional.of(Constants.ANY_ROLE)), podInfoBuilder);
         Assert.assertTrue(outcome.isPassing());
 
         Protos.DiscoveryInfo discoveryInfo = podInfoBuilder.getTaskBuilder(TestConstants.TASK_NAME).getDiscovery();
@@ -109,8 +107,7 @@ public class NamedVIPEvaluationStageTest extends DefaultCapabilitiesTestSuite {
                 containerPort, Optional.empty(), Optional.of(bridgeNetwork));
 
         EvaluationOutcome outcome = vipEvaluationStage.evaluate(
-                new MesosResourcePool(offer, Optional.of(Constants.ANY_ROLE)),
-                podInfoBuilder);
+                new MesosResourcePool(offer, Optional.of(Constants.ANY_ROLE)), podInfoBuilder);
         Assert.assertTrue(outcome.isPassing());
 
         Protos.DiscoveryInfo discoveryInfo = podInfoBuilder.getTaskBuilder(TestConstants.TASK_NAME).getDiscovery();
@@ -148,8 +145,7 @@ public class NamedVIPEvaluationStageTest extends DefaultCapabilitiesTestSuite {
                 containerPort, Optional.empty(), Optional.of(overlayNetwork));
 
         EvaluationOutcome outcome = vipEvaluationStage.evaluate(
-                new MesosResourcePool(offer, Optional.of(Constants.ANY_ROLE)),
-                podInfoBuilder);
+                new MesosResourcePool(offer, Optional.of(Constants.ANY_ROLE)), podInfoBuilder);
         Assert.assertTrue(outcome.isPassing());
 
         Protos.DiscoveryInfo discoveryInfo = podInfoBuilder.getTaskBuilder(TestConstants.TASK_NAME).getDiscovery();

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluationUtilsTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluationUtilsTest.java
@@ -102,9 +102,9 @@ public class OfferEvaluationUtilsTest extends DefaultCapabilitiesTestSuite {
             Protos.Resource resource = recommendation.getOperation().getReserve().getResources(0);
             Assert.assertEquals(desired.getScalar(), resource.getScalar());
             if (namespace.isPresent()) {
-                Assert.assertEquals(namespace.get(), ResourceUtils.getResourceNamespace(resource).get());
+                Assert.assertEquals(namespace.get(), ResourceUtils.getNamespace(resource).get());
             } else {
-                Assert.assertFalse(ResourceUtils.getResourceNamespace(resource).isPresent());
+                Assert.assertFalse(ResourceUtils.getNamespace(resource).isPresent());
             }
         }
     }
@@ -137,9 +137,9 @@ public class OfferEvaluationUtilsTest extends DefaultCapabilitiesTestSuite {
         Protos.Resource resource = recommendation.getOperation().getReserve().getResources(0);
         Assert.assertEquals(toAdd.getScalar(), resource.getScalar());
         if (namespace.isPresent()) {
-            Assert.assertEquals(namespace.get(), ResourceUtils.getResourceNamespace(resource).get());
+            Assert.assertEquals(namespace.get(), ResourceUtils.getNamespace(resource).get());
         } else {
-            Assert.assertFalse(ResourceUtils.getResourceNamespace(resource).isPresent());
+            Assert.assertFalse(ResourceUtils.getNamespace(resource).isPresent());
         }
     }
 
@@ -197,9 +197,9 @@ public class OfferEvaluationUtilsTest extends DefaultCapabilitiesTestSuite {
         Protos.Resource resource = recommendation.getOperation().getUnreserve().getResources(0);
         Assert.assertEquals(toSubtract.getScalar(), resource.getScalar());
         if (namespace.isPresent()) {
-            Assert.assertEquals(namespace.get(), ResourceUtils.getResourceNamespace(resource).get());
+            Assert.assertEquals(namespace.get(), ResourceUtils.getNamespace(resource).get());
         } else {
-            Assert.assertFalse(ResourceUtils.getResourceNamespace(resource).isPresent());
+            Assert.assertFalse(ResourceUtils.getNamespace(resource).isPresent());
         }
     }
 

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/PlacementRuleEvaluationStageTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/PlacementRuleEvaluationStageTest.java
@@ -30,8 +30,7 @@ public class PlacementRuleEvaluationStageTest extends DefaultCapabilitiesTestSui
         PlacementRule rule = AgentRule.require(agent);
         Protos.Offer offer = offerWithAgent(agent, offered);
 
-        MesosResourcePool mesosResourcePool =
-                new MesosResourcePool(offer, Optional.of(Constants.ANY_ROLE));
+        MesosResourcePool mesosResourcePool = new MesosResourcePool(offer, Optional.of(Constants.ANY_ROLE));
 
         PodSpec podSpec = PodInstanceRequirementTestUtils.getCpuRequirement(1.0).getPodInstance().getPod();
         DefaultPodSpec.newBuilder(podSpec)
@@ -70,8 +69,7 @@ public class PlacementRuleEvaluationStageTest extends DefaultCapabilitiesTestSui
         PlacementRule rule = AgentRule.require(agent);
         Protos.Offer offer = offerWithAgent("other-agent", offered);
 
-        MesosResourcePool mesosResourcePool =
-                new MesosResourcePool(offer, Optional.of(Constants.ANY_ROLE));
+        MesosResourcePool mesosResourcePool = new MesosResourcePool(offer, Optional.of(Constants.ANY_ROLE));
         PodSpec podSpec = PodInstanceRequirementTestUtils.getCpuRequirement(1.0).getPodInstance().getPod();
         DefaultPodSpec.newBuilder(podSpec)
                 .placementRule(rule);

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/PortEvaluationStageTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/PortEvaluationStageTest.java
@@ -135,8 +135,7 @@ public class PortEvaluationStageTest extends DefaultCapabilitiesTestSuite {
         PortEvaluationStage portEvaluationStage = new PortEvaluationStage(
                 portSpec, TestConstants.TASK_NAME, Optional.empty(), Optional.empty());
         EvaluationOutcome outcome = portEvaluationStage.evaluate(
-                new MesosResourcePool(offer, Optional.of(Constants.ANY_ROLE)),
-                podInfoBuilder);
+                new MesosResourcePool(offer, Optional.of(Constants.ANY_ROLE)), podInfoBuilder);
         Assert.assertTrue(outcome.isPassing());
         Assert.assertEquals(0, outcome.getOfferRecommendations().size());
         Protos.TaskInfo.Builder taskBuilder = podInfoBuilder.getTaskBuilder(TestConstants.TASK_NAME);
@@ -176,8 +175,7 @@ public class PortEvaluationStageTest extends DefaultCapabilitiesTestSuite {
         PortEvaluationStage portEvaluationStage = new PortEvaluationStage(
                 portSpec, TestConstants.TASK_NAME, Optional.empty(), Optional.empty());
         EvaluationOutcome outcome = portEvaluationStage.evaluate(
-                new MesosResourcePool(offer, Optional.of(Constants.ANY_ROLE)),
-                podInfoBuilder);
+                new MesosResourcePool(offer, Optional.of(Constants.ANY_ROLE)), podInfoBuilder);
         Assert.assertTrue(outcome.isPassing());
         Assert.assertEquals(0, outcome.getOfferRecommendations().size());
         Protos.TaskInfo.Builder taskBuilder = podInfoBuilder.getTaskBuilder(TestConstants.TASK_NAME);
@@ -228,20 +226,21 @@ public class PortEvaluationStageTest extends DefaultCapabilitiesTestSuite {
         Assert.assertTrue(String.format("podInfoBuilder has incorrect number of pre-assigned overlay ports " +
                         "should be 1, got %s", podInfoBuilder.getAssignedOverlayPorts().size()),
                 podInfoBuilder.getAssignedOverlayPorts().size() == 1);
-        MesosResourcePool mesosResourcePool =
-                new MesosResourcePool(offer, Optional.of(Constants.ANY_ROLE));
+
         PortEvaluationStage portEvaluationStage_ = new PortEvaluationStage(
                 portSpec, TestConstants.TASK_NAME, Optional.empty(), Optional.empty());
-        EvaluationOutcome outcome0 = portEvaluationStage_.evaluate(mesosResourcePool, podInfoBuilder);
+        EvaluationOutcome outcome0 = portEvaluationStage_.evaluate(
+                new MesosResourcePool(offer, Optional.of(Constants.ANY_ROLE)), podInfoBuilder);
         Assert.assertTrue(outcome0.isPassing());
         Assert.assertEquals(0, outcome0.getOfferRecommendations().size());
+
         PortEvaluationStage portEvaluationStage = new PortEvaluationStage(
                 dynamPortSpec, TestConstants.TASK_NAME, Optional.empty(), Optional.empty());
         EvaluationOutcome outcome1 = portEvaluationStage.evaluate(
-                new MesosResourcePool(offer, Optional.of(Constants.ANY_ROLE)),
-                podInfoBuilder);
+                new MesosResourcePool(offer, Optional.of(Constants.ANY_ROLE)), podInfoBuilder);
         Assert.assertTrue(outcome1.isPassing());
         Assert.assertEquals(0, outcome1.getOfferRecommendations().size());
+
         Assert.assertTrue(String.format("podInfoBuilder has incorrect number of assigned overlay ports, " +
                         "should be 2 got %s", podInfoBuilder.getAssignedOverlayPorts().size()),
                 podInfoBuilder.getAssignedOverlayPorts().size() == 2);
@@ -277,8 +276,7 @@ public class PortEvaluationStageTest extends DefaultCapabilitiesTestSuite {
                 getPortSpec(podInstance), TestConstants.TASK_NAME, Optional.empty(), Optional.empty());
 
         EvaluationOutcome outcome = portEvaluationStage.evaluate(
-                new MesosResourcePool(offer, Optional.of(Constants.ANY_ROLE)),
-                podInfoBuilder);
+                new MesosResourcePool(offer, Optional.of(Constants.ANY_ROLE)), podInfoBuilder);
         Assert.assertTrue(outcome.isPassing());
         Assert.assertEquals(1, outcome.getOfferRecommendations().size());
         OfferRecommendation recommendation = outcome.getOfferRecommendations().iterator().next();
@@ -418,8 +416,7 @@ public class PortEvaluationStageTest extends DefaultCapabilitiesTestSuite {
                 getPortSpec(podInstance), TestConstants.TASK_NAME, Optional.empty(), Optional.empty());
 
         EvaluationOutcome outcome = portEvaluationStage.evaluate(
-                new MesosResourcePool(offer, Optional.of(Constants.ANY_ROLE)),
-                podInfoBuilder);
+                new MesosResourcePool(offer, Optional.of(Constants.ANY_ROLE)), podInfoBuilder);
         Assert.assertTrue(outcome.isPassing());
         Assert.assertEquals(1, outcome.getOfferRecommendations().size());
         OfferRecommendation recommendation = outcome.getOfferRecommendations().iterator().next();
@@ -467,11 +464,10 @@ public class PortEvaluationStageTest extends DefaultCapabilitiesTestSuite {
                 true,
                 Collections.emptyMap());
 
-        PortEvaluationStage portEvaluationStage = new PortEvaluationStage(
-                portSpec, TestConstants.TASK_NAME, Optional.empty(), Optional.empty());
+        PortEvaluationStage portEvaluationStage =
+                new PortEvaluationStage(portSpec, TestConstants.TASK_NAME, Optional.empty(), Optional.empty());
 
-        MesosResourcePool mesosResourcePool =
-                new MesosResourcePool(offer, Optional.of(Constants.ANY_ROLE));
+        MesosResourcePool mesosResourcePool = new MesosResourcePool(offer, Optional.of(Constants.ANY_ROLE));
         EvaluationOutcome outcome = portEvaluationStage.evaluate(mesosResourcePool, podInfoBuilder);
         Assert.assertEquals(true, outcome.isPassing());
 

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/TLSEvaluationStageTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/TLSEvaluationStageTest.java
@@ -32,6 +32,7 @@ import static org.mockito.Mockito.*;
 
 public class TLSEvaluationStageTest {
 
+    @Mock private SchedulerConfig mockSchedulerConfig;
     @Mock private TLSArtifactsUpdater mockTLSArtifactsUpdater;
 
     private TLSArtifactPaths tlsArtifactPaths;
@@ -40,6 +41,8 @@ public class TLSEvaluationStageTest {
     @Before
     public void init() throws Exception {
         MockitoAnnotations.initMocks(this);
+
+        when(mockSchedulerConfig.getServiceTLD()).thenReturn(Constants.DNS_TLD);
 
         // echo -n "pod-type-0-test-task-name.service-name.autoip.dcos.thisdcos.directory" | sha1sum
         String sanHash = "8ffc618c478beb31a043d978652d7bc571fedfe2";
@@ -52,7 +55,7 @@ public class TLSEvaluationStageTest {
                 TestConstants.TASK_NAME,
                 "test-namespace",
                 mockTLSArtifactsUpdater,
-                SchedulerConfig.fromEnv());
+                mockSchedulerConfig);
     }
 
     private static PodInstanceRequirement getRequirementWithTransportEncryption(

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/security/CertificateNamesGeneratorTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/security/CertificateNamesGeneratorTest.java
@@ -25,6 +25,7 @@ public class CertificateNamesGeneratorTest {
 
     private static final String POD_NAME = "some-pod";
 
+    @Mock private SchedulerConfig mockSchedulerConfig;
     @Mock private PodInstance mockPodInstance;
     @Mock private TaskSpec mockTaskSpec;
     @Mock private ResourceSet mockResourceSet;
@@ -34,6 +35,8 @@ public class CertificateNamesGeneratorTest {
     @Before
     public void beforeEach() {
         MockitoAnnotations.initMocks(this);
+
+        Mockito.when(mockSchedulerConfig.getServiceTLD()).thenReturn(Constants.DNS_TLD);
 
         Mockito.when(mockPodInstance.getIndex()).thenReturn(0);
         Mockito.when(mockPodInstance.getName()).thenReturn(POD_NAME);
@@ -48,10 +51,7 @@ public class CertificateNamesGeneratorTest {
     @Test
     public void testGetSubject() throws Exception {
         CertificateNamesGenerator certificateNamesGenerator =
-                new CertificateNamesGenerator(TestConstants.SERVICE_NAME,
-                        mockTaskSpec,
-                        mockPodInstance,
-                        SchedulerConfig.fromEnv());
+                new CertificateNamesGenerator(TestConstants.SERVICE_NAME, mockTaskSpec, mockPodInstance, mockSchedulerConfig);
         RDN[] cnRDNs = certificateNamesGenerator.getSubject().getRDNs(BCStyle.CN);
         Assert.assertEquals(cnRDNs.length, 1);
         Assert.assertEquals(String.format("%s-%s.%s", POD_NAME, TestConstants.TASK_NAME, TestConstants.SERVICE_NAME),
@@ -62,10 +62,7 @@ public class CertificateNamesGeneratorTest {
     public void testGetSubjectWithLongCN() throws Exception {
         Mockito.when(mockTaskSpec.getName()).thenReturn(UUID.randomUUID().toString());
         CertificateNamesGenerator certificateNamesGenerator =
-                new CertificateNamesGenerator(UUID.randomUUID().toString(),
-                        mockTaskSpec,
-                        mockPodInstance,
-                        SchedulerConfig.fromEnv());
+                new CertificateNamesGenerator(UUID.randomUUID().toString(), mockTaskSpec, mockPodInstance, mockSchedulerConfig);
         RDN[] cnRDNs = certificateNamesGenerator.getSubject().getRDNs(BCStyle.CN);
         Assert.assertEquals(cnRDNs.length, 1);
         Assert.assertEquals(64, cnRDNs[0].getFirst().getValue().toString().length());
@@ -74,10 +71,7 @@ public class CertificateNamesGeneratorTest {
     @Test
     public void testGetSANs() throws Exception {
         CertificateNamesGenerator certificateNamesGenerator =
-                new CertificateNamesGenerator(TestConstants.SERVICE_NAME,
-                        mockTaskSpec,
-                        mockPodInstance,
-                        SchedulerConfig.fromEnv());
+                new CertificateNamesGenerator(TestConstants.SERVICE_NAME, mockTaskSpec, mockPodInstance, mockSchedulerConfig);
 
         GeneralNames sans = certificateNamesGenerator.getSANs();
         Assert.assertEquals(1, sans.getNames().length);
@@ -99,10 +93,7 @@ public class CertificateNamesGeneratorTest {
         String serviceNameWithoutSlashes = "servicenamewithslashes";
 
         CertificateNamesGenerator certificateNamesGenerator =
-                new CertificateNamesGenerator(serviceNameWithSlashes,
-                        mockTaskSpec,
-                        mockPodInstance,
-                        SchedulerConfig.fromEnv());
+                new CertificateNamesGenerator(serviceNameWithSlashes, mockTaskSpec, mockPodInstance, mockSchedulerConfig);
 
         Assert.assertEquals(String.format("%s-%s.%s", POD_NAME, TestConstants.TASK_NAME, serviceNameWithoutSlashes),
                 certificateNamesGenerator.getSubject().getRDNs(BCStyle.CN)[0].getFirst().getValue().toString());
@@ -123,10 +114,7 @@ public class CertificateNamesGeneratorTest {
         Mockito.when(mockTaskSpec.getDiscovery()).thenReturn(Optional.of(mockDiscoverySpec));
         Mockito.when(mockDiscoverySpec.getPrefix()).thenReturn(Optional.of("custom-name"));
         CertificateNamesGenerator certificateNamesGenerator =
-                new CertificateNamesGenerator(TestConstants.SERVICE_NAME,
-                        mockTaskSpec,
-                        mockPodInstance,
-                        SchedulerConfig.fromEnv());
+                new CertificateNamesGenerator(TestConstants.SERVICE_NAME, mockTaskSpec, mockPodInstance, mockSchedulerConfig);
 
         GeneralNames sans = certificateNamesGenerator.getSANs();
         Assert.assertEquals(1, sans.getNames().length);
@@ -146,10 +134,7 @@ public class CertificateNamesGeneratorTest {
         Mockito.when(mockVIPSpec.getVipName()).thenReturn("test-vip");
         Mockito.when(mockVIPSpec.getPort()).thenReturn(8000L);
         CertificateNamesGenerator certificateNamesGenerator =
-                new CertificateNamesGenerator(TestConstants.SERVICE_NAME,
-                        mockTaskSpec,
-                        mockPodInstance,
-                        SchedulerConfig.fromEnv());
+                new CertificateNamesGenerator(TestConstants.SERVICE_NAME, mockTaskSpec, mockPodInstance, mockSchedulerConfig);
 
         GeneralNames sans = certificateNamesGenerator.getSANs();
         Assert.assertEquals(2, sans.getNames().length);

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/security/TLSArtifactsGeneratorTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/security/TLSArtifactsGeneratorTest.java
@@ -40,6 +40,7 @@ import static org.mockito.Mockito.when;
 
 public class TLSArtifactsGeneratorTest {
 
+    @Mock private SchedulerConfig mockSchedulerConfig;
     @Mock private KeyPairGenerator mockKeyPairGenerator;
     @Mock private CertificateAuthorityClient mockCAClient;
     @Mock private PodInstance mockPodInstance;
@@ -68,11 +69,8 @@ public class TLSArtifactsGeneratorTest {
         when(mockTaskSpec.getResourceSet()).thenReturn(mockResourceSet);
         when(mockResourceSet.getResources()).thenReturn(Collections.emptyList());
 
-        certificateNamesGenerator =
-                new CertificateNamesGenerator(TestConstants.SERVICE_NAME,
-                        mockTaskSpec,
-                        mockPodInstance,
-                        SchedulerConfig.fromEnv());
+        certificateNamesGenerator = new CertificateNamesGenerator(
+                TestConstants.SERVICE_NAME, mockTaskSpec, mockPodInstance, mockSchedulerConfig);
         tlsArtifactsGenerator = new TLSArtifactsGenerator(mockCAClient, mockKeyPairGenerator);
     }
 

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/AbstractSchedulerTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/AbstractSchedulerTest.java
@@ -45,6 +45,7 @@ public class AbstractSchedulerTest {
             .build();
 
     @Mock private ConfigStore<ServiceSpec> mockConfigStore;
+    @Mock private ServiceSpec mockServiceSpec;
     @Mock private SchedulerDriver mockSchedulerDriver;
     @Mock private SecretsClient mockSecretsClient;
 
@@ -153,7 +154,6 @@ public class AbstractSchedulerTest {
                 frameworkInfo,
                 frameworkStore,
                 stateStore,
-                mockConfigStore,
                 SchedulerConfigTestUtils.getTestSchedulerConfig());
         // Customize...
         if (!waitForApiServer) {
@@ -172,7 +172,7 @@ public class AbstractSchedulerTest {
         return scheduler;
     }
 
-    private static class TestScheduler extends AbstractScheduler {
+    private class TestScheduler extends AbstractScheduler {
 
         private final PlanCoordinator mockPlanCoordinator = mock(PlanCoordinator.class);
 
@@ -182,9 +182,8 @@ public class AbstractSchedulerTest {
                 Protos.FrameworkInfo frameworkInfo,
                 FrameworkStore frameworkStore,
                 StateStore stateStore,
-                ConfigStore<ServiceSpec> configStore,
                 SchedulerConfig schedulerConfig) {
-            super(frameworkInfo, frameworkStore, stateStore, configStore, schedulerConfig, Optional.empty());
+            super(frameworkInfo, frameworkStore, mockServiceSpec, stateStore, mockConfigStore, schedulerConfig, Optional.empty());
             when(mockPlanCoordinator.getPlanManagers()).thenReturn(Collections.emptyList());
             when(mockPlanCoordinator.getCandidates()).thenReturn(Collections.emptyList());
         }

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/SchedulerBuilderTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/SchedulerBuilderTest.java
@@ -9,78 +9,180 @@ import com.mesosphere.sdk.scheduler.plan.Plan;
 import com.mesosphere.sdk.specification.DefaultPodSpec;
 import com.mesosphere.sdk.specification.DefaultServiceSpec;
 import com.mesosphere.sdk.specification.PodSpec;
+import com.mesosphere.sdk.specification.ServiceSpec;
 import com.mesosphere.sdk.storage.MemPersister;
 import com.mesosphere.sdk.storage.Persister;
+import com.mesosphere.sdk.storage.PersisterException;
 import com.mesosphere.sdk.testutils.SchedulerConfigTestUtils;
 import com.mesosphere.sdk.testutils.TestConstants;
 import com.mesosphere.sdk.testutils.TestPodFactory;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import java.io.File;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Optional;
 
 /**
  * This class tests the {@link SchedulerBuilder}.
  */
 public class SchedulerBuilderTest {
 
-    private static final SchedulerConfig SCHEDULER_CONFIG = SchedulerConfigTestUtils.getTestSchedulerConfig();
+    private static ServiceSpec minimalServiceSpec;
 
+    private SchedulerConfig mockSchedulerConfig;
     @Mock private Capabilities mockCapabilities;
+
+    @BeforeClass
+    public static void beforeAll() throws Exception {
+        ClassLoader classLoader = SchedulerBuilderTest.class.getClassLoader();
+        File file = new File(classLoader.getResource("valid-minimal.yml").getFile());
+        minimalServiceSpec =
+                DefaultServiceSpec.newGenerator(file, SchedulerConfigTestUtils.getTestSchedulerConfig()).build();
+    }
 
     @Before
     public void beforeEach() {
         MockitoAnnotations.initMocks(this);
+        mockSchedulerConfig = SchedulerConfigTestUtils.getTestSchedulerConfig();
+        when(mockSchedulerConfig.getSchedulerRegion()).thenReturn(Optional.empty());
         when(mockCapabilities.supportsDomains()).thenReturn(true);
         Capabilities.overrideCapabilities(mockCapabilities);
     }
 
     @Test
-    public void leaveRegionRuleUnmodified() {
-        PodSpec originalPodSpec = DefaultPodSpec.newBuilder(getPodSpec())
-                .placementRule(getRemoteRegionRule())
+    public void testExistingRegionRuleUnmodified() throws PersisterException {
+        PlacementRule remoteRegionRule = RegionRuleFactory.getInstance().require(ExactMatcher.create(TestConstants.REMOTE_REGION));
+        PlacementRule localRegionRule = new IsLocalRegionRule();
+        ServiceSpec serviceSpec = DefaultServiceSpec.newBuilder(minimalServiceSpec)
+                .addPod(DefaultPodSpec.newBuilder(getPodSpec("foo"))
+                        .placementRule(remoteRegionRule)
+                        .build())
+                .addPod(DefaultPodSpec.newBuilder(getPodSpec("bar"))
+                        .placementRule(localRegionRule)
+                        .build())
                 .build();
-        PodSpec updatedPodSpec = SchedulerBuilder.updatePodPlacement(originalPodSpec);
 
-        Assert.assertEquals(originalPodSpec, updatedPodSpec);
+        ServiceSpec updatedServiceSpec = DefaultScheduler.newBuilder(
+                serviceSpec, mockSchedulerConfig, new MemPersister())
+                .withSingleRegionConstraint()
+                .build()
+                .getServiceSpec();
+
+        // Pod without placement rules from valid-minimal.yml had a rule added:
+        Assert.assertTrue(updatedServiceSpec.getPods().get(0).getPlacementRule().get() instanceof IsLocalRegionRule);
+        // Pods with region placement rules were left as-is:
+        Assert.assertSame(remoteRegionRule, updatedServiceSpec.getPods().get(1).getPlacementRule().get());
+        Assert.assertSame(localRegionRule, updatedServiceSpec.getPods().get(2).getPlacementRule().get());
     }
 
     @Test
-    public void setLocalRegionRule() {
-        PodSpec originalPodSpec = getPodSpec();
-        PodSpec updatedPodSpec = SchedulerBuilder.updatePodPlacement(originalPodSpec);
+    public void testRegionAwarenessEnabledJavaWithSchedulerRegion() throws PersisterException {
+        when(mockSchedulerConfig.getSchedulerRegion()).thenReturn(Optional.of(TestConstants.REMOTE_REGION));
 
-        Assert.assertTrue(updatedPodSpec.getPlacementRule().isPresent());
-        Assert.assertTrue(updatedPodSpec.getPlacementRule().get() instanceof IsLocalRegionRule);
+        ServiceSpec updatedServiceSpec = DefaultScheduler.newBuilder(
+                minimalServiceSpec, mockSchedulerConfig, new MemPersister())
+                .withSingleRegionConstraint()
+                .build()
+                .getServiceSpec();
+
+        Optional<PlacementRule> rule = updatedServiceSpec.getPods().get(0).getPlacementRule();
+        // Pod updated with exact region rule:
+        Assert.assertTrue(rule.isPresent());
+        Assert.assertTrue(rule.get() instanceof RegionRule);
+
+        // Not hit since enabled directly in java:
+        verify(mockSchedulerConfig, never()).isRegionAwarenessEnabled();
     }
 
     @Test
-    public void addLocalRegionRule() {
-        PodSpec originalPodSpec = DefaultPodSpec.newBuilder(getPodSpec())
-                .placementRule(ZoneRuleFactory.getInstance().require(ExactMatcher.create(TestConstants.ZONE)))
-                .build();
-        PodSpec updatedPodSpec = SchedulerBuilder.updatePodPlacement(originalPodSpec);
+    public void testRegionAwarenessEnabledEnvWithSchedulerRegion() throws PersisterException {
+        when(mockSchedulerConfig.getSchedulerRegion()).thenReturn(Optional.of(TestConstants.REMOTE_REGION));
+        when(mockSchedulerConfig.isRegionAwarenessEnabled()).thenReturn(true);
 
-        Assert.assertTrue(updatedPodSpec.getPlacementRule().isPresent());
-        Assert.assertTrue(updatedPodSpec.getPlacementRule().get() instanceof AndRule);
-        Assert.assertTrue(PlacementUtils.placementRuleReferencesRegion(updatedPodSpec));
+        ServiceSpec updatedServiceSpec = DefaultScheduler.newBuilder(
+                minimalServiceSpec, mockSchedulerConfig, new MemPersister())
+                .build()
+                .getServiceSpec();
+
+        Optional<PlacementRule> rule = updatedServiceSpec.getPods().get(0).getPlacementRule();
+        // Pod updated with exact region rule:
+        Assert.assertTrue(rule.isPresent());
+        Assert.assertTrue(rule.get() instanceof RegionRule);
+
+        verify(mockSchedulerConfig, times(2)).isRegionAwarenessEnabled(); // TODO(nickbp): Remove times(2) when scheduler init is updated
+    }
+
+    @Test
+    public void testRegionAwarenessEnabledWithoutSchedulerRegion() throws PersisterException {
+        ServiceSpec updatedServiceSpec = DefaultScheduler.newBuilder(
+                minimalServiceSpec, mockSchedulerConfig, new MemPersister())
+                .withSingleRegionConstraint()
+                .build()
+                .getServiceSpec();
+
+        Optional<PlacementRule> rule = updatedServiceSpec.getPods().get(0).getPlacementRule();
+        // Pod updated with local region rule:
+        Assert.assertTrue(rule.isPresent());
+        Assert.assertTrue(rule.get() instanceof IsLocalRegionRule);
+    }
+
+    @Test
+    public void testRegionAwarenessDisabledWithSchedulerRegion() throws PersisterException {
+        when(mockSchedulerConfig.getSchedulerRegion()).thenReturn(Optional.of(TestConstants.REMOTE_REGION));
+
+        ServiceSpec updatedServiceSpec = DefaultScheduler.newBuilder(
+                minimalServiceSpec, mockSchedulerConfig, new MemPersister())
+                .build()
+                .getServiceSpec();
+
+        Optional<PlacementRule> rule = updatedServiceSpec.getPods().get(0).getPlacementRule();
+        // Pod updated with local region rule:
+        Assert.assertTrue(rule.isPresent());
+        Assert.assertTrue(rule.get() instanceof IsLocalRegionRule);
+    }
+
+    @Test
+    public void testRegionAwarenessDisabledWithoutSchedulerRegion() throws PersisterException {
+        ServiceSpec updatedServiceSpec = DefaultScheduler.newBuilder(
+                minimalServiceSpec, mockSchedulerConfig, new MemPersister())
+                .build()
+                .getServiceSpec();
+
+        Optional<PlacementRule> rule = updatedServiceSpec.getPods().get(0).getPlacementRule();
+        // Pod updated with local region rule:
+        Assert.assertTrue(rule.isPresent());
+        Assert.assertTrue(rule.get() instanceof IsLocalRegionRule);
+    }
+
+    @Test
+    public void testDomainsNotSupportedByCluster() throws Exception {
+        when(mockCapabilities.supportsDomains()).thenReturn(false);
+
+        ServiceSpec updatedServiceSpec = DefaultScheduler.newBuilder(
+                minimalServiceSpec, mockSchedulerConfig, new MemPersister())
+                .build()
+                .getServiceSpec();
+        // No rule changes:
+        Assert.assertFalse(updatedServiceSpec.getPods().get(0).getPlacementRule().isPresent());
+
+        // Not hit since unsupported by cluster:
+        verify(mockCapabilities, times(2)).supportsDomains(); // TODO(nickbp): Remove times(2) when scheduler init is updated
+        verify(mockSchedulerConfig).isRegionAwarenessEnabled(); // TODO(nickbp): Change to never() when FrameworkRunner is broken out
+        verify(mockSchedulerConfig, never()).getSchedulerRegion();
     }
 
     @Test
     public void testDeployPlanOverriddenDuringUpdate() throws Exception {
-        ClassLoader classLoader = getClass().getClassLoader();
-        File file = new File(classLoader.getResource("valid-minimal.yml").getFile());
-        DefaultServiceSpec serviceSpec = DefaultServiceSpec.newGenerator(file, SCHEDULER_CONFIG).build();
         Persister persister = new MemPersister();
-        SchedulerBuilder builder = new SchedulerBuilder(serviceSpec, SCHEDULER_CONFIG, persister);
+        SchedulerBuilder builder = DefaultScheduler.newBuilder(minimalServiceSpec, mockSchedulerConfig, persister);
 
         Collection<Plan> plans = builder.selectDeployPlan(getDeployUpdatePlans(), true);
 
@@ -94,11 +196,8 @@ public class SchedulerBuilderTest {
 
     @Test
     public void testDeployPlanPreservedDuringInstall() throws Exception {
-        ClassLoader classLoader = getClass().getClassLoader();
-        File file = new File(classLoader.getResource("valid-minimal.yml").getFile());
-        DefaultServiceSpec serviceSpec = DefaultServiceSpec.newGenerator(file, SCHEDULER_CONFIG).build();
         Persister persister = new MemPersister();
-        SchedulerBuilder builder = new SchedulerBuilder(serviceSpec, SCHEDULER_CONFIG, persister);
+        SchedulerBuilder builder = DefaultScheduler.newBuilder(minimalServiceSpec, mockSchedulerConfig, persister);
 
         Collection<Plan> plans = builder.selectDeployPlan(getDeployUpdatePlans(), false);
 
@@ -110,13 +209,9 @@ public class SchedulerBuilderTest {
         Assert.assertEquals(2, deployPlan.getChildren().size());
     }
 
-    private PlacementRule getRemoteRegionRule() {
-        return RegionRuleFactory.getInstance().require(ExactMatcher.create(TestConstants.REMOTE_REGION));
-    }
-
-    private static PodSpec getPodSpec() {
+    private static PodSpec getPodSpec(String type) {
         return TestPodFactory.getPodSpec(
-                TestConstants.POD_TYPE,
+                type,
                 TestConstants.RESOURCE_SET_ID,
                 TestConstants.TASK_NAME,
                 TestConstants.TASK_CMD,

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/SchedulerConfigTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/SchedulerConfigTest.java
@@ -1,44 +1,60 @@
 package com.mesosphere.sdk.scheduler;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.junit.Assert;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.contrib.java.lang.system.EnvironmentVariables;
+
+import com.mesosphere.sdk.framework.EnvStore;
 
 public class SchedulerConfigTest {
 
-    @Rule
-    public final EnvironmentVariables environmentVariables = new EnvironmentVariables();
-
     @Test
-    public void testUninstallIsEnabled() throws Exception {
-        environmentVariables.set("SDK_UNINSTALL", "true");
-        SchedulerConfig schedulerConfig = SchedulerConfig.fromEnv();
-        Assert.assertTrue(schedulerConfig.isUninstallEnabled());
-        environmentVariables.set("SDK_UNINSTALL", "can be set to anything");
-        schedulerConfig = SchedulerConfig.fromEnv();
-        Assert.assertTrue(schedulerConfig.isUninstallEnabled());
-    }
+    public void testUninstall() throws Exception {
+        Map<String, String> confMap = getMinimalMap();
 
-    @Test
-    public void testUninstallIsDisabled() throws Exception {
-        environmentVariables.set("SDK_UNINSTALL", null);
-        SchedulerConfig schedulerConfig = SchedulerConfig.fromEnv();
+        confMap.put("SDK_UNINSTALL", "true");
+        SchedulerConfig schedulerConfig = SchedulerConfig.fromEnvStore(EnvStore.fromMap(confMap));
+        Assert.assertTrue(schedulerConfig.isUninstallEnabled());
+
+        confMap.put("SDK_UNINSTALL", "can be set to anything");
+        schedulerConfig = SchedulerConfig.fromEnvStore(EnvStore.fromMap(confMap));
+        Assert.assertTrue(schedulerConfig.isUninstallEnabled());
+
+        confMap.put("SDK_UNINSTALL", "");
+        schedulerConfig = SchedulerConfig.fromEnvStore(EnvStore.fromMap(confMap));
+        Assert.assertTrue(schedulerConfig.isUninstallEnabled());
+
+        confMap.remove("SDK_UNINSTALL");
+        schedulerConfig = SchedulerConfig.fromEnvStore(EnvStore.fromMap(confMap));
         Assert.assertFalse(schedulerConfig.isUninstallEnabled());
     }
 
     @Test
-    public void regionAwareness() {
-        SchedulerConfig schedulerConfig = SchedulerConfig.fromEnv();
-        Assert.assertFalse(schedulerConfig.isregionAwarenessEnabled());
+    public void testRegionAwareness() {
+        Map<String, String> confMap = getMinimalMap();
+        SchedulerConfig schedulerConfig = SchedulerConfig.fromEnvStore(EnvStore.fromMap(confMap));
+        Assert.assertFalse(schedulerConfig.isRegionAwarenessEnabled());
 
-        environmentVariables.set("ALLOW_REGION_AWARENESS", null);
-        Assert.assertFalse(schedulerConfig.isregionAwarenessEnabled());
+        confMap.put("ALLOW_REGION_AWARENESS", "false");
+        schedulerConfig = SchedulerConfig.fromEnvStore(EnvStore.fromMap(confMap));
+        Assert.assertFalse(schedulerConfig.isRegionAwarenessEnabled());
 
-        environmentVariables.set("ALLOW_REGION_AWARENESS", "false");
-        Assert.assertFalse(schedulerConfig.isregionAwarenessEnabled());
+        confMap.put("ALLOW_REGION_AWARENESS", "true");
+        schedulerConfig = SchedulerConfig.fromEnvStore(EnvStore.fromMap(confMap));
+        Assert.assertTrue(schedulerConfig.isRegionAwarenessEnabled());
 
-        environmentVariables.set("ALLOW_REGION_AWARENESS", "true");
-        Assert.assertTrue(schedulerConfig.isregionAwarenessEnabled());
+        confMap.remove("ALLOW_REGION_AWARENESS");
+        schedulerConfig = SchedulerConfig.fromEnvStore(EnvStore.fromMap(confMap));
+        Assert.assertFalse(schedulerConfig.isRegionAwarenessEnabled());
+    }
+
+    private static Map<String, String> getMinimalMap() {
+        Map<String, String> map = new HashMap<>();
+        map.put("PACKAGE_NAME", "test-package");
+        map.put("PACKAGE_VERSION", "1.5");
+        map.put("PACKAGE_BUILD_TIME_EPOCH_MS", "1234567890");
+        return map;
     }
 }

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/SchedulerRunnerTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/SchedulerRunnerTest.java
@@ -1,0 +1,59 @@
+package com.mesosphere.sdk.scheduler;
+
+import java.nio.charset.StandardCharsets;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import com.mesosphere.sdk.curator.CuratorLocker;
+import com.mesosphere.sdk.specification.ServiceSpec;
+import com.mesosphere.sdk.storage.MemPersister;
+import com.mesosphere.sdk.storage.Persister;
+
+import static org.mockito.Mockito.*;
+
+public class SchedulerRunnerTest {
+
+    @Mock SchedulerBuilder mockSchedulerBuilder;
+    @Mock SchedulerConfig mockSchedulerConfig;
+    @Mock ServiceSpec mockServiceSpec;
+
+    @BeforeClass
+    public static void beforeAll() {
+        CuratorLocker.setEnabledForTests(false);
+    }
+
+    @AfterClass
+    public static void afterAll() {
+        CuratorLocker.setEnabledForTests(true);
+    }
+
+    @Before
+    public void beforeEach() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void checkSchemaVersion() throws Exception {
+        // Set up a schema version which shouldn't work, to verify that the schema version is being checked:
+        Persister persister = new MemPersister();
+        persister.set("SchemaVersion", "123".getBytes(StandardCharsets.UTF_8));
+
+        when(mockSchedulerBuilder.getPersister()).thenReturn(persister);
+        when(mockSchedulerBuilder.getSchedulerConfig()).thenReturn(mockSchedulerConfig);
+        when(mockSchedulerBuilder.getServiceSpec()).thenReturn(mockServiceSpec);
+        SchedulerRunner runner = SchedulerRunner.fromSchedulerBuilder(mockSchedulerBuilder);
+        try {
+            runner.run();
+            Assert.fail("Expected exception due to bad schema version");
+        } catch (IllegalStateException e) {
+            Assert.assertEquals(
+                    "Storage schema version 123 is not supported by this software (expected: 1)", e.getMessage());
+        }
+    }
+}

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/specification/validation/ZoneValidatorTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/specification/validation/ZoneValidatorTest.java
@@ -18,13 +18,12 @@ import java.util.*;
  * This class tests the {@link ZoneValidator} class.
  */
 public class ZoneValidatorTest {
-    private static final ZoneValidator validator = new ZoneValidator();
     private static final String POD_TYPE = TestConstants.POD_TYPE;
     private static final String TASK_NAME = TestConstants.TASK_NAME;
 
     @Test
     public void noOldConfig() {
-        Collection<ConfigValidationError> errors = validator.validate(
+        Collection<ConfigValidationError> errors = ZoneValidator.validate(
                 Optional.empty(), null, POD_TYPE);
         Assert.assertTrue(errors.isEmpty());
     }
@@ -36,8 +35,7 @@ public class ZoneValidatorTest {
         ServiceSpec oldSpec = getServiceSpec(oldTaskSpec);
         ServiceSpec newSpec = getServiceSpec(newTaskSpec);
 
-        Collection<ConfigValidationError> errors = validator.validate(
-                Optional.of(oldSpec), newSpec, POD_TYPE);
+        Collection<ConfigValidationError> errors = ZoneValidator.validate(Optional.of(oldSpec), newSpec, POD_TYPE);
         Assert.assertTrue(errors.isEmpty());
     }
 
@@ -48,8 +46,7 @@ public class ZoneValidatorTest {
         ServiceSpec oldSpec = getServiceSpec(oldTaskSpec);
         ServiceSpec newSpec = getServiceSpec(true);
 
-        Collection<ConfigValidationError> errors = validator.validate(
-                Optional.of(oldSpec), newSpec, POD_TYPE);
+        Collection<ConfigValidationError> errors = ZoneValidator.validate(Optional.of(oldSpec), newSpec, POD_TYPE);
         Assert.assertEquals(1, errors.size());
     }
 
@@ -60,8 +57,7 @@ public class ZoneValidatorTest {
         ServiceSpec oldSpec = getServiceSpec(oldTaskSpec);
         ServiceSpec newSpec = getServiceSpec(false);
 
-        Collection<ConfigValidationError> errors = validator.validate(
-                Optional.of(oldSpec), newSpec, POD_TYPE);
+        Collection<ConfigValidationError> errors = ZoneValidator.validate(Optional.of(oldSpec), newSpec, POD_TYPE);
         Assert.assertTrue(errors.isEmpty());
     }
 
@@ -70,8 +66,7 @@ public class ZoneValidatorTest {
         ServiceSpec oldSpec = getServiceSpec(true);
         ServiceSpec newSpec = getServiceSpec(false);
 
-        Collection<ConfigValidationError> errors = validator.validate(
-                Optional.of(oldSpec), newSpec, POD_TYPE);
+        Collection<ConfigValidationError> errors = ZoneValidator.validate(Optional.of(oldSpec), newSpec, POD_TYPE);
         Assert.assertEquals(1, errors.size());
     }
 
@@ -80,8 +75,7 @@ public class ZoneValidatorTest {
         ServiceSpec oldSpec = getServiceSpec(false);
         ServiceSpec newSpec = getServiceSpec(true);
 
-        Collection<ConfigValidationError> errors = validator.validate(
-                Optional.of(oldSpec), newSpec, POD_TYPE);
+        Collection<ConfigValidationError> errors = ZoneValidator.validate(Optional.of(oldSpec), newSpec, POD_TYPE);
         Assert.assertEquals(1, errors.size());
     }
 
@@ -90,8 +84,7 @@ public class ZoneValidatorTest {
         ServiceSpec oldSpec = getServiceSpec(true);
         ServiceSpec newSpec = getServiceSpec(true);
 
-        Collection<ConfigValidationError> errors = validator.validate(
-                Optional.of(oldSpec), newSpec, POD_TYPE);
+        Collection<ConfigValidationError> errors = ZoneValidator.validate(Optional.of(oldSpec), newSpec, POD_TYPE);
         Assert.assertTrue(errors.isEmpty());
     }
 
@@ -146,11 +139,11 @@ public class ZoneValidatorTest {
                 TestConstants.SERVICE_NAME,
                 TestConstants.ROLE,
                 TestConstants.PRINCIPAL,
+                TestConstants.SERVICE_USER,
+                null,
                 "http://web-url",
                 "http://zookeeper",
-                Arrays.asList(podSpec),
                 null,
-                TestConstants.SERVICE_USER,
-                null);
+                Arrays.asList(podSpec));
     }
 }

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/testutils/OfferTestUtils.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/testutils/OfferTestUtils.java
@@ -9,6 +9,7 @@ import com.mesosphere.sdk.offer.Constants;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -21,24 +22,24 @@ public class OfferTestUtils {
         // do not instantiate
     }
 
-    public static List<Protos.Offer> getCompleteOffers(List<Protos.Resource> resources) {
-        return Arrays.asList(getCompleteOffer(resources));
+    public static List<Protos.Offer> getCompleteOffers(Collection<Protos.Resource> resources) {
+        return Collections.singletonList(getCompleteOffer(resources));
     }
 
     public static Protos.Offer getCompleteOffer(Protos.Resource resource) {
-        return getCompleteOffer(Arrays.asList(resource));
+        return getCompleteOffer(Collections.singletonList(resource));
     }
 
     public static List<Protos.Offer> getOffers(Protos.Resource resource) {
-        return getOffers(Arrays.asList(resource));
+        return getOffers(Collections.singletonList(resource));
     }
 
-    public static List<Protos.Offer> getOffers(List<Protos.Resource> resources) {
-        return Arrays.asList(getOffer(resources));
+    public static List<Protos.Offer> getOffers(Collection<Protos.Resource> resources) {
+        return Collections.singletonList(getOffer(resources));
     }
 
     public static Protos.Offer getOffer(Protos.Resource resource) {
-        return getOffer(Arrays.asList(resource));
+        return getOffer(Collections.singletonList(resource));
     }
 
     public static Protos.Offer getOffer(Collection<Protos.Resource> resources) {
@@ -50,11 +51,11 @@ public class OfferTestUtils {
      * @param resources The desired task resources to offer
      * @return An offer with both executor resources and the supplied resources available
      */
-    public static Protos.Offer getCompleteOffer(List<Protos.Resource> resources) {
+    public static Protos.Offer getCompleteOffer(Collection<Protos.Resource> resources) {
         return getCompleteOffer(resources, Constants.ANY_ROLE);
     }
 
-    public static Protos.Offer getCompleteOffer(List<Protos.Resource> resources, String preReservedRole) {
+    public static Protos.Offer getCompleteOffer(Collection<Protos.Resource> resources, String preReservedRole) {
         return getEmptyOfferBuilder()
                 .addAllResources(getExecutorResources(preReservedRole))
                 .addAllResources(resources)
@@ -69,7 +70,7 @@ public class OfferTestUtils {
     }
 
     public static List<Protos.Offer> getCompleteOffers(Protos.Resource resource) {
-        return getCompleteOffers(Arrays.asList(resource));
+        return getCompleteOffers(Collections.singletonList(resource));
     }
 
     public static Protos.Offer getCompleteOffer(Protos.ExecutorID executorId, List<Protos.Resource> resources) {

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/testutils/ResourceTestUtils.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/testutils/ResourceTestUtils.java
@@ -134,17 +134,18 @@ public class ResourceTestUtils {
     @SuppressWarnings("deprecation") // for Resource.setRole()
     private static Protos.Resource.Builder addReservation(
             Protos.Resource.Builder builder, String resourceId) {
+        Protos.Resource.ReservationInfo.Builder reservationBuilder;
         if (Capabilities.getInstance().supportsPreReservedResources()) {
-            Protos.Resource.ReservationInfo.Builder reservationBuilder = builder.addReservationsBuilder()
+            reservationBuilder = builder.addReservationsBuilder()
                     .setRole(TestConstants.ROLE)
                     .setPrincipal(TestConstants.PRINCIPAL);
-            AuxLabelAccess.setResourceId(reservationBuilder, resourceId);
         } else {
             builder.setRole(TestConstants.ROLE);
-            Protos.Resource.ReservationInfo.Builder reservationBuilder = builder.getReservationBuilder()
+            reservationBuilder = builder.getReservationBuilder()
                     .setPrincipal(TestConstants.PRINCIPAL);
-            AuxLabelAccess.setResourceId(reservationBuilder, resourceId);
         }
+        AuxLabelAccess.setResourceId(reservationBuilder, resourceId);
+        AuxLabelAccess.setResourceNamespace(reservationBuilder, TestConstants.SERVICE_NAME);
         return builder;
     }
 


### PR DESCRIPTION
- `FrameworkConfig`: Handles options relating to framework init. With a single service, it's derived from the service spec, whereas with multiple services it's derived from envvars (with reasonable defaults in most cases)
- `SchedulerConfig`: `EnvStore` is broken out to be shared with `FrameworkConfig`.

Includes other cascading changes relating to this:
- Started testing `ServiceRunner`, needed to update `CuratorLocker` (invoked by `ServiceRunner`) to support that.
- Created initial version of `FrameworkRunner` which currently just handles creating the `FrameworkInfo` object (this will do more later).
- Consolidates existing region `PlacementRule` initialization within `SchedulerBuilder`.

Also has some nitpicky reformatting/ordering fixes, such as giving `ServiceSpec`/`DefaultServiceSpec` a consistent field ordering, and addressing protobufs as `Proto.Foo` in several places.