### PR TITLE
DCOS-38149 Cleanup salvaged from PodInstanceRequirement breakup

### DIFF
--- a/frameworks/cassandra/src/main/java/com/mesosphere/sdk/cassandra/scheduler/CassandraRecoveryPlanOverrider.java
+++ b/frameworks/cassandra/src/main/java/com/mesosphere/sdk/cassandra/scheduler/CassandraRecoveryPlanOverrider.java
@@ -47,7 +47,7 @@ public class CassandraRecoveryPlanOverrider implements RecoveryPlanOverrider {
         }
 
         int index = stoppedPod.getPodInstance().getIndex();
-        logger.info(String.format("Returning replacement plan for node %d.", index));
+        logger.info("Returning replacement plan for node {}.", index);
         return Optional.ofNullable(getNodeRecoveryPhase(replaceNodePlan, index));
     }
 
@@ -56,7 +56,8 @@ public class CassandraRecoveryPlanOverrider implements RecoveryPlanOverrider {
         Step inputLaunchStep = inputPhase.getChildren().get(index);
 
         // Dig all the way down into the command, so we can append the replace_address option to it.
-        PodInstance podInstance = inputLaunchStep.start().get().getPodInstance();
+        inputLaunchStep.start();
+        PodInstance podInstance = inputLaunchStep.getPodInstanceRequirement().get().getPodInstance();
         PodSpec podSpec = podInstance.getPod();
         TaskSpec taskSpec = podSpec.getTasks().stream().filter(t -> t.getName().equals("server")).findFirst().get();
         CommandSpec command = taskSpec.getCommand().get();

--- a/frameworks/hdfs/src/main/java/com/mesosphere/sdk/hdfs/scheduler/HdfsRecoveryPlanOverrider.java
+++ b/frameworks/hdfs/src/main/java/com/mesosphere/sdk/hdfs/scheduler/HdfsRecoveryPlanOverrider.java
@@ -80,8 +80,8 @@ public class HdfsRecoveryPlanOverrider implements RecoveryPlanOverrider {
         Step inputBootstrapStep = inputPhase.getChildren().get(offset + 0);
         PodInstanceRequirement bootstrapPodInstanceRequirement =
                 PodInstanceRequirement.newBuilder(
-                        inputBootstrapStep.start().get().getPodInstance(),
-                        inputBootstrapStep.start().get().getTasksToLaunch())
+                        inputBootstrapStep.getPodInstanceRequirement().get().getPodInstance(),
+                        inputBootstrapStep.getPodInstanceRequirement().get().getTasksToLaunch())
                 .recoveryType(RecoveryType.PERMANENT)
                 .build();
         Step bootstrapStep =
@@ -95,8 +95,8 @@ public class HdfsRecoveryPlanOverrider implements RecoveryPlanOverrider {
         Step inputNodeStep = inputPhase.getChildren().get(offset + 1);
         PodInstanceRequirement nameNodePodInstanceRequirement =
                 PodInstanceRequirement.newBuilder(
-                        inputNodeStep.start().get().getPodInstance(),
-                        inputNodeStep.start().get().getTasksToLaunch())
+                        inputNodeStep.getPodInstanceRequirement().get().getPodInstance(),
+                        inputNodeStep.getPodInstanceRequirement().get().getTasksToLaunch())
                 .recoveryType(RecoveryType.TRANSIENT)
                 .build();
         Step nodeStep =
@@ -113,7 +113,7 @@ public class HdfsRecoveryPlanOverrider implements RecoveryPlanOverrider {
                 Collections.emptyList());
     }
 
