### PR TITLE
DCOS-38473 Log and exit if exception is about to reach Mesos code

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/framework/FrameworkScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/framework/FrameworkScheduler.java
@@ -115,52 +115,64 @@ public class FrameworkScheduler implements Scheduler {
 
     @Override
     public void registered(SchedulerDriver driver, Protos.FrameworkID frameworkId, Protos.MasterInfo masterInfo) {
-        if (registerCalled.getAndSet(true)) {
-            // This may occur as the result of a master election.
-            LOGGER.info("Already registered, calling reregistered()");
-            reregistered(driver, masterInfo);
-            return;
-        }
-
-        LOGGER.info("Registered framework with frameworkId: {}", frameworkId.getValue());
         try {
-            frameworkStore.storeFrameworkId(frameworkId);
-        } catch (Exception e) {
-            LOGGER.error(String.format(
-                    "Unable to store registered framework ID '%s'", frameworkId.getValue()), e);
-            ProcessExit.exit(ProcessExit.REGISTRATION_FAILURE, e);
+            if (registerCalled.getAndSet(true)) {
+                // This may occur as the result of a master election.
+                LOGGER.info("Already registered, calling reregistered()");
+                reregistered(driver, masterInfo);
+                return;
+            }
+
+            LOGGER.info("Registered framework with frameworkId: {}", frameworkId.getValue());
+            try {
+                frameworkStore.storeFrameworkId(frameworkId);
+            } catch (Exception e) {
+                LOGGER.error(String.format(
+                        "Unable to store registered framework ID '%s'", frameworkId.getValue()), e);
+                ProcessExit.exit(ProcessExit.REGISTRATION_FAILURE, e);
+            }
+
+            updateDriverAndDomain(driver, masterInfo);
+            mesosEventClient.registered(false);
+
+            // Start background threads:
+            offerProcessor.start();
+            implicitReconciler.start();
+        } catch (Throwable e) {
+            logExceptionAndExit(e);
         }
-
-        updateDriverAndDomain(driver, masterInfo);
-        mesosEventClient.registered(false);
-
-        // Start background threads:
-        offerProcessor.start();
-        implicitReconciler.start();
     }
 
     @Override
     public void reregistered(SchedulerDriver driver, Protos.MasterInfo masterInfo) {
-        LOGGER.info("Re-registered with master: {}", TextFormat.shortDebugString(masterInfo));
-        updateDriverAndDomain(driver, masterInfo);
-        mesosEventClient.registered(true);
+        try {
+            LOGGER.info("Re-registered with master: {}", TextFormat.shortDebugString(masterInfo));
+            updateDriverAndDomain(driver, masterInfo);
+            mesosEventClient.registered(true);
+        } catch (Throwable e) {
+            logExceptionAndExit(e);
+        }
     }
 
     @Override
     public void resourceOffers(SchedulerDriver driver, List<Protos.Offer> offers) {
-        Metrics.incrementReceivedOffers(offers.size());
+        try {
+            Metrics.incrementReceivedOffers(offers.size());
 
-        if (!apiServerStarted.get()) {
-            LOGGER.info("Declining {} offer{}: Waiting for API Server to start.",
-                    offers.size(), offers.size() == 1 ? "" : "s");
-            OfferProcessor.declineShort(offers);
-            return;
+            if (!apiServerStarted.get()) {
+                LOGGER.info("Declining {} offer{}: Waiting for API Server to start.",
+                        offers.size(), offers.size() == 1 ? "" : "s");
+                OfferProcessor.declineShort(offers);
+                return;
+            }
+
+            // Filter any bad resources from the offers before they even enter processing.
+            offerProcessor.enqueue(offers.stream()
+                    .map(offer -> filterBadResources(offer))
+                    .collect(Collectors.toList()));
+        } catch (Throwable e) {
+            logExceptionAndExit(e);
         }
-
-        // Filter any bad resources from the offers before they even enter processing.
-        offerProcessor.enqueue(offers.stream()
-                .map(offer -> filterBadResources(offer))
-                .collect(Collectors.toList()));
     }
 
     /**
@@ -211,68 +223,108 @@ public class FrameworkScheduler implements Scheduler {
 
     @Override
     public void statusUpdate(SchedulerDriver driver, Protos.TaskStatus status) {
-        LOGGER.info("Received status update for taskId={} state={} message={} protobuf={}",
-                status.getTaskId().getValue(),
-                status.getState().toString(),
-                status.getMessage(),
-                TextFormat.shortDebugString(status));
-        Metrics.record(status);
-        TaskStatusResponse response = mesosEventClient.taskStatus(status);
-        boolean eligibleToKill = TaskKiller.update(status);
-        switch (response.result) {
-        case UNKNOWN_TASK:
-            if (eligibleToKill) {
-                LOGGER.info("Got unknown task in response to status update, marking task to be killed: {}",
-                        status.getTaskId().getValue());
-                TaskKiller.killTask(status.getTaskId());
-            } else {
-                // Special case: Mesos can send TASK_LOST+REASON_RECONCILIATION as a response to a prior kill request
-                // against a task that is unknown to Mesos. When this happens, we don't want to repeat the kill, because
-                // that would create a Kill -> Status -> Kill -> ... loop
-                LOGGER.warn("Received status update for unknown task, but task should not be killed again: {}",
-                        status.getTaskId().getValue());
+        try {
+            LOGGER.info("Received status update for taskId={} state={} message={} protobuf={}",
+                    status.getTaskId().getValue(),
+                    status.getState().toString(),
+                    status.getMessage(),
+                    TextFormat.shortDebugString(status));
+            Metrics.record(status);
+            TaskStatusResponse response = mesosEventClient.taskStatus(status);
+            boolean eligibleToKill = TaskKiller.update(status);
+            switch (response.result) {
+            case UNKNOWN_TASK:
+                if (eligibleToKill) {
+                    LOGGER.info("Received status update for unknown task, marking task to be killed: {}",
+                            status.getTaskId().getValue());
+                    TaskKiller.killTask(status.getTaskId());
+                } else {
+                    // Special case: Mesos can send TASK_LOST+REASON_RECONCILIATION as a response to a prior kill
+                    // request against a task that is unknown to Mesos. When this happens, we don't want to repeat the
+                    // kill, because that would create a Kill -> Status -> Kill -> ... loop
+                    LOGGER.warn("Received status update for unknown task, but task should not be killed again: {}",
+                            status.getTaskId().getValue());
+                }
+                break;
+            case PROCESSED:
+                // No-op
+                break;
             }
-            break;
-        case PROCESSED:
-            // No-op
-            break;
+        } catch (Throwable e) {
+            logExceptionAndExit(e);
         }
     }
 
     @Override
     public void offerRescinded(SchedulerDriver driver, Protos.OfferID offerId) {
-        LOGGER.info("Rescinding offer: {}", offerId.getValue());
-        offerProcessor.dequeue(offerId);
+        try {
+            LOGGER.info("Rescinding offer: {}", offerId.getValue());
+            offerProcessor.dequeue(offerId);
+        } catch (Throwable e) {
+            logExceptionAndExit(e);
+        }
     }
 
     @Override
     public void frameworkMessage(
             SchedulerDriver driver, Protos.ExecutorID executorId, Protos.SlaveID agentId, byte[] data) {
-        LOGGER.error("Received unsupported {} byte Framework Message from Executor {} on Agent {}",
-                data.length, executorId.getValue(), agentId.getValue());
+        try {
+            LOGGER.error("Received unsupported {} byte Framework Message from Executor {} on Agent {}",
+                    data.length, executorId.getValue(), agentId.getValue());
+        } catch (Throwable e) {
+            logExceptionAndExit(e);
+        }
     }
 
     @Override
     public void disconnected(SchedulerDriver driver) {
-        LOGGER.error("Disconnected from Master, shutting down.");
-        ProcessExit.exit(ProcessExit.DISCONNECTED);
+        try {
+            LOGGER.error("Disconnected from Master, shutting down.");
+            ProcessExit.exit(ProcessExit.DISCONNECTED);
+        } catch (Throwable e) {
+            logExceptionAndExit(e);
+        }
     }
 
     @Override
     public void slaveLost(SchedulerDriver driver, Protos.SlaveID agentId) {
-        LOGGER.warn("Agent lost: {}", agentId.getValue());
+        try {
+            LOGGER.warn("Agent lost: {}", agentId.getValue());
+        } catch (Throwable e) {
+            logExceptionAndExit(e);
+        }
     }
 
     @Override
-    public void executorLost(
-            SchedulerDriver driver, Protos.ExecutorID executorId, Protos.SlaveID agentId, int status) {
-        LOGGER.warn("Lost Executor: {} on Agent: {}", executorId.getValue(), agentId.getValue());
+    public void executorLost(SchedulerDriver driver, Protos.ExecutorID executorId, Protos.SlaveID agentId, int status) {
+        try {
+            LOGGER.warn("Lost Executor: {} on Agent: {}", executorId.getValue(), agentId.getValue());
+        } catch (Throwable e) {
+            logExceptionAndExit(e);
+        }
     }
 
     @Override
     public void error(SchedulerDriver driver, String message) {
-        LOGGER.error("SchedulerDriver returned an error, shutting down: {}", message);
-        ProcessExit.exit(ProcessExit.ERROR);
+        try {
+            LOGGER.error("SchedulerDriver returned an error, shutting down: {}", message);
+            ProcessExit.exit(ProcessExit.ERROR);
+        } catch (Throwable e) {
+            logExceptionAndExit(e);
+        }
+    }
+
+    /**
+     * Logs an exception that we threw in response to a call from the Mesos adapter, and then kills the scheduler
+     * process so that it can be restarted. We carefully avoid the possibility of any exceptions reaching the Mesos
+     * adapter, because doing so can leave the Scheduler process in a zombie state: no offers/statuses being processed,
+     * but HTTP (on its own thread) still looking fine.
+     *
+     * @param e the exception that was thrown
+     */
+    private static void logExceptionAndExit(Throwable e) {
+        LOGGER.error("Got exception when invoked by Mesos, shutting down");
+        ProcessExit.exit(ProcessExit.ERROR, e);
     }
 
     private static void updateDriverAndDomain(SchedulerDriver driver, Protos.MasterInfo masterInfo) {

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/framework/OfferProcessor.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/framework/OfferProcessor.java
@@ -124,7 +124,7 @@ class OfferProcessor {
                 while (true) {
                     try {
                         processQueuedOffers(DEFAULT_OFFER_WAIT);
-                    } catch (Exception e) {
+                    } catch (Throwable e) {
                         LOGGER.error("Error encountered when processing offers, exiting to avoid zombie state", e);
                         ProcessExit.exit(ProcessExit.ERROR, e);
                     }
@@ -167,6 +167,9 @@ class OfferProcessor {
                 }
             }
         }
+
+        // TODO(nick): This is for debugging. Remove it after DCOS-38473 is resolved.
+        LOGGER.info("Enqueued {} offer{}", offers.size(), offers.size() == 1 ? "" : "s");
 
         if (!multithreaded) {
             // Immediately process on this thread, rather than depending on offerExecutor to do it.

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/framework/OfferProcessor.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/framework/OfferProcessor.java
@@ -233,8 +233,8 @@ class OfferProcessor {
             try {
                 if (checkStatus()) {
                     evaluateOffers(offers);
-                } else {
-                    // Offers not needed, at least not right now. Decline long.
+                } else if (!offers.isEmpty()) {
+                    // The offers are not needed by the service, at least for the moment. Decline long.
                     declineLong(offers);
                 }
             } finally {

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/framework/OfferQueue.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/framework/OfferQueue.java
@@ -59,9 +59,10 @@ public class OfferQueue {
     }
 
     /**
-     * This method enqueues an Offer from Mesos if there is capacity. If there is not capacity the Offer is not added
-     * to the queue.
-     * @return true if the Offer was successfully put in the queue, false otherwise
+     * This method enqueues an Offer from Mesos if there is capacity. If there is not capacity the Offer is not added to
+     * the queue and {@code false} is returned.
+     *
+     * @return {@code true} if the Offer was successfully put in the queue, {@code false} otherwise
      */
     public boolean offer(Protos.Offer offer) {
         return queue.offer(offer);

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/framework/ReviveManager.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/framework/ReviveManager.java
@@ -12,6 +12,10 @@ import com.mesosphere.sdk.scheduler.SchedulerConfig;
 /**
  * Handles scheduling of Mesos suppress and revive calls.
  *
+ * NOTE: Does not protect against multithreaded access. All calls should only be made on a single thread, separate from
+ * the thread that receives offers. Otherwise there is a risk of a deadlock because SchedulerDriver.reviveOffers() can
+ * block on sending us new offers.
+ *
  * <ul>
  * <li>Suppress is performed whenever the underlying services are all idle and no further offers are needed. This allows
  * Mesos to scale to more frameworks. When the framework is suppressed, it will not receive any offers for any reason.
@@ -61,7 +65,7 @@ class ReviveManager {
      * Note that this also ensures that by flipping the {@code isSuppressed} flag if we receive an offer when we
      * SHOULD BE suppressed, we are ensuring that the future calls to {@code suppressIfActive} would reissue SUPPRESS.
      */
-    synchronized void notifyOffersReceived() {
+    void notifyOffersReceived() {
         isSuppressed = false;
         Metrics.notSuppressed();
     }
@@ -71,7 +75,7 @@ class ReviveManager {
      * This should be invoked when the service(s) are all in an IDLE state, so that the offer stream may be temporarily
      * halted.
      */
-    synchronized void suppressIfActive() {
+    void suppressIfActive() {
         if (isSuppressed) {
             // Service doesn't need offers, but offers are already suppressed. Avoid duplicate suppress call.
             return;
@@ -97,7 +101,7 @@ class ReviveManager {
      * Notifies the manager that a revive should be sent, but only if we're currently suppressed.
      * This should be invoked when the service(s) are in a WORKING state, so that any suppressed state gets cleared.
      */
-    synchronized void requestReviveIfSuppressed() {
+    void requestReviveIfSuppressed() {
         if (!isSuppressed) {
             // Not suppressed, skip.
             return;
@@ -112,7 +116,7 @@ class ReviveManager {
      * <li>Offers are suppressed but the service is not idle (via {@link #requestReviveIfSuppressed()}</li>
      * </ul>
      */
-    synchronized void requestRevive() {
+    void requestRevive() {
         reviveRequested = true;
     }
 
@@ -120,7 +124,7 @@ class ReviveManager {
      * Pings the manager to perform a revive call to Mesos if one was previously requested. This must be invoked
      * periodically to trigger revives. This structure allows us to enforce a rate limit on revive calls.
      */
-    synchronized void reviveIfRequested() {
+    void reviveIfRequested() {
         if (!reviveRequested) {
             return;
         }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/http/endpoints/ConfigResource.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/http/endpoints/ConfigResource.java
@@ -1,26 +1,26 @@
 package com.mesosphere.sdk.http.endpoints;
 
+import javax.inject.Singleton;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.core.Response;
 
-import com.mesosphere.sdk.config.Configuration;
 import com.mesosphere.sdk.http.queries.ConfigQueries;
 import com.mesosphere.sdk.http.types.PrettyJsonResource;
+import com.mesosphere.sdk.specification.ServiceSpec;
 import com.mesosphere.sdk.state.ConfigStore;
 
 /**
  * A read-only API for accessing active and inactive configurations from persistent storage.
- *
- * @param <T> The configuration type which is being stored by the service.
  */
+@Singleton
 @Path("/v1/configurations")
-public class ConfigResource<T extends Configuration> extends PrettyJsonResource {
+public class ConfigResource extends PrettyJsonResource {
 
-    private final ConfigStore<T> configStore;
+    private final ConfigStore<ServiceSpec> configStore;
 
-    public ConfigResource(ConfigStore<T> configStore) {
+    public ConfigResource(ConfigStore<ServiceSpec> configStore) {
         this.configStore = configStore;
     }
 
@@ -29,7 +29,7 @@ public class ConfigResource<T extends Configuration> extends PrettyJsonResource 
      */
     @GET
     public Response getConfigurationIds() {
-        return ConfigQueries.<T>getConfigurationIds(configStore);
+        return ConfigQueries.<ServiceSpec>getConfigurationIds(configStore);
     }
 
     /**
@@ -38,7 +38,7 @@ public class ConfigResource<T extends Configuration> extends PrettyJsonResource 
     @Path("/{configurationId}")
     @GET
     public Response getConfiguration(@PathParam("configurationId") String configurationId) {
-        return ConfigQueries.<T>getConfiguration(configStore, configurationId);
+        return ConfigQueries.<ServiceSpec>getConfiguration(configStore, configurationId);
     }
 
     /**
@@ -47,7 +47,7 @@ public class ConfigResource<T extends Configuration> extends PrettyJsonResource 
     @Path("/targetId")
     @GET
     public Response getTargetId() {
-        return ConfigQueries.<T>getTargetId(configStore);
+        return ConfigQueries.<ServiceSpec>getTargetId(configStore);
     }
 
     /**
@@ -56,6 +56,6 @@ public class ConfigResource<T extends Configuration> extends PrettyJsonResource 
     @Path("/target")
     @GET
     public Response getTarget() {
-        return ConfigQueries.<T>getTarget(configStore);
+        return ConfigQueries.<ServiceSpec>getTarget(configStore);
     }
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/http/endpoints/MultiConfigResource.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/http/endpoints/MultiConfigResource.java
@@ -2,6 +2,7 @@ package com.mesosphere.sdk.http.endpoints;
 
 import java.util.Optional;
 
+import javax.inject.Singleton;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -18,6 +19,7 @@ import com.mesosphere.sdk.state.ConfigStore;
 /**
  * A read-only API for accessing active and inactive configurations from persistent storage.
  */
+@Singleton
 @Path("/v1/service")
 public class MultiConfigResource extends PrettyJsonResource {
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/http/endpoints/MultiPlansResource.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/http/endpoints/MultiPlansResource.java
@@ -7,6 +7,7 @@ import com.mesosphere.sdk.scheduler.AbstractScheduler;
 import com.mesosphere.sdk.scheduler.plan.PlanCoordinator;
 import com.mesosphere.sdk.scheduler.multi.MultiServiceManager;
 
+import javax.inject.Singleton;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -22,6 +23,7 @@ import java.util.Optional;
 /**
  * API for management of Plan(s).
  */
+@Singleton
 @Path("/v1/service")
 public class MultiPlansResource extends PrettyJsonResource {
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/http/endpoints/MultiPodResource.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/http/endpoints/MultiPodResource.java
@@ -10,6 +10,7 @@ import com.mesosphere.sdk.state.StateStore;
 
 import java.util.Optional;
 
+import javax.inject.Singleton;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -20,6 +21,7 @@ import javax.ws.rs.core.Response;
  * A read-only API for accessing information about the pods which compose the service, and restarting/replacing those
  * pods.
  */
+@Singleton
 @Path("/v1/service")
 public class MultiPodResource extends PrettyJsonResource {
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/http/endpoints/PlansResource.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/http/endpoints/PlansResource.java
@@ -4,6 +4,8 @@ import com.mesosphere.sdk.http.queries.PlansQueries;
 import com.mesosphere.sdk.http.types.PrettyJsonResource;
 import com.mesosphere.sdk.scheduler.plan.PlanCoordinator;
 import com.mesosphere.sdk.scheduler.plan.PlanManager;
+
+import javax.inject.Singleton;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -19,6 +21,7 @@ import java.util.Map;
 /**
  * API for management of Plan(s).
  */
+@Singleton
 @Path("/v1/plans")
 public class PlansResource extends PrettyJsonResource {
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/http/endpoints/PodResource.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/http/endpoints/PodResource.java
@@ -6,6 +6,8 @@ import com.mesosphere.sdk.scheduler.recovery.RecoveryType;
 import com.mesosphere.sdk.specification.ServiceSpec;
 import com.mesosphere.sdk.state.ConfigStore;
 import com.mesosphere.sdk.state.StateStore;
+
+import javax.inject.Singleton;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -16,6 +18,7 @@ import javax.ws.rs.core.Response;
  * A read-only API for accessing information about the pods which compose the service, and restarting/replacing those
  * pods.
  */
+@Singleton
 @Path("/v1/pod")
 public class PodResource extends PrettyJsonResource {
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/DefaultScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/DefaultScheduler.java
@@ -144,7 +144,7 @@ public class DefaultScheduler extends AbstractScheduler {
         Collection<Object> resources = new ArrayList<>();
         resources.addAll(customResources);
         resources.add(new ArtifactResource(configStore));
-        resources.add(new ConfigResource<>(configStore));
+        resources.add(new ConfigResource(configStore));
         EndpointsResource endpointsResource = new EndpointsResource(stateStore, serviceSpec.getName(), schedulerConfig);
         for (Map.Entry<String, EndpointProducer> entry : customEndpointProducers.entrySet()) {
             endpointsResource.setCustomEndpoint(entry.getKey(), entry.getValue());

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/Metrics.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/Metrics.java
@@ -11,6 +11,7 @@ import io.prometheus.client.dropwizard.DropwizardExports;
 
 import java.util.Collection;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.mesos.Protos;
 import org.eclipse.jetty.servlet.ServletContextHandler;
@@ -81,23 +82,23 @@ public class Metrics {
     static final String SUPPRESSES = "suppresses";
     static final String IS_SUPPRESSED = "is_suppressed";
 
-    private static boolean isSuppressed = false;
+    private static AtomicBoolean isSuppressed = new AtomicBoolean(false);
     static {
         metrics.register(IS_SUPPRESSED, new Gauge<Boolean>() {
             @Override
             public Boolean getValue() {
-                return isSuppressed;
+                return isSuppressed.get();
             }
         });
     }
 
     public static void notSuppressed() {
-        Metrics.isSuppressed = false;
+        Metrics.isSuppressed.set(false);
     }
 
     public static void incrementSuppresses() {
         metrics.counter(SUPPRESSES).inc();
-        Metrics.isSuppressed = true;
+        Metrics.isSuppressed.set(true);
     }
 
     // Revive

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/Metrics.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/Metrics.java
@@ -82,7 +82,8 @@ public class Metrics {
     static final String SUPPRESSES = "suppresses";
     static final String IS_SUPPRESSED = "is_suppressed";
 
-    private static AtomicBoolean isSuppressed = new AtomicBoolean(false);
+    // This may be accessed both by whatever thread metrics runs on, and the main offer processing thread:
+    private static final AtomicBoolean isSuppressed = new AtomicBoolean(false);
     static {
         metrics.register(IS_SUPPRESSED, new Gauge<Boolean>() {
             @Override


### PR DESCRIPTION
If an exception is passed up into the Mesos HTTP adapter, it could result in a zombie scheduler. Instead, log the exception and restart the scheduler process.

Also cleans up some HTTP resource-related warnings that the scheduler was emitting in stderr during startup.