### PR TITLE
[COPS-3222][DCOS-38688] Cassandra pod replace performs rolling update

### DIFF
--- a/frameworks/cassandra/tests/test_tls.py
+++ b/frameworks/cassandra/tests/test_tls.py
@@ -131,4 +131,4 @@ def test_tls_recovery(cassandra_service, service_account):
                                               cassandra_service["service"]["name"],
                                               pod,
                                               recovery_timeout_s=25 * 60,
-                                              pods_whos_tasks_should_change=pod_list)
+                                              pods_with_updated_tasks=pod_list)

--- a/frameworks/cassandra/tests/test_tls.py
+++ b/frameworks/cassandra/tests/test_tls.py
@@ -120,7 +120,6 @@ def test_tls_connection(cassandra_service, dcos_ca_bundle):
 
 @pytest.mark.tls
 @pytest.mark.sanity
-@pytest.mark.recovery
 def test_tls_recovery(cassandra_service, service_account):
     pod_list = sdk_cmd.svc_cli(cassandra_service["package_name"],
                                cassandra_service["service"]["name"],
@@ -131,4 +130,5 @@ def test_tls_recovery(cassandra_service, service_account):
         sdk_recovery.check_permanent_recovery(cassandra_service["package_name"],
                                               cassandra_service["service"]["name"],
                                               pod,
-                                              recovery_timeout_s=25 * 60)
+                                              recovery_timeout_s=25 * 60,
+                                              pods_whos_tasks_should_change=pod_list)

--- a/testing/sdk_recovery.py
+++ b/testing/sdk_recovery.py
@@ -14,7 +14,7 @@ def check_permanent_recovery(
     service_name: str,
     pod_name: str,
     recovery_timeout_s: int,
-    pods_whos_tasks_should_change: typing.List[str] = None,
+    pods_with_updated_tasks: typing.List[str] = None,
 ):
     """
     Perform a replace operation on a specified pod and check that it is replaced
@@ -28,7 +28,7 @@ def check_permanent_recovery(
 
     pod_list = set(sdk_cmd.svc_cli(package_name, service_name, "pod list", json=True))
 
-    pods_to_update = set(pods_whos_tasks_should_change + [pod_name, ])
+    pods_to_update = set(pods_with_updated_tasks + [pod_name])
 
     tasks_to_replace = {}
     for pod in pods_to_update:

--- a/testing/sdk_recovery.py
+++ b/testing/sdk_recovery.py
@@ -28,7 +28,9 @@ def check_permanent_recovery(
 
     pod_list = set(sdk_cmd.svc_cli(package_name, service_name, "pod list", json=True))
 
-    pods_to_update = set(pods_with_updated_tasks + [pod_name])
+    pods_to_update = set(
+        pods_with_updated_tasks if pods_with_updated_tasks else [] + [pod_name]
+    )
 
     tasks_to_replace = {}
     for pod in pods_to_update:

--- a/testing/sdk_recovery.py
+++ b/testing/sdk_recovery.py
@@ -17,9 +17,21 @@ def check_permanent_recovery(
     pods_with_updated_tasks: typing.List[str] = None,
 ):
     """
-    Perform a replace operation on a specified pod and check that it is replaced
+    Perform a replace (permanent recovery) operation on the specified pod.
 
-    All other pods are checked to see if they remain consistent.
+    The specified pod AND any additional pods in `pods_with_updated_tasks` are
+    checked to ensure that their tasks have been restarted.
+
+    Any remaining pods are checked to ensure that their tasks are not changed.
+
+    For example, performing a pod replace kafka-0 on a Kafka framework should
+    result in ONLY the kafa-0-broker task being restarted. In this case,
+    pods_with_updated_tasks is specified as None.
+
+    When performing a pod replace operation on a Cassandra seed node (node-0),
+    a rolling restart of other nodes is triggered, and
+    pods_with_updated_tasks = ["node-0", "node-1", "node-2"]
+    (assuming a three node Cassandra ring)
     """
     LOG.info("Testing pod replace operation for %s:%s", service_name, pod_name)
 


### PR DESCRIPTION
This is a follow up for #2556 which was not triggered as part of the PR fro Cassandra as that specific PR job has `-k "sanity and not recovery"` selector. It failed the nightlies since a permanent node recovery results in a rolling update of other node tasks.

This PR:
* Removes the `recovery` mark from the test (it could be re-added once it is confirmed that this fix addresses the issue)
* Adds support to the `check_permanent_recovery` for updating multiple pods.