### PR TITLE
[INFINITY-3446] Reject Service Names that violate DNS length requirements.

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/config/validate/DefaultConfigValidators.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/config/validate/DefaultConfigValidators.java
@@ -27,6 +27,7 @@ public class DefaultConfigValidators {
                 new TLSRequiresServiceAccount(schedulerConfig),
                 new DomainCapabilityValidator(),
                 new PlacementRuleIsValid(),
-                new RegionCannotChange());
+                new RegionCannotChange(),
+                new ServiceNameCannotBreakDNS());
     }
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/config/validate/ServiceNameCannotBreakDNS.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/config/validate/ServiceNameCannotBreakDNS.java
@@ -1,0 +1,47 @@
+package com.mesosphere.sdk.config.validate;
+
+import com.mesosphere.sdk.http.EndpointUtils;
+import com.mesosphere.sdk.offer.LoggingUtils;
+import com.mesosphere.sdk.specification.ServiceSpec;
+import org.slf4j.Logger;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
+
+public class ServiceNameCannotBreakDNS implements ConfigValidator<ServiceSpec> {
+
+    public static final Logger LOGGER = LoggingUtils.getLogger(ServiceNameCannotBreakDNS.class);
+
+
+    private static final int MAX_SERVICE_NAME_LENGTH = 63;
+
+    @Override
+    public Collection<ConfigValidationError> validate(Optional<ServiceSpec> oldConfig, ServiceSpec newConfig) {
+        // Is there a prior config?
+        if (oldConfig.isPresent()) {
+            // There is. We can at most WARN that the name is going to cause truncated DNS.
+            if (!nameWithinSubDomainLimit(newConfig.getName())) {
+                LOGGER.warn("The service name (without slashes) exceeds the maximum size allowed in a DNS subdomain.");
+            }
+
+            return Collections.emptyList();
+        } else {
+            // This is a new deployment, we can fail it if the service name is too large.
+            if (!nameWithinSubDomainLimit(newConfig.getName())) {
+                return Collections.singletonList(ConfigValidationError.valueError(
+                        "service.name",
+                        newConfig.getName(),
+                        "Service name (without slashes) exceeds 63 characters. In order for service DNS " +
+                                "to work correctly, the service name (without slashes) must not exceed 63 characters"));
+            }
+
+            return Collections.emptyList();
+        }
+    }
+
+    private boolean nameWithinSubDomainLimit(String name) {
+        // Each subdomain of a DNS address must be less than 63 characters.
+        return EndpointUtils.removeSlashes(name).length() <= MAX_SERVICE_NAME_LENGTH;
+    }
+}

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/config/validate/ServiceNameCannotBreakDNS.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/config/validate/ServiceNameCannotBreakDNS.java
@@ -9,10 +9,16 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Optional;
 
+/**
+ * This validator enforces that the specified service name (e.g. /foo/bar/service) does not exceed 63 characters with
+ * slashes removed. This is to ensure the DNS subdomain of the service does not exceed the character limit specified
+ * in https://www.ietf.org/rfc/rfc1035.txt.
+ *
+ * The validator is only enforced on _new_ deployments and not on service upgrades.
+ */
 public class ServiceNameCannotBreakDNS implements ConfigValidator<ServiceSpec> {
 
-    public static final Logger LOGGER = LoggingUtils.getLogger(ServiceNameCannotBreakDNS.class);
-
+    private static final Logger LOGGER = LoggingUtils.getLogger(ServiceNameCannotBreakDNS.class);
 
     private static final int MAX_SERVICE_NAME_LENGTH = 63;
 

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/config/validate/ServiceNameCannotBreakDNSTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/config/validate/ServiceNameCannotBreakDNSTest.java
@@ -1,0 +1,50 @@
+package com.mesosphere.sdk.config.validate;
+
+import com.mesosphere.sdk.specification.ServiceSpec;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.Optional;
+
+public class ServiceNameCannotBreakDNSTest {
+
+    ServiceNameCannotBreakDNS validator = new ServiceNameCannotBreakDNS();
+    ServiceSpec mockNewSpec = Mockito.mock(ServiceSpec.class);
+    ServiceSpec mockOldSpec = Mockito.mock(ServiceSpec.class);
+
+    @Test
+    public void serviceNameUnderLimitNewDeploy() {
+        Mockito.when(mockNewSpec.getName()).thenReturn("i/am/a/short/name");
+        Assert.assertEquals(0, validator.validate(Optional.empty(), mockNewSpec).size());
+    }
+
+    @Test
+    public void serviceNameAtLimitNewDeploy() {
+        Mockito.when(mockNewSpec.getName())
+                .thenReturn("i/am/a/name/that/is/exactly/sixty/three/characters/long/no/really/do/you/not/b");
+        Assert.assertEquals(0, validator.validate(Optional.empty(), mockNewSpec).size());
+    }
+
+    @Test
+    public void serviceNameOverLimitNewDeploy() {
+        Mockito.when(mockNewSpec.getName())
+                .thenReturn("i/am/a/name/that/is/" +
+                        "loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong");
+        Assert.assertEquals(1, validator.validate(Optional.empty(), mockNewSpec).size());
+    }
+
+    @Test
+    public void serviceNameOverLimitExistingDeploy() {
+        Mockito.when(mockNewSpec.getName())
+                .thenReturn("i/am/a/name/that/is/" +
+                        "loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong");
+        Assert.assertEquals(0, validator.validate(Optional.of(mockOldSpec), mockNewSpec).size());
+    }
+
+    @Test
+    public void serviceNameUnderLimitExistingDeploy() {
+        Mockito.when(mockNewSpec.getName()).thenReturn("i/am/a/short/name");
+        Assert.assertEquals(0, validator.validate(Optional.of(mockOldSpec), mockNewSpec).size());
+    }
+}


### PR DESCRIPTION
did:
ERROR new deployments on a too long DNS name
Do nothing to old deployments (but do warn)

I can't decide if we can actually do this or not. It's probably possible for a user to wind up in a situation where they can't re-install their service with a too long name.

Maybe we don't even work at all with too long names? I'll find out...