### PR TITLE
[DCOS-38840] Drop mesos v0 support across frameworks

### DIFF
--- a/frameworks/cassandra/tests/test_sanity.py
+++ b/frameworks/cassandra/tests/test_sanity.py
@@ -41,17 +41,6 @@ def test_service_health():
     assert shakedown.service_healthy(config.get_foldered_service_name())
 
 
-# @pytest.mark.sanity
-# @pytest.mark.smoke
-# @pytest.mark.mesos_v0
-# def test_mesos_v0_api():
-#     service_name = config.get_foldered_service_name()
-#     prior_api_version = sdk_marathon.get_mesos_api_version(service_name)
-#     if prior_api_version is not "V0":
-#         sdk_marathon.set_mesos_api_version(service_name, "V0")
-#         sdk_marathon.set_mesos_api_version(service_name, prior_api_version)
-
-
 @pytest.mark.sanity
 def test_endpoints():
     # check that we can reach the scheduler via admin router, and that returned endpoints are sanitized:

--- a/frameworks/cassandra/tests/test_sanity.py
+++ b/frameworks/cassandra/tests/test_sanity.py
@@ -41,15 +41,15 @@ def test_service_health():
     assert shakedown.service_healthy(config.get_foldered_service_name())
 
 
-@pytest.mark.sanity
-@pytest.mark.smoke
-@pytest.mark.mesos_v0
-def test_mesos_v0_api():
-    service_name = config.get_foldered_service_name()
-    prior_api_version = sdk_marathon.get_mesos_api_version(service_name)
-    if prior_api_version is not "V0":
-        sdk_marathon.set_mesos_api_version(service_name, "V0")
-        sdk_marathon.set_mesos_api_version(service_name, prior_api_version)
+# @pytest.mark.sanity
+# @pytest.mark.smoke
+# @pytest.mark.mesos_v0
+# def test_mesos_v0_api():
+#     service_name = config.get_foldered_service_name()
+#     prior_api_version = sdk_marathon.get_mesos_api_version(service_name)
+#     if prior_api_version is not "V0":
+#         sdk_marathon.set_mesos_api_version(service_name, "V0")
+#         sdk_marathon.set_mesos_api_version(service_name, prior_api_version)
 
 
 @pytest.mark.sanity

--- a/frameworks/cassandra/universe/config.json
+++ b/frameworks/cassandra/universe/config.json
@@ -40,15 +40,6 @@
           "type": "string",
           "default": ""
         },
