### PR TITLE
[DCOS-38249][TESTS] Use foldered service name for HDFS security settings

### DIFF
--- a/frameworks/hdfs/tests/test_kerberos_auth.py
+++ b/frameworks/hdfs/tests/test_kerberos_auth.py
@@ -32,10 +32,10 @@ def service_account(configure_security):
     Sets up a service account for use with TLS.
     """
     try:
-        service_account_info = transport_encryption.setup_service_account(config.SERVICE_NAME)
+        service_account_info = transport_encryption.setup_service_account(config.FOLDERED_SERVICE_NAME)
         yield service_account_info
     finally:
-        transport_encryption.cleanup_service_account(config.SERVICE_NAME, service_account_info)
+        transport_encryption.cleanup_service_account(config.FOLDERED_SERVICE_NAME, service_account_info)
 
 
 @pytest.fixture(scope='module', autouse=True)


### PR DESCRIPTION
There was an inconsistency when setting up the service accounts for HDFS. This causes builds to fail on strict mode.