### PR TITLE
[DCOS-38238][BACKPORT] Temporarily disable tests that are failing due to Mesos Fetcher regression.

### DIFF
--- a/frameworks/elastic/tests/test_sanity.py
+++ b/frameworks/elastic/tests/test_sanity.py
@@ -166,6 +166,8 @@ def test_custom_yaml_base64():
 
 @pytest.mark.sanity
 @pytest.mark.timeout(60 * 60)
+@pytest.mark.skipif(sdk_utils.dcos_version_at_least('1.12'),
+                    reason='MESOS-9008: Mesos Fetcher fails to extract Kibana archive')
 def test_xpack_toggle_with_kibana(default_populated_index):
     log.info("\n***** Verify X-Pack disabled by default in elasticsearch")
     config.verify_commercial_api_status(False, service_name=foldered_name)

--- a/frameworks/elastic/tests/test_tls.py
+++ b/frameworks/elastic/tests/test_tls.py
@@ -117,5 +117,7 @@ def test_crud_over_tls(elastic_service_tls):
 
 @pytest.mark.tls
 @pytest.mark.sanity
+@pytest.mark.skipif(sdk_utils.dcos_version_at_least('1.12'),
+                    reason='MESOS-9008: Mesos Fetcher fails to extract Kibana archive')
 def test_kibana_tls(kibana_application_tls):
     config.check_kibana_adminrouter_integration("service/{}/login".format(config.KIBANA_SERVICE_NAME))


### PR DESCRIPTION
This PR backports https://github.com/mesosphere/dcos-commons/pull/2539.