### PR TITLE
Add strict checking to svc yml tests

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/RawServiceSpec.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/RawServiceSpec.java
@@ -65,8 +65,8 @@ public class RawServiceSpec {
         /**
          * Set whether the rendering should be strict.
          */
-        public Builder setStrictRendering(boolean isStrict) {
-            this.isRenderingStrict = isStrict;
+        public Builder enableStrictRendering() {
+            this.isRenderingStrict = true;
             return this;
         }
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/RawServiceSpec.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/RawServiceSpec.java
@@ -47,6 +47,7 @@ public class RawServiceSpec {
 
         private final File pathToYamlTemplate;
         private Map<String, String> env;
+        private boolean isRenderingStrict = false;
 
         private Builder(File pathToYamlTemplate) {
             this.pathToYamlTemplate = pathToYamlTemplate;
@@ -58,6 +59,14 @@ public class RawServiceSpec {
          */
         public Builder setEnv(Map<String, String> env) {
             this.env = env;
+            return this;
+        }
+
+        /**
+         * Set whether the rendering should be strict.
+         */
+        public Builder setStrictRendering(boolean isStrict) {
+            this.isRenderingStrict = isStrict;
             return this;
         }
 
@@ -76,6 +85,11 @@ public class RawServiceSpec {
                     missingValues);
             LOGGER.info("Rendered ServiceSpec from {}:\nMissing template values: {}\n{}",
                     pathToYamlTemplate.getAbsolutePath(), missingValues, yamlWithEnv);
+
+            if (this.isRenderingStrict) {
+                TemplateUtils.validateMissingValues(pathToYamlTemplate.getName(), env, missingValues);
+            }
+
             return fromBytes(yamlWithEnv.getBytes(StandardCharsets.UTF_8));
         }
     }

--- a/sdk/testing/src/main/java/com/mesosphere/sdk/testing/ServiceTestRunner.java
+++ b/sdk/testing/src/main/java/com/mesosphere/sdk/testing/ServiceTestRunner.java
@@ -317,7 +317,7 @@ public class ServiceTestRunner {
         // Test 1: Does RawServiceSpec render?
         RawServiceSpec rawServiceSpec = RawServiceSpec.newBuilder(specPath)
                 .setEnv(schedulerEnvironment)
-                .setStrictRendering(true)
+                .enableStrictRendering()
                 .build();
 
         // Test 2: Does ServiceSpec render?

--- a/sdk/testing/src/main/java/com/mesosphere/sdk/testing/ServiceTestRunner.java
+++ b/sdk/testing/src/main/java/com/mesosphere/sdk/testing/ServiceTestRunner.java
@@ -317,6 +317,7 @@ public class ServiceTestRunner {
         // Test 1: Does RawServiceSpec render?
         RawServiceSpec rawServiceSpec = RawServiceSpec.newBuilder(specPath)
                 .setEnv(schedulerEnvironment)
+                .setStrictRendering(true)
                 .build();
 
         // Test 2: Does ServiceSpec render?

--- a/tools/universe/package_manager.py
+++ b/tools/universe/package_manager.py
@@ -40,7 +40,7 @@ class PackageManager:
     def get_package_versions(self, package_name):
         """Get all versions for a specified package"""
         if self._dry_run:
-            return DryRunPackages()
+            return DryRunPackages(package_name)
 
         if package_name not in self.__package_cache:
             LOGGER.info("Retrieving information for package: %s", package_name)
@@ -70,6 +70,9 @@ class PackageManager:
 
 
 class DryRunPackages:
-    def get(self, package_name, default):
-        return [package.Package(package_name,
-                                package.Version(0, "DRY_RUN_VERSION")), ]
+
+    def __init__(self, package_name: str):
+        self._package = package.Package(package_name, package.Version(0, "DRY_RUN_VERSION"))
+
+    def __getitem__(self, key):
+        return self._package


### PR DESCRIPTION
While reviewing mesosphere/prometheus#12 I noted that there were issues due to undefined envvars in `svc.yml` were not triggering any errors in the unit tests.

This PR adds a strict mode in the `RawServiceSpec.Builder` that is enabled for the tests.

It may be good to backport the change too so that it ends up in an earlier SDK package.