### PR TITLE
Skip ZooKeeper authnz tests in Open

### DIFF
--- a/frameworks/kafka/tests/test_zookeeper_auth.py
+++ b/frameworks/kafka/tests/test_zookeeper_auth.py
@@ -18,6 +18,12 @@ from tests import client
 from tests import config
 
 
+pytestmark = [pytest.mark.skipif(sdk_utils.is_open_dcos(),
+                                 reason="Feature only supported in DC/OS EE"),
+              pytest.mark.skipif(sdk_utils.dcos_version_less_than("1.10"),
+                                 reason="Kerberos tests require DC/OS 1.10 or higher")]
+
+
 log = logging.getLogger(__name__)
 
 

--- a/frameworks/kafka/tests/test_zookeeper_authz.py
+++ b/frameworks/kafka/tests/test_zookeeper_authz.py
@@ -21,6 +21,12 @@ from tests import config
 log = logging.getLogger(__name__)
 
 
+pytestmark = [pytest.mark.skipif(sdk_utils.is_open_dcos(),
+                                 reason="Feature only supported in DC/OS EE"),
+              pytest.mark.skipif(sdk_utils.dcos_version_less_than("1.10"),
+                                 reason="Kerberos tests require DC/OS 1.10 or higher")]
+
+
 def get_zookeeper_principals(service_name: str, realm: str) -> list:
     primaries = ["zookeeper", ]
 


### PR DESCRIPTION
The CI tests are failing in open due to authnz tests being included for Kafka/ZooKeeper.

https://teamcity.mesosphere.io/project.html?projectId=DcosIo_DcosCommons_Kafka_Open&tab=projectOverview

This disables them.