### PR TITLE
DCOS-38586 Don't wait for restart to store "finished-deploy" bit in ZK

### DIFF
--- a/frameworks/helloworld/src/test/java/com/mesosphere/sdk/helloworld/scheduler/ServiceTest.java
+++ b/frameworks/helloworld/src/test/java/com/mesosphere/sdk/helloworld/scheduler/ServiceTest.java
@@ -10,6 +10,7 @@ import com.mesosphere.sdk.scheduler.recovery.RecoveryStep;
 import com.mesosphere.sdk.scheduler.recovery.RecoveryType;
 import com.mesosphere.sdk.scheduler.recovery.constrain.UnconstrainedLaunchConstrainer;
 import com.mesosphere.sdk.state.StateStore;
+import com.mesosphere.sdk.state.StateStoreUtils;
 import com.mesosphere.sdk.storage.Persister;
 import com.mesosphere.sdk.testing.*;
 import org.apache.mesos.Protos;
@@ -38,7 +39,9 @@ public class ServiceTest {
      */
     @Test
     public void testDefaultDeployment() throws Exception {
-        new ServiceTestRunner().run(getDefaultDeploymentTicks());
+        ServiceTestResult result = new ServiceTestRunner().run(getDefaultDeploymentTicks());
+        // After deployment completed, service should have stored that fact to ZK:
+        Assert.assertTrue(StateStoreUtils.getDeploymentWasCompleted(new StateStore(result.getPersister())));
     }
 
     /**

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/framework/FrameworkScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/framework/FrameworkScheduler.java
@@ -323,7 +323,7 @@ public class FrameworkScheduler implements Scheduler {
      * @param e the exception that was thrown
      */
     private static void logExceptionAndExit(Throwable e) {
-        LOGGER.error("Got exception when invoked by Mesos, shutting down");
+        LOGGER.error("Got exception when invoked by Mesos, shutting down.");
         ProcessExit.exit(ProcessExit.ERROR, e);
     }
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/framework/OfferProcessor.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/framework/OfferProcessor.java
@@ -163,9 +163,6 @@ class OfferProcessor {
             }
         }
 
-        // TODO(nick): This is for debugging. Remove it after DCOS-38473 is resolved.
-        LOGGER.info("Enqueued {} offer{}", offers.size(), offers.size() == 1 ? "" : "s");
-
         if (!multithreaded) {
             // Immediately process on this thread, rather than depending on offerExecutor to do it.
             // In the single-threaded case, we also disable waiting for offers to come in.

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/state/StateStoreUtils.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/state/StateStoreUtils.java
@@ -270,7 +270,10 @@ public class StateStoreUtils {
      * Sets whether the service has previously completed deployment.
      */
     public static void setDeploymentWasCompleted(StateStore stateStore) {
-        stateStore.storeProperty(LAST_COMPLETED_UPDATE_TYPE_KEY, DEPLOYMENT_TYPE);
+        // Optimization: Avoid writing through to curator if possible. We cache reads but not writes.
+        if (!getDeploymentWasCompleted(stateStore)) {
+            stateStore.storeProperty(LAST_COMPLETED_UPDATE_TYPE_KEY, DEPLOYMENT_TYPE);
+        }
     }
 
     /**

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/DefaultSchedulerTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/DefaultSchedulerTest.java
@@ -895,10 +895,17 @@ public class DefaultSchedulerTest {
         taskIds.add(installStep(1, 0, getSufficientOfferForTaskB(), Status.PENDING, true));
         taskIds.add(installStep(1, 1, getSufficientOfferForTaskB(), Status.PENDING, true));
 
+        // Deployment should be complete:
         Assert.assertTrue(getDeploymentPlan().isComplete());
         Assert.assertEquals(Arrays.asList(Status.COMPLETE, Status.COMPLETE, Status.COMPLETE),
                 getStepStatuses(getDeploymentPlan()));
         Assert.assertTrue(defaultScheduler.getPlanCoordinator().getCandidates().isEmpty());
+
+        // After we call getClientStatus() once more with the completed deploy plan, completion should be persisted to ZK:
+        StateStore stateStore = new StateStore(persister);
+        Assert.assertFalse(StateStoreUtils.getDeploymentWasCompleted(stateStore));
+        Assert.assertEquals(ClientStatusResponse.idle(), defaultScheduler.getClientStatus());
+        Assert.assertTrue(StateStoreUtils.getDeploymentWasCompleted(stateStore));
 
         return taskIds;
     }


### PR DESCRIPTION
Before this change, we only checked whether the service finished deployment following a scheduler restart. In that situation, we can effectively end up comparing the OLD persisted task states against the NEW deploy plan (not the old plan, because plans are not persisted). If, for example, new steps had been added to the deploy plan in the meantime, this can lead to us thinking that deployment didn't complete before, when in reality it did.

To avoid this problem, we can simply store the fact that we've finished deployment at the moment that it happens, rather than waiting for the next scheduler restart and hoping that the plans vs state happen to line up.

In the meantime, the previous 'after restart' check is left as-is, as users upgrading from prior SDK releases may only be caught by that check.