### PR TITLE
[DCOS-37718] fix sdk security

### DIFF
--- a/frameworks/kafka/tests/test_sanity.py
+++ b/frameworks/kafka/tests/test_sanity.py
@@ -144,7 +144,7 @@ def test_broker_invalid():
         assert False, "Should have failed"
     except AssertionError as arg:
         raise arg
-    except Exception as e:
+    except Exception:
         pass  # expected to fail
 
 

--- a/frameworks/kafka/tests/test_zookeeper.py
+++ b/frameworks/kafka/tests/test_zookeeper.py
@@ -35,7 +35,10 @@ def zookeeper_server(configure_security):
                 }
             }, service_options)
 
-            service_account_info = sdk_security.setup_security(config.ZOOKEEPER_SERVICE_NAME, zk_account, zk_secret)
+            service_account_info = sdk_security.setup_security(config.ZOOKEEPER_SERVICE_NAME,
+                                                               linux_user="nobody",
+                                                               service_account=zk_account,
+                                                               service_account_secret=zk_secret)
 
         sdk_install.install(
             config.ZOOKEEPER_PACKAGE_NAME,

--- a/frameworks/kafka/tests/test_zookeeper.py
+++ b/frameworks/kafka/tests/test_zookeeper.py
@@ -35,7 +35,7 @@ def zookeeper_server(configure_security):
                 }
             }, service_options)
 
