### PR TITLE
Add PYTHONPATH for pylint checks

### DIFF
--- a/tools/ci/checks/run_pylint_checks.sh
+++ b/tools/ci/checks/run_pylint_checks.sh
@@ -4,6 +4,7 @@ DOCKER_TAG=${DOCKER_TAG:-latest}
 DOCKER_IMAGE=${DOCKER_IMAGE:-mesosphere/dcos-commons:${DOCKER_TAG}}
 
 docker run --rm -t \
+    -e PYTHONPATH="$PYTHONPATH" \
     -v $(pwd):/build:ro \
     -w /build \
         ${DOCKER_IMAGE} \


### PR DESCRIPTION
This PR is a follow-up for #2532 and adds passing the `PYTHONPATH` environment variable to the `pylint -E` check. This is needed when changed files are not in the `testing` folder, for example. 