### PR TITLE
Update kafka-client image for Kafka tests

### DIFF
--- a/frameworks/kafka/tests/client.py
+++ b/frameworks/kafka/tests/client.py
@@ -93,7 +93,7 @@ class KafkaClient:
             "container": {
                 "type": "MESOS",
                 "docker": {
-                    "image": "elezar/kafka-client:4b9c060",
+                    "image": "elezar/kafka-client:deca3d0",
                     "forcePullImage": True
                 }
             },


### PR DESCRIPTION
Resolves [DCOS-38359](https://jira.mesosphere.com/browse/DCOS-38359)

This PR updates the `kafka-client` used in the Kafka tests and will be necessary when upgrading Kafka to version 1.1.0. 

Commit [39b7994](https://github.com/mesosphere/dcos-commons/commit/39b79941874522adf100062f5808757abd48d1b1) will verify that the `kafka-client` is backwards compatible and if so, this PR will be merged with #2534.