### PR TITLE
tools: add SCHEDULER_API_HOSTNAME as an exception

### DIFF
--- a/tools/airgap_linter.py
+++ b/tools/airgap_linter.py
@@ -57,6 +57,9 @@ def is_bad_uri(uri, file_name):
         "{{FRAMEWORK_HOST}}",
         "$FRAMEWORK_HOST",
         "${FRAMEWORK_HOST}",
+        "{{SCHEDULER_API_HOSTNAME}}",
+        "${SCHEDULER_API_HOSTNAME}",
+        "$SCHEDULER_API_HOSTNAME",
     ]
 
     # Are any of the exceptions present?


### PR DESCRIPTION
When using the `SCHEDULER_API_HOSTNAME` var instead of `FRAMEWORK_HOST` the airgap_linter complains.