### PR TITLE
Parameterize version of package from build.sh scripts

### DIFF
--- a/frameworks/elastic/build-kibana.sh
+++ b/frameworks/elastic/build-kibana.sh
@@ -9,6 +9,7 @@ ROOT_DIR="$(dirname "$(dirname ${FRAMEWORK_DIR})")"
 export TOOLS_DIR=${ROOT_DIR}/tools
 
 PUBLISH_STEP=${1-none}
+PACKAGE_VERSION=${2-"stub-universe"}
 UNIVERSE_DIR=${UNIVERSE_DIR:=${FRAMEWORK_DIR}/universe-kibana}
 case "$PUBLISH_STEP" in
     local)
@@ -34,5 +35,5 @@ esac
 
 if [ -n "$PUBLISH_SCRIPT" ]; then
     TEMPLATE_DOCUMENTATION_PATH="https://docs.mesosphere.com/services/elastic/" \
-        $PUBLISH_SCRIPT kibana ${UNIVERSE_DIR}
+        $PUBLISH_SCRIPT kibana "${PACKAGE_VERSION}" ${UNIVERSE_DIR}
 fi

--- a/frameworks/elastic/build.sh
+++ b/frameworks/elastic/build.sh
@@ -30,8 +30,8 @@ $REPO_ROOT_DIR/tools/build_package.sh \
 if [ "$UNIVERSE_URL_PATH" ]; then
     # append kibana stub universe URL to UNIVERSE_URL_PATH file (used in CI):
     KIBANA_URL_PATH=${UNIVERSE_URL_PATH}.kibana
-    UNIVERSE_URL_PATH=$KIBANA_URL_PATH $FRAMEWORK_DIR/build-kibana.sh $1
+    UNIVERSE_URL_PATH=$KIBANA_URL_PATH $FRAMEWORK_DIR/build-kibana.sh $1 $2
     cat $KIBANA_URL_PATH >> $UNIVERSE_URL_PATH
 else
-    $FRAMEWORK_DIR/build-kibana.sh $1
+    $FRAMEWORK_DIR/build-kibana.sh $1 $2
 fi

--- a/tools/build_package.sh
+++ b/tools/build_package.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -e
+set -e -x
 
 user_usage() {
     # This script is generally called by an upstream 'build.sh' which would be invoked directly by users.
@@ -109,7 +109,9 @@ case "$publish_method" in
         ;;
 esac
 
+PACKAGE_VERSION=${1:-"stub-universe"}
+
 if [ -n "$PUBLISH_SCRIPT" ]; then
-    # Both scripts use the same argument format:
-    $PUBLISH_SCRIPT ${FRAMEWORK_NAME} ${UNIVERSE_DIR} ${custom_artifacts}
+    # All the scripts use the same argument format:
+    $PUBLISH_SCRIPT "${FRAMEWORK_NAME}" "${PACKAGE_VERSION}" "${UNIVERSE_DIR}" ${custom_artifacts}
 fi

--- a/tools/publish_aws.py
+++ b/tools/publish_aws.py
@@ -2,7 +2,6 @@
 #
 # Uploads artifacts to S3.
 # Produces a universe, and uploads it to S3.
-# If running in jenkins ($WORKSPACE is defined), writes $WORKSPACE/stub-universe.properties
 #
 # Env:
 #   S3_BUCKET (default: infinity-artifacts)
@@ -29,9 +28,9 @@ class AWSPublisher(object):
     def __init__(
             self,
             package_name,
+            package_version,
             input_dir_path,
-            artifact_paths,
-            package_version='stub-universe'):
+            artifact_paths):
         self._dry_run = os.environ.get('DRY_RUN', '')
         self._pkg_name = package_name
         self._pkg_version = package_version
@@ -150,18 +149,21 @@ def main(argv):
         return 1
     # the package name:
     package_name = argv[1]
+    # the package version:
+    package_version = argv[2]
     # local path where the package template is located:
-    package_dir_path = argv[2].rstrip('/')
+    package_dir_path = argv[3].rstrip('/')
     # artifact paths (to upload along with stub universe)
-    artifact_paths = argv[3:]
+    artifact_paths = argv[4:]
     logger.info('''###
 Package:         {}
+Version:         {}
 Template path:   {}
 Artifacts:
 {}
-###'''.format(package_name, package_dir_path, '\n'.join(['- {}'.format(path) for path in artifact_paths])))
+###'''.format(package_name, package_version, package_dir_path, '\n'.join(['- {}'.format(path) for path in artifact_paths])))
 
-    AWSPublisher(package_name, package_dir_path, artifact_paths).upload()
+    AWSPublisher(package_name, package_version, package_dir_path, artifact_paths).upload()
     return 0
 
 

--- a/tools/publish_http.py
+++ b/tools/publish_http.py
@@ -28,9 +28,9 @@ class HTTPPublisher(object):
     def __init__(
             self,
             package_name,
+            package_version,
             input_dir_path,
-            artifact_paths,
-            package_version = 'stub-universe'):
+            artifact_paths):
         self._pkg_name = package_name
         self._pkg_version = package_version
         self._input_dir_path = input_dir_path
@@ -202,18 +202,21 @@ def main(argv):
         return 1
     # the package name:
     package_name = argv[1]
+    # the package version:
+    package_version = argv[2]
     # local path where the package template is located:
-    package_dir_path = argv[2].rstrip('/')
+    package_dir_path = argv[3].rstrip('/')
     # artifact paths (to copy along with stub universe)
-    artifact_paths = argv[3:]
+    artifact_paths = argv[4:]
     logger.info('''###
 Package:         {}
+Version:         {}
 Template path:   {}
 Artifacts:
 {}
-###'''.format(package_name, package_dir_path, '\n'.join(['- {}'.format(path) for path in artifact_paths])))
+###'''.format(package_name, package_version, package_dir_path, '\n'.join(['- {}'.format(path) for path in artifact_paths])))
 
-    publisher = HTTPPublisher(package_name, package_dir_path, artifact_paths)
+    publisher = HTTPPublisher(package_name, package_version, package_dir_path, artifact_paths)
     http_url_root = publisher.launch_http()
     universe_url = publisher.build(http_url_root)
     repo_added = publisher.add_repo_to_cli(universe_url)


### PR DESCRIPTION
Now, `build.sh` can take a `version` parameter to populate the package version. Something like : 
`.../build.sh .dcos 1.2.3`. This however forces `elastic` to have same version for `elastic` and `kibana` (which is acceptable for now).