### PR TITLE
[DCOS-29232] sdk_security: more the package functions more configurable

### DIFF
--- a/frameworks/template/tests/config.py
+++ b/frameworks/template/tests/config.py
@@ -1,4 +1,4 @@
 PACKAGE_NAME = 'template'
 SERVICE_NAME = 'template'
 DEFAULT_TASK_COUNT = 1
-
+DEFAULT_LINUX_USER = 'nobody'

--- a/frameworks/template/tests/conftest.py
+++ b/frameworks/template/tests/conftest.py
@@ -1,8 +1,12 @@
 import pytest
 import sdk_security
 from tests import config
+from typing import List
 
 
 @pytest.fixture(scope='session')
 def configure_security(configure_universe):
-    yield from sdk_security.security_session(config.SERVICE_NAME)
+    service_account_name = 'service-acct'
+    # Add the permissions you want to grant/revoke during the installation
+    permissions = []
+    yield from sdk_security.security_session(config.SERVICE_NAME, permissions, config.DEFAULT_LINUX_USER, service_account_name)


### PR DESCRIPTION
It'd be good to make more configurable the sdk_security package. In our case, we need to add additional permissions to the default ones, but we'd like to define the service account or even the linux user.

related to: https://jira.mesosphere.com/browse/DCOS-29232