### PR TITLE
[TOOLS][TESTS][BACKPORT] Add tooling for running flake8 in CI (#2532)

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 120
+ignore = E501

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+repos:
+-   repo: local
+    hooks:
+    - id: flake8
+      name: flake8
+      language: script
+      entry: tools/ci/checks/run_flake8_checks.sh
+      files: \.py$
+      pass_filenames: true
+    - id: pylint
+      name: pylint
+      language: script
+      entry: tools/ci/checks/run_pylint_checks.sh
+      files: \.py$
+      pass_filenames: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,11 +8,20 @@ Contributors Guide
 
 Discuss contributions to DC/OS SDK using GitHub [issues](https://github.com/mesosphere/dcos-commons/issues) and make contributions with GitHub [pull requests](https://github.com/mesosphere/dcos-commons/pulls).
 
-### Proposing Features
-If you would like to propose a new feature or a significant change, first open an issue to discuss it.  Project shepherds will provide feedback on the proposed change in terms of feasibility, design, and implementation guidance.  While all proposals are welcome, those that conflict with our roadmap or design principles may not be accepted.
+### Bugs / Feature Requests
+Think you’ve found a bug? Want to see a new feature? Please open a case in our issue management tool, JIRA:
+* Login to the [DC/OS SDK Public JIRA](https://jira.mesosphere.com/projects/DCOS_SDK/issues).  You will need a Github or Google account to use this service.
+* Navigate to the **DC/OS SDK project**.
+* Click **Create Issue** - Please provide as much information as possible about the issue type and how to reproduce it.
+* Github Issues for this project have been disabled.
+* Bug reports in JIRA for the DC/OS SDK project are public.
+
+If you would like to propose a new feature or a significant change, first open an issue (instructions above) to discuss it.  Project shepherds will provide feedback on the proposed change in terms of feasibility, design, and implementation guidance.  While all proposals are welcome, those that conflict with our roadmap or design principles may not be accepted.
 
 ### Creating Pull Requests
 Create pull requests against the [`master`](https://github.com/mesosphere/dcos-commons/tree/master) branch. Be sure to include unit tests and integration tests, as well as updates to the documentation, default scheduler, and reference framework if necessary.
+
+See the (testing documentation)[TESTING.md] for instructions on running static code checks and system integration tests.
 
 Simple pull requests (e.g., to fix documentation or comments) are welcome without an issue, but any substantial changes require an issue and discussion ahead of time.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get install -y \
     python3 \
     python3-dev \
     python3-pip \
+    rsync \
     tox \
     software-properties-common \
     python-software-properties \
@@ -25,7 +26,7 @@ ENV PATH=$PATH:/usr/local/go/bin
 RUN go version
 
 # AWS CLI for uploading build artifacts
-RUN pip install awscli
+RUN pip3 install awscli
 # Install the testing dependencies
 COPY test_requirements.txt test_requirements.txt
 RUN pip3 install -r test_requirements.txt
@@ -41,7 +42,8 @@ RUN mkdir /build-tools
 ENV PATH /build-tools:$PATH
 
 COPY tools/distribution/init /build-tools/
-COPY tools/ci/* /build-tools/
+COPY tools/ci/test_runner.sh /build-tools/
+COPY tools/ci/launch_cluster.sh /build-tools/
 
 # Create a folder to store the distributed artefacts
 RUN mkdir /dcos-commons-dist

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,5 +1,28 @@
 # DC/OS SDK framework testing tools
 
+## Static checking
+
+In order to minimize errors in the system integration tests, static checks and code analysis tools are used on testing and utility code not explicitly exercised by unit tests. In order to make this process as simple and uniform as possible, the repo contains a number of helper scripts to run these tools. These same scripts are used by the build system to check the changes to the source code.
+
+*Note*: These checks are only run against **modified** files relative to the target Git branch.
+
+### Python files
+
+In order to run the checks against *modified* Python files, run the following from the root of the repository:
+```bash
+./tools/ci/steps/check_python_files.sh
+```
+
+### Using pre-commit
+
+The repository also contains a `.pre-commit-config.yaml` to be used with (`pre-commit`)[https://pre-commit.com/]. Once `pre-commit` is installed, the hooks can be added using
+```bash
+pre-commit install
+```
+in the project root.
+
+## System integration tests
+
 The `test.sh` script works with the `mesosphere/dcos-commons` Docker image to set up a reproducible test environment for testing any DC/OS SDK-based frameworks such as [dcos-commons](https://github.com/mesosphere/dcos-commons). In order to pull the testing utilities into a target framework, say `my-framework` in the current working folder, run:
 ```bash
 docker run --rm -ti -v $(pwd):$(pwd) mesosphere/dcos-commons:latest init $(pwd)
@@ -11,7 +34,7 @@ to the current working directory.
 
 *Note:* If these files exist in the `$(pwd)` folder, they will be overwritten.
 
-## Running tests
+### Running tests
 With the testing utilities in place, the tests for the framework(s) in the current folder can be run using:
 
 ```bash
@@ -21,7 +44,7 @@ This automatically detects the frameworks in the current folder and for each fra
 
 *Note:* That this assumes that the DC/OS CLI has already been associated with a DC/OS cluster using the `dcos cluster setup` or `dcos cluster attach` commands.
 
-### Detection of frameworks
+#### Detection of frameworks
 As mentioned above, the `test.sh` script detects all the frameworks in the current folder. This is done with the following precednce:
 
 * If a `frameworks` folder exists
@@ -51,7 +74,7 @@ The detected frameworks would be:
 
 If no `frameworks` folder exists, the current folder is assumed to be the root of a single framework. Note that the name of the framework displayed in this case (and above) is purely cosmetic, and the package name for the framework is determined from the catalog definition files.
 
-### Advanced usage
+#### Advanced usage
 Running
 ```bash
 ./test.sh --help

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -6,3 +6,5 @@ dcos-shakedown==1.4.12
 git+https://github.com/dcos/dcos-test-utils.git@c9a4fc583a4a0bca18040ad4c7772e187e51aa74
 git+https://github.com/dcos/dcos-launch.git@e44c5cb521925cd6efd71da343a806ce2f22b496
 teamcity-messages
+flake8
+pylint

--- a/testing/sdk_diag.py
+++ b/testing/sdk_diag.py
@@ -32,7 +32,8 @@ _testlogs_task_id_limit = 250
 # 1 Test suite test_sanity_py starts with 2 tasks to ignore: [test_placement-0, test_placement-1]
 # 2 test_sanity_py.health_check passes, with 3 tasks created: [test-scheduler, pod-0-task, pod-1-task]
 # 3 test_sanity_py.replace_0 fails, with 1 task created: [pod-0-task-NEWUUID]
-#   Upon failure, the following task logs should be collected: [test-scheduler, pod-0-task, pod-1-task, pod-0-task-NEWUUID]
+#   Upon failure, the following task logs should be collected:
+#                   [test-scheduler, pod-0-task, pod-1-task, pod-0-task-NEWUUID]
 # 4 test_sanity_py.replace_1 succeeds, with 1 task created: [pod-1-task-NEWUUID]
 # 5 test_sanity_py.restart_1 fails, with 1 new task: [pod-1-task-NEWUUID2]
 #   Upon failure, the following task logs should be collected: [pod-1-task-NEWUUID, pod-1-task-NEWUUID2]
@@ -61,7 +62,7 @@ def get_test_suite_name(item: pytest.Item):
     '''Returns the test suite name to use for a given test.'''
     # frameworks/template/tests/test_sanity.py => test_sanity_py
     # tests/test_sanity.py => test_sanity_py
-    return os.path.basename(item.parent.name).replace('.','_')
+    return os.path.basename(item.parent.name).replace('.', '_')
 
 
 def handle_test_setup(item: pytest.Item):
@@ -95,14 +96,14 @@ def handle_test_setup(item: pytest.Item):
     _testlogs_test_index += 1
 
 
-def handle_test_report(item: pytest.Item, result): # _pytest.runner.TestReport
+def handle_test_report(item: pytest.Item, result):  # _pytest.runner.TestReport
     '''Collects information from the cluster following a failed test.
 
     This should be called in a hookimpl fixture.
     See also handle_test_setup() which must be called in a pytest_runtest_setup() hook.'''
 
     if not result.failed:
-        return # passed, nothing to do
+        return  # passed, nothing to do
 
     # Fetch all plans from all currently-installed services.
     # We do this retrieval first in order to be closer to the actual test failure.
@@ -114,7 +115,7 @@ def handle_test_report(item: pytest.Item, result): # _pytest.runner.TestReport
         for service_name in service_names:
             try:
                 _dump_plans(item, service_name)
-            except:
+            except Exception:
                 log.exception('Plan collection from service {} failed!'.format(service_name))
 
     # Fetch all logs from tasks created since the last failure, or since the start of the suite.
@@ -131,17 +132,17 @@ def handle_test_report(item: pytest.Item, result): # _pytest.runner.TestReport
         log.info('Fetching logs for {} tasks launched in this suite since last failure: {}'.format(
             len(new_task_ids), ', '.join(new_task_ids)))
         _dump_task_logs(item, new_task_ids)
-    except:
+    except Exception:
         log.exception('Task log collection failed!')
     try:
         log.info('Fetching mesos state:')
         _dump_mesos_state(item)
-    except:
+    except Exception:
         log.exception('Mesos state collection failed!')
     try:
         log.info('Creating/fetching cluster diagnostics bundle:')
         _dump_diagnostics_bundle(item)
-    except:
+    except Exception:
         log.exception('Diagnostics bundle creation failed')
     log.info('Post-failure collection complete')
 
@@ -159,7 +160,7 @@ def _dump_plans(item: pytest.Item, service_name: str):
         log.info('=> Writing {} ({} bytes)'.format(out_path, len(out_content)))
         with open(out_path, 'w') as f:
             f.write(out_content)
-            f.write('\n') # ... and a trailing newline
+            f.write('\n')  # ... and a trailing newline
 
 
 def _dump_diagnostics_bundle(item: pytest.Item):
@@ -171,7 +172,7 @@ def _dump_diagnostics_bundle(item: pytest.Item):
 
     @retrying.retry(
         wait_fixed=5000,
-        stop_max_delay=10*60*1000,
+        stop_max_delay=10 * 60 * 1000,
         retry_on_result=lambda result: result is None)
     def wait_for_bundle_file():
         rc, stdout, stderr = sdk_cmd.run_raw_cli('node diagnostics --status --json')
@@ -200,13 +201,15 @@ def _dump_mesos_state(item: pytest.Item):
         r = sdk_cmd.cluster_request('GET', '/mesos/{}'.format(name), verify=False, raise_on_error=False)
         if r.ok:
             if name.endswith('.json'):
-                name = name[:-len('.json')] # avoid duplicate '.json'
+                name = name[:-len('.json')]  # avoid duplicate '.json'
             with open(_setup_artifact_path(item, 'mesos_{}.json'.format(name)), 'w') as f:
                 f.write(r.text)
 
 
 def _dump_task_logs(item: pytest.Item, task_ids: list):
-    '''For all of the provided tasks, downloads their task, executor, and agent logs to the artifact path for this test.'''
+    '''
+    For all of the provided tasks, downloads their task, executor, and agent logs to the artifact path for this test.
+    '''
     task_ids_set = set(task_ids)
     cluster_tasks = sdk_cmd.cluster_request('GET', '/mesos/tasks').json()
     matching_tasks_by_agent = {}
@@ -220,7 +223,7 @@ def _dump_task_logs(item: pytest.Item, task_ids: list):
     for agent_id, agent_tasks in matching_tasks_by_agent.items():
         try:
             _dump_task_logs_for_agent(item, agent_id, agent_tasks)
-        except:
+        except Exception:
             log.exception('Failed to get logs for agent {}'.format(agent_id))
 
 
@@ -229,7 +232,6 @@ class _TaskEntry(object):
         self.task_id = cluster_task['id']
         self.executor_id = cluster_task['executor_id']
         self.agent_id = cluster_task['slave_id']
-
 
     def __repr__(self):
         return 'Task[task_id={} executor_id={} agent_id={}]'.format(
@@ -242,7 +244,7 @@ def _dump_task_logs_for_agent(item: pytest.Item, agent_id: str, agent_tasks: lis
     for task_entry in agent_tasks:
         try:
             task_byte_count += _dump_task_logs_for_task(item, agent_id, agent_executor_paths, task_entry)
-        except:
+        except Exception:
             log.exception('Failed to get logs for task {}'.format(task_entry))
     log.info('Downloaded {} bytes of logs from {} tasks on agent {}'.format(
         task_byte_count, len(agent_tasks), agent_id))
@@ -279,7 +281,7 @@ def _dump_task_logs_for_task(item: pytest.Item, agent_id: str, agent_executor_pa
                 try:
                     task_file_infos = sdk_cmd.cluster_request(
                         'GET', '/slave/{}/files/browse?path={}'.format(agent_id, task_browse_path)).json()
-                except:
+                except Exception:
                     log.exception('Failed to fetch task sandbox from presumed default executor')
 
     # Select all log files to be fetched from the above list.
@@ -311,7 +313,7 @@ def _dump_task_logs_for_task(item: pytest.Item, agent_id: str, agent_executor_pa
             with open(out_path, 'wb') as f:
                 for chunk in stream.iter_content(chunk_size=8192):
                     f.write(chunk)
-        except:
+        except Exception:
             log.exception('Failed to get file for task {}: {}'.format(task_entry, file_info))
     return byte_count
 
@@ -321,14 +323,17 @@ def _find_matching_executor_path(agent_executor_paths: dict, task_entry: _TaskEn
 
     Mesos has changed its schema for executor directories with each DC/OS release:
     - 1.9: There are only '/var/lib/mesos/...' paths. There are no '/runs/latest' paths, only '/runs/<UUID>'.
-    - 1.10: There are only '/var/lib/mesos/...' paths, but '/runs/latest' paths are available in addition to '/runs/<UUID>'.
-    - 1.11: There are both '/frameworks/...' paths and '/var/lib/mesos/...' paths. Both have '/runs/latest' as well as '/runs/<UUID>'.
+    - 1.10: There are only '/var/lib/mesos/...' paths, but '/runs/latest' paths are available in addition to
+                           '/runs/<UUID>'.
+    - 1.11: There are both '/frameworks/...' paths and '/var/lib/mesos/...' paths. Both have '/runs/latest' as well as
+                           '/runs/<UUID>'.
     (and Mesos folks tell me that '/frameworks/...' is the way forward, so '/var/lib/mesos/...' may be going away)
     SEE ALSO: https://issues.apache.org/jira/browse/MESOS-7899
 
     Additionally, given the correct path, there are also differences depending on the task/executor type:
     - Marathon/Metronome: The task id is used as the 'executor id'. Logs are at the advertised directory.
-    - Custom executor: 'executor id' + 'task id' are both used. Executor+Task logs are all combined into the same file(s) at the advertised directory.
+    - Custom executor: 'executor id' + 'task id' are both used. Executor+Task logs are all combined into the same
+                       file(s) at the advertised directory.
     - Default executor: 'executor id' + 'task id' are both used. Executor logs are at the advertised directory,
                         while task logs are under 'tasks/<task_id>/' relative to the advertised directory.
     '''
@@ -365,7 +370,8 @@ def _find_matching_executor_path(agent_executor_paths: dict, task_entry: _TaskEn
     return ''
 
 
-def _select_log_files(item: pytest.Item, task_id: str, file_infos: list, source: str, selected: collections.OrderedDict):
+def _select_log_files(item: pytest.Item, task_id: str, file_infos: list, source: str,
+                      selected: collections.OrderedDict):
     '''Finds and produces the 'stderr'/'stdout' file entries from the provided directory list returned by the agent.
 
     Results are placed in the 'selected' param.

--- a/testing/sdk_hosts.py
+++ b/testing/sdk_hosts.py
@@ -7,6 +7,7 @@ SHOULD ALSO BE APPLIED TO sdk_hosts IN ANY OTHER PARTNER REPOS
 '''
 import json
 import logging
+import retrying
 import shakedown
 
 import sdk_cmd
@@ -55,6 +56,7 @@ def custom_host(service_name, task_name, custom_domain, port=-1):
         _safe_name(service_name),
         custom_domain,
         port)
+
 
 def vip_host(service_name, vip_name, port=-1):
     '''Returns the hostname of a specified service VIP, with handling of foldered services.'''
@@ -122,6 +124,9 @@ def get_foldered_dns_name(service_name):
     return sdk_utils.get_foldered_name(service_name).replace("/", "")
 
 
+@retrying.retry(
+    wait_fixed=2000,
+    stop_max_delay=5 * 60 * 1000)
 def get_crypto_id_domain():
     """
     Returns the cluster cryptographic ID equivalent of autoip.dcos.thisdcos.directory.

--- a/testing/sdk_install.py
+++ b/testing/sdk_install.py
@@ -162,7 +162,7 @@ def _uninstall(
     try:
         _installed_service_names.remove(service_name)
     except KeyError:
-        pass # allow tests to 'uninstall' up-front
+        pass  # allow tests to 'uninstall' up-front
 
     if sdk_utils.dcos_version_less_than('1.10'):
         log.info('Uninstalling/janitoring {}'.format(service_name))
@@ -171,7 +171,7 @@ def _uninstall(
                 package_name, service_name=service_name)
         except (dcos.errors.DCOSException, ValueError) as e:
             log.info('Got exception when uninstalling package, ' +
-                          'continuing with janitor anyway: {}'.format(e))
+                     'continuing with janitor anyway: {}'.format(e))
             if 'marathon' in str(e):
                 log.info('Detected a probable marathon flake. Raising so retry will trigger.')
                 raise
@@ -214,6 +214,7 @@ def _uninstall(
 
             # wait for service to be gone according to marathon
             client = shakedown.marathon.create_client()
+
             def marathon_dropped_service():
                 app_ids = [app['id'] for app in client.get_apps()]
                 log.info('Marathon apps: {}'.format(app_ids))
@@ -244,8 +245,7 @@ def merge_dictionaries(dict1, dict2):
     for k, v in dict1.items():
         ret[k] = v
     for k, v in dict2.items():
-        if (k in dict1 and isinstance(dict1[k], dict)
-                and isinstance(dict2[k], collections.Mapping)):
+        if (k in dict1 and isinstance(dict1[k], dict) and isinstance(dict2[k], collections.Mapping)):
             ret[k] = merge_dictionaries(dict1[k], dict2[k])
         else:
             ret[k] = dict2[k]

--- a/testing/sdk_jobs.py
+++ b/testing/sdk_jobs.py
@@ -40,7 +40,7 @@ def _remove_job_by_name(job_name):
             'DELETE', 'metronome', '/v1/jobs/{}'.format(job_name),
             retry=False,
             params={'stopCurrentJobRuns': 'true'})
-    except:
+    except Exception:
         log.info('Failed to remove any existing job named {} (this is likely as expected):\n{}'.format(
             job_name, traceback.format_exc()))
 
@@ -73,7 +73,7 @@ def run_job(job_dict, timeout_seconds=600, raise_on_failure=True):
     # Wait for run to succeed, throw if run fails:
     @retrying.retry(
         wait_fixed=1000,
-        stop_max_delay=timeout_seconds*1000,
+        stop_max_delay=timeout_seconds * 1000,
         retry_on_result=lambda res: not res)
     def wait():
         # Note: We COULD directly query the run here via /v1/jobs/<job_name>/runs/<run_id>, but that

--- a/testing/sdk_metrics.py
+++ b/testing/sdk_metrics.py
@@ -18,18 +18,18 @@ import sdk_cmd
 log = logging.getLogger(__name__)
 
 
-def get_scheduler_metrics(service_name, timeout_seconds=15*60):
+def get_scheduler_metrics(service_name, timeout_seconds=15 * 60):
     """Returns a dict tree of Scheduler metrics fetched directly from the scheduler.
     Returned data will match the content of /service/<svc_name>/v1/metrics.
     """
     return sdk_cmd.service_request('GET', service_name, '/v1/metrics').json()
 
 
-def get_scheduler_counter(service_name, counter_name, timeout_seconds=15*60):
+def get_scheduler_counter(service_name, counter_name, timeout_seconds=15 * 60):
     """Waits for and returns the specified counter value from the scheduler"""
     @retrying.retry(
         wait_fixed=1000,
-        stop_max_delay=timeout_seconds*1000,
+        stop_max_delay=timeout_seconds * 1000,
         retry_on_result=lambda res: not res)
     def check_for_value():
         try:
@@ -53,12 +53,12 @@ def get_scheduler_counter(service_name, counter_name, timeout_seconds=15*60):
     return check_for_value()
 
 
-def wait_for_scheduler_counter_value(service_name, counter_name, min_value, timeout_seconds=15*60):
+def wait_for_scheduler_counter_value(service_name, counter_name, min_value, timeout_seconds=15 * 60):
     """Waits for the specified counter value to be reached by the scheduler
     For example, check that `offers.processed` is equal or greater to 1."""
     @retrying.retry(
         wait_fixed=1000,
-        stop_max_delay=timeout_seconds*1000,
+        stop_max_delay=timeout_seconds * 1000,
         retry_on_result=lambda res: not res)
     def check_for_value():
         value = get_scheduler_counter(service_name, counter_name, timeout_seconds)
@@ -151,7 +151,7 @@ def wait_for_service_metrics(package_name, service_name, task_name, timeout, exp
     """
     @retrying.retry(
         wait_fixed=1000,
-        stop_max_delay=timeout*1000,
+        stop_max_delay=timeout * 1000,
         retry_on_result=lambda res: not res)
     def check_for_service_metrics():
         try:

--- a/testing/sdk_plan.py
+++ b/testing/sdk_plan.py
@@ -6,15 +6,10 @@ SHOULD ALSO BE APPLIED TO sdk_plan IN ANY OTHER PARTNER REPOS
 ************************************************************************
 '''
 
-import json
 import logging
-import os.path
-import traceback
-
 import retrying
 
 import sdk_cmd
-import sdk_utils
 
 TIMEOUT_SECONDS = 15 * 60
 SHORT_TIMEOUT_SECONDS = 30
@@ -29,8 +24,10 @@ def get_deployment_plan(service_name, timeout_seconds=TIMEOUT_SECONDS):
 def get_recovery_plan(service_name, timeout_seconds=TIMEOUT_SECONDS):
     return get_plan(service_name, 'recovery', timeout_seconds)
 
+
 def get_decommission_plan(service_name, timeout_seconds=TIMEOUT_SECONDS):
     return get_plan(service_name, 'decommission', timeout_seconds)
+
 
 def list_plans(service_name, timeout_seconds=TIMEOUT_SECONDS):
     return sdk_cmd.service_request('GET', service_name, '/v1/plans', timeout_seconds=timeout_seconds).json()
@@ -40,14 +37,14 @@ def get_plan(service_name, plan, timeout_seconds=TIMEOUT_SECONDS):
     # We need to DIY error handling/retry because the query will return 417 if the plan has errors.
     @retrying.retry(
         wait_fixed=1000,
-        stop_max_delay=timeout_seconds*1000)
+        stop_max_delay=timeout_seconds * 1000)
     def wait_for_plan():
         response = sdk_cmd.service_request(
             'GET', service_name, '/v1/plans/{}'.format(plan),
             retry=False,
             raise_on_error=False)
         if response.status_code == 417:
-            return response # avoid throwing, return plan with errors
+            return response  # avoid throwing, return plan with errors
         response.raise_for_status()
         return response
 
@@ -113,7 +110,7 @@ def wait_for_plan_status(service_name, plan_name, status, timeout_seconds=TIMEOU
 
     @retrying.retry(
         wait_fixed=1000,
-        stop_max_delay=timeout_seconds*1000,
+        stop_max_delay=timeout_seconds * 1000,
         retry_on_result=lambda res: not res)
     def fn():
         plan = get_plan(service_name, plan_name, SHORT_TIMEOUT_SECONDS)
@@ -130,7 +127,7 @@ def wait_for_plan_status(service_name, plan_name, status, timeout_seconds=TIMEOU
 def wait_for_phase_status(service_name, plan_name, phase_name, status, timeout_seconds=TIMEOUT_SECONDS):
     @retrying.retry(
         wait_fixed=1000,
-        stop_max_delay=timeout_seconds*1000,
+        stop_max_delay=timeout_seconds * 1000,
         retry_on_result=lambda res: not res)
     def fn():
         plan = get_plan(service_name, plan_name, SHORT_TIMEOUT_SECONDS)
@@ -148,7 +145,7 @@ def wait_for_phase_status(service_name, plan_name, phase_name, status, timeout_s
 def wait_for_step_status(service_name, plan_name, phase_name, step_name, status, timeout_seconds=TIMEOUT_SECONDS):
     @retrying.retry(
         wait_fixed=1000,
-        stop_max_delay=timeout_seconds*1000,
+        stop_max_delay=timeout_seconds * 1000,
         retry_on_result=lambda res: not res)
     def fn():
         plan = get_plan(service_name, plan_name, SHORT_TIMEOUT_SECONDS)

--- a/testing/sdk_tasks.py
+++ b/testing/sdk_tasks.py
@@ -22,7 +22,7 @@ log = logging.getLogger(__name__)
 def check_running(service_name, expected_task_count, timeout_seconds=DEFAULT_TIMEOUT_SECONDS, allow_more=True):
     @retrying.retry(
         wait_fixed=1000,
-        stop_max_delay=timeout_seconds*1000,
+        stop_max_delay=timeout_seconds * 1000,
         retry_on_result=lambda res: not res)
     def fn():
         try:
@@ -76,7 +76,6 @@ class Task(object):
             cli_task_tokens[4],
             cli_task_tokens[5])
 
-
     def __init__(self, name, host, user, state_char, id, agent):
         self.name = name
         self.host = host
@@ -84,7 +83,6 @@ class Task(object):
         self.state_char = state_char
         self.id = id
         self.agent = agent
-
 
     def __repr__(self):
         return 'Task[name={} host={} user={} state_char={} id={} agent={}]'.format(
@@ -159,7 +157,7 @@ def get_completed_task_id(task_name):
 def check_task_relaunched(task_name, old_task_id, timeout_seconds=DEFAULT_TIMEOUT_SECONDS):
     @retrying.retry(
         wait_fixed=1000,
-        stop_max_delay=timeout_seconds*1000,
+        stop_max_delay=timeout_seconds * 1000,
         retry_on_result=lambda res: not res)
     def fn():
         try:
@@ -192,7 +190,7 @@ def check_tasks_updated(service_name, prefix, old_task_ids, timeout_seconds=DEFA
     # atomic test, that the plan completed properly where properly includes that no old tasks remain.
     @retrying.retry(
         wait_fixed=1000,
-        stop_max_delay=timeout_seconds*1000,
+        stop_max_delay=timeout_seconds * 1000,
         retry_on_result=lambda res: not res)
     def fn():
         try:

--- a/testing/sdk_upgrade.py
+++ b/testing/sdk_upgrade.py
@@ -18,7 +18,9 @@ import sdk_plan
 import sdk_tasks
 import sdk_utils
 
+
 log = logging.getLogger(__name__)
+
 
 # Installs a universe version of a package, then upgrades it to a test version
 #
@@ -30,7 +32,7 @@ def test_upgrade(
         running_task_count,
         additional_options={},
         test_version_additional_options=None,
-        timeout_seconds=25*60,
+        timeout_seconds=25 * 60,
         wait_for_deployment=True):
     # allow providing different options dicts to the universe version vs the test version:
     if test_version_additional_options is None:
@@ -91,7 +93,7 @@ def soak_upgrade_downgrade(
         service_name,
         running_task_count,
         additional_options={},
-        timeout_seconds=25*60,
+        timeout_seconds=25 * 60,
         wait_for_deployment=True):
     sdk_cmd.run_cli("package install --cli {} --yes".format(package_name))
     version = 'stub-universe'
@@ -125,7 +127,6 @@ def _get_universe_url():
             log.info("Found Universe URL: {}".format(repo['uri']))
             return repo['uri']
     assert False, "Unable to find 'Universe' in list of repos: {}".format(repositories)
-
 
 
 @retrying.retry(stop_max_attempt_number=15,
@@ -207,7 +208,7 @@ def _upgrade_or_downgrade(
 
 @retrying.retry(
     wait_fixed=1000,
-    stop_max_delay=10*1000,
+    stop_max_delay=10 * 1000,
     retry_on_result=lambda result: result is None)
 def _get_pkg_version(package_name):
     cmd = 'package describe {}'.format(package_name)
@@ -224,7 +225,7 @@ def _get_pkg_version(package_name):
             # Old location (until 1.9 or until 1.10):
             version = describe['version']
         return version
-    except:
+    except Exception:
         log.warning('Failed to extract package version from "{}":\nSTDOUT:\n{}\nSTDERR:\n{}'.format(cmd, stdout, stderr))
         log.warning(traceback.format_exc())
         return None
@@ -232,7 +233,7 @@ def _get_pkg_version(package_name):
 
 @retrying.retry(
     wait_fixed=1000,
-    stop_max_delay=60*1000,
+    stop_max_delay=60 * 1000,
     retry_on_result=lambda result: result is None)
 def _wait_for_new_package_version(package_name, prev_version):
     cur_version = _get_pkg_version(package_name)

--- a/tools/ci/checks/get_applicable_changes.py
+++ b/tools/ci/checks/get_applicable_changes.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+
+import argparse
+import itertools
+import subprocess
+
+from typing import List
+
+
+BUILD_FOLDERS = ["cli/", "clivendor/", "govendor/", "sdk/", "testing/", "tools/"]
+BUILD_FILES = ["conftest.py", "test_requirements.txt", "Dockerfile"]
+
+
+def get_changed_files(git_reference: str) -> List[str]:
+    """
+    Get the list of files changed relative to the specified git reference.
+    """
+    cmd = ["git", "diff", git_reference, "--name-only"]
+
+    file_list = subprocess.check_output(cmd).decode("utf-8").split("\n")
+
+    return file_list
+
+
+def ignore_extensions(input: List[str], extensions: str) -> List[str]:
+    if not extensions:
+        return input
+    extension_filter = tuple(f.strip() for f in extensions.split(","))
+
+    return list(filter(lambda f: not f.lower().endswith(extension_filter), input))
+
+
+def filter_extensions(input: List[str], extensions: str) -> List[str]:
+    if not extensions:
+        return input
+    extension_filter = tuple(f.strip() for f in extensions.split(","))
+
+    return list(filter(lambda f: f.lower().endswith(extension_filter), input))
+
+
+def filter_build_files_and_folders(input: List[str], limit_to_build: bool) -> List[str]:
+    """
+    Filter the list of files to those that would affect the build in some way.
+    """
+    if not limit_to_build:
+        return input
+
+    return list(filter(lambda f: f.startswith(BUILD_FILES + BUILD_FOLDERS), input))
+
+
+def flatten_file_list(file_args: List[str]) -> List[str]:
+    return list(itertools.chain.from_iterable([f.split() for f in file_args]))
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Filter out applicable files")
+
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("--files", type=str, nargs="+", help="The file list to process")
+    group.add_argument(
+        "--from-git",
+        type=str,
+        nargs="?",
+        const="HEAD",
+        help="A git reference to use as a base for determining the list of changed files to process",
+    )
+
+    parser.add_argument(
+        "--extensions", type=str, help="A comma-separated list of extensions"
+    )
+    parser.add_argument(
+        "--ignore-extensions",
+        type=str,
+        help="A comma-separated list of extensions to ignore",
+    )
+    parser.add_argument("--only-build-files", action="store_true")
+
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    if args.from_git is not None:
+        files = get_changed_files(args.from_git)
+    else:
+        files = flatten_file_list(args.files)
+
+    filtered_files = filter_build_files_and_folders(
+        ignore_extensions(
+            filter_extensions(files, args.extensions), args.ignore_extensions
+        ),
+        args.only_build_files,
+    )
+
+    for f in filtered_files:
+        print(f)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/ci/checks/get_base_branch.sh
+++ b/tools/ci/checks/get_base_branch.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+set -e
+
+current_branch="${CURRENT_GIT_BRANCH:-$( git symbolic-ref --short HEAD )}"
+
+base_branch="master"
+
+if [[ x"$current_branch" == x*"pull/"* ]]; then
+    # This is a PR and we need to determine the branch from the API.
+    pr_name="${current_branch/pull/pulls}"
+
+    if [ -z ${GIT_REPO} ]; then
+        set -x
+        git_repo="$( git remote get-url origin )"
+        git_repo="$( echo "${git_repo}" | sed -e 's/.*github\.com[:\/]//g' )"
+        GIT_REPO="${git_repo//.git/}"
+        set +x
+    fi
+
+    output="$( curl --silent "https://api.github.com/repos/${GIT_REPO}/${pr_name}" --retry 3 )"
+    # Note, curl does not return success/failure based on the HTTP code.
+    # Check for a valid return value by retrieving the ID.
+    pr_id="$( echo "$output" | jq -r .id )"
+    if [ x"$pr_id" == x"null" ]; then
+        # Check for a message
+        message="$( echo "$output" | jq -r .message )"
+        if [ x"$message" == x"Not Found" ]; then
+            echo "The specified PR (${git_repo}/${pr_name}) could not be found"
+            exit 1
+        else
+            echo "The cURL output could not be parsed:"
+            echo "$output"
+        fi
+        exit 1
+    fi
+
+    base_branch="$( echo "$output" | jq -r .base.ref )"
+    current_branch="$( echo "$output" | jq -r .head.ref )"
+
+    # Fetch the base branch to ensure that it is available locally
+    git fetch origin ${base_branch}:${base_branch}
+fi
+
+echo "${base_branch}"

--- a/tools/ci/checks/run_flake8_checks.sh
+++ b/tools/ci/checks/run_flake8_checks.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+DOCKER_TAG=${DOCKER_TAG:-latest}
+DOCKER_IMAGE=${DOCKER_IMAGE:-mesosphere/dcos-commons:${DOCKER_TAG}}
+
+docker run --rm -t \
+    -v $(pwd):/build:ro \
+    -w /build \
+        ${DOCKER_IMAGE} \
+            flake8 "$@"

--- a/tools/ci/checks/run_pylint_checks.sh
+++ b/tools/ci/checks/run_pylint_checks.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+DOCKER_TAG=${DOCKER_TAG:-latest}
+DOCKER_IMAGE=${DOCKER_IMAGE:-mesosphere/dcos-commons:${DOCKER_TAG}}
+
+docker run --rm -t \
+    -v $(pwd):/build:ro \
+    -w /build \
+        ${DOCKER_IMAGE} \
+            pylint -E "$@"

--- a/tools/ci/checks/run_pylint_checks.sh
+++ b/tools/ci/checks/run_pylint_checks.sh
@@ -4,6 +4,7 @@ DOCKER_TAG=${DOCKER_TAG:-latest}
 DOCKER_IMAGE=${DOCKER_IMAGE:-mesosphere/dcos-commons:${DOCKER_TAG}}
 
 docker run --rm -t \
+    -e PYTHONPATH="$PYTHONPATH" \
     -v $(pwd):/build:ro \
     -w /build \
         ${DOCKER_IMAGE} \

--- a/tools/ci/steps/check_python_files.sh
+++ b/tools/ci/steps/check_python_files.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# This script is used by the build system to check MODIFIED Python files in the repository.
+#
+# By default, the BASE_BRANCH is determined using the get_base_branch script, but this
+# can be overridden by setting the BASE_BRANCH environment variable before invoking this
+# script
+
+TOOL_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../checks" && pwd )"
+
+# Determine the target branch for the diff calculation
+BASE_BRANCH=${BASE_BRANCH:-$( ${TOOL_DIR}/get_base_branch.sh )}
+
+# Get the list of changed .py files relative to the base branch
+CHANGESET="$( ${TOOL_DIR}/get_applicable_changes.py --extensions ".py" --from-git "${BASE_BRANCH}" )"
+
+if [[ -n ${CHANGESET} ]]; then
+    echo "Changeset:"
+    echo "${CHANGESET}"
+
+    echo
+    echo "Running flake8 on $( echo \"${CHANGESET}\" | wc -w ) files:"
+    ${TOOL_DIR}/run_flake8_checks.sh ${CHANGESET}
+    rc=$?
+    if [ ${rc} -eq 0 ]; then
+        echo "Success!"
+    else
+        exit ${rc}
+    fi
+
+    echo "Running pylint on $( echo \"${CHANGESET}\" | wc -w ) files:"
+    ${TOOL_DIR}/run_pylint_checks.sh ${CHANGESET}
+    rc=$?
+    if [ ${rc} -eq 0 ]; then
+        echo "Success!"
+    else
+        exit ${rc}
+    fi
+
+    exit 0
+fi
+
+echo "No Python files in changeset."

--- a/tools/distribution/init
+++ b/tools/distribution/init
@@ -76,9 +76,13 @@ def distribute_test_utils(output_path: str):
     for f in files:
         copy_dist_file(f, output_path)
 
-    folders = [("tools", ["tools/ci", "tools/distribution"]), ("testing", []), ]
-    for f in folders:
-        copy_dist_folder(f[0], output_path, f[1])
+    folders = {"testing": [],
+               "tools": ["tools/distribution",
+                         "tools/ci/test_runner.sh",
+                         "tools/ci/launch_cluster.sh", ]}
+
+    for folder, exclude in folders.items():
+        copy_dist_folder(folder, output_path, exclude)
 
 
 def update_sdk(output_path: str, target_version: str):


### PR DESCRIPTION
This is a backport with minor formatting modifications of #2532 and #2562.

The PR makes the following specific changes:
* Adds `flake8` as a requirement in the docker image
* Adds `pylint` as a requirement in the docker image
* Adds a collection of scripts to drive these kinds of checks
* adds a `pre-commit-config.yaml` file for enabling checks locally
* Make some change to Python files in `testing/` while checking the commit hooks and scripts.
