### PR TITLE
[DCOS_OSS-3555] Use a valid boolean value for Kafka envvar

### DIFF
--- a/frameworks/kafka/universe/marathon.json.mustache
+++ b/frameworks/kafka/universe/marathon.json.mustache
@@ -125,7 +125,7 @@
     "KAFKA_ZOOKEEPER_URI": "{{kafka.kafka_zookeeper_uri}}",
 
     {{#kafka.kafka_advertise_host_ip}}
-    "TASKCFG_ALL_KAFKA_ADVERTISE_HOST" : "set",
+    "TASKCFG_ALL_KAFKA_ADVERTISE_HOST" : "true",
     {{/kafka.kafka_advertise_host_ip}}
 
     "TASKCFG_ALL_KAFKA_RESERVED_BROKER_MAX_ID": "{{kafka.reserved_broker_max_id}}",


### PR DESCRIPTION
Following on from #2512 this PR sets the `KAFKA_ADVERTISE_HOST` for use with the setup helper utility.

Using the value `"set"` was breaking legacy behaviour when `kafka.kafka_advertise_host_ip` was set to `true` in the configuration options.

@kohend your comments are welcome here.

## Release Notes:
### Bug Fixes
* Fix Kafka behaviour when specifying the `kafka.kafka_advertise_host_ip` configuration option.