### PR TITLE
[CASSANDRA-677][CASSANDRA-668] Improve Cassandra backup

### DIFF
--- a/frameworks/cassandra/src/main/dist/svc.yml
+++ b/frameworks/cassandra/src/main/dist/svc.yml
@@ -135,12 +135,16 @@ pods:
         cmd: |
               export PATH=$MESOS_SANDBOX/python-dist/bin:$PATH
               export LD_LIBRARY_PATH=$MESOS_SANDBOX/openssl-dist:$LD_LIBRARY_PATH
-              echo "Checking access to s3://${S3_BUCKET_NAME}"
-              aws s3 ls s3://${S3_BUCKET_NAME} > /dev/null 2>&1
-              if [ $? -ne 0 ]; then
-                echo "Checking s3 connection failed. Please check your settings and try again"
-                exit 1
-              fi
+              while true; do
+                echo "Checking access to s3://${S3_BUCKET_NAME}"
+                aws s3 ls s3://${S3_BUCKET_NAME} > /dev/null 2>&1
+                if [ $? -eq 0 ]; then
+                  echo "Connection to s3 successful"
+                  exit 0
+                fi
+                echo "Connection to s3 failed. Please check your settings and try again"
+                sleep 60
+              done
         resource-set: sidecar-resources
       upload-s3:
         goal: ONCE
@@ -306,10 +310,18 @@ plans:
         pod: node
         steps:
           - default: [[cleanup]]
+  check-settings-s3:
+    strategy: serial
+    phases:
+      check-settings:
+        strategy: {{BACKUP_RESTORE_STRATEGY}}
+        pod: node
+        steps:
+          - default: [[check-settings-s3]]
   backup-s3:
     strategy: serial
     phases:
-      check-settings-s3:
+      check-settings:
         strategy: {{BACKUP_RESTORE_STRATEGY}}
         pod: node
         steps:
@@ -337,7 +349,7 @@ plans:
   restore-s3:
     strategy: serial
     phases:
-      check-settings-s3:
+      check-settings:
         strategy: {{BACKUP_RESTORE_STRATEGY}}
         pod: node
         steps:

--- a/frameworks/cassandra/src/main/dist/svc.yml
+++ b/frameworks/cassandra/src/main/dist/svc.yml
@@ -130,6 +130,18 @@ pods:
                     (cd container-path/snapshot/"$keyspace" && ln -s ../../../"$f" "$table") ;
                 done
         resource-set: sidecar-resources
+      check-settings-s3:
+        goal: ONCE
+        cmd: |
+              export PATH=$MESOS_SANDBOX/python-dist/bin:$PATH
+              export LD_LIBRARY_PATH=$MESOS_SANDBOX/openssl-dist:$LD_LIBRARY_PATH
+              echo "Checking access to s3://${S3_BUCKET_NAME}"
+              aws s3 ls s3://${S3_BUCKET_NAME} > /dev/null 2>&1
+              if [ $? -ne 0 ]; then
+                echo "Checking s3 connection failed. Please check your settings and try again"
+                exit 1
+              fi
+        resource-set: sidecar-resources
       upload-s3:
         goal: ONCE
         cmd: >
@@ -297,6 +309,11 @@ plans:
   backup-s3:
     strategy: serial
     phases:
+      check-settings-s3:
+        strategy: {{BACKUP_RESTORE_STRATEGY}}
+        pod: node
+        steps:
+          - default: [[check-settings-s3]]
       backup-schema:
         strategy: serial
         pod: node
@@ -320,6 +337,11 @@ plans:
   restore-s3:
     strategy: serial
     phases:
+      check-settings-s3:
+        strategy: {{BACKUP_RESTORE_STRATEGY}}
+        pod: node
+        steps:
+          - default: [[check-settings-s3]]
       fetch-s3:
         strategy: {{BACKUP_RESTORE_STRATEGY}}
         pod: node

--- a/frameworks/cassandra/src/main/dist/svc.yml
+++ b/frameworks/cassandra/src/main/dist/svc.yml
@@ -152,7 +152,7 @@ pods:
         cmd: >
                 export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jdk*/jre/) ;
                 ./apache-cassandra-{{CASSANDRA_VERSION}}/bin/nodetool clearsnapshot -p ${JMX_PORT} -t "$SNAPSHOT_NAME" -- $(eval "echo $CASSANDRA_KEYSPACES") ;
-                rm -r container-path/snapshot
+                rm -rf container-path/snapshot
         resource-set: sidecar-resources
       fetch-s3:
         goal: ONCE
@@ -376,3 +376,11 @@ plans:
         pod: node
         steps:
           - default: [[restore-snapshot]]
+  cleanup-snapshots:
+    strategy: serial
+    phases:
+      cleanup-snapshots:
+        strategy: {{BACKUP_RESTORE_STRATEGY}}
+        pod: node
+        steps:
+          - default: [[cleanup-snapshot]]


### PR DESCRIPTION
This PR does the following:
* Adds a `cleanup-snapshots` plan and improves the `cleanup-snapshot` task (originally #2362)
* Adds a `check-settings` plan and a `check-settings-s3` task that runs `aws s3 ls` with the provided backup settings

Some open questions:
* Are `-f` flags required in any other tasks?
* Or should the `cleanup-snapshot` task be added to other plans? (e.g. `restore-`)