-    private Phase getPhaseForNodeType(Plan inputPlan, String phaseName) {
+    private static Phase getPhaseForNodeType(Plan inputPlan, String phaseName) {
         Optional<Phase> phaseOptional = inputPlan.getChildren().stream()
                 .filter(phase -> phase.getName().equals(phaseName))
                 .findFirst();

--- a/frameworks/helloworld/src/main/java/com/mesosphere/sdk/helloworld/scheduler/DecomissionCustomizer.java
+++ b/frameworks/helloworld/src/main/java/com/mesosphere/sdk/helloworld/scheduler/DecomissionCustomizer.java
@@ -46,12 +46,10 @@ public class DecomissionCustomizer implements PlanCustomizer {
             Object lock = new Object();
 
             @Override
-            public Optional<PodInstanceRequirement> start() {
+            public void start() {
                 synchronized (lock) {
                     status = Status.COMPLETE;
                 }
-
-                return Optional.empty();
             }
 
             @Override

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/AbstractRoundRobinRule.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/AbstractRoundRobinRule.java
@@ -2,6 +2,7 @@ package com.mesosphere.sdk.offer.evaluate.placement;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.mesosphere.sdk.offer.LoggingUtils;
+import com.mesosphere.sdk.offer.TaskUtils;
 import com.mesosphere.sdk.offer.evaluate.EvaluationOutcome;
 import com.mesosphere.sdk.specification.PodInstance;
 import org.apache.commons.lang3.builder.EqualsBuilder;
@@ -61,7 +62,7 @@ abstract class AbstractRoundRobinRule implements PlacementRule {
             if (!taskFilter.matches(task.getName())) {
                 continue;
             }
-            if (PlacementUtils.areEquivalent(task, podInstance)) {
+            if (TaskUtils.areEquivalent(task, podInstance)) {
                 // This is stale data for the same task that we're currently evaluating for
                 // placement. Don't worry about counting its usage. This occurs when we're
                 // redeploying a given task with a new configuration (old data not deleted yet).

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/MaxPerRule.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/MaxPerRule.java
@@ -1,6 +1,7 @@
 package com.mesosphere.sdk.offer.evaluate.placement;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.mesosphere.sdk.offer.TaskUtils;
 import com.mesosphere.sdk.specification.PodInstance;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -53,7 +54,7 @@ public abstract class MaxPerRule implements PlacementRule {
 
         tasks = tasks.stream()
                 .filter(task -> getTaskFilter().matches(task.getName()))
-                .filter(task -> !PlacementUtils.areEquivalent(task, podInstance))
+                .filter(task -> !TaskUtils.areEquivalent(task, podInstance))
                 .collect(Collectors.toList());
 
         Map<String, Integer> counts = new HashMap<>();

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/PlacementUtils.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/PlacementUtils.java
@@ -1,22 +1,13 @@
 package com.mesosphere.sdk.offer.evaluate.placement;
 
-import com.mesosphere.sdk.offer.LoggingUtils;
-import com.mesosphere.sdk.offer.TaskException;
-import com.mesosphere.sdk.offer.TaskUtils;
-import com.mesosphere.sdk.specification.PodInstance;
 import com.mesosphere.sdk.specification.PodSpec;
 import org.apache.mesos.Protos;
-import org.apache.mesos.Protos.TaskInfo;
-import org.slf4j.Logger;
-
 import java.util.*;
 
 /**
  * This class provides Utilities for commonly needed Placement rule scenarios.
  */
 public class PlacementUtils {
-
-    private static final Logger LOGGER = LoggingUtils.getLogger(PlacementUtils.class);
 
     private static final String HOSTNAME_FIELD_LEGACY = "hostname";
     private static final String HOSTNAME_FIELD = "@hostname";
@@ -58,19 +49,6 @@ public class PlacementUtils {
         }
 
         return placement;
-    }
-
-    /**
-     * Returns whether the provided {@link TaskInfo}, representing a previously-launched task,
-     * is in the same provided pod provided in the {@link PodInstance}.
-     */
-    public static boolean areEquivalent(TaskInfo taskInfo, PodInstance podInstance) {
-        try {
-            return TaskUtils.isSamePodInstance(taskInfo, podInstance.getPod().getType(), podInstance.getIndex());
-        } catch (TaskException e) {
-            LOGGER.warn("Unable to extract pod type or index from TaskInfo", e);
-            return false;
-        }
     }
 
     /**

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/TaskTypeRule.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/placement/TaskTypeRule.java
@@ -10,6 +10,8 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.mesos.Protos.Offer;
 import org.apache.mesos.Protos.TaskInfo;
+
+import com.mesosphere.sdk.offer.TaskUtils;
 import com.mesosphere.sdk.offer.evaluate.EvaluationOutcome;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -152,7 +154,7 @@ public class TaskTypeRule implements PlacementRule {
             Collection<TaskInfo> tasksToAvoid) {
 
         for (TaskInfo taskToAvoid : tasksToAvoid) {
-            if (PlacementUtils.areEquivalent(taskToAvoid, podInstance)) {
+            if (TaskUtils.areEquivalent(taskToAvoid, podInstance)) {
                 // This is stale data for the same task that we're currently evaluating for
                 // placement. Don't worry about avoiding it. This occurs when we're redeploying
                 // a given task with a new configuration (old data not deleted yet).
@@ -182,7 +184,7 @@ public class TaskTypeRule implements PlacementRule {
             Collection<TaskInfo> tasksToColocate) {
 
         for (TaskInfo taskToColocate : tasksToColocate) {
-            if (PlacementUtils.areEquivalent(taskToColocate, podInstance)) {
+            if (TaskUtils.areEquivalent(taskToColocate, podInstance)) {
                 // This is stale data for the same task that we're currently evaluating for
                 // placement. Don't worry about colocating with it. This occurs when we're
                 // redeploying a given task with a new configuration (old data not deleted yet).

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerConfig.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerConfig.java
@@ -430,5 +430,7 @@ public class SchedulerConfig {
      * Returns the IP of the scheduler task's container. Note, this is dependent on the fact we are using the command
      * executor.
      */
-    public String getSchedulerIP() { return envStore.getRequired(LIBPROCESS_IP_ENVVAR); }
+    public String getSchedulerIP() {
+        return envStore.getRequired(LIBPROCESS_IP_ENVVAR);
+    }
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/decommission/EraseTaskStateStep.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/decommission/EraseTaskStateStep.java
@@ -2,7 +2,6 @@ package com.mesosphere.sdk.scheduler.decommission;
 
 import java.util.Optional;
 
-import com.mesosphere.sdk.scheduler.plan.PodInstanceRequirement;
 import com.mesosphere.sdk.scheduler.plan.Status;
 import com.mesosphere.sdk.scheduler.uninstall.UninstallStep;
 import com.mesosphere.sdk.state.StateStore;
@@ -22,10 +21,9 @@ public class EraseTaskStateStep extends UninstallStep {
     }
 
     @Override
-    public Optional<PodInstanceRequirement> start() {
+    public void start() {
         logger.info("Deleting remnants of decommissioned task from state store: {}", taskName);
         stateStore.clearTask(taskName);
         setStatus(Status.COMPLETE);
-        return Optional.empty();
     }
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/decommission/TriggerDecommissionStep.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/decommission/TriggerDecommissionStep.java
@@ -1,7 +1,6 @@
 package com.mesosphere.sdk.scheduler.decommission;
 
 import com.mesosphere.sdk.framework.TaskKiller;
-import com.mesosphere.sdk.scheduler.plan.PodInstanceRequirement;
 import com.mesosphere.sdk.scheduler.plan.Status;
 import com.mesosphere.sdk.scheduler.uninstall.UninstallStep;
 import com.mesosphere.sdk.state.StateStore;
@@ -24,12 +23,11 @@ public class TriggerDecommissionStep extends UninstallStep {
     }
 
     @Override
-    public Optional<PodInstanceRequirement> start() {
+    public void start() {
         logger.info("Marking task for decommissioning: {}", taskInfo.getName());
         setStatus(Status.IN_PROGRESS);
         stateStore.storeGoalOverrideStatus(taskInfo.getName(), DecommissionPlanFactory.DECOMMISSIONING_STATUS);
         TaskKiller.killTask(taskInfo.getTaskId());
         setStatus(Status.COMPLETE);
-        return getPodInstanceRequirement();
     }
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/DeploymentStep.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/DeploymentStep.java
@@ -79,8 +79,8 @@ public class DeploymentStep extends AbstractStep {
     }
 
     @Override
-    public Optional<PodInstanceRequirement> start() {
-        return getPodInstanceRequirement();
+    public void start() {
+        // Do nothing.
     }
 
     @Override

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/PlanScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/PlanScheduler.java
@@ -62,7 +62,8 @@ public class PlanScheduler {
         }
 
         logger.info("Processing resource offers for step: {}", step.getName());
-        Optional<PodInstanceRequirement> podInstanceRequirementOptional = step.start();
+        step.start();
+        Optional<PodInstanceRequirement> podInstanceRequirementOptional = step.getPodInstanceRequirement();
         if (!podInstanceRequirementOptional.isPresent()) {
             logger.info("No PodInstanceRequirement for step: {}", step.getName());
             step.updateOfferStatus(Collections.emptyList());

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/Step.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/Step.java
@@ -14,15 +14,13 @@ import java.util.Optional;
  */
 public interface Step extends Element, Interruptible {
     /**
-     * Starts the Step, whose {@link Status} should be {@link Status#PENDING}. Returns an
-     * {@link PodInstanceRequirement}, or an empty Optional if obtaining/updating resource requirements are not
-     * applicable to the Step. This will continue to be called for as long as {@link Element#isPending()} returns
-     * true.
+     * Starts the Step, whose {@link Status} should be {@link Status#PENDING}. This will continue to be called for as
+     * long as {@link Element#isPending()} returns {@code true}.
      *
      * @see {@link #updateOfferStatus(Collection<org.apache.mesos.Protos.Offer.Operation>)} which returns the outcome of
      *      the {@link PodInstanceRequirement}
      */
-    Optional<PodInstanceRequirement> start();
+    void start();
 
     /**
      * Return the pod instance that this Step intends to work on.

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/recovery/DefaultRecoveryPlanManager.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/recovery/DefaultRecoveryPlanManager.java
@@ -286,10 +286,8 @@ public class DefaultRecoveryPlanManager implements PlanManager {
 
         List<PodInstanceRequirement> incompleteRecoveries = getPlan().getChildren().stream()
                 .flatMap(phase -> phase.getChildren().stream())
-                .filter(step -> !step.isComplete())
-                .map(step -> step.getPodInstanceRequirement())
-                .filter(requirement -> requirement.isPresent())
-                .map(requirement -> requirement.get())
+                .filter(step -> !step.isComplete() && step.getPodInstanceRequirement().isPresent())
+                .map(step -> step.getPodInstanceRequirement().get())
                 .collect(Collectors.toList());
         if (!incompleteRecoveries.isEmpty()) {
             logger.info("Pods with incomplete recoveries: {}", getPodNames(incompleteRecoveries));

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/recovery/RecoveryPlanOverrider.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/recovery/RecoveryPlanOverrider.java
@@ -10,5 +10,12 @@ import java.util.Optional;
  * by the PodInstanceRequirement.
  */
 public interface RecoveryPlanOverrider {
+
+    /**
+     * Returns a phase to be used when recovering the pod as described in the provided {@link PodLaunch}, or an empty
+     * Optional if a default recovery phase should be used instead.
+     *
+     * @param podInstanceRequirement specifies the pod to be recovered, and the type of recovery
+     */
     Optional<Phase> override(PodInstanceRequirement podInstanceRequirement);
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/recovery/RecoveryPlanOverriderFactory.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/recovery/RecoveryPlanOverriderFactory.java
@@ -10,5 +10,13 @@ import java.util.Collection;
  * with a custom implementation that addresses applicaiton specific failure recovery mechanisms.
  */
 public interface RecoveryPlanOverriderFactory {
+
+    /**
+     * Returns a new {@link RecoveryPlanOverrider} which will be queried for custom overridden phases when task recovery
+     * occurs.
+     *
+     * @param stateStore the state store being used by the service
+     * @param plans all plans being used by the service, as of the time that the service is being initialized
+     */
     RecoveryPlanOverrider create(StateStore stateStore, Collection<Plan> plans);
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/recovery/RecoveryStep.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/recovery/RecoveryStep.java
@@ -39,12 +39,10 @@ public class RecoveryStep extends DeploymentStep {
     }
 
     @Override
-    public Optional<PodInstanceRequirement> start() {
+    public void start() {
         if (podInstanceRequirement.getRecoveryType().equals(RecoveryType.PERMANENT)) {
             FailureUtils.setPermanentlyFailed(stateStore, podInstanceRequirement.getPodInstance());
         }
-
-        return super.start();
     }
 
     @Override

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/uninstall/DeregisterStep.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/uninstall/DeregisterStep.java
@@ -1,6 +1,5 @@
 package com.mesosphere.sdk.scheduler.uninstall;
 
-import com.mesosphere.sdk.scheduler.plan.PodInstanceRequirement;
 import com.mesosphere.sdk.scheduler.plan.Status;
 
 import java.util.Optional;
@@ -17,12 +16,10 @@ public class DeregisterStep extends UninstallStep {
     }
 
     @Override
-    public Optional<PodInstanceRequirement> start() {
+    public void start() {
         if (isPending()) {
             setStatus(Status.PREPARED);
         }
-
-        return getPodInstanceRequirement();
     }
 
     /**

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/uninstall/ResourceCleanupStep.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/uninstall/ResourceCleanupStep.java
@@ -1,6 +1,5 @@
 package com.mesosphere.sdk.scheduler.uninstall;
 
-import com.mesosphere.sdk.scheduler.plan.PodInstanceRequirement;
 import com.mesosphere.sdk.scheduler.plan.Status;
 
 import java.util.Optional;
@@ -23,13 +22,11 @@ public class ResourceCleanupStep extends UninstallStep {
     }
 
     @Override
-    public Optional<PodInstanceRequirement> start() {
+    public void start() {
         if (isPending()) {
             logger.info("Setting state to Prepared for resource {}", resourceId);
             setStatus(Status.PREPARED);
         }
-
-        return getPodInstanceRequirement();
     }
 
     /**

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/uninstall/TLSCleanupStep.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/uninstall/TLSCleanupStep.java
@@ -31,7 +31,7 @@ public class TLSCleanupStep extends AbstractStep {
     }
 
     @Override
-    public Optional<PodInstanceRequirement> start() {
+    public void start() {
         logger.info("Cleaning up TLS resources in namespace {}...", namespace);
 
         try {
@@ -52,8 +52,6 @@ public class TLSCleanupStep extends AbstractStep {
             logger.error(String.format("Failed to clean up secrets in namespace %s", namespace), e);
             setStatus(Status.ERROR);
         }
-
-        return Optional.empty();
     }
 
     @Override

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/uninstall/TaskKillStep.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/uninstall/TaskKillStep.java
@@ -1,7 +1,6 @@
 package com.mesosphere.sdk.scheduler.uninstall;
 
 import com.mesosphere.sdk.framework.TaskKiller;
-import com.mesosphere.sdk.scheduler.plan.PodInstanceRequirement;
 import com.mesosphere.sdk.scheduler.plan.Status;
 import org.apache.mesos.Protos;
 
@@ -20,11 +19,9 @@ public class TaskKillStep extends UninstallStep {
     }
 
     @Override
-    public Optional<PodInstanceRequirement> start() {
+    public void start() {
         setStatus(Status.IN_PROGRESS);
         TaskKiller.killTask(taskID);
         setStatus(Status.COMPLETE);
-
-        return getPodInstanceRequirement();
     }
 }

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluatorTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluatorTest.java
@@ -614,7 +614,7 @@ public class OfferEvaluatorTest extends OfferEvaluatorTestBase {
                 ResourceTestUtils.getUnreservedDisk(500.0)));
 
         List<OfferRecommendation> recommendations = evaluator.evaluate(
-                deploymentStep.start().get(),
+                deploymentStep.getPodInstanceRequirement().get(),
                 Arrays.asList(sufficientOffer));
 
         Assert.assertEquals(recommendations.toString(), 8, recommendations.size());
@@ -638,7 +638,7 @@ public class OfferEvaluatorTest extends OfferEvaluatorTestBase {
         Assert.assertTrue(FailureUtils.isPermanentlyFailed(stateStore.fetchTask(taskInfo.getName()).get()));
 
         recommendations = evaluator.evaluate(
-                deploymentStep.start().get(),
+                deploymentStep.getPodInstanceRequirement().get(),
                 Arrays.asList(sufficientOffer));
         Assert.assertEquals(recommendations.toString(), 8, recommendations.size());
 

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/plan/PlanSchedulerTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/plan/PlanSchedulerTest.java
@@ -101,13 +101,8 @@ public class PlanSchedulerTest {
         }
 
         @Override
-        public Optional<PodInstanceRequirement> start() {
-            super.start();
-            if (podInstanceRequirement == null) {
-                return Optional.empty();
-            } else {
-                return Optional.of(podInstanceRequirement);
-            }
+        public Optional<PodInstanceRequirement> getPodInstanceRequirement() {
+            return Optional.ofNullable(podInstanceRequirement);
         }
 
         @Override

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/plan/TestStep.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/plan/TestStep.java
@@ -30,9 +30,8 @@ public class TestStep extends AbstractStep {
     }
 
     @Override
-    public Optional<PodInstanceRequirement> start() {
+    public void start() {
         setStatus(Status.PREPARED);
-        return getPodInstanceRequirement();
     }
 
     @Override

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/uninstall/ResourceCleanupStepTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/uninstall/ResourceCleanupStepTest.java
@@ -25,7 +25,8 @@ public class ResourceCleanupStepTest extends DefaultCapabilitiesTestSuite {
     @Test
     public void testStart() throws Exception {
         Assert.assertEquals(Status.PENDING, resourceCleanupStep.getStatus());
-        Assert.assertFalse(resourceCleanupStep.start().isPresent());
+        resourceCleanupStep.start();
+        Assert.assertFalse(resourceCleanupStep.getPodInstanceRequirement().isPresent());
         Assert.assertEquals(Status.PREPARED, resourceCleanupStep.getStatus());
     }
 

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/uninstall/TaskKillStepTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/uninstall/TaskKillStepTest.java
@@ -28,7 +28,8 @@ public class TaskKillStepTest {
     @Test
     public void testStart() {
         TaskKillStep step = createStep();
-        Assert.assertEquals(Optional.empty(), step.start());
+        step.start();
+        Assert.assertEquals(Optional.empty(), step.getPodInstanceRequirement());
         Assert.assertEquals(Status.COMPLETE, step.getStatus());
         Mockito.verify(driver).killTask(taskID);
     }

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/specification/PlanGeneratorTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/specification/PlanGeneratorTest.java
@@ -3,7 +3,6 @@ package com.mesosphere.sdk.specification;
 import com.mesosphere.sdk.scheduler.SchedulerConfig;
 import com.mesosphere.sdk.scheduler.plan.Phase;
 import com.mesosphere.sdk.scheduler.plan.Plan;
-import com.mesosphere.sdk.scheduler.plan.PodInstanceRequirement;
 import com.mesosphere.sdk.specification.yaml.RawPlan;
 import com.mesosphere.sdk.specification.yaml.RawServiceSpec;
 import com.mesosphere.sdk.state.ConfigStore;
@@ -130,9 +129,8 @@ public class PlanGeneratorTest {
     private void validatePhase(Phase phase, List<List<String>> stepTasks) {
         Assert.assertEquals(phase.getChildren().size(), stepTasks.size());
         for (int i = 0; i < stepTasks.size(); i++) {
-            PodInstanceRequirement podInstanceRequirement = phase.getChildren().get(i).start().get();
-            List<String> tasksToLaunch = new ArrayList<>(podInstanceRequirement.getTasksToLaunch());
-
+            List<String> tasksToLaunch =
+                    new ArrayList<>(phase.getChildren().get(i).getPodInstanceRequirement().get().getTasksToLaunch());
             for (int j = 0; j < tasksToLaunch.size(); j++) {
                 Assert.assertEquals(tasksToLaunch.get(j), stepTasks.get(i).get(j));
             }


### PR DESCRIPTION
While working towards footprint-up-front, an initial pass was made to break up `PodInstanceRequirement`. A better strategy has since been worked out, but it'd make sense to retain some of the minor cleanup from that initial effort:
- `Step.start()` now returns void, instead of returning the content of getPodInstanceRequirement(). This greatly clarifies the expected behavior of the `start()` function.
- Remove duplicate code between `TaskUtils.isSamePodInstance(TaskInfo, PodInstance)` and `PlacementUtils.areEquivalent(TaskInfo, PodInstance)`
- Various other minor changes like cleaning up log statements and adding javadoc where missing.