### PR TITLE
[BACKPORT][TESTS][TOOLS] Add strict rendering checks to svc.yml tests

### DIFF
--- a/frameworks/cassandra/universe/marathon.json.mustache
+++ b/frameworks/cassandra/universe/marathon.json.mustache
@@ -48,6 +48,9 @@
     "TASKCFG_ALL_SECURITY_TRANSPORT_ENCRYPTION_ALLOW_PLAINTEXT": "{{service.security.transport_encryption.allow_plaintext}}",
     {{/service.security.transport_encryption.allow_plaintext}}
     {{/service.security.transport_encryption.enabled}}
+    {{^service.security.transport_encryption.enabled}}
+    "CASSANDRA_CQLSH_SSL_FLAGS": "",
+    {{/service.security.transport_encryption.enabled}}
 
     "TASKCFG_ALL_CASSANDRA_CLUSTER_NAME": "{{cassandra.cluster_name}}",
     "TASKCFG_ALL_CASSANDRA_AUTHENTICATOR": "{{cassandra.authenticator}}",

--- a/frameworks/helloworld/src/test/java/com/mesosphere/sdk/helloworld/scheduler/ServiceTest.java
+++ b/frameworks/helloworld/src/test/java/com/mesosphere/sdk/helloworld/scheduler/ServiceTest.java
@@ -673,6 +673,9 @@ public class ServiceTest {
                 "WORLD_SECRET2", "hello-world/secret2",
                 "WORLD_SECRET3", "hello-world/secret3"));
 
+        schedulerEnvForExamples.put("isolation.yml", toMap(
+                "HELLO_ISOLATION", "true"));
+
         // Iterate over yml files in dist/examples/, run sanity check for each:
         File[] exampleFiles = ServiceTestRunner.getDistDir().listFiles();
         Assert.assertNotNull(exampleFiles);

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/RawServiceSpec.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/RawServiceSpec.java
@@ -39,6 +39,7 @@ public class RawServiceSpec {
 
         private final File pathToYamlTemplate;
         private Map<String, String> env;
+        private boolean isRenderingStrict = false;
 
         private Builder(File pathToYamlTemplate) {
             this.pathToYamlTemplate = pathToYamlTemplate;
@@ -51,6 +52,14 @@ public class RawServiceSpec {
         @VisibleForTesting
         public Builder setEnv(Map<String, String> env) {
             this.env = env;
+            return this;
+        }
+
+        /**
+         * Set whether the rendering should be strict.
+         */
+        public Builder enableStrictRendering() {
+            this.isRenderingStrict = true;
             return this;
         }
 
@@ -69,6 +78,11 @@ public class RawServiceSpec {
                     missingValues);
             LOGGER.info("Rendered ServiceSpec from {}:\nMissing template values: {}\n{}",
                     pathToYamlTemplate.getAbsolutePath(), missingValues, yamlWithEnv);
+
+            if (this.isRenderingStrict) {
+                TemplateUtils.validateMissingValues(pathToYamlTemplate.getName(), env, missingValues);
+            }
+
             return YAML_MAPPER.readValue(yamlWithEnv.getBytes(StandardCharsets.UTF_8), RawServiceSpec.class);
         }
     }

--- a/sdk/testing/src/main/java/com/mesosphere/sdk/testing/ServiceTestRunner.java
+++ b/sdk/testing/src/main/java/com/mesosphere/sdk/testing/ServiceTestRunner.java
@@ -309,6 +309,7 @@ public class ServiceTestRunner {
         // Test 1: Does RawServiceSpec render?
         RawServiceSpec rawServiceSpec = RawServiceSpec.newBuilder(specPath)
                 .setEnv(schedulerEnvironment)
+                .enableStrictRendering()
                 .build();
 
         // Test 2: Does ServiceSpec render?


### PR DESCRIPTION
This PR backports #2527  the addition of a strict rendering mode for `svc.yml` files.

Additional changes required:
* Set the `CASSANDRA_CQLSH_SSL_FLAGS` envvar to blank instead of leaving it unset.