### PR TITLE
[DCOS-38379] adding logging in the retry to find cause of multi service test flakiness

### DIFF
--- a/frameworks/helloworld/tests/test_multiservice_dynamic.py
+++ b/frameworks/helloworld/tests/test_multiservice_dynamic.py
@@ -54,6 +54,7 @@ def check_scheduler_relaunched(service_name: str, old_scheduler_task_id: str,
     def fn():
         try:
             task_ids = set([t['id'] for t in shakedown.get_tasks(completed=True) if t['name'].startswith(service_name)])
+            log.info('found the following task ids {}'.format(task_ids))
         except dcos.errors.DCOSHTTPException:
             log.info('Failed to get task ids. service_name=%s', service_name)
             task_ids = set([])


### PR DESCRIPTION
Seems there is a flaw in the retry logic since the scheduler seems to be restarted, adding logging here so we can see the list of task_ids returned. 