### PR TITLE
DCOS-29329 Uninstall: Group resources by hosting agent

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/strategy/DependencyStrategyHelper.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/strategy/DependencyStrategyHelper.java
@@ -24,9 +24,11 @@ public class DependencyStrategyHelper<C extends Element> {
     }
 
     /**
-     * Marks a direct dependency between two nodes. NOTE: This helper does NOT handle any inferred/chained dependencies.
-     * It is the responsibility of the caller to explicitly add each dependency directly. For example, given c->b->a,
-     * the caller MUST explicitly specify c->b, b->a, AND c->a as dependencies.
+     * Marks a direct dependency between two nodes, where {@code child} depends on {@code parent}.
+     *
+     * <p>NOTE: This helper does NOT handle any inferred/chained dependencies. It is the responsibility of the caller to
+     * explicitly add each dependency directly. For example, given c->b->a, the caller MUST explicitly specify c->b,
+     * b->a, AND c->a as dependencies.
      */
     public void addDependency(C child, C parent) {
         // Ensure parent element is listed:
@@ -57,8 +59,8 @@ public class DependencyStrategyHelper<C extends Element> {
             return Collections.emptyList();
         }
         return dependencies.entrySet().stream()
-                .filter(entry -> PlanUtils.isEligible(entry.getKey(), dirtyAssets))
-                .filter(entry -> dependenciesFulfilled(entry.getValue()))
+                .filter(entry ->
+                        PlanUtils.isEligible(entry.getKey(), dirtyAssets) && dependenciesFulfilled(entry.getValue()))
                 .map(entry -> entry.getKey())
                 .collect(Collectors.toList());
     }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/uninstall/TLSCleanupStep.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/uninstall/TLSCleanupStep.java
