### PR TITLE
INFINITY-3439 Fix timing flake in TokenBucketTest.replenishTokens

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/framework/TokenBucket.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/framework/TokenBucket.java
@@ -57,16 +57,7 @@ public class TokenBucket {
                     String.format("TokenBucket construction failed with invalid configuration: %s", msg));
         }
 
-        executor.scheduleAtFixedRate(
-                new Runnable() {
-                    @Override
-                    public void run() {
-                        increment();
-                    }
-                },
-                incrementInterval.toMillis(),
-                incrementInterval.toMillis(),
-                TimeUnit.MILLISECONDS);
+        startIncrementThread();
     }
 
     public static Builder newBuilder() {
@@ -103,6 +94,24 @@ public class TokenBucket {
     }
 
     /**
+     * Schedules a background thread for incrementing the token count. Broken out into a separate function to allow
+     * overriding in tests.
+     */
+    @VisibleForTesting
+    protected void startIncrementThread() {
+        executor.scheduleAtFixedRate(
+                new Runnable() {
+                    @Override
+                    public void run() {
+                        increment();
+                    }
+                },
+                incrementInterval.toMillis(),
+                incrementInterval.toMillis(),
+                TimeUnit.MILLISECONDS);
+    }
+
+    /**
      * Resets internal counters for tests.
      */
     @VisibleForTesting
@@ -112,9 +121,10 @@ public class TokenBucket {
     }
 
     /**
-     * This method adds a token to the bucket up to the capacity of the bucket.
+     * This method adds a token to the bucket up to the capacity of the bucket. Visible to tests for manual execution.
      */
-    private synchronized void increment() {
+    @VisibleForTesting
+    protected synchronized void increment() {
         if (count < capacity) {
             count++;
         }

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/framework/TokenBucketTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/framework/TokenBucketTest.java
@@ -65,7 +65,7 @@ public class TokenBucketTest {
 
         Assert.assertTrue(bucket.tryAcquire());
         Assert.assertFalse(bucket.tryAcquire());
-        Thread.sleep(incrementInterval.toMillis() + 50); // Give 50ms of breathing room to the token incrementing thread
+        bucket.increment();
         Assert.assertTrue(bucket.tryAcquire());
     }
 
@@ -132,6 +132,11 @@ public class TokenBucketTest {
         @Override
         protected long now() {
             return now;
+        }
+
+        @Override
+        protected void startIncrementThread() {
+            // do nothing: avoid background thread in tests
         }
     }
 }


### PR DESCRIPTION
Invoke `increment()` manually to avoid dependence on the executor thread behaving consistently. In CPU-starved CI machines, it apparently doesn't!