### PR TITLE
[BACKPORT][DCOS_OSS-3555] Make sure MESOS_CONTAINER_IP is set before running helper (#2510)

### DIFF
--- a/frameworks/kafka/src/main/dist/svc.yml
+++ b/frameworks/kafka/src/main/dist/svc.yml
@@ -87,6 +87,9 @@ pods:
       {{/TASKCFG_ALL_SECURITY_KERBEROS_ENABLED}}
 
           # setup-helper determines the correct listeners and security.inter.broker.protocol.
+          # it relies on the task IP being stored in MESOS_CONTAINER_IP
+          export MESOS_CONTAINER_IP=$( ./bootstrap --get-task-ip )
+          export LIB_PROCESS_IP=$MESOS_CONTAINER_IP
           ./setup-helper
           export SETUP_HELPER_ADVERTISED_LISTENERS=`cat advertised.listeners`
           export SETUP_HELPER_LISTENERS=`cat listeners`


### PR DESCRIPTION
This is a straight backport of #2510. 

It fixes a possible issue running Kafka when `MESOS_CONTAINER_IP` is not set when starting the broker tasks.