### PR TITLE
[BACKPORT][DCOS_OSS-3555] Use a valid boolean value for Kafka envvar (#2558)

### DIFF
--- a/frameworks/kafka/universe/marathon.json.mustache
+++ b/frameworks/kafka/universe/marathon.json.mustache
@@ -126,7 +126,7 @@
     "KAFKA_ZOOKEEPER_URI": "{{kafka.kafka_zookeeper_uri}}",
 
     {{#kafka.kafka_advertise_host_ip}}
-    "TASKCFG_ALL_KAFKA_ADVERTISE_HOST" : "set",
+    "TASKCFG_ALL_KAFKA_ADVERTISE_HOST" : "true",
     {{/kafka.kafka_advertise_host_ip}}
 
     "TASKCFG_ALL_KAFKA_RESERVED_BROKER_MAX_ID": "{{kafka.reserved_broker_max_id}}",


### PR DESCRIPTION
This is a straight backport of #2558.

It sets the `KAFKA_ADVERTISE_HOST` for use with the setup helper utility.

Using the value `"set"` was breaking legacy behaviour when `kafka.kafka_advertise_host_ip` was set to `true` in the configuration options.

## Release Notes:
### Bug Fixes
* Fix Kafka behaviour when specifying the `kafka.kafka_advertise_host_ip` configuration option.