### PR TITLE
[DCOS-38592] Scheduler DNS is not resolvable when the first tasks launch

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/framework/FrameworkRunner.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/framework/FrameworkRunner.java
@@ -3,6 +3,7 @@ package com.mesosphere.sdk.framework;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.TextFormat;
 import com.mesosphere.sdk.dcos.Capabilities;
+import com.mesosphere.sdk.http.EndpointUtils;
 import com.mesosphere.sdk.http.endpoints.HealthResource;
 import com.mesosphere.sdk.http.endpoints.PlansResource;
 import com.mesosphere.sdk.offer.Constants;
@@ -100,7 +101,7 @@ public class FrameworkRunner {
                 frameworkStore,
                 mesosEventClient);
         ApiServer httpServer = ApiServer.start(
-                frameworkConfig.getFrameworkName(),
+                EndpointUtils.toSchedulerAutoIpHostname(frameworkConfig.getFrameworkName(), schedulerConfig),
                 schedulerConfig,
                 mesosEventClient.getHTTPEndpoints(),
                 new Runnable() {
@@ -189,7 +190,7 @@ public class FrameworkRunner {
                 // /v1/health: Invoked by Mesos as directed a configured health check in the scheduler Marathon app.
                 new HealthResource(Collections.singletonList(uninstallPlanManager)));
         ApiServer httpServer = ApiServer.start(
-                frameworkConfig.getFrameworkName(),
+                EndpointUtils.toSchedulerAutoIpHostname(frameworkConfig.getFrameworkName(), schedulerConfig),
                 schedulerConfig,
                 resources,
                 new Runnable() {

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/http/EndpointUtils.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/http/EndpointUtils.java
@@ -3,7 +3,6 @@ package com.mesosphere.sdk.http;
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.google.common.collect.Lists;
-
 import com.mesosphere.sdk.offer.Constants;
 import com.mesosphere.sdk.scheduler.SchedulerConfig;
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerConfig.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerConfig.java
@@ -1,13 +1,5 @@
 package com.mesosphere.sdk.scheduler;
 
-import com.mesosphere.sdk.offer.Constants;
-import com.mesosphere.sdk.state.GoalStateOverride;
-import org.apache.http.impl.client.LaxRedirectStrategy;
-import org.apache.mesos.Protos.Credential;
-import org.bouncycastle.util.io.pem.PemReader;
-import org.json.JSONObject;
-import org.slf4j.Logger;
-
 import com.auth0.jwt.algorithms.Algorithm;
 import com.mesosphere.sdk.dcos.DcosHttpClientBuilder;
 import com.mesosphere.sdk.dcos.DcosHttpExecutor;
@@ -16,7 +8,14 @@ import com.mesosphere.sdk.dcos.auth.TokenProvider;
 import com.mesosphere.sdk.dcos.clients.ServiceAccountIAMTokenClient;
 import com.mesosphere.sdk.framework.EnvStore;
 import com.mesosphere.sdk.generated.SDKBuildInfo;
+import com.mesosphere.sdk.offer.Constants;
 import com.mesosphere.sdk.offer.LoggingUtils;
+import com.mesosphere.sdk.state.GoalStateOverride;
+import org.apache.http.impl.client.LaxRedirectStrategy;
+import org.apache.mesos.Protos.Credential;
+import org.bouncycastle.util.io.pem.PemReader;
+import org.json.JSONObject;
+import org.slf4j.Logger;
 
 import java.io.IOException;
 import java.io.StringReader;
@@ -173,6 +172,12 @@ public class SchedulerConfig {
      * Environment variable for setting a custom TLD for the service (replaces Constants.TLD_NET).
      */
     private static final String USER_SPECIFIED_TLD_ENVVAR = "SERVICE_TLD";
+
+    /**
+     * Environment variable for the IP address of the scheduler task. Note, this is dependent on the fact we are using
+     * the command executor.
+     */
+    private static final String LIBPROCESS_IP_ENVVAR = "LIBPROCESS_IP";
 
     /**
      * We print the build info here because this is likely to be a very early point in the service's execution. In a
@@ -420,4 +425,10 @@ public class SchedulerConfig {
     public boolean isRegionAwarenessEnabled() {
         return envStore.getOptionalBoolean(ALLOW_REGION_AWARENESS_ENV, false);
     }
+
+    /**
+     * Returns the IP of the scheduler task's container. Note, this is dependent on the fact we are using the command
+     * executor.
+     */
+    public String getSchedulerIP() { return envStore.getRequired(LIBPROCESS_IP_ENVVAR); }
 }

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/framework/ApiServerTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/framework/ApiServerTest.java
@@ -10,6 +10,7 @@ import org.junit.Test;
 
 import com.mesosphere.sdk.scheduler.SchedulerConfig;
 
+import java.net.InetAddress;
 import java.net.URI;
 import java.time.Duration;
 import java.util.Arrays;
@@ -30,14 +31,26 @@ public class ApiServerTest {
     private static final int LONG_TIMEOUT_MILLIS = 30000;
 
     @Test
+    public void testSchedulerDNSResolution() throws Exception {
+        // localhost -> 127.0.0.1
+        Assert.assertTrue(ApiServer.resolveSchedulerDNS(InetAddress.getLoopbackAddress().getHostName(),
+                InetAddress.getLoopbackAddress().getHostAddress()));
+
+        // google.com -> fail due to incorrect address
+        Assert.assertFalse(ApiServer.resolveSchedulerDNS("google.com",
+                InetAddress.getLoopbackAddress().getHostAddress()));
+    }
+
+    @Test
     public void testApiServerEndpointHandling() throws Exception {
         SchedulerConfig mockSchedulerConfig = mock(SchedulerConfig.class);
         when(mockSchedulerConfig.getApiServerInitTimeout()).thenReturn(Duration.ofMillis(LONG_TIMEOUT_MILLIS));
         when(mockSchedulerConfig.getApiServerPort()).thenReturn(0);
+        when(mockSchedulerConfig.getSchedulerIP()).thenReturn(InetAddress.getLoopbackAddress().getHostAddress());
 
         Listener listener = new Listener();
         ApiServer server = ApiServer.start(
-                "schedulerName",
+                "localhost",
                 mockSchedulerConfig,
                 Arrays.asList(
                         new TestResourcePlans(),

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/framework/ApiServerTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/framework/ApiServerTest.java
@@ -37,6 +37,7 @@ public class ApiServerTest {
 
         Listener listener = new Listener();
         ApiServer server = ApiServer.start(
+                "schedulerName",
                 mockSchedulerConfig,
                 Arrays.asList(
                         new TestResourcePlans(),

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/framework/FrameworkRunnerTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/framework/FrameworkRunnerTest.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.*;
 public class FrameworkRunnerTest {
 
     @Mock private SchedulerConfig mockSchedulerConfig;
+    @Mock private FrameworkConfig mockFrameworkConfig;
     @Mock private Capabilities mockCapabilities;
     @Mock private MesosEventClient mockMesosEventClient;
     @Mock private Persister mockPersister;
@@ -48,9 +49,10 @@ public class FrameworkRunnerTest {
 
     @Test
     public void testFinishedUninstall() throws Exception {
-        FrameworkRunner runner = new FrameworkRunner(mockSchedulerConfig, null, false, false);
+        FrameworkRunner runner = new FrameworkRunner(mockSchedulerConfig, mockFrameworkConfig, false, false);
         when(mockSchedulerConfig.isUninstallEnabled()).thenReturn(true);
         when(mockPersister.get("FrameworkID")).thenThrow(new PersisterException(Reason.NOT_FOUND, "hi"));
+        when(mockFrameworkConfig.getFrameworkName()).thenReturn("frameworkName");
         Exception abort = new IllegalStateException("Aborting HTTP server run");
         // Don't actually run the HTTP server -- it won't exit:
         when(mockSchedulerConfig.getApiServerPort()).thenThrow(abort);

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/testutils/SchedulerConfigTestUtils.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/testutils/SchedulerConfigTestUtils.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.when;
  */
 public class SchedulerConfigTestUtils {
 
+    @SuppressWarnings("PMD.AvoidUsingHardCodedIP")
     public static SchedulerConfig getTestSchedulerConfig() {
         SchedulerConfig schedulerConfig = mock(SchedulerConfig.class);
         when(schedulerConfig.getApiServerPort()).thenReturn(TestConstants.PORT_API_VALUE);
@@ -26,6 +27,7 @@ public class SchedulerConfigTestUtils {
         when(schedulerConfig.getServiceTLD()).thenReturn(Constants.DNS_TLD);
         when(schedulerConfig.getSchedulerRegion()).thenReturn(Optional.of("test-region"));
         when(schedulerConfig.getMultiServiceRemovalTimeout()).thenReturn(Duration.ofSeconds(60));
+        when(schedulerConfig.getSchedulerIP()).thenReturn("127.0.0.1");
         return schedulerConfig;
     }
 }


### PR DESCRIPTION
This adds a check that the scheduler DNS entry is correct before completing the API server bring-up.