### PR TITLE
Add thread dumps to diagnostics

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/framework/ProcessExit.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/framework/ProcessExit.java
@@ -1,5 +1,9 @@
 package com.mesosphere.sdk.framework;
 
+import com.codahale.metrics.jvm.ThreadDump;
+
+import java.lang.management.ManagementFactory;
+
 /**
  * This class handles exiting the Scheduler process, after completed teardown or after a fatal error.
  */
@@ -29,6 +33,8 @@ public class ProcessExit {
         String message = String.format("Process exiting immediately with code: %s[%d]", code, code.getValue());
         System.err.println(message);
         System.out.println(message);
+        System.err.println("Printing final thread state");
+        new ThreadDump(ManagementFactory.getThreadMXBean()).dump(System.err);
         System.exit(code.getValue());
     }
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/framework/ProcessExit.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/framework/ProcessExit.java
@@ -33,7 +33,7 @@ public class ProcessExit {
         String message = String.format("Process exiting immediately with code: %s[%d]", code, code.getValue());
         System.err.println(message);
         System.out.println(message);
-        System.err.println("Printing final thread state");
+        System.err.println("Printing final thread state...");
         new ThreadDump(ManagementFactory.getThreadMXBean()).dump(System.err);
         System.exit(code.getValue());
     }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/http/endpoints/DebugResource.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/http/endpoints/DebugResource.java
@@ -3,6 +3,7 @@ package com.mesosphere.sdk.http.endpoints;
 import com.codahale.metrics.jvm.ThreadDump;
 import com.mesosphere.sdk.http.ResponseUtils;
 import com.mesosphere.sdk.offer.history.OfferOutcomeTracker;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -10,9 +11,6 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.StreamingOutput;
-import java.io.BufferedOutputStream;
-import java.io.BufferedWriter;
-import java.io.OutputStream;
 import java.lang.management.ManagementFactory;
 
 /**

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/http/endpoints/DebugResource.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/http/endpoints/DebugResource.java
@@ -11,11 +11,11 @@ import javax.ws.rs.core.Response;
  *  A read-only API for accessing the most recently processed offers. It does _not_ return any information
  *  about offers that were declined but never evaluated.
  */
-@Path("/v1/debug/offers")
-public class OfferOutcomeResource {
+@Path("/v1/debug")
+public class DebugResource {
     private final OfferOutcomeTracker offerOutcomeTracker;
 
-    public OfferOutcomeResource(OfferOutcomeTracker offerOutcomeTracker) {
+    public DebugResource(OfferOutcomeTracker offerOutcomeTracker) {
         this.offerOutcomeTracker = offerOutcomeTracker;
     }
 
@@ -24,6 +24,7 @@ public class OfferOutcomeResource {
      * @return HTML response of the table.
      */
     @GET
+    @Path("offers")
     public Response getOfferOutcomes(@QueryParam("json") boolean json) {
         if (json) {
             return ResponseUtils.jsonOkResponse(offerOutcomeTracker.toJson());

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/DefaultScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/DefaultScheduler.java
@@ -157,7 +157,7 @@ public class DefaultScheduler extends AbstractScheduler {
         resources.add(new PodResource(stateStore, configStore, serviceSpec.getName()));
         resources.add(new StateResource(frameworkStore, stateStore, new StringPropertyDeserializer()));
         if (offerOutcomeTracker.isPresent()) {
-            resources.add(new OfferOutcomeResource(offerOutcomeTracker.get()));
+            resources.add(new DebugResource(offerOutcomeTracker.get()));
         }
         return resources;
     }

--- a/testing/sdk_diag.py
+++ b/testing/sdk_diag.py
@@ -169,7 +169,7 @@ def _dump_plans(item: pytest.Item, service_name: str):
 
 def _dump_threads(item: pytest.Item, service_name: str):
     threads = sdk_cmd.service_request('GET', 'v1/debug/threads')
-    out_path = _setup_artifact_path(item, 'threads_{}.json'.format(service_name.replace('/', '_')))
+    out_path = _setup_artifact_path(item, 'threads_{}.out'.format(service_name.replace('/', '_')))
     log.info('=> Writing {} ({} bytes)'.format(out_path, len(threads)))
     with open(out_path, 'w') as f:
         f.write(threads)


### PR DESCRIPTION
1. Adds an API to get a thread dump on-demand
2. Adds a thread dump to any Process.exit() call.
3. Grab thread dump of scheduler when test fails