### PR TITLE
Add sdk_install.get_package_json

### DIFF
--- a/testing/sdk_install.py
+++ b/testing/sdk_install.py
@@ -32,6 +32,26 @@ Used by post-test diagnostics to retrieve stuff from currently running services.
 _installed_service_names = set([])
 
 
+def get_package_json(package: str,
+                     version: str=None,
+                     options: dict=None) -> dict:
+    """Get the Marathon app JSON for a given package with the desired
+    options.
+
+    Args:
+        package: Package name
+        version: Package version
+        options: Package installation options
+
+    Returns: Marathon app def
+
+    """
+    pkg_version = dcos.packagemanager.CosmosPackageVersion(
+            package, version, dcos.cosmos.get_cosmos_url())
+    opts = options if options else dict()
+    return pkg_version.marathon_json(opts)
+
+
 def get_installed_service_names() -> set:
     '''Returns the a set of service names which had been installed via sdk_install in this session.'''
     return _installed_service_names


### PR DESCRIPTION
Add `get_package_json` to `sdk_install` that returns the Marathon app definition for a package
as a dict object. This can then be used in a later `POST` to Marathon directly.

Example:

```
options = {"service": {"name": service_name}}
pkg_json = sdk_install.get_package_json('jenkins', None, options)
client = shakedown.marathon.create_client()
client.add_app(pkg_json)
```