### PR TITLE
DCOS-37673: Upstream buildchain modifications from edgelb

### DIFF
--- a/tools/build_go_exe.sh
+++ b/tools/build_go_exe.sh
@@ -89,7 +89,7 @@ cd $GOPATH_EXE_DIR
 # previous native build. if the sha1 matches, then we can skip the rebuild.
 NATIVE_FILENAME=".native-${EXE_BASE_NAME}"
 NATIVE_SHA1SUM_FILENAME="${NATIVE_FILENAME}.sha1sum"
-go build -o $NATIVE_FILENAME
+go build -a -o $NATIVE_FILENAME
 # 'shasum' is available on OSX as well as (most?) Linuxes:
 NATIVE_SHA1SUM=$(shasum $NATIVE_FILENAME | awk '{print $1}')
 

--- a/tools/build_go_exe.sh
+++ b/tools/build_go_exe.sh
@@ -71,6 +71,7 @@ GOPATH_REPO_ORG=${ORG_PATH:=github.com/mesosphere}
 GOPATH_REPO_ORG_DIR=${GOPATH}/src/${GOPATH_REPO_ORG}
 # ex: /.gopath/src/github.com/mesosphere/dcos-commons/sdk/cli
 GOPATH_EXE_DIR="$GOPATH_REPO_ORG_DIR/$REPO_NAME/$RELATIVE_EXE_DIR"
+GO_LDFLAGS=${GO_LDFLAGS:-""}
 
 # Add symlink from GOPATH which points into the repository directory, if necessary:
 SYMLINK_LOCATION="$GOPATH_REPO_ORG_DIR/$REPO_NAME"
@@ -89,7 +90,7 @@ cd $GOPATH_EXE_DIR
 # previous native build. if the sha1 matches, then we can skip the rebuild.
 NATIVE_FILENAME=".native-${EXE_BASE_NAME}"
 NATIVE_SHA1SUM_FILENAME="${NATIVE_FILENAME}.sha1sum"
-go build -a -o $NATIVE_FILENAME
+go build -a -ldflags "${GO_LDFLAGS}" -o $NATIVE_FILENAME
 # 'shasum' is available on OSX as well as (most?) Linuxes:
 NATIVE_SHA1SUM=$(shasum $NATIVE_FILENAME | awk '{print $1}')
 
@@ -145,7 +146,7 @@ else
 
         # available GOOS/GOARCH permutations are listed at:
         # https://golang.org/doc/install/source#environment
-        CGO_ENABLED=0 GOOS=$PLATFORM GOARCH=386 go build -ldflags="-s -w" -o $PLATFORM_FILENAME
+        CGO_ENABLED=0 GOOS=$PLATFORM GOARCH=386 go build -ldflags="-s -w ${GO_LDFLAGS}" -o $PLATFORM_FILENAME
 
         # use upx if:
         # - upx is installed


### PR DESCRIPTION
## High-level description

This PR upstreams some the build chain modifications we had in edgelb's SDK integration[1]:
* permit specifying custom Go linker flags in `build_go_exe.sh`. We were using it to add version information to `edgelb` CLI via `git describe --tags`
* force rebuilding of all the native executable deps when deciding if the rebuild of all the executables is necessary.
* airgap linter should not try to lint binary files

I do not have much information on the technical reasoning behind the second bullet point apart from the edgelb's original git commit message [2]:

```
Switched cli builds to `go build -a`. There is some weird caching that
breaks compiling without the `-a` flag
```

[1] https://github.com/mesosphere/dcos-edge-lb/tree/master/framework
[2] https://github.com/mesosphere/dcos-edge-lb/commit/94635e25fea71c9f4f138b50f68710a9660099d2

## Corresponding DC/OS tickets 

* https://jira.mesosphere.com/browse/DCOS-37673 `edgelb: SDK buildscripts cleanup`