### PR TITLE
[DCOS-38379] Correctly check for a relaunched scheduler task

### DIFF
--- a/frameworks/helloworld/tests/test_multiservice_dynamic.py
+++ b/frameworks/helloworld/tests/test_multiservice_dynamic.py
@@ -84,6 +84,7 @@ def test_add_deploy_restart_remove():
 
     # restart and check that service is recovered:
     sdk_marathon.restart_app(config.SERVICE_NAME)
+    sdk_marathon.wait_for_app_running(config.SERVICE_NAME, sdk_marathon.TIMEOUT_SECONDS)
 
     # check that scheduler task was relaunched
     check_scheduler_relaunched(config.SERVICE_NAME, old_task_id)
@@ -155,6 +156,7 @@ def test_add_multiple_uninstall():
 
     # restart app and wait for removal to succeed after restart:
     sdk_marathon.restart_app(config.SERVICE_NAME)
+    sdk_marathon.wait_for_app_running(config.SERVICE_NAME, sdk_marathon.TIMEOUT_SECONDS)
     wait_for_service_count(1)
 
     plan = sdk_plan.wait_for_plan_status(config.SERVICE_NAME, 'deploy', 'COMPLETE', multiservice_name=svc1)

--- a/frameworks/helloworld/tests/test_multiservice_dynamic.py
+++ b/frameworks/helloworld/tests/test_multiservice_dynamic.py
@@ -35,7 +35,7 @@ def configure_package(configure_security):
         yamls = sdk_cmd.service_request('GET', config.SERVICE_NAME, '/v1/multi/yaml').json()
         assert 'svc' in yamls
 
-        yield # let the test session execute
+        yield  # let the test session execute
     finally:
         sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
 
@@ -85,7 +85,7 @@ def test_add_deploy_restart_remove():
     # restart and check that service is recovered:
     sdk_marathon.restart_app(config.SERVICE_NAME)
 
-    #check that scheduler task was relaunched
+    # check that scheduler task was relaunched
     check_scheduler_relaunched(config.SERVICE_NAME, old_task_id)
 
     service = wait_for_service_count(1)[0]


### PR DESCRIPTION
Looking at #2545, I think the check that we are performing for a relaunched scheduler is incorrect. 

When we initially get the task ID of the scheduler (a `marathon` task) we use `.startswith(SERVICE_NAME)` as a match condition, but in the current `check_task_relaunched` function, we check `== SERVICE_NAME` which does not seem to yield the desired result.

This PR adds a *local* check function to the test file that is affected by this error. If this passes, we can move the function to `sdk_tasks` in a separate PR.

Note that this is also blocking the DC/OS smoke tests: https://teamcity.mesosphere.io/viewLog.html?buildId=1112832&buildTypeId=DcOs_Enterprise_Test_FrameworkTests_DcOsCommonsSmokeTest&tab=buildResultsDiv