### PR TITLE
Updating min dcos release version from 1.9 to 1.10

### DIFF
--- a/frameworks/cassandra/universe/package.json
+++ b/frameworks/cassandra/universe/package.json
@@ -2,7 +2,7 @@
   "packagingVersion": "4.0",
   "upgradesFrom": ["{{upgrades-from}}"],
   "downgradesTo": ["{{downgrades-to}}"],
-  "minDcosReleaseVersion": "1.9",
+  "minDcosReleaseVersion": "1.10",
   "name": "cassandra",
   "version": "{{package-version}}",
   "maintainer": "support@mesosphere.io",

--- a/frameworks/elastic/universe/package.json
+++ b/frameworks/elastic/universe/package.json
@@ -2,7 +2,7 @@
   "packagingVersion": "4.0",
   "upgradesFrom": ["{{upgrades-from}}"],
   "downgradesTo": ["{{downgrades-to}}"],
-  "minDcosReleaseVersion": "1.9",
+  "minDcosReleaseVersion": "1.10",
   "name": "elastic",
   "version": "{{package-version}}",
   "maintainer": "support@mesosphere.io",

--- a/frameworks/hdfs/universe/package.json
+++ b/frameworks/hdfs/universe/package.json
@@ -2,7 +2,7 @@
   "packagingVersion": "4.0",
   "upgradesFrom": ["{{upgrades-from}}"],
   "downgradesTo": ["{{downgrades-to}}"],
-  "minDcosReleaseVersion": "1.9",
+  "minDcosReleaseVersion": "1.10",
   "name": "hdfs",
   "version": "{{package-version}}",
   "maintainer": "support@mesosphere.io",

--- a/frameworks/helloworld/universe/package.json
+++ b/frameworks/helloworld/universe/package.json
@@ -2,7 +2,7 @@
   "packagingVersion": "4.0",
   "upgradesFrom": ["*"],
   "downgradesTo": ["*"],
-  "minDcosReleaseVersion": "1.9",
+  "minDcosReleaseVersion": "1.10",
   "name": "hello-world",
   "version":  "{{package-version}}",
   "maintainer": "support@mesosphere.io",

--- a/frameworks/kafka/universe/package.json
+++ b/frameworks/kafka/universe/package.json
@@ -2,7 +2,7 @@
   "packagingVersion": "4.0",
   "upgradesFrom": ["{{upgrades-from}}"],
   "downgradesTo": ["{{downgrades-to}}"],
-  "minDcosReleaseVersion": "1.9",
+  "minDcosReleaseVersion": "1.10",
   "name": "kafka",
   "version": "{{package-version}}",
   "maintainer": "support@mesosphere.io",

--- a/frameworks/template/universe/package.json
+++ b/frameworks/template/universe/package.json
@@ -2,7 +2,7 @@
   "packagingVersion": "4.0",
   "upgradesFrom": ["{{upgrades-from}}"],
   "downgradesTo": ["{{downgrades-to}}"],
-  "minDcosReleaseVersion": "1.9",
+  "minDcosReleaseVersion": "1.10",
   "name": "template",
   "version": "{{package-version}}",
   "maintainer": "support@YOURNAMEHERE.COM",


### PR DESCRIPTION
small change to test CI, part of changes to remove custom executor and move to default executor in dcos versions greater than 1.9