### PR TITLE
Bump libmesos bundle version

### DIFF
--- a/tools/universe/package_builder.py
+++ b/tools/universe/package_builder.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.DEBUG, format="%(message)s")
 
 _jre_url = 'https://downloads.mesosphere.com/java/server-jre-8u162-linux-x64.tar.gz'
-_libmesos_bundle_url = 'https://downloads.mesosphere.com/libmesos-bundle/libmesos-bundle-master-28f8827.tar.gz'
+_libmesos_bundle_url = 'https://downloads.mesosphere.com/libmesos-bundle/libmesos-bundle-1.11.0.tar.gz'
 _dcos_sdk_version = '0.41.0-SNAPSHOT'
 
 _docs_root = "https://docs.mesosphere.com"


### PR DESCRIPTION
Addresses [INFINITY-3455](https://jira.mesosphere.com/browse/INFINITY-3455). 

`libmesos-bundle-1.9.0-rc2-1.2.0-rc2-1.tar.gz` is being used `queries/testdata` of cli as well. Comment if I am incorrect in assuming `testdata` need not be updated.