-        "mesos_api_version": {
-          "description": "Configures the Mesos API version to use. Possible values: V0 (non-HTTP), V1 (HTTP)",
-          "type": "string",
-          "enum": [
-            "V0",
-            "V1"
-          ],
-          "default": "V1"
-        },
         "log_level": {
           "description": "The log level for the DC/OS service.",
           "type": "string",

--- a/frameworks/cassandra/universe/marathon.json.mustache
+++ b/frameworks/cassandra/universe/marathon.json.mustache
@@ -39,8 +39,6 @@
     "MESOS_AUTHENTICATEE": "com_mesosphere_dcos_ClassicRPCAuthenticatee",
     "MESOS_HTTP_AUTHENTICATEE": "com_mesosphere_dcos_http_Authenticatee",
     {{/service.service_account_secret}}
-    "MESOS_API_VERSION": "{{service.mesos_api_version}}",
-
     {{#service.security.transport_encryption.enabled}}
     "TASKCFG_ALL_SECURITY_TRANSPORT_ENCRYPTION_ENABLED": "{{service.security.transport_encryption.enabled}}",
     "CASSANDRA_CQLSH_SSL_FLAGS": "--ssl --cqlshrc=./apache-cassandra-3.0.16/conf/cqlshrc",

--- a/frameworks/elastic/tests/test_sanity.py
+++ b/frameworks/elastic/tests/test_sanity.py
@@ -81,17 +81,17 @@ def test_pod_replace_then_immediate_config_update():
     sdk_plan.wait_for_completed_recovery(foldered_name)
 
 
-@pytest.mark.sanity
-@pytest.mark.smoke
-@pytest.mark.mesos_v0
-def test_mesos_v0_api():
-    prior_api_version = sdk_marathon.get_mesos_api_version(foldered_name)
-    if prior_api_version is not "V0":
-        sdk_marathon.set_mesos_api_version(foldered_name, "V0")
-        sdk_marathon.set_mesos_api_version(foldered_name, prior_api_version)
-
-    sdk_plan.wait_for_completed_deployment(foldered_name)
-    sdk_plan.wait_for_completed_recovery(foldered_name)
+# @pytest.mark.sanity
+# @pytest.mark.smoke
+# @pytest.mark.mesos_v0
+# def test_mesos_v0_api():
+#     prior_api_version = sdk_marathon.get_mesos_api_version(foldered_name)
+#     if prior_api_version is not "V0":
+#         sdk_marathon.set_mesos_api_version(foldered_name, "V0")
+#         sdk_marathon.set_mesos_api_version(foldered_name, prior_api_version)
+#
+#     sdk_plan.wait_for_completed_deployment(foldered_name)
+#     sdk_plan.wait_for_completed_recovery(foldered_name)
 
 
 @pytest.mark.sanity

--- a/frameworks/elastic/tests/test_sanity.py
+++ b/frameworks/elastic/tests/test_sanity.py
@@ -81,19 +81,6 @@ def test_pod_replace_then_immediate_config_update():
     sdk_plan.wait_for_completed_recovery(foldered_name)
 
 
-# @pytest.mark.sanity
-# @pytest.mark.smoke
-# @pytest.mark.mesos_v0
-# def test_mesos_v0_api():
-#     prior_api_version = sdk_marathon.get_mesos_api_version(foldered_name)
-#     if prior_api_version is not "V0":
-#         sdk_marathon.set_mesos_api_version(foldered_name, "V0")
-#         sdk_marathon.set_mesos_api_version(foldered_name, prior_api_version)
-#
-#     sdk_plan.wait_for_completed_deployment(foldered_name)
-#     sdk_plan.wait_for_completed_recovery(foldered_name)
-
-
 @pytest.mark.sanity
 def test_endpoints():
     # check that we can reach the scheduler via admin router, and that returned endpoints are sanitized:

--- a/frameworks/elastic/universe/config.json
+++ b/frameworks/elastic/universe/config.json
@@ -40,15 +40,6 @@
           "type": "string",
           "default": ""
         },
-        "mesos_api_version": {
-          "description": "Configures the Mesos API version to use. Possible values: V0 (non-HTTP), V1 (HTTP)",
-          "type": "string",
-          "enum": [
-            "V0",
-            "V1"
-          ],
-          "default": "V1"
-        },
         "log_level": {
           "description": "The log level for the DC/OS service.",
           "type": "string",

--- a/frameworks/elastic/universe/marathon.json.mustache
+++ b/frameworks/elastic/universe/marathon.json.mustache
@@ -37,7 +37,6 @@
     "BOOTSTRAP_URI": "{{resource.assets.uris.bootstrap-zip}}",
     "JAVA_URI": "{{resource.assets.uris.jre-tar-gz}}",
     "LIBMESOS_URI": "{{resource.assets.uris.libmesos-bundle-tar-gz}}",
-    "MESOS_API_VERSION": "{{service.mesos_api_version}}",
     "FRAMEWORK_NAME": "{{service.name}}",
     "FRAMEWORK_USER": "{{service.user}}",
     "FRAMEWORK_PRINCIPAL": "{{service.service_account}}",

--- a/frameworks/hdfs/tests/test_sanity.py
+++ b/frameworks/hdfs/tests/test_sanity.py
@@ -48,18 +48,6 @@ def configure_package(configure_security):
 def pre_test_setup():
     config.check_healthy(service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
 
-
-# @pytest.mark.sanity
-# @pytest.mark.smoke
-# @pytest.mark.mesos_v0
-# def test_mesos_v0_api():
-#     service_name = sdk_utils.get_foldered_name(config.SERVICE_NAME)
-#     prior_api_version = sdk_marathon.get_mesos_api_version(service_name)
-#     if prior_api_version is not "V0":
-#         sdk_marathon.set_mesos_api_version(service_name, "V0")
-#         sdk_marathon.set_mesos_api_version(service_name, prior_api_version)
-
-
 @pytest.mark.sanity
 def test_endpoints():
     foldered_name = sdk_utils.get_foldered_name(config.SERVICE_NAME)

--- a/frameworks/hdfs/tests/test_sanity.py
+++ b/frameworks/hdfs/tests/test_sanity.py
@@ -49,15 +49,15 @@ def pre_test_setup():
     config.check_healthy(service_name=sdk_utils.get_foldered_name(config.SERVICE_NAME))
 
 
-@pytest.mark.sanity
-@pytest.mark.smoke
-@pytest.mark.mesos_v0
-def test_mesos_v0_api():
-    service_name = sdk_utils.get_foldered_name(config.SERVICE_NAME)
-    prior_api_version = sdk_marathon.get_mesos_api_version(service_name)
-    if prior_api_version is not "V0":
-        sdk_marathon.set_mesos_api_version(service_name, "V0")
-        sdk_marathon.set_mesos_api_version(service_name, prior_api_version)
+# @pytest.mark.sanity
+# @pytest.mark.smoke
+# @pytest.mark.mesos_v0
+# def test_mesos_v0_api():
+#     service_name = sdk_utils.get_foldered_name(config.SERVICE_NAME)
+#     prior_api_version = sdk_marathon.get_mesos_api_version(service_name)
+#     if prior_api_version is not "V0":
+#         sdk_marathon.set_mesos_api_version(service_name, "V0")
+#         sdk_marathon.set_mesos_api_version(service_name, prior_api_version)
 
 
 @pytest.mark.sanity

--- a/frameworks/hdfs/universe/config.json
+++ b/frameworks/hdfs/universe/config.json
@@ -40,15 +40,6 @@
           "type": "string",
           "default": ""
         },
-        "mesos_api_version": {
-          "description": "Configures the Mesos API version to use. Possible values: V0 (non-HTTP), V1 (HTTP)",
-          "type": "string",
-          "enum": [
-            "V0",
-            "V1"
-          ],
-          "default": "V1"
-        },
         "log_level": {
           "description": "The log level for the DC/OS service.",
           "type": "string",

--- a/frameworks/hdfs/universe/marathon.json.mustache
+++ b/frameworks/hdfs/universe/marathon.json.mustache
@@ -48,7 +48,6 @@
     "DATA_DISK": "{{data_node.disk}}",
     "DATA_DISK_TYPE": "{{data_node.disk_type}}",
     "LIBMESOS_URI": "{{resource.assets.uris.libmesos-bundle-tar-gz}}",
-    "MESOS_API_VERSION": "{{service.mesos_api_version}}",
     "HDFS_URI": "{{resource.assets.uris.hdfs-tar-gz}}",
     "HDFS_BIN_URI": "{{resource.assets.uris.hdfs-bin-tar-gz}}",
     "HDFS_JAVA_URI": "{{resource.assets.uris.hdfs-jre-tar-gz}}",

--- a/frameworks/helloworld/tests/test_sanity.py
+++ b/frameworks/helloworld/tests/test_sanity.py
@@ -39,15 +39,15 @@ def test_install():
     config.check_running(sdk_utils.get_foldered_name(config.SERVICE_NAME))
 
 
-@pytest.mark.sanity
-@pytest.mark.smoke
-@pytest.mark.mesos_v0
-def test_mesos_v0_api():
-    service_name = sdk_utils.get_foldered_name(config.SERVICE_NAME)
-    prior_api_version = sdk_marathon.get_mesos_api_version(service_name)
-    if prior_api_version is not "V0":
-        sdk_marathon.set_mesos_api_version(service_name, "V0")
-        sdk_marathon.set_mesos_api_version(service_name, prior_api_version)
+# @pytest.mark.sanity
+# @pytest.mark.smoke
+# @pytest.mark.mesos_v0
+# def test_mesos_v0_api():
+#     service_name = sdk_utils.get_foldered_name(config.SERVICE_NAME)
+#     prior_api_version = sdk_marathon.get_mesos_api_version(service_name)
+#     if prior_api_version is not "V0":
+#         sdk_marathon.set_mesos_api_version(service_name, "V0")
+#         sdk_marathon.set_mesos_api_version(service_name, prior_api_version)
 
 
 @pytest.mark.sanity

--- a/frameworks/helloworld/tests/test_sanity.py
+++ b/frameworks/helloworld/tests/test_sanity.py
@@ -38,18 +38,6 @@ def configure_package(configure_security):
 def test_install():
     config.check_running(sdk_utils.get_foldered_name(config.SERVICE_NAME))
 
-
-# @pytest.mark.sanity
-# @pytest.mark.smoke
-# @pytest.mark.mesos_v0
-# def test_mesos_v0_api():
-#     service_name = sdk_utils.get_foldered_name(config.SERVICE_NAME)
-#     prior_api_version = sdk_marathon.get_mesos_api_version(service_name)
-#     if prior_api_version is not "V0":
-#         sdk_marathon.set_mesos_api_version(service_name, "V0")
-#         sdk_marathon.set_mesos_api_version(service_name, prior_api_version)
-
-
 @pytest.mark.sanity
 @pytest.mark.smoke
 def test_bump_hello_cpus():

--- a/frameworks/helloworld/universe/config.json
+++ b/frameworks/helloworld/universe/config.json
@@ -25,15 +25,6 @@
           "type": "string",
           "default": ""
         },
-        "mesos_api_version": {
-          "description": "Configures the Mesos API version to use. Possible values: V0 (non-HTTP), V1 (HTTP)",
-          "type": "string",
-          "enum": [
-            "V0",
-            "V1"
-          ],
-          "default": "V1"
-        },
         "log_level": {
           "description": "The log level for the DC/OS service.",
           "type": "string",

--- a/frameworks/helloworld/universe/marathon.json.mustache
+++ b/frameworks/helloworld/universe/marathon.json.mustache
@@ -85,7 +85,7 @@
     "SERVICE_TLD": "{{service.custom_service_tld}}",
     {{/service.custom_service_tld}}
 
-    "MESOS_API_VERSION": "{{service.mesos_api_version}}",
+    "MESOS_API_VERSION": "V1",
     "KEYSTORE_APP_VERSION": "{{tls.keystore_app_version}}",
     "NGINX_CONTAINER_VERSION": "{{tls.nginx_container_version}}",
     "TEST_BOOLEAN": "{{service.test_boolean}}",

--- a/frameworks/helloworld/universe/marathon.json.mustache
+++ b/frameworks/helloworld/universe/marathon.json.mustache
@@ -85,7 +85,6 @@
     "SERVICE_TLD": "{{service.custom_service_tld}}",
     {{/service.custom_service_tld}}
 
-    "MESOS_API_VERSION": "V1",
     "KEYSTORE_APP_VERSION": "{{tls.keystore_app_version}}",
     "NGINX_CONTAINER_VERSION": "{{tls.nginx_container_version}}",
     "TEST_BOOLEAN": "{{service.test_boolean}}",

--- a/frameworks/kafka/tests/test_sanity.py
+++ b/frameworks/kafka/tests/test_sanity.py
@@ -40,17 +40,6 @@ def test_service_health():
     assert shakedown.service_healthy(sdk_utils.get_foldered_name(config.SERVICE_NAME))
 
 
-# @pytest.mark.sanity
-# @pytest.mark.smoke
-# @pytest.mark.mesos_v0
-# def test_mesos_v0_api():
-#     service_name = sdk_utils.get_foldered_name(config.SERVICE_NAME)
-#     prior_api_version = sdk_marathon.get_mesos_api_version(service_name)
-#     if prior_api_version is not "V0":
-#         sdk_marathon.set_mesos_api_version(service_name, "V0")
-#         sdk_marathon.set_mesos_api_version(service_name, prior_api_version)
-
-
 # --------- Endpoints -------------
 
 

--- a/frameworks/kafka/tests/test_sanity.py
+++ b/frameworks/kafka/tests/test_sanity.py
@@ -40,15 +40,15 @@ def test_service_health():
     assert shakedown.service_healthy(sdk_utils.get_foldered_name(config.SERVICE_NAME))
 
 
-@pytest.mark.sanity
-@pytest.mark.smoke
-@pytest.mark.mesos_v0
-def test_mesos_v0_api():
-    service_name = sdk_utils.get_foldered_name(config.SERVICE_NAME)
-    prior_api_version = sdk_marathon.get_mesos_api_version(service_name)
-    if prior_api_version is not "V0":
-        sdk_marathon.set_mesos_api_version(service_name, "V0")
-        sdk_marathon.set_mesos_api_version(service_name, prior_api_version)
+# @pytest.mark.sanity
+# @pytest.mark.smoke
+# @pytest.mark.mesos_v0
+# def test_mesos_v0_api():
+#     service_name = sdk_utils.get_foldered_name(config.SERVICE_NAME)
+#     prior_api_version = sdk_marathon.get_mesos_api_version(service_name)
+#     if prior_api_version is not "V0":
+#         sdk_marathon.set_mesos_api_version(service_name, "V0")
+#         sdk_marathon.set_mesos_api_version(service_name, prior_api_version)
 
 
 # --------- Endpoints -------------

--- a/frameworks/kafka/universe/config.json
+++ b/frameworks/kafka/universe/config.json
@@ -40,15 +40,6 @@
           "type": "string",
           "default": ""
         },
-        "mesos_api_version": {
-          "description": "Configures the Mesos API version to use. Possible values: V0 (non-HTTP), V1 (HTTP)",
-          "type": "string",
-          "enum": [
-            "V0",
-            "V1"
-          ],
-          "default": "V1"
-        },
         "log_level": {
           "description": "The log level for the DC/OS service.",
           "type": "string",

--- a/frameworks/kafka/universe/marathon.json.mustache
+++ b/frameworks/kafka/universe/marathon.json.mustache
@@ -36,7 +36,6 @@
     "KAFKA_URI": "{{resource.assets.uris.kafka-tgz}}",
     "KAFKA_JAVA_URI": "{{resource.assets.uris.kafka-jre-tar-gz}}",
     "JAVA_URI": "{{resource.assets.uris.jre-tar-gz}}",
-    "MESOS_API_VERSION": "{{service.mesos_api_version}}",
     "KAFKA_STATSD_URI": "{{resource.assets.uris.kafka-statsd-jar}}",
     "CLIENT_STATSD_URI": "{{resource.assets.uris.statsd-client-jar}}",
     "SETUP_HELPER_URI": "{{resource.assets.uris.setup-helper-zip}}",

--- a/frameworks/template/universe/config.json
+++ b/frameworks/template/universe/config.json
@@ -43,15 +43,6 @@
           "type": "string",
           "default": ""
         },
-        "mesos_api_version": {
-          "description": "Configures the Mesos API version to use. Possible values: V0 (non-HTTP), V1 (HTTP)",
-          "type": "string",
-          "enum": [
-            "V0",
-            "V1"
-          ],
-          "default": "V1"
-        },
         "log_level": {
           "description": "The log level for the DC/OS service.",
           "type": "string",

--- a/frameworks/template/universe/marathon.json.mustache
+++ b/frameworks/template/universe/marathon.json.mustache
@@ -31,7 +31,6 @@
     "FRAMEWORK_USER": "{{service.user}}",
     "FRAMEWORK_PRINCIPAL": "{{service.service_account}}",
     "FRAMEWORK_LOG_LEVEL": "{{service.log_level}}",
-    "MESOS_API_VERSION": "{{service.mesos_api_version}}",
 
     "NODE_COUNT": "{{node.count}}",
     "NODE_PLACEMENT": "{{{node.placement_constraint}}}",

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerConfig.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerConfig.java
@@ -386,9 +386,7 @@ public class SchedulerConfig {
     /**
      * Returns the Mesos API version.
      */
-    public String getMesosApiVersion() {
-        return envStore.getRequired(MESOS_API_VERSION_ENV);
-    }
+    public String getMesosApiVersion() { return envStore.getOptional(MESOS_API_VERSION_ENV, "V1"); }
 
     /**
      * Returns the command to be run when pausing a Task.

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerConfig.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerConfig.java
@@ -386,7 +386,9 @@ public class SchedulerConfig {
     /**
      * Returns the Mesos API version.
      */
-    public String getMesosApiVersion() { return envStore.getOptional(MESOS_API_VERSION_ENV, "V1"); }
+    public String getMesosApiVersion() {
+        return envStore.getOptional(MESOS_API_VERSION_ENV, "V1");
+    }
 
     /**
      * Returns the command to be run when pausing a Task.

--- a/testing/sdk_marathon.py
+++ b/testing/sdk_marathon.py
@@ -225,3 +225,16 @@ def bump_task_count_config(service_name, key_name, delta=1):
     updated_node_count = int(config['env'][key_name]) + delta
     config['env'][key_name] = str(updated_node_count)
     update_app(service_name, config)
+
+
+def get_mesos_api_version(service_name):
+    return get_config(service_name)['env']['MESOS_API_VERSION']
+
+
+def set_mesos_api_version(service_name, api_version, timeout=600):
+    '''Sets the mesos API version to the provided value, and then verifies that the scheduler comes back successfully'''
+    config = get_config(service_name)
+    config['env']['MESOS_API_VERSION'] = api_version
+    update_app(service_name, config, timeout=timeout)
+    # wait for scheduler to come back and successfully receive/process offers:
+    sdk_metrics.wait_for_scheduler_counter_value(service_name, 'offers.processed', 1, timeout_seconds=timeout)

--- a/testing/sdk_marathon.py
+++ b/testing/sdk_marathon.py
@@ -225,16 +225,3 @@ def bump_task_count_config(service_name, key_name, delta=1):
     updated_node_count = int(config['env'][key_name]) + delta
     config['env'][key_name] = str(updated_node_count)
     update_app(service_name, config)
-
-
-def get_mesos_api_version(service_name):
-    return get_config(service_name)['env']['MESOS_API_VERSION']
-
-
-def set_mesos_api_version(service_name, api_version, timeout=600):
-    '''Sets the mesos API version to the provided value, and then verifies that the scheduler comes back successfully'''
-    config = get_config(service_name)
-    config['env']['MESOS_API_VERSION'] = api_version
-    update_app(service_name, config, timeout=timeout)
-    # wait for scheduler to come back and successfully receive/process offers:
-    sdk_metrics.wait_for_scheduler_counter_value(service_name, 'offers.processed', 1, timeout_seconds=timeout)


### PR DESCRIPTION
drop option to use mesos v0 api. Seems to be causing CI issues and is no longer necessary for support