@@ -19,7 +19,7 @@ import java.util.*;
 public class TLSCleanupStep extends AbstractStep {
 
     private final SecretsClient secretsClient;
-    private final String namespace;
+    private final String secretsNamespace;
 
     /**
      * Creates a new instance with initial {@code status}.
@@ -27,29 +27,29 @@ public class TLSCleanupStep extends AbstractStep {
     TLSCleanupStep(SecretsClient secretsClient, String secretsNamespace, Optional<String> namespace) {
         super("tls-cleanup", namespace);
         this.secretsClient = secretsClient;
-        this.namespace = secretsNamespace;
+        this.secretsNamespace = secretsNamespace;
     }
 
     @Override
     public void start() {
-        logger.info("Cleaning up TLS resources in namespace {}...", namespace);
+        logger.info("Cleaning up TLS resources in namespace {}...", secretsNamespace);
 
         try {
             Collection<String> secretPathsToClean =
-                    TLSArtifactPaths.getKnownTLSArtifacts(secretsClient.list(namespace));
+                    TLSArtifactPaths.getKnownTLSArtifacts(secretsClient.list(secretsNamespace));
             if (secretPathsToClean.isEmpty()) {
                 logger.info("No TLS resources to clean up.");
             } else {
-                logger.info("{} paths to clean in namespace {}:", secretPathsToClean.size(), namespace);
+                logger.info("{} paths to clean in namespace {}:", secretPathsToClean.size(), secretsNamespace);
                 for (String path : secretPathsToClean) {
                     logger.info("Removing secret: '{}'", path);
-                    secretsClient.delete(namespace + "/" + path);
+                    secretsClient.delete(secretsNamespace + "/" + path);
                 }
             }
 
             setStatus(Status.COMPLETE);
         } catch (IOException e) {
-            logger.error(String.format("Failed to clean up secrets in namespace %s", namespace), e);
+            logger.error(String.format("Failed to clean up secrets in namespace %s", secretsNamespace), e);
             setStatus(Status.ERROR);
         }
     }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/uninstall/UninstallPlanFactory.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/uninstall/UninstallPlanFactory.java
@@ -3,8 +3,15 @@ package com.mesosphere.sdk.scheduler.uninstall;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
 import java.util.stream.Collectors;
 
 import org.apache.http.impl.client.LaxRedirectStrategy;
@@ -17,13 +24,17 @@ import com.mesosphere.sdk.dcos.clients.SecretsClient;
 import com.mesosphere.sdk.offer.Constants;
 import com.mesosphere.sdk.offer.LoggingUtils;
 import com.mesosphere.sdk.offer.ResourceUtils;
+import com.mesosphere.sdk.offer.TaskException;
 import com.mesosphere.sdk.offer.TaskUtils;
+import com.mesosphere.sdk.offer.taskdata.TaskLabelReader;
 import com.mesosphere.sdk.scheduler.SchedulerConfig;
 import com.mesosphere.sdk.scheduler.plan.DefaultPhase;
 import com.mesosphere.sdk.scheduler.plan.DefaultPlan;
 import com.mesosphere.sdk.scheduler.plan.Phase;
 import com.mesosphere.sdk.scheduler.plan.Plan;
 import com.mesosphere.sdk.scheduler.plan.Step;
+import com.mesosphere.sdk.scheduler.plan.strategy.DependencyStrategy;
+import com.mesosphere.sdk.scheduler.plan.strategy.DependencyStrategyHelper;
 import com.mesosphere.sdk.scheduler.plan.strategy.ParallelStrategy;
 import com.mesosphere.sdk.scheduler.plan.strategy.SerialStrategy;
 import com.mesosphere.sdk.scheduler.recovery.FailureUtils;
@@ -37,12 +48,12 @@ public class UninstallPlanFactory {
     private static final Logger LOGGER = LoggingUtils.getLogger(UninstallPlanFactory.class);
 
     private static final String TASK_KILL_PHASE = "kill-tasks";
-    private static final String RESOURCE_PHASE = "unreserve-resources";
+    private static final String RESOURCE_PHASE_PREFIX = "unreserve-resources-";
     private static final String TLS_CLEANUP_PHASE = "tls-cleanup";
     private static final String DEREGISTER_PHASE = "deregister-service";
 
     private final Plan plan;
-    private final Collection<ResourceCleanupStep> resourceCleanupSteps;
+    private final Collection<ResourceCleanupStep> allResourceCleanupSteps;
     private final DeregisterStep deregisterStep;
 
     UninstallPlanFactory(
@@ -68,32 +79,23 @@ public class UninstallPlanFactory {
         // We filter to unique Resource Id's, because Executor level resources are tracked on multiple Tasks.
         // So in this scenario we should have 3 uninstall steps around resources A, B, and C.
 
-        // Filter the tasks to those that have actually created resources. Tasks in an ERROR state which are also
-        // flagged as permanently failed are assumed to not have resources reserved on Mesos' end, despite our State
-        // Store still listing them with resources. This is because we log the planned reservation before it occurs.
-        Collection<Protos.TaskInfo> allTasks = stateStore.fetchTasks();
-        List<Protos.TaskID> taskIdsInErrorState = stateStore.fetchStatuses().stream()
-                .filter(taskStatus -> taskStatus.getState() == Protos.TaskState.TASK_ERROR)
-                .map(Protos.TaskStatus::getTaskId)
-                .collect(Collectors.toList());
-        List<Protos.TaskInfo> tasksNotFailedAndErrored = allTasks.stream()
-                .filter(taskInfo -> !(FailureUtils.isPermanentlyFailed(taskInfo)
-                        && taskIdsInErrorState.contains(taskInfo.getTaskId())))
-                .collect(Collectors.toList());
+        // Group the tasks by agent hostname, which is then used as the phase name:
+        Map<String, Collection<ResourceCleanupStep>> resourceCleanupStepsByAgent =
+                getResourceCleanupStepsByAgent(namespace, stateStore);
 
-        this.resourceCleanupSteps =
-                ResourceUtils.getResourceIds(ResourceUtils.getAllResources(tasksNotFailedAndErrored)).stream()
-                        .map(resourceId -> new ResourceCleanupStep(resourceId, namespace))
-                        .collect(Collectors.toList());
-        LOGGER.info("Configuring resource cleanup of {}/{} tasks: {}/{} expected resources have been unreserved",
-                tasksNotFailedAndErrored.size(), allTasks.size(),
-                resourceCleanupSteps.stream().filter(step -> step.isComplete()).count(),
-                resourceCleanupSteps.size());
-        phases.add(new DefaultPhase(
-                RESOURCE_PHASE,
-                resourceCleanupSteps.stream().collect(Collectors.toList()), // hack to get around collection typing
-                new ParallelStrategy<>(),
-                Collections.emptyList()));
+        this.allResourceCleanupSteps = resourceCleanupStepsByAgent.values().stream()
+                .flatMap(Collection::stream)
+                .collect(Collectors.toList());
+        LOGGER.info("{}/{} expected resources are already unreserved",
+                allResourceCleanupSteps.stream().filter(step -> step.isComplete()).count(),
+                allResourceCleanupSteps.size());
+        for (Map.Entry<String, Collection<ResourceCleanupStep>> agentSteps : resourceCleanupStepsByAgent.entrySet()) {
+            phases.add(new DefaultPhase(
+                    RESOURCE_PHASE_PREFIX + agentSteps.getKey(),
+                    agentSteps.getValue().stream().collect(Collectors.toList()), // hack to get around collection typing
+                    new ParallelStrategy<>(),
+                    Collections.emptyList()));
+        }
 
         // If applicable, we also clean up any TLS secrets that we'd created before.
         // Note: This won't catch certificates where the user installed the service with TLS enabled, then disabled TLS
@@ -126,13 +128,30 @@ public class UninstallPlanFactory {
         // Finally, we wipe remaining ZK data and unregister the framework from Mesos.
         // This is done upstream in FrameworkRunner, then the step is notified when it completes.
         this.deregisterStep = new DeregisterStep(namespace);
-        phases.add(new DefaultPhase(
+        Phase deregisterPhase = new DefaultPhase(
                 DEREGISTER_PHASE,
                 Collections.singletonList(deregisterStep),
                 new SerialStrategy<>(),
-                Collections.emptyList()));
+                Collections.emptyList());
+        phases.add(deregisterPhase);
 
-        plan = new DefaultPlan(Constants.DEPLOY_PLAN_NAME, phases);
+        // We need to construct a custom strategy in order to allow the resource phases to operate in parallel.
+        // In other words, the dependencies should look like this:
+        // 1. Kill all tasks, unreserve all resources, and delete any automatically created TLS certs as needed
+        // 2. When all of the above is complete, deregister
+        DependencyStrategyHelper<Phase> uninstallPhaseDependencies = new DependencyStrategyHelper<>(phases);
+        for (Phase phase : phases) {
+            if (phase == deregisterPhase) {
+                continue;
+            }
+            // Mark this phase as a dependency of deregisterPhase:
+            uninstallPhaseDependencies.addDependency(deregisterPhase, phase);
+        }
+
+        plan = new DefaultPlan(
+                Constants.DEPLOY_PLAN_NAME,
+                phases,
+                new DependencyStrategy<>(uninstallPhaseDependencies));
     }
 
     /**
@@ -146,7 +165,7 @@ public class UninstallPlanFactory {
      * Returns the resource cleanup steps.
      */
     Collection<ResourceCleanupStep> getResourceCleanupSteps() {
-        return resourceCleanupSteps;
+        return allResourceCleanupSteps;
     }
 
     /**
@@ -154,5 +173,68 @@ public class UninstallPlanFactory {
      */
     DeregisterStep getDeregisterStep() {
         return deregisterStep;
+    }
+
+    /**
+     * Determines what resources need to be unreserved and builds {@link ResourceCleanupStep}s for each of them.
+     * The returned mapping groups the steps according to the hostname of the agent where they are located.
+     */
+    private static Map<String, Collection<ResourceCleanupStep>> getResourceCleanupStepsByAgent(
+            Optional<String> namespace, StateStore stateStore) {
+        Collection<Protos.TaskInfo> allTasks = stateStore.fetchTasks();
+        Set<String> taskIdsInErrorState = stateStore.fetchStatuses().stream()
+                .filter(taskStatus -> taskStatus.getState() == Protos.TaskState.TASK_ERROR)
+                .map(taskStatus -> taskStatus.getTaskId().getValue())
+                .collect(Collectors.toSet());
+
+        // Filter the tasks to those that have actually created resources. Tasks in an ERROR state which are also
+        // flagged as permanently failed are assumed to not have resources reserved on Mesos' end, despite our State
+        // Store still listing them with resources. This is because we log the planned reservation before it occurs.
+        Collection<Protos.TaskInfo> tasksNotFailedAndErrored = allTasks.stream()
+                .filter(taskInfo -> !(FailureUtils.isPermanentlyFailed(taskInfo)
+                        && taskIdsInErrorState.contains(taskInfo.getTaskId().getValue())))
+                .collect(Collectors.toList());
+
+        Map<String, Set<String>> dedupedResourceIdsByAgent = new HashMap<>();
+        for (Protos.TaskInfo taskInfo : tasksNotFailedAndErrored) {
+            String hostname;
+            try {
+                hostname = new TaskLabelReader(taskInfo).getHostname();
+            } catch (TaskException e) {
+                LOGGER.warn(String.format("Failed to determine hostname of task %s", taskInfo.getName()), e);
+                hostname = "UNKNOWN_AGENT";
+            }
+
+            Set<String> agentResourceIds = dedupedResourceIdsByAgent.get(hostname);
+            if (agentResourceIds == null) {
+                agentResourceIds = new HashSet<>();
+                dedupedResourceIdsByAgent.put(hostname, agentResourceIds);
+            }
+
+            agentResourceIds.addAll(ResourceUtils.getResourceIds(ResourceUtils.getAllResources(taskInfo)));
+        }
+
+        LOGGER.info("Configuring resource cleanup of {}/{} tasks across {} agents",
+                tasksNotFailedAndErrored.size(), allTasks.size(), dedupedResourceIdsByAgent.size());
+
+        // Map the resource IDs into ResourceCleanupSteps
+        return dedupedResourceIdsByAgent.entrySet().stream().collect(Collectors.toMap(
+                entry -> entry.getKey(),
+                entry -> entry.getValue().stream()
+                        .map(resourceId -> new ResourceCleanupStep(resourceId, namespace))
+                        // Order the resulting resource steps by name. Not required, just nice to have.
+                        .collect(Collectors.toCollection(() -> new TreeSet<ResourceCleanupStep>(
+                                new Comparator<ResourceCleanupStep>() {
+                            @Override
+                            public int compare(ResourceCleanupStep s1, ResourceCleanupStep s2) {
+                                return s1.getName().compareTo(s2.getName());
+                            }
+                        }))),
+                (u, v) -> {
+                    throw new IllegalStateException(String.format("Duplicate key %s", u));
+                },
+                // Use a tree map so that the resulting phases are sorted by agent hostname.
+                // This isn't required, just a nice to have for users.
+                TreeMap::new));
     }
 }

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/placement/MaxPerHostnameRuleTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/placement/MaxPerHostnameRuleTest.java
@@ -5,10 +5,8 @@ import com.mesosphere.sdk.offer.CommonIdUtils;
 import com.mesosphere.sdk.offer.taskdata.TaskLabelWriter;
 import com.mesosphere.sdk.testutils.OfferTestUtils;
 import com.mesosphere.sdk.testutils.TaskTestUtils;
-import org.apache.mesos.Protos.Attribute;
-import org.apache.mesos.Protos.Offer;
-import org.apache.mesos.Protos.TaskInfo;
-import org.apache.mesos.Protos.Value;
+
+import org.apache.mesos.Protos;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -21,20 +19,20 @@ import java.util.Collections;
 public class MaxPerHostnameRuleTest {
     private static final String HOSTNAME_1 = "www.hostname.1";
 
-    private static final Offer OFFER_HOSTNAME;
+    private static final Protos.Offer OFFER_HOSTNAME;
     static {
-        Attribute.Builder a = Attribute.newBuilder()
-                .setType(Value.Type.TEXT)
+        Protos.Attribute.Builder a = Protos.Attribute.newBuilder()
+                .setType(Protos.Value.Type.TEXT)
                 .setName("footext");
         a.getTextBuilder().setValue("123");
-        OFFER_HOSTNAME = getOfferWithResources().toBuilder().setHostname(HOSTNAME_1).build();
+        OFFER_HOSTNAME = getOfferWithResources().setHostname(HOSTNAME_1).build();
     }
 
-    private static final TaskInfo TASK_NO_HOSTNAME = TaskTestUtils.getTaskInfo(Collections.emptyList());
-    private static final TaskInfo TASK_HOSTNAME = getTask("match-1__abc", OFFER_HOSTNAME);
+    private static final Protos.TaskInfo TASK_NO_HOSTNAME = TaskTestUtils.getTaskInfo(Collections.emptyList());
+    private static final Protos.TaskInfo TASK_HOSTNAME = getTask("match-1__abc", OFFER_HOSTNAME);
 
-    private static TaskInfo getTask(String id, Offer offer) {
-        TaskInfo.Builder taskBuilder = TaskTestUtils.getTaskInfo(Collections.emptyList()).toBuilder();
+    private static Protos.TaskInfo getTask(String id, Protos.Offer offer) {
+        Protos.TaskInfo.Builder taskBuilder = TaskTestUtils.getTaskInfo(Collections.emptyList()).toBuilder();
         taskBuilder.getTaskIdBuilder().setValue(id);
         try {
             taskBuilder.setName(CommonIdUtils.toTaskName(taskBuilder.getTaskId()));
@@ -45,11 +43,11 @@ public class MaxPerHostnameRuleTest {
         return taskBuilder.build();
     }
 
-    private static Offer getOfferWithResources() {
-        Offer.Builder o = OfferTestUtils.getEmptyOfferBuilder();
+    private static Protos.Offer.Builder getOfferWithResources() {
+        Protos.Offer.Builder o = OfferTestUtils.getEmptyOfferBuilder();
         OfferTestUtils.addResource(o, "a");
         OfferTestUtils.addResource(o, "b");
-        return o.build();
+        return o;
     }
 
     @Test

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/uninstall/UninstallSchedulerTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/uninstall/UninstallSchedulerTest.java
@@ -195,7 +195,7 @@ public class UninstallSchedulerTest extends DefaultCapabilitiesTestSuite {
         Assert.assertEquals(plan.toString(), expected, getStepStatuses(plan));
 
         // Invoke getClientStatus so that plan status is correctly processed before offers are passed.
-        // Shouldn't see any new work since all the uninstall steps were considered candidates up-front. 
+        // Shouldn't see any new work since all the uninstall steps were considered candidates up-front.
         Assert.assertEquals(ClientStatusResponse.launching(false), uninstallScheduler.getClientStatus());
         offer = OfferTestUtils.getOffer(Collections.singletonList(RESERVED_RESOURCE_3));
         uninstallScheduler.offers(Collections.singletonList(offer));
@@ -407,7 +407,10 @@ public class UninstallSchedulerTest extends DefaultCapabilitiesTestSuite {
     }
 
     private static Plan getUninstallPlan(AbstractScheduler scheduler) {
-        return scheduler.getPlanCoordinator().getPlanManagers().stream().findFirst().get().getPlan();
+        return scheduler.getPlanCoordinator().getPlanManagers().stream()
+                .findFirst()
+                .get()
+                .getPlan();
     }
 
     private static ServiceSpec getServiceSpec() {

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/uninstall/UninstallSchedulerTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/uninstall/UninstallSchedulerTest.java
@@ -5,6 +5,7 @@ import com.mesosphere.sdk.framework.Driver;
 import com.mesosphere.sdk.offer.CommonIdUtils;
 import com.mesosphere.sdk.offer.taskdata.TaskLabelWriter;
 import com.mesosphere.sdk.scheduler.MesosEventClient.OfferResponse;
+import com.mesosphere.sdk.scheduler.AbstractScheduler;
 import com.mesosphere.sdk.scheduler.MesosEventClient.ClientStatusResponse;
 import com.mesosphere.sdk.scheduler.MesosEventClient.UnexpectedResourcesResponse;
 import com.mesosphere.sdk.scheduler.plan.*;
@@ -31,10 +32,10 @@ import static org.mockito.Mockito.*;
 
 public class UninstallSchedulerTest extends DefaultCapabilitiesTestSuite {
 
-    private static final String RESERVED_RESOURCE_1_ID = "reserved-resource-id";
-    private static final String RESERVED_RESOURCE_2_ID = "reserved-volume-id";
-    private static final String RESERVED_RESOURCE_3_ID = "reserved-cpu-id-0";
-    private static final String RESERVED_RESOURCE_4_ID = "reserved-cpu-id-1";
+    private static final String RESERVED_RESOURCE_1_ID = "resource-1";
+    private static final String RESERVED_RESOURCE_2_ID = "resource-2";
+    private static final String RESERVED_RESOURCE_3_ID = "resource-3";
+    private static final String RESERVED_RESOURCE_4_ID = "resource-4";
 
     private static final Protos.Resource RESERVED_RESOURCE_1 =
             ResourceTestUtils.getReservedPorts(123, 234, RESERVED_RESOURCE_1_ID);
@@ -45,22 +46,42 @@ public class UninstallSchedulerTest extends DefaultCapabilitiesTestSuite {
     private static final Protos.Resource RESERVED_RESOURCE_4 =
             ResourceTestUtils.getReservedCpus(1.0, RESERVED_RESOURCE_4_ID);
 
-    private static final Protos.TaskInfo TASK_A =
-            TaskTestUtils.getTaskInfo(Arrays.asList(RESERVED_RESOURCE_1, RESERVED_RESOURCE_2, RESERVED_RESOURCE_3));
+    private static final Protos.TaskInfo TASK_A;
     private static final Protos.TaskInfo TASK_B;
+    private static final Protos.TaskInfo TASK_C;
     static {
-        // Mark this one as permanently failed. Doesn't take effect unless the task is ALSO in an error state:
         Protos.TaskInfo.Builder builder = Protos.TaskInfo.newBuilder(
+                TaskTestUtils.getTaskInfo(Arrays.asList(RESERVED_RESOURCE_1, RESERVED_RESOURCE_2, RESERVED_RESOURCE_3)));
+        builder.setLabels(new TaskLabelWriter(builder)
+                .setHostname(OfferTestUtils.getEmptyOfferBuilder().setHostname("host-1").build())
+                .toProto());
+        TASK_A = builder.build();
+
+        // - Marked as permanently failed: Filtered from resources to clean up if the TaskStatus is ALSO ERROR.
+        // - No agent id: put into a default 'UNKNOWN_AGENT' phase.
+        // - Shares resources with TASK_A, but they are not deduped due to the different agent.
+        builder = Protos.TaskInfo.newBuilder(
                 TaskTestUtils.getTaskInfo(Arrays.asList(RESERVED_RESOURCE_2, RESERVED_RESOURCE_4)))
-                .setTaskId(CommonIdUtils.toTaskId(TestConstants.SERVICE_NAME, "other-task-info"))
-                .setName("other-task-info");
+                .setTaskId(CommonIdUtils.toTaskId(TestConstants.SERVICE_NAME, "task-b"))
+                .setName("task-b");
         builder.setLabels(new TaskLabelWriter(builder)
                 .setPermanentlyFailed()
                 .toProto());
         TASK_B = builder.build();
+
+        // - Marked as permanently failed: Filtered from resources to clean up if the TaskStatus is ALSO ERROR.
+        // - Same agent as TASK_A.
+        // - Shares resources with TASK_A, which are deduped because they share the same agent.
+        builder = Protos.TaskInfo.newBuilder(
+                TaskTestUtils.getTaskInfo(Arrays.asList(RESERVED_RESOURCE_1, RESERVED_RESOURCE_4)))
+                .setTaskId(CommonIdUtils.toTaskId(TestConstants.SERVICE_NAME, "task-c"))
+                .setName("task-c");
+        builder.setLabels(new TaskLabelWriter(builder)
+                .setHostname(OfferTestUtils.getEmptyOfferBuilder().setHostname("host-1").build())
+                .setPermanentlyFailed()
+                .toProto());
+        TASK_C = builder.build();
     }
-    private static final Protos.TaskStatus TASK_B_STATUS_ERROR =
-            TaskTestUtils.generateStatus(TASK_B.getTaskId(), Protos.TaskState.TASK_ERROR);
 
     private StateStore stateStore;
 
@@ -94,7 +115,7 @@ public class UninstallSchedulerTest extends DefaultCapabilitiesTestSuite {
     @Test
     public void testInitialPlan() throws Exception {
         UninstallScheduler uninstallScheduler = getUninstallScheduler();
-        Plan plan = uninstallScheduler.getPlanCoordinator().getPlanManagers().stream().findFirst().get().getPlan();
+        Plan plan = getUninstallPlan(uninstallScheduler);
         // 1 task kill + 3 unique resources + deregister step
         List<Status> expected = Arrays.asList(Status.PENDING, Status.PENDING, Status.PENDING, Status.PENDING, Status.PENDING);
         Assert.assertEquals(plan.toString(), expected, getStepStatuses(plan));
@@ -102,33 +123,38 @@ public class UninstallSchedulerTest extends DefaultCapabilitiesTestSuite {
 
     @Test
     public void testInitialPlanTaskResourceOverlap() throws Exception {
-        // Add TASK_B, which overlaps partially with TASK_A.
-        stateStore.storeTasks(Collections.singletonList(TASK_B));
+        // Add TASK_B and TASK_C:
+        // - TASK_B overlaps partially with TASK_A, but is on a different agent so resources aren't deduped.
+        // - TASK_C meanwhile is on the same agent as TASK_A, so its resources ARE deduped.
+        stateStore.storeTasks(Arrays.asList(TASK_B, TASK_C));
 
         UninstallScheduler uninstallScheduler = getUninstallScheduler();
-        Plan plan = uninstallScheduler.getPlanCoordinator().getPlanManagers().stream().findFirst().get().getPlan();
-        // 2 task kills + 4 unique resources + deregister step.
+        Plan plan = getUninstallPlan(uninstallScheduler);
         List<Status> expected = Arrays.asList(
-                Status.PENDING, Status.PENDING, Status.PENDING, Status.PENDING, Status.PENDING,
-                Status.PENDING, Status.PENDING);
+                Status.PENDING, Status.PENDING, Status.PENDING, // 3 task kills
+                Status.PENDING, Status.PENDING, // 2 resources on UNKNOWN_AGENT (TASK_B)
+                Status.PENDING, Status.PENDING, Status.PENDING, Status.PENDING, // 4 deduped resources on host-1 (TASK_A + TASK_C)
+                Status.PENDING); // deregister step
         Assert.assertEquals(plan.toString(), expected, getStepStatuses(plan));
     }
 
     @Test
     public void testInitialPlanTaskError() throws Exception {
-        // Specify TASK_ERROR status for TASK_B. Its sole exclusive resource should then be omitted from the plan:
-        stateStore.storeTasks(Collections.singletonList(TASK_B));
-        stateStore.storeStatus(TASK_B.getName(), TASK_B_STATUS_ERROR);
+        // Specify TASK_ERROR status for TASK_B and TASK_C. Their exclusive resources should then be omitted from the plan:
+        stateStore.storeTasks(Arrays.asList(TASK_B, TASK_C));
+        stateStore.storeStatus(TASK_B.getName(), TaskTestUtils.generateStatus(TASK_B.getTaskId(), Protos.TaskState.TASK_ERROR));
+        stateStore.storeStatus(TASK_C.getName(), TaskTestUtils.generateStatus(TASK_C.getTaskId(), Protos.TaskState.TASK_ERROR));
 
         UninstallScheduler uninstallScheduler = getUninstallScheduler();
 
         // Invoke getClientStatus so that plan status is correctly processed before offers are passed:
         Assert.assertEquals(ClientStatusResponse.launching(true), uninstallScheduler.getClientStatus());
 
-        Plan plan = uninstallScheduler.getPlanCoordinator().getPlanManagers().stream().findFirst().get().getPlan();
-        // 2 task kills + 3 unique resources (from task A, not task B) + deregister step.
+        Plan plan = getUninstallPlan(uninstallScheduler);
         List<Status> expected = Arrays.asList(
-                Status.PENDING, Status.PENDING, Status.PENDING, Status.PENDING, Status.PENDING, Status.PENDING);
+                Status.PENDING, Status.PENDING, Status.PENDING, // 3 task kills
+                Status.PENDING, Status.PENDING, Status.PENDING, // 3 resources from task A. nothing from task B or C which are ERROR+permfail
+                Status.PENDING); // deregister step
         Assert.assertEquals(plan.toString(), expected, getStepStatuses(plan));
     }
 
@@ -142,17 +168,9 @@ public class UninstallSchedulerTest extends DefaultCapabilitiesTestSuite {
         Assert.assertEquals(ClientStatusResponse.launching(true), uninstallScheduler.getClientStatus());
         uninstallScheduler.offers(Collections.singletonList(getOffer()));
 
-        Plan plan = uninstallScheduler.getPlanCoordinator().getPlanManagers().stream().findFirst().get().getPlan();
-        // 1 task kill + 3 resources + deregister step.
-        List<Status> expected = Arrays.asList(Status.COMPLETE, Status.PENDING, Status.PENDING, Status.PENDING, Status.PENDING);
-        Assert.assertEquals(plan.toString(), expected, getStepStatuses(plan));
-
-        // Invoke getClientStatus so that plan status is correctly processed before offers are passed:
-        Assert.assertEquals(ClientStatusResponse.launching(true), uninstallScheduler.getClientStatus());
-        // Another offer cycle should get the resources pending
-        uninstallScheduler.offers(Collections.singletonList(getOffer()));
-        // 1 task kill + 3 resources + deregister step.
-        expected = Arrays.asList(Status.COMPLETE, Status.PREPARED, Status.PREPARED, Status.PREPARED, Status.PENDING);
+        Plan plan = getUninstallPlan(uninstallScheduler);
+        // 1 task kill + 3 resources + deregister step. The resource steps do not depend on the kill step so they are PREPARED right away.
+        List<Status> expected = Arrays.asList(Status.COMPLETE, Status.PREPARED, Status.PREPARED, Status.PREPARED, Status.PENDING);
         Assert.assertEquals(plan.toString(), expected, getStepStatuses(plan));
     }
 
@@ -171,13 +189,14 @@ public class UninstallSchedulerTest extends DefaultCapabilitiesTestSuite {
         Assert.assertEquals(1, response.offerResources.size());
         Assert.assertEquals(offer.getResourcesList(), response.offerResources.iterator().next().getResources());
 
-        // Check that _1 and _2 are now marked as complete:
-        Plan plan = uninstallScheduler.getPlanCoordinator().getPlanManagers().stream().findFirst().get().getPlan();
-        List<Status> expected = Arrays.asList(Status.COMPLETE, Status.COMPLETE, Status.COMPLETE, Status.PENDING, Status.PENDING);
+        // Check that _1 and _2 are now marked as complete, while _3 is still prepared:
+        Plan plan = getUninstallPlan(uninstallScheduler);
+        List<Status> expected = Arrays.asList(Status.COMPLETE, Status.COMPLETE, Status.COMPLETE, Status.PREPARED, Status.PENDING);
         Assert.assertEquals(plan.toString(), expected, getStepStatuses(plan));
 
-        // Invoke getClientStatus so that plan status is correctly processed before offers are passed:
-        Assert.assertEquals(ClientStatusResponse.launching(true), uninstallScheduler.getClientStatus());
+        // Invoke getClientStatus so that plan status is correctly processed before offers are passed.
+        // Shouldn't see any new work since all the uninstall steps were considered candidates up-front. 
+        Assert.assertEquals(ClientStatusResponse.launching(false), uninstallScheduler.getClientStatus());
         offer = OfferTestUtils.getOffer(Collections.singletonList(RESERVED_RESOURCE_3));
         uninstallScheduler.offers(Collections.singletonList(offer));
 
@@ -207,7 +226,7 @@ public class UninstallSchedulerTest extends DefaultCapabilitiesTestSuite {
         Assert.assertEquals(1, response.offerResources.size());
         Assert.assertEquals(offer.getResourcesList(), response.offerResources.iterator().next().getResources());
 
-        Plan plan = uninstallScheduler.getPlanCoordinator().getPlanManagers().stream().findFirst().get().getPlan();
+        Plan plan = getUninstallPlan(uninstallScheduler);
         List<Status> expected = Arrays.asList(Status.COMPLETE, Status.COMPLETE, Status.COMPLETE, Status.COMPLETE, Status.PENDING);
         Assert.assertEquals(plan.toString(), expected, getStepStatuses(plan));
 
@@ -241,7 +260,7 @@ public class UninstallSchedulerTest extends DefaultCapabilitiesTestSuite {
                 new TestTimeFetcher());
         uninstallScheduler.registered(false);
         // Starts with a near-empty plan with only the deregistered call incomplete
-        Plan plan = uninstallScheduler.getPlanCoordinator().getPlanManagers().stream().findFirst().get().getPlan();
+        Plan plan = getUninstallPlan(uninstallScheduler);
 
         List<Status> expected = Arrays.asList(Status.PENDING);
         Assert.assertEquals(plan.toString(), expected, getStepStatuses(plan));
@@ -275,11 +294,11 @@ public class UninstallSchedulerTest extends DefaultCapabilitiesTestSuite {
         when(serviceSpecWithTLSTasks.getPods()).thenReturn(Arrays.asList(mockPod));
 
         UninstallScheduler uninstallScheduler = getUninstallScheduler(serviceSpecWithTLSTasks, new TestTimeFetcher());
-        Plan plan = uninstallScheduler.getPlanCoordinator().getPlanManagers().stream().findFirst().get().getPlan();
+        Plan plan = getUninstallPlan(uninstallScheduler);
 
         when(mockSecretsClient.list(TestConstants.SERVICE_NAME)).thenReturn(Collections.emptyList());
 
-        // Run through the task cleanup phase
+        // Run through the task cleanup and TLS phases
         Assert.assertEquals(ClientStatusResponse.launching(true), uninstallScheduler.getClientStatus());
         Protos.Offer offer = OfferTestUtils.getOffer(Arrays.asList(
                 RESERVED_RESOURCE_1, RESERVED_RESOURCE_2, RESERVED_RESOURCE_3));
@@ -292,14 +311,8 @@ public class UninstallSchedulerTest extends DefaultCapabilitiesTestSuite {
         Assert.assertEquals(1, response.offerResources.size());
         Assert.assertEquals(offer.getResourcesList(), response.offerResources.iterator().next().getResources());
 
+        // The TLS phase should also have completed, as it doesn't depend on task kill/unreserve:
         List<Status> expected = Arrays.asList(
-                Status.COMPLETE, Status.COMPLETE, Status.COMPLETE, Status.COMPLETE, Status.PENDING, Status.PENDING);
-        Assert.assertEquals(plan.toString(), expected, getStepStatuses(plan));
-
-        // Then the TLS cleanup phase
-        Assert.assertEquals(ClientStatusResponse.launching(true), uninstallScheduler.getClientStatus());
-        uninstallScheduler.offers(Collections.singletonList(getOffer()));
-        expected = Arrays.asList(
                 Status.COMPLETE, Status.COMPLETE, Status.COMPLETE, Status.COMPLETE, Status.COMPLETE, Status.PENDING);
         Assert.assertEquals(plan.toString(), expected, getStepStatuses(plan));
 
@@ -335,12 +348,12 @@ public class UninstallSchedulerTest extends DefaultCapabilitiesTestSuite {
                 Optional.of(mockSecretsClient),
                 new TestTimeFetcher());
 
-        Plan plan = uninstallScheduler.getPlanCoordinator().getPlanManagers().stream().findFirst().get().getPlan();
+        Plan plan = getUninstallPlan(uninstallScheduler);
 
         // The standard order is kill-tasks, unreserve-resources, deregister-service. Verify the inverse
         // is now true.
         Assert.assertEquals("deregister-service", plan.getChildren().get(0).getName());
-        Assert.assertEquals("unreserve-resources", plan.getChildren().get(1).getName());
+        Assert.assertEquals("unreserve-resources-host-1", plan.getChildren().get(1).getName());
         Assert.assertEquals("kill-tasks", plan.getChildren().get(2).getName());
     }
 
@@ -391,6 +404,10 @@ public class UninstallSchedulerTest extends DefaultCapabilitiesTestSuite {
                 timeFetcher);
         uninstallScheduler.registered(false);
         return uninstallScheduler;
+    }
+
+    private static Plan getUninstallPlan(AbstractScheduler scheduler) {
+        return scheduler.getPlanCoordinator().getPlanManagers().stream().findFirst().get().getPlan();
     }
 
     private static ServiceSpec getServiceSpec() {


### PR DESCRIPTION
Each resource to be unreserve gets its own step. At the moment, we have a single flat phase for all resources in the cluster to be unreserved. With this PR, we will now group the resources by agent hostname. This provides two benefits to the operator:
- Makes it obvious when resources tied to a given agent are all stuck, since they should all be grouped within a given phase.
- Makes it easier to bypass all resources on a given stuck agent by specifying the (per-agent) phase name when invoking the CLI command.