### PR TITLE
[DCOS-38168] Port testing changes from spark-build.

### DIFF
--- a/testing/sdk_marathon.py
+++ b/testing/sdk_marathon.py
@@ -89,7 +89,9 @@ def get_config(app_name, timeout=TIMEOUT_SECONDS):
 
 
 def is_app_running(app: dict) -> bool:
-    return app['tasksStaged'] == 0 and app['tasksUnhealthy'] == 0 and app['tasksRunning'] > 0
+    return (app.get('tasksStaged', 0) == 0
+            and app.get('tasksUnhealthy', 0) == 0
+            and app.get('tasksRunning', 0) > 0)
 
 
 def wait_for_deployment_and_app_running(app_name: str, timeout: int):


### PR DESCRIPTION
1. Fix sdk_marathon.install_app infinite waiting bug.
The shakedown.wait_for_task call keeps blocking even after the app task starts running.

2. Allow installation of Marathon apps with slashes in the name.