-            sdk_security.setup_security(config.ZOOKEEPER_SERVICE_NAME, zk_account, zk_secret)
+            service_account_info = sdk_security.setup_security(config.ZOOKEEPER_SERVICE_NAME, zk_account, zk_secret)
 
         sdk_install.install(
             config.ZOOKEEPER_PACKAGE_NAME,
@@ -49,9 +49,7 @@ def zookeeper_server(configure_security):
 
     finally:
         sdk_install.uninstall(config.ZOOKEEPER_PACKAGE_NAME, config.ZOOKEEPER_SERVICE_NAME)
-        if sdk_utils.is_strict_mode():
-            sdk_security.delete_service_account(
-                service_account_name=zk_account, service_account_secret=zk_secret)
+        sdk_security.cleanup_security(config.ZOOKEEPER_SERVICE_NAME, service_account_info)
 
 
 @pytest.fixture(scope='module', autouse=True)

--- a/frameworks/kafka/tests/test_zookeeper_auth.py
+++ b/frameworks/kafka/tests/test_zookeeper_auth.py
@@ -92,7 +92,7 @@ def zookeeper_server(kerberos):
 
     try:
         sdk_install.uninstall(config.ZOOKEEPER_PACKAGE_NAME, config.ZOOKEEPER_SERVICE_NAME)
-        sdk_security.setup_security(config.ZOOKEEPER_SERVICE_NAME, zk_account, zk_secret)
+        service_account_info = sdk_security.setup_security(config.ZOOKEEPER_SERVICE_NAME, zk_account, zk_secret)
         sdk_install.install(
             config.ZOOKEEPER_PACKAGE_NAME,
             config.ZOOKEEPER_SERVICE_NAME,
@@ -105,6 +105,7 @@ def zookeeper_server(kerberos):
 
     finally:
         sdk_install.uninstall(config.ZOOKEEPER_PACKAGE_NAME, config.ZOOKEEPER_SERVICE_NAME)
+        sdk_security.cleanup_security(config.ZOOKEEPER_SERVICE_NAME, service_account_info)
 
 
 @pytest.fixture(scope='module', autouse=True)

--- a/frameworks/kafka/tests/test_zookeeper_auth.py
+++ b/frameworks/kafka/tests/test_zookeeper_auth.py
@@ -92,7 +92,10 @@ def zookeeper_server(kerberos):
 
     try:
         sdk_install.uninstall(config.ZOOKEEPER_PACKAGE_NAME, config.ZOOKEEPER_SERVICE_NAME)
-        service_account_info = sdk_security.setup_security(config.ZOOKEEPER_SERVICE_NAME, zk_account, zk_secret)
+        service_account_info = sdk_security.setup_security(config.ZOOKEEPER_SERVICE_NAME,
+                                                           linux_user="nobody",
+                                                           service_account=zk_account,
+                                                           service_account_secret=zk_secret)
         sdk_install.install(
             config.ZOOKEEPER_PACKAGE_NAME,
             config.ZOOKEEPER_SERVICE_NAME,

--- a/frameworks/kafka/tests/test_zookeeper_authz.py
+++ b/frameworks/kafka/tests/test_zookeeper_authz.py
@@ -92,7 +92,7 @@ def zookeeper_server(kerberos):
 
     try:
         sdk_install.uninstall(config.ZOOKEEPER_PACKAGE_NAME, config.ZOOKEEPER_SERVICE_NAME)
-        sdk_security.setup_security(config.ZOOKEEPER_SERVICE_NAME, zk_account, zk_secret)
+        service_account_info = sdk_security.setup_security(config.ZOOKEEPER_SERVICE_NAME, zk_account, zk_secret)
         sdk_install.install(
             config.ZOOKEEPER_PACKAGE_NAME,
             config.ZOOKEEPER_SERVICE_NAME,
@@ -105,6 +105,7 @@ def zookeeper_server(kerberos):
 
     finally:
         sdk_install.uninstall(config.ZOOKEEPER_PACKAGE_NAME, config.ZOOKEEPER_SERVICE_NAME)
+        sdk_security.cleanup_security(config.ZOOKEEPER_SERVICE_NAME, service_account_info)
 
 
 @pytest.fixture(scope='module', autouse=True)

--- a/frameworks/kafka/tests/test_zookeeper_authz.py
+++ b/frameworks/kafka/tests/test_zookeeper_authz.py
@@ -92,7 +92,10 @@ def zookeeper_server(kerberos):
 
     try:
         sdk_install.uninstall(config.ZOOKEEPER_PACKAGE_NAME, config.ZOOKEEPER_SERVICE_NAME)
-        service_account_info = sdk_security.setup_security(config.ZOOKEEPER_SERVICE_NAME, zk_account, zk_secret)
+        service_account_info = sdk_security.setup_security(config.ZOOKEEPER_SERVICE_NAME,
+                                                           linux_user="nobody",
+                                                           service_account=zk_account,
+                                                           service_account_secret=zk_secret)
         sdk_install.install(
             config.ZOOKEEPER_PACKAGE_NAME,
             config.ZOOKEEPER_SERVICE_NAME,

--- a/frameworks/template/tests/config.py
+++ b/frameworks/template/tests/config.py
@@ -1,4 +1,3 @@
 PACKAGE_NAME = 'template'
 SERVICE_NAME = 'template'
 DEFAULT_TASK_COUNT = 1
-DEFAULT_LINUX_USER = 'nobody'

--- a/frameworks/template/tests/conftest.py
+++ b/frameworks/template/tests/conftest.py
@@ -1,12 +1,17 @@
 import pytest
+
 import sdk_security
+
 from tests import config
-from typing import List
 
-
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def configure_security(configure_universe):
-    service_account_name = 'service-acct'
+    service_account_name = "{}-service-account".format(config.SERVICE_NAME)
+    service_account_secret = "{}-service-account-secret".format(config.SERVICE_NAME)
     # Add the permissions you want to grant/revoke during the installation
     permissions = []
-    yield from sdk_security.security_session(config.SERVICE_NAME, permissions, config.DEFAULT_LINUX_USER, service_account_name)
+    yield from sdk_security.security_session(config.SERVICE_NAME,
+                                             permissions,
+                                             sdk_security.DEFAULT_LINUX_USER,
+                                             service_account_name,
+                                             service_account_secret)

--- a/testing/sdk_auth.py
+++ b/testing/sdk_auth.py
@@ -20,6 +20,8 @@ import uuid
 import retrying
 import subprocess
 
+from typing import List
+
 import sdk_cmd
 import sdk_hosts
 import sdk_marathon
@@ -196,7 +198,7 @@ class KerberosEnvironment:
                 log.info("Found installed KDC app, reusing it")
                 return _get_kdc_task(self.app_definition["id"])
             log.info("Found installed KDC app, destroying it first")
-            sdk_marathon.destroy(self.app_definition["id"])
+            sdk_marathon.destroy_app(self.app_definition["id"])
 
         log.info("Installing KDC Marathon app")
         _install_marathon_app(self.app_definition)
@@ -338,7 +340,7 @@ class KerberosEnvironment:
         keytab_id = self.get_keytab_path().replace("/", "_")
         return self.get_keytab_for_principals(keytab_id, self.principals)
 
-    def __encode_secret(self, keytab_path: str) -> str:
+    def __encode_secret(self, keytab_path: str) -> List[str]:
         if self.get_keytab_path().startswith(DCOS_BASE64_PREFIX):
             try:
                 base64_encoded_keytab_path = "{}.base64".format(keytab_path)

--- a/testing/sdk_cmd.py
+++ b/testing/sdk_cmd.py
@@ -339,7 +339,7 @@ def resolve_hosts(marathon_task_name: str, hosts: list, bootstrap_cmd: str='./bo
     """
     Use bootstrap to resolve the specified list of hosts
     """
-    bootstrap_cmd = [
+    bootstrap_cmd_list = [
         bootstrap_cmd,
         '-print-env=false',
         '-template=false',
@@ -347,7 +347,7 @@ def resolve_hosts(marathon_task_name: str, hosts: list, bootstrap_cmd: str='./bo
         '-self-resolve=false',
         '-resolve-hosts', ','.join(hosts)]
     log.info("Running bootstrap to wait for DNS resolution of: %s", ', '.join(hosts))
-    _, bootstrap_stdout, bootstrap_stderr = marathon_task_exec(marathon_task_name, ' '.join(bootstrap_cmd))
+    _, bootstrap_stdout, bootstrap_stderr = marathon_task_exec(marathon_task_name, ' '.join(bootstrap_cmd_list))
 
     # Note that bootstrap returns its output in STDERR
     resolved = 'SDK Bootstrap successful.' in bootstrap_stderr

--- a/testing/sdk_security.py
+++ b/testing/sdk_security.py
@@ -265,7 +265,7 @@ def setup_security(service_name: str,
     security_info["roles"] = roles.copy() if roles else _get_service_role(service_name)
 
     for role_name in security_info["roles"]:
-        security_info["permissions"] = grant_permissions(
+        security_info["permissions"][role_name] = grant_permissions(
             linux_user=linux_user,
             role_name=role_name,
             service_account_name=service_account,

--- a/testing/sdk_security.py
+++ b/testing/sdk_security.py
@@ -19,6 +19,9 @@ import sdk_utils
 log = logging.getLogger(__name__)
 
 
+DEFAULT_LINUX_USER = "nobody"
+
+
 def install_enterprise_cli(force=False):
     """ Install the enterprise CLI if required """
 
@@ -224,7 +227,7 @@ def _get_role_list(service_name: str) -> List[str]:
 
 def setup_security(service_name: str,
                    permissions: List[dict]=[],
-                   linux_user: str="nobody",
+                   linux_user: str=DEFAULT_LINUX_USER,
                    service_account: str="service-acct",
                    service_account_secret: str="secret") -> dict:
 
@@ -268,7 +271,7 @@ def cleanup_security(service_name: str,
 
     log.info("Cleaning up strict-mode security")
 
-    linux_user = service_account_info.get("linux_user", "nobody")
+    linux_user = service_account_info.get("linux_user", DEFAULT_LINUX_USER)
     permissions = service_account_info.get("permissions", [])
     roles = service_account_info.get("roles", _get_role_list(service_name))
 
@@ -287,7 +290,7 @@ def cleanup_security(service_name: str,
 
 def security_session(framework_name: str,
                      permissions: List[dict]=[],
-                     linux_user: str="nobody",
+                     linux_user: str=DEFAULT_LINUX_USER,
                      service_account: str="service-acct",
                      service_account_secret: str="secret") -> None:
     """Create a service account and configure permissions for strict-mode tests.
@@ -296,7 +299,7 @@ def security_session(framework_name: str,
 
     @pytest.fixture(scope='session')
     def configure_security(configure_universe):
-        yield from sdk_security.security_session(framework_name, permissions, 'nobody', 'service-acct')
+        yield from sdk_security.security_session(framework_name, permissions, linux_user, 'service-acct')
     """
     try:
         is_strict = sdk_utils.is_strict_mode()

--- a/testing/security/transport_encryption.py
+++ b/testing/security/transport_encryption.py
@@ -61,12 +61,7 @@ def cleanup_service_account(service_name: str, service_account_info: dict):
     if isinstance(service_account_info, str):
         service_account_info = {"name": service_account_info}
 
-    name = service_account_info["name"]
-    secret = service_account_info["secret"] if "secret" in service_account_info else name
-
-    sdk_security.cleanup_security(service_name,
-                                  service_account=name,
-                                  service_account_secret=secret)
+    sdk_security.cleanup_security(service_name, service_account_info)
 
 
 def fetch_dcos_ca_bundle(marathon_task: str) -> str:

--- a/testing/security/transport_encryption.py
+++ b/testing/security/transport_encryption.py
@@ -27,6 +27,7 @@ def setup_service_account(service_name: str,
     secret = name if service_account_secret is None else service_account_secret
 
     service_account_info = sdk_security.setup_security(service_name,
+                                                       linux_user="nobody",
                                                        service_account=name,
                                                        service_account_secret=secret)
 


### PR DESCRIPTION
In order to address DCOS-37718, I had to make some sdk_security changes, and I am upstreaming these here.

This also builds on @hectorj2f's change in #2498.

Some changes:
* The security setup now supports arbitrary *foldered* service names
* Security info is now stored for cleanup in the teardown fixtures