### PR TITLE
Add variant info to DcosVersion object

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/dcos/DcosVersion.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/dcos/DcosVersion.java
@@ -1,8 +1,11 @@
 package com.mesosphere.sdk.dcos;
 
+import com.mesosphere.sdk.offer.LoggingUtils;
+import com.mesosphere.sdk.specification.DefaultPlanGenerator;
 import org.json.JSONObject;
 
 import com.google.common.annotations.VisibleForTesting;
+import org.slf4j.Logger;
 
 /**
  * This class encapsulates the response from a DC/OS cluster's dcos-metadata/dcos-version.json endpoint.
@@ -20,10 +23,13 @@ import com.google.common.annotations.VisibleForTesting;
  *     {
  *         "bootstrap-id": "27f0ee12ec563574dd9a6fa93faba1a1be38bde5",
  *         "dcos-image-commit": "3fe4305af8ab9b4c2c3606569f3c0cb5c5437aa3",
- *         "version": "1.7.3"
+ *         "version": "1.7.3",
+ *         "dcos-variant": "open"
  *     }
  */
 public class DcosVersion {
+
+    private static final Logger LOGGER = LoggingUtils.getLogger(DefaultPlanGenerator.class);
 
     /**
      * A broken-down representation of a version string's elements.
@@ -55,17 +61,61 @@ public class DcosVersion {
     }
 
     private static final String VERSION_KEY = "version";
+    private static final String VARIANT_KEY = "dcos-variant";
     private static final String DEV_VERSION_SUFFIX = "-dev";
 
     private final String version;
+    private final DcosVariant variant;
+
+    /**
+     * We parse dcos-variant if DC/OS provides it. If the value is absent
+     * or is not one of [open|enterprise], we default to `UNKNOWN`.
+     *
+     * NOTE: This should not be used to build security features.
+     */
+    public enum DcosVariant {
+        OPEN("open"),
+        ENTERPRISE("enterprise"),
+        UNKNOWN("UNKNOWN");
+
+        private final String variant;
+
+        DcosVariant(String variant) {
+            this.variant = variant;
+        }
+
+        @Override
+        public String toString() {
+            return variant;
+        }
+
+        private static DcosVariant parseVariant(JSONObject jsonObject) {
+            DcosVariant variant = DcosVariant.UNKNOWN;
+            if (jsonObject.has(VARIANT_KEY)) {
+                String variantStr = jsonObject.getString(VARIANT_KEY);
+
+                if (variantStr.equals(DcosVariant.OPEN.toString())) {
+                    variant = DcosVariant.OPEN;
+                } else if (variantStr.equals(DcosVariant.ENTERPRISE.toString())) {
+                    variant = DcosVariant.ENTERPRISE;
+                } else {
+                    LOGGER.error("Unexpected dcos-variant : {}", variantStr);
+                }
+            } else {
+                LOGGER.info("{} key not found in {}", VARIANT_KEY, jsonObject);
+            }
+            return variant;
+        }
+    }
 
     @VisibleForTesting
-    public DcosVersion(String version) {
+    public DcosVersion(String version, DcosVariant variant) {
         this.version = version;
+        this.variant = variant;
     }
 
     public DcosVersion(JSONObject jsonObject) {
-        this(jsonObject.getString(DcosVersion.VERSION_KEY));
+        this(jsonObject.getString(DcosVersion.VERSION_KEY), DcosVariant.parseVariant(jsonObject));
     }
 
     public String getVersion() {
@@ -74,6 +124,10 @@ public class DcosVersion {
 
     public Elements getElements() {
         return new Elements(version);
+    }
+
+    public DcosVariant getDcosVariant() {
+        return variant;
     }
 
     private static String getVersionElement(String version, int index) {

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/config/validate/DomainCapabilityValidatorTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/config/validate/DomainCapabilityValidatorTest.java
@@ -117,7 +117,8 @@ public class DomainCapabilityValidatorTest {
     private void setNewCluster() throws IOException {
         setVersion("1.11");
     }
+
     private void setVersion(String version) throws IOException {
-        Capabilities.overrideCapabilities(new Capabilities(new DcosVersion(version)));
+        Capabilities.overrideCapabilities(new Capabilities(new DcosVersion(version, DcosVersion.DcosVariant.UNKNOWN)));
     }
 }

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/dcos/CapabilitiesTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/dcos/CapabilitiesTest.java
@@ -195,6 +195,6 @@ public class CapabilitiesTest {
     }
 
     private static Capabilities testCapabilities(String version) throws IOException {
-        return new Capabilities(new DcosVersion(version));
+        return new Capabilities(new DcosVersion(version, DcosVersion.DcosVariant.UNKNOWN));
     }
 }

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/dcos/DcosVersionTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/dcos/DcosVersionTest.java
@@ -1,5 +1,6 @@
 package com.mesosphere.sdk.dcos;
 
+import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -8,10 +9,50 @@ import org.junit.Test;
  */
 public class DcosVersionTest {
     private String testVersion = "test-version";
+    private String dcosVariantKey = "dcos-variant";
+    private String dcosVersionKey = "version";
 
     @Test
     public void testConstruction() {
-        DcosVersion dcosVersion = new DcosVersion(testVersion);
+        DcosVersion dcosVersion = new DcosVersion(testVersion, DcosVersion.DcosVariant.UNKNOWN);
         Assert.assertEquals(testVersion, dcosVersion.getVersion());
+    }
+
+    @Test
+    public void testJsonContruction() {
+        JSONObject j = new JSONObject();
+        j.put(dcosVersionKey, testVersion);
+        Assert.assertEquals(DcosVersion.DcosVariant.UNKNOWN, new DcosVersion(j).getDcosVariant());
+
+        Assert.assertEquals(
+                DcosVersion.DcosVariant.OPEN,
+                new DcosVersion(
+                        j.put(dcosVariantKey, DcosVersion.DcosVariant.OPEN.toString())
+                ).getDcosVariant()
+        );
+        j.remove(dcosVariantKey);
+
+        Assert.assertEquals(
+                DcosVersion.DcosVariant.ENTERPRISE,
+                new DcosVersion(
+                        j.put(dcosVariantKey, DcosVersion.DcosVariant.ENTERPRISE.toString())
+                ).getDcosVariant()
+        );
+        j.remove(dcosVariantKey);
+
+        Assert.assertEquals(
+                DcosVersion.DcosVariant.UNKNOWN,
+                new DcosVersion(
+                        j.put(dcosVariantKey, DcosVersion.DcosVariant.UNKNOWN.toString())
+                ).getDcosVariant()
+        );
+        j.remove(dcosVariantKey);
+
+        Assert.assertEquals(
+                DcosVersion.DcosVariant.UNKNOWN,
+                new DcosVersion(
+                        j.put(dcosVariantKey, "DC/OS Enterprise")
+                ).getDcosVariant()
+        );
     }
 }

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/DefaultSchedulerTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/DefaultSchedulerTest.java
@@ -156,7 +156,7 @@ public class DefaultSchedulerTest {
     }
 
     private Capabilities getCapabilities() throws Exception {
-        return new Capabilities(new DcosVersion("1.10-dev")) {
+        return new Capabilities(new DcosVersion("1.10-dev", DcosVersion.DcosVariant.UNKNOWN)) {
             @Override
             public boolean supportsGpuResource() {
                 return DEFAULT_GPU_POLICY;


### PR DESCRIPTION
Addresses [INFINITY-3420](https://jira.mesosphere.com/browse/INFINITY-3420). Detailed discussion of DC/OS feature at [DCOS_OSS-2283](https://jira.mesosphere.com/browse/DCOS_OSS-2283). 
This can be used after https://github.com/dcos/dcos/pull/2663 is merged.