### PR TITLE
DCOS-38687 Add update plan test, and fix suppress when one is provided

### DIFF
--- a/frameworks/helloworld/src/main/dist/update_plan.yml
+++ b/frameworks/helloworld/src/main/dist/update_plan.yml
@@ -1,0 +1,28 @@
+name: {{FRAMEWORK_NAME}}
+scheduler:
+  principal: {{FRAMEWORK_PRINCIPAL}}
+  user: {{FRAMEWORK_USER}}
+pods:
+  hello:
+    count: {{HELLO_COUNT}}
+    tasks:
+      server:
+        goal: RUNNING
+        cmd: "echo hello >> output && sleep $SLEEP_DURATION"
+        cpus: {{HELLO_CPUS}}
+        memory: {{HELLO_MEM}}
+        env:
+          SLEEP_DURATION: {{SLEEP_DURATION}}
+plans:
+  deploy:
+    strategy: parallel
+    phases:
+      hello-deploy:
+        strategy: parallel
+        pod: hello
+  update:
+    strategy: serial
+    phases:
+      hello-update:
+        strategy: serial
+        pod: hello

--- a/frameworks/helloworld/src/test/java/com/mesosphere/sdk/helloworld/scheduler/ServiceTest.java
+++ b/frameworks/helloworld/src/test/java/com/mesosphere/sdk/helloworld/scheduler/ServiceTest.java
@@ -128,6 +128,90 @@ public class ServiceTest {
     }
 
     /**
+     * Validates that the update plan is correctly used (only) after a deployment had completed.
+     */
+    @Test
+    public void testUpdatePlan() throws Exception {
+
+        // First session: Launch one task, then restart scheduler before it's RUNNING:
+
+        Collection<SimulationTick> ticks = new ArrayList<>();
+        ticks.add(Send.register());
+        ticks.add(Expect.reconciledImplicitly());
+
+        // Verify that service launches 1 hello pod (and nothing else):
+        ticks.add(Expect.deployStepStatus("hello-deploy", "hello-0:[server]", Status.PENDING));
+        ticks.add(Send.offerBuilder("hello").build());
+        ticks.add(Expect.launchedTasks("hello-0-server"));
+        ticks.add(Expect.deployStepStatus("hello-deploy", "hello-0:[server]", Status.STARTING));
+
+        // Offers revived due to changed work set (NULL => hello-0):
+        ticks.add(Expect.revivedOffers(1));
+        ticks.add(Expect.suppressedOffers(0));
+
+        // Pretend that the scheduler was restarted before the task started RUNNING:
+        ServiceTestResult result = new ServiceTestRunner("update_plan.yml").run(ticks);
+        // Deployment didn't complete:
+        Assert.assertFalse(StateStoreUtils.getDeploymentWasCompleted(new StateStore(result.getPersister())));
+
+        // Second session: Scheduler restarts before task starts running.
+        // The task gets launched again, and succeeds this time, finishing the deploy plan.
+
+        ticks = new ArrayList<>();
+        ticks.add(Send.register());
+        ticks.add(Expect.reconciledExplicitly(result.getPersister()));
+        // The task is now running, but we still restart it below (shouldn't need to relaunch, could revisit this behavior):
+        ticks.add(Send.taskStatus("hello-0-server", Protos.TaskState.TASK_RUNNING).build());
+        ticks.add(Expect.reconciledImplicitly());
+
+        // Send an offer to turn the crank. The task gets restarted since it hadn't completed in the last run:
+        ticks.add(Expect.deployStepStatus("hello-deploy", "hello-0:[server]", Status.PENDING));
+        ticks.add(Send.offerBuilder("hello").build());
+        ticks.add(Expect.taskNameKilled("hello-0-server", 1));
+
+        // Now send the resources from hello-0. The task should get relaunched:
+        ticks.add(Send.offerBuilder("hello").setPodIndexToReoffer(0).build());
+        ticks.add(Expect.launchedTasks("hello-0-server"));
+        ticks.add(Expect.deployStepStatus("hello-deploy", "hello-0:[server]", Status.STARTING));
+        ticks.add(Send.taskStatus("hello-0-server", Protos.TaskState.TASK_RUNNING).build());
+
+        // Now all tasks are done (and note use of 'hello-deploy' phase name):
+        ticks.add(Expect.deployStepStatus("hello-deploy", "hello-0:[server]", Status.COMPLETE));
+        ticks.add(Expect.allPlansComplete());
+
+        // Suppress offers after the next offer has turned the crank:
+        ticks.add(Expect.suppressedOffers(0));
+        ticks.add(Send.offerBuilder("hello").build());
+        ticks.add(Expect.declinedLastOffer());
+        ticks.add(Expect.suppressedOffers(1));
+
+        result = new ServiceTestRunner("update_plan.yml").setState(result).run(ticks);
+        // After deployment completed, service should have stored that fact to ZK:
+        Assert.assertTrue(StateStoreUtils.getDeploymentWasCompleted(new StateStore(result.getPersister())));
+
+        // Third session: Scheduler restarts again. This time it's using the update plan as the 'deploy' plan:
+
+        ticks = new ArrayList<>();
+        ticks.add(Send.register());
+        ticks.add(Expect.reconciledExplicitly(result.getPersister()));
+        ticks.add(Send.taskStatus("hello-0-server", Protos.TaskState.TASK_RUNNING).build());
+        ticks.add(Expect.reconciledImplicitly());
+
+        // No config changes, nothing left to do:
+        ticks.add(Send.offerBuilder("hello").build());
+        ticks.add(Expect.declinedLastOffer());
+
+        // "deploy" plan should match our expected update plan (note 'hello-update' phase name):
+        ticks.add(Expect.deployStepStatus("hello-update", "hello-0:[server]", Status.COMPLETE));
+        ticks.add(Expect.suppressedOffers(1));
+        ticks.add(Expect.allPlansComplete());
+
+        new ServiceTestRunner("update_plan.yml").setState(result).run(ticks);
+        // Deployment bit still set in ZK:
+        Assert.assertTrue(StateStoreUtils.getDeploymentWasCompleted(new StateStore(result.getPersister())));
+    }
+
+    /**
      * Checks that if an unessential task in a pod fails, that the other task in the same pod is unaffected.
      */
     @Test

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerBuilder.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerBuilder.java
@@ -602,20 +602,27 @@ public class SchedulerBuilder {
         Optional<Plan> updatePlanOptional = plans.stream()
                 .filter(plan -> plan.getName().equals(Constants.UPDATE_PLAN_NAME))
                 .findFirst();
-
-        if (!hasCompletedDeployment || !updatePlanOptional.isPresent()) {
-            logger.info("Using regular deploy plan. (Has completed deployment: {}, Custom update plan defined: {})",
-                    hasCompletedDeployment, updatePlanOptional.isPresent());
+        if (!updatePlanOptional.isPresent()) {
+            logger.info("Using regular deploy plan: No custom update plan is defined");
             return plans;
         }
 
-        logger.info("Overriding deploy plan with custom update plan. " +
-                "(Has completed deployment: {}, Custom update plan defined: {})",
-                hasCompletedDeployment, updatePlanOptional.isPresent());
+        if (!hasCompletedDeployment) {
+            logger.info("Using regular deploy plan and filtering custom update plan: Deployment hasn't completed");
+            // Filter out the custom update plan, as it isn't being used.
+            return plans.stream()
+                    .filter(plan -> !plan.getName().equals(Constants.UPDATE_PLAN_NAME))
+                    .collect(Collectors.toList());
+        }
+
+        logger.info("Overriding deploy plan with custom update plan: "
+                + "Deployment has completed and custom update plan is defined");
         Collection<Plan> newPlans = new ArrayList<>();
+        // Remove the current deploy and update plans:
         newPlans.addAll(plans.stream()
                 .filter(plan -> !plan.isDeployPlan() && !plan.getName().equals(Constants.UPDATE_PLAN_NAME))
                 .collect(Collectors.toList()));
+        // Re-add the update plan as the "deploy" plan:
         newPlans.add(new DefaultPlan(
                 Constants.DEPLOY_PLAN_NAME,
                 updatePlanOptional.get().getChildren(),

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/SchedulerBuilderTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/SchedulerBuilderTest.java
@@ -190,6 +190,7 @@ public class SchedulerBuilderTest {
 
         Collection<Plan> plans = builder.selectDeployPlan(getDeployUpdatePlans(), true);
 
+        // Update plan should have replaced the deploy plan:
         Assert.assertEquals(1, plans.size());
         Plan deployPlan = plans.stream()
                 .filter(plan -> plan.isDeployPlan())
@@ -205,7 +206,8 @@ public class SchedulerBuilderTest {
 
         Collection<Plan> plans = builder.selectDeployPlan(getDeployUpdatePlans(), false);
 
-        Assert.assertEquals(2, plans.size());
+        // Should have omitted the update plan since it's not being used:
+        Assert.assertEquals(1, plans.size());
         Plan deployPlan = plans.stream()
                 .filter(plan -> plan.isDeployPlan())
                 .findFirst().get();


### PR DESCRIPTION
- Adds a new ServiceTest to hello-world which verifies expected behavior around custom update plans.
- Fixes a minor bug where suppress didn't occur when a custom update plan is defined AND we're on the initial deployment of the scheduler: The update plan was included in the list of plans even when it's not used. This can lead to suppress never occurring because it iterates over all defined plans to determine if the service is idle. This only affects suppress logic, and it resolves itself if the scheduler is restarted after initial deployment, at which point the plan list is built correctly.