### PR TITLE
Add ipc.maximum.data.length config option for hdfs

### DIFF
--- a/frameworks/hdfs/src/main/dist/core-site.xml
+++ b/frameworks/hdfs/src/main/dist/core-site.xml
@@ -41,6 +41,10 @@
         <value>{{IPC_CLIENT_CONNECT_MAX_RETRIES}}</value>
     </property>
     <property>
+        <name>ipc.maximum.data.length</name>
+        <value>{{IPC_MAXIMUM_DATA_LENGTH}}</value>
+    </property>
+    <property>
         <name>hadoop.tmp.dir</name>
         <value>{{HADOOP_TMP_DIR}}</value>
     </property>

--- a/frameworks/hdfs/universe/config.json
+++ b/frameworks/hdfs/universe/config.json
@@ -1666,6 +1666,11 @@
           "description": "The default implementation of Hash. Currently this can take one of the two values: 'murmur' to select MurmurHash and 'jenkins' to select JenkinsHash.",
           "default": "murmur"
         },
+        "ipc_maximum_data_length": {
+          "type": "string",
+          "description": "Defines the maximum length of rpc calls for data node reports to the name node.",
+          "default": "67108864"
+        },
         "ipc_client_idlethreshold": {
           "type": "string",
           "description": "Defines the threshold number of connections after which connections will be inspected for idleness.",

--- a/frameworks/hdfs/universe/marathon.json.mustache
+++ b/frameworks/hdfs/universe/marathon.json.mustache
@@ -359,6 +359,7 @@
     "TASKCFG_ALL_IO_SEQFILE_BLOOM_SIZE": "{{hdfs.io_seqfile_bloom_size}}",
     "TASKCFG_ALL_IO_SEQFILE_BLOOM_ERROR_RATE": "{{hdfs.io_seqfile_bloom_error_rate}}",
     "TASKCFG_ALL_HADOOP_UTIL_HASH_TYPE": "{{hdfs.hadoop_util_hash_type}}",
+    "TASKCFG_ALL_IPC_MAXIMUM_DATA_LENGTH": "{{hdfs.ipc_maximum_data_length}}",
     "TASKCFG_ALL_IPC_CLIENT_IDLETHRESHOLD": "{{hdfs.ipc_client_idlethreshold}}",
     "TASKCFG_ALL_IPC_CLIENT_KILL_MAX": "{{hdfs.ipc_client_kill_max}}",
     "TASKCFG_ALL_IPC_CLIENT_CONNECTION_MAXIDLETIME": "{{hdfs.ipc_client_connection_maxidletime}}",


### PR DESCRIPTION
We encountered a problem with HDFS where hdfs had too many files and block reports to the namenodes failed because the reports were too big (see https://community.hortonworks.com/questions/101841/issue-requested-data-length-146629817-is-longer-th.html for more info). To fix this the option ipc.maximum.data.length needs to be set to a higher value (default is 64MB).
This PR adds the setting to the core-site.xml and as a optional config option to the framework.

We run this change in our production cluster with a value of 256MB. 