### PR TITLE
DCOS-37981 Just retrieve individual packages, instead of whole repo

### DIFF
--- a/frameworks/helloworld/tests/test_tls.py
+++ b/frameworks/helloworld/tests/test_tls.py
@@ -161,17 +161,17 @@ def test_java_keystore():
             config.SERVICE_NAME, KEYSTORE_TASK_HTTPS_PORT_NAME) + '/hello-world'
         )
 
-    _, output = sdk_cmd.service_task_exec(config.SERVICE_NAME, 'artifacts-0-node', curl, return_stderr_in_stdout=True)
+    _, _, stderr = sdk_cmd.service_task_exec(config.SERVICE_NAME, 'artifacts-0-node', curl)
     # Check that HTTP request was successful with response 200 and make sure
     # that curl with pre-configured cert was used and that task was matched
     # by SAN in certificate.
-    assert 'HTTP/1.1 200 OK' in output
-    assert 'CAfile: secure-tls-pod.ca' in output
+    assert 'HTTP/1.1 200 OK' in stderr
+    assert 'CAfile: secure-tls-pod.ca' in stderr
     tls_verification_msg = (
         'host "keystore-https.hello-world.l4lb.thisdcos.directory" matched '
         'cert\'s "keystore-https.hello-world.l4lb.thisdcos.directory"'
     )
-    assert tls_verification_msg in output
+    assert tls_verification_msg in stderr
 
 
 @pytest.mark.tls

--- a/testing/sdk_security.py
+++ b/testing/sdk_security.py
@@ -318,8 +318,8 @@ def is_cipher_enabled(service_name: str,
             'openssl', 's_client', '-cipher', cipher, '-connect', endpoint
         ])
 
-        _, output = sdk_cmd.service_task_exec(service_name, task_name, command, True)
-        return output
+        _, stdout, stderr = sdk_cmd.service_task_exec(service_name, task_name, command)
+        return stdout + '\n' + stderr
 
     output = run_openssl_command()
 

--- a/tools/universe/package_manager.py
+++ b/tools/universe/package_manager.py
@@ -9,13 +9,9 @@ import subprocess
 import json
 import os
 import tempfile
+import urllib.request
 
 from . import package
-try:
-    import requests
-    _HAS_REQUESTS = True
-except ImportError:
-    _HAS_REQUESTS = False
 
 
 LOGGER = logging.getLogger(__name__)
@@ -23,114 +19,53 @@ LOGGER = logging.getLogger(__name__)
 
 class PackageManager:
     """A simple package manager for retrieving universe packages"""
-    def __init__(self, universe_url="https://universe.mesosphere.com/repo",
-                 dcos_version="1.10",
+    def __init__(self,
+                 universe_package_prefix="https://universe.mesosphere.com/package/",
+                 dcos_version="1.11",
                  package_version="4",
                  dry_run=False):
 
         self._dry_run = dry_run
-        self._universe_url = universe_url
+        self._universe_package_prefix = universe_package_prefix
         self._headers = {
             "User-Agent": "dcos/{}".format(dcos_version),
             "Accept": "application/vnd.dcos.universe.repo+json;"
                       "charset=utf-8;version=v{}".format(package_version),
         }
 
-        self.__package_cache = None
+        self.__package_cache = {}
 
-        if _HAS_REQUESTS:
-            self._get_packages = _get_packages_with_requests
-        else:
-            self._get_packages = _get_packages_with_curl
 
     def get_package_versions(self, package_name):
         """Get all versions for a specified package"""
+        if self._dry_run:
+            return DryRunPackages()
 
-        packages = self.get_packages()
+        if package_name not in self.__package_cache:
+            LOGGER.info("Retrieving information for package: %s", package_name)
+            url = self._universe_package_prefix + package_name
+            try:
+                req = urllib.request.Request(url, headers=self._headers)
+                with urllib.request.urlopen(req, timeout=60) as f:
+                    # Returned data: {"packages": [releases for the specified package]}
+                    package_releases = json.loads(f.read().decode())['packages']
+                    self.__package_cache[package_name] = [package.Package.from_json(p) for p in package_releases]
+            except Exception as e:
+                LOGGER.error("Failed to fetch package information at %s: %s", url, e)
 
-        return packages.get(package_name, [])
+        return self.__package_cache.get(package_name, [])
+
 
     def get_latest(self, package_name):
         if isinstance(package_name, package.Package):
             package_name = package_name.get_name()
 
         all_package_versions = self.get_package_versions(package_name)
-
         if all_package_versions:
+            # Releases should be in order of oldest to latest:
             return all_package_versions[-1]
 
         return None
-
-    def get_packages(self):
-        """Query the uninverse to get a list of packages"""
-        if self._dry_run:
-            return DryRunPackages()
-
-        if not self.__package_cache:
-            LOGGER.info("Package cache is empty. Retrieving package information")
-            raw_package_list = self._get_packages(self._universe_url, self._headers)
-
-            package_dict = {}
-            for p in raw_package_list:
-                package_name = p['name']
-                package_object = package.Package.from_json(p)
-
-                if package_name in package_dict:
-                    package_dict[package_name].append(package_object)
-                else:
-                    package_dict[package_name] = [package_object, ]
-
-            self.__package_cache = {}
-            for p, packages in package_dict.items():
-                self.__package_cache[p] = sorted(packages)
-
-        return self.__package_cache
-
-
-def _get_packages_with_curl(universe_url, headers):
-    """Use curl to download the packages from the universe"""
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        tmp_filename = os.path.join(tmp_dir, 'packages.json')
-
-        cmd = ["curl",
-               "--write-out", "%{http_code}",
-               "--silent",
-               "-L",
-               "--max-time", "60",
-               "-X", "GET",
-               "-o", tmp_filename, ]
-        for k, header in headers.items():
-            cmd.extend(["-H", "{}: {}".format(k, header)])
-
-        cmd.append(universe_url)
-
-        try:
-            output = subprocess.check_output(cmd)
-            status_code = int(output)
-
-            if status_code != 200:
-                raise Exception("Curl returned status code {}".format(status_code))
-
-            with open(tmp_filename, "r") as f:
-                packages = json.load(f)['packages']
-        except Exception as e:
-            LOGGER.error("Retrieving packages with curl failed. %s", e)
-            packages = []
-
-    return packages
-
-
-def _get_packages_with_requests(universe_url, headers):
-    """Use the requests module to get the packages from the universe"""
-    try:
-        response = requests.get(universe_url, headers=headers)
-        response.raise_for_status()
-        packages = response.json()['packages']
-    except Exception as e:
-        LOGGER.error("Retrieving packages with requests failed. %s", e)
-        packages = []
-
-    return packages
 
 
 class DryRunPackages:

--- a/tools/universe/package_manager.py
+++ b/tools/universe/package_manager.py
@@ -9,6 +9,7 @@ import subprocess
 import json
 import os
 import tempfile
+import urllib.parse
 import urllib.request
 
 from . import package

--- a/tools/universe/package_manager.py
+++ b/tools/universe/package_manager.py
@@ -43,7 +43,7 @@ class PackageManager:
 
         if package_name not in self.__package_cache:
             LOGGER.info("Retrieving information for package: %s", package_name)
-            url = self._universe_package_prefix + package_name
+            url = urllib.parse.urljoin(self._universe_package_prefix, package_name)
             try:
                 req = urllib.request.Request(url, headers=self._headers)
                 with urllib.request.urlopen(req, timeout=60) as f:


### PR DESCRIPTION
- Use new endpoint to just download info for the targeted package, instead of all packages
- Just use urllib instead of `requests` -> `curl` fallback