### PR TITLE
[DCOS-29208] Add post_push hook to add additional docker tags

### DIFF
--- a/hooks/post_push
+++ b/hooks/post_push
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -x
+
+DATE_STAMP="$(date +%Y%m%d)"
+SOURCE_COMMIT=${SOURCE_COMMIT:-$(git rev-parse HEAD)}
+
+additional_tags=("${SOURCE_COMMIT}" "${DATE_STAMP}-${SOURCE_COMMIT}")
+
+for tag in ${additional_tags[@]}; do
+    target="${DOCKER_REPO}:${tag}"
+    docker tag ${IMAGE_NAME} ${target}
+    docker push ${target}
+done


### PR DESCRIPTION
This PR adds a docker hub post_push hook to add additional tags to the Docker image automatically built off the master branch.

The following tags are added:
- `{{SHA}}`
- `YYYYMMDD-{{SHA}}`

where `SHA` is the git SHA of `master` at the time of the build and `YYYYMMDD` is a date timestamp for the build.

*Note:* I tested the automatic build settings in my own [clone](https://github.com/elezar/dcos-commons) of the `dcos-commons` repo: https://hub.docker.com/r/elezar/dcos-commons/