### PR TITLE
[COPS-3222][DCOS-38688] Ensure Mounts for TLS secrets are not duplicate

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,425 @@
+[MASTER]
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code
+extension-pkg-whitelist=
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=CVS
+
+# Add files or directories matching the regex patterns to the blacklist. The
+# regex matches against base names, not paths.
+ignore-patterns=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+init-hook='import sys; sys.path.append("testing")'
+
+# Use multiple processes to speed up Pylint.
+jobs=1
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# Specify a configuration file.
+#rcfile=
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED
+confidence=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once).You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use"--disable=all --enable=classes
+# --disable=W"
+disable=print-statement,parameter-unpacking,unpacking-in-except,old-raise-syntax,backtick,long-suffix,old-ne-operator,old-octal-literal,import-star-module-level,raw-checker-failed,bad-inline-option,locally-disabled,locally-enabled,file-ignored,suppressed-message,useless-suppression,deprecated-pragma,apply-builtin,basestring-builtin,buffer-builtin,cmp-builtin,coerce-builtin,execfile-builtin,file-builtin,long-builtin,raw_input-builtin,reduce-builtin,standarderror-builtin,unicode-builtin,xrange-builtin,coerce-method,delslice-method,getslice-method,setslice-method,no-absolute-import,old-division,dict-iter-method,dict-view-method,next-method-called,metaclass-assignment,indexing-exception,raising-string,reload-builtin,oct-method,hex-method,nonzero-method,cmp-method,input-builtin,round-builtin,intern-builtin,unichr-builtin,map-builtin-not-iterating,zip-builtin-not-iterating,range-builtin-not-iterating,filter-builtin-not-iterating,using-cmp-argument,eq-without-hash,div-method,idiv-method,rdiv-method,exception-message-attribute,invalid-str-codec,sys-max-int,bad-python3-import,deprecated-string-function,deprecated-str-translate-call
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=
+
+
+[REPORTS]
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details
+#msg-template=
+
+# Set the output format. Available formats are text, parseable, colorized, json
+# and msvs (visual studio).You can also give a reporter class, eg
+# mypackage.mymodule.MyReporterClass.
+output-format=parseable
+
+# Tells whether to display a full report or only the messages
+reports=no
+
+# Activate the evaluation score.
+score=yes
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+
+[LOGGING]
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format
+logging-modules=logging
+
+
+[SPELLING]
+
+# Spelling dictionary name. Available dictionaries: none. To make it working
+# install python-enchant package.
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to indicated private dictionary in
+# --spelling-private-dict-file option instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,XXX,TODO
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis. It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=tests.config
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The minimum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid to define new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,_cb
+
+# A regular expression matching the name of dummy variables (i.e. expectedly
+# not used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,future.builtins
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging  or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
+max-line-length=100
+
+# Maximum number of lines in a module
+max-module-lines=1000
+
+# List of optional constructs for which whitespace checking is disabled. `dict-
+# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
+# `trailing-comma` allows a space between comma and closing bracket: (a, ).
+# `empty-line` allows space-only lines.
+no-space-check=trailing-comma,dict-separator
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[SIMILARITIES]
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+
+[BASIC]
+
+# Naming hint for argument names
+argument-name-hint=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
+
+# Regular expression matching correct argument names
+argument-rgx=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
+
+# Naming hint for attribute names
+attr-name-hint=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
+
+# Regular expression matching correct attribute names
+attr-rgx=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
+
+# Bad variable names which should always be refused, separated by a comma
+bad-names=foo,bar,baz,toto,tutu,tata
+
+# Naming hint for class attribute names
+class-attribute-name-hint=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
+
+# Regular expression matching correct class attribute names
+class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
+
+# Naming hint for class names
+class-name-hint=[A-Z_][a-zA-Z0-9]+$
+
+# Regular expression matching correct class names
+class-rgx=[A-Z_][a-zA-Z0-9]+$
+
+# Naming hint for constant names
+const-name-hint=(([A-Z_][A-Z0-9_]*)|(__.*__))$
+
+# Regular expression matching correct constant names
+const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming hint for function names
+function-name-hint=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
+
+# Regular expression matching correct function names
+function-rgx=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
+
+# Good variable names which should always be accepted, separated by a comma
+good-names=i,j,k,ex,Run,_
+
+# Include a hint for the correct naming format with invalid-name
+include-naming-hint=no
+
+# Naming hint for inline iteration names
+inlinevar-name-hint=[A-Za-z_][A-Za-z0-9_]*$
+
+# Regular expression matching correct inline iteration names
+inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
+
+# Naming hint for method names
+method-name-hint=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
+
+# Regular expression matching correct method names
+method-rgx=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
+
+# Naming hint for module names
+module-name-hint=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+
+# Regular expression matching correct module names
+module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+property-classes=abc.abstractproperty
+
+# Naming hint for variable names
+variable-name-hint=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
+
+# Regular expression matching correct variable names
+variable-rgx=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
+
+
+[IMPORTS]
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Deprecated modules which should not be used, separated by a comma
+deprecated-modules=optparse,tkinter.tix
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled)
+ext-import-graph=
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled)
+import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled)
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,__new__,setUp
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,_fields,_replace,_source,_make
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=mcs
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method
+max-args=5
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Maximum number of boolean expressions in a if statement
+max-bool-expr=5
+
+# Maximum number of branch for function / method body
+max-branches=12
+
+# Maximum number of locals for function / method body
+max-locals=15
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of return / yield for function / method body
+max-returns=6
+
+# Maximum number of statements in function / method body
+max-statements=50
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "Exception"
+overgeneral-exceptions=Exception

--- a/frameworks/cassandra/tests/test_tls.py
+++ b/frameworks/cassandra/tests/test_tls.py
@@ -2,17 +2,22 @@ import os
 import uuid
 
 import pytest
-import shakedown
 
 import sdk_cmd
 import sdk_install
 import sdk_jobs
 import sdk_plan
+import sdk_recovery
 import sdk_utils
 
 from security import transport_encryption
 
 from tests import config
+
+pytestmark = [pytest.mark.skipif(sdk_utils.is_open_dcos(),
+                                 reason="Feature only supported in DC/OS EE"),
+              pytest.mark.skipif(sdk_utils.dcos_version_less_than("1.10"),
+                                 reason="TLS tests require DC/OS 1.10+")]
 
 
 @pytest.fixture(scope='module')
@@ -20,10 +25,7 @@ def dcos_ca_bundle():
     """
     Retrieve DC/OS CA bundle and returns the content.
     """
-    resp = sdk_cmd.cluster_request('GET', '/ca/dcos-ca.crt')
-    cert = resp.content.decode('ascii')
-    assert cert is not None
-    return cert
+    return transport_encryption.fetch_dcos_ca_bundle_contents().decode("ascii")
 
 
 @pytest.fixture(scope='module')
@@ -42,41 +44,38 @@ def service_account(configure_security):
 
 
 @pytest.fixture(scope='module')
-def cassandra_service_tls(service_account):
-    sdk_install.uninstall(package_name=config.PACKAGE_NAME, service_name=config.SERVICE_NAME)
-    sdk_install.install(
-        config.PACKAGE_NAME,
-        config.SERVICE_NAME,
-        config.DEFAULT_TASK_COUNT,
-        additional_options={
-            "service": {
-                "service_account": service_account["name"],
-                "service_account_secret": service_account["secret"],
-                "security": {
-                    "transport_encryption": {
-                        "enabled": True
-                    }
+def cassandra_service(service_account):
+    service_options = {
+        "service": {
+            "name": config.SERVICE_NAME,
+            "service_account": service_account["name"],
+            "service_account_secret": service_account["secret"],
+            "security": {
+                "transport_encryption": {
+                    "enabled": True
                 }
             }
         }
-    )
+    }
 
-    sdk_plan.wait_for_completed_deployment(config.SERVICE_NAME)
+    sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
+    try:
+        sdk_install.install(
+            config.PACKAGE_NAME,
+            service_name=config.SERVICE_NAME,
+            expected_running_tasks=config.DEFAULT_TASK_COUNT,
+            additional_options=service_options,
+            timeout_seconds=30 * 60)
 
-    # Wait for service health check to pass
-    shakedown.service_healthy(config.SERVICE_NAME)
-
-    yield
-
-    sdk_install.uninstall(package_name=config.PACKAGE_NAME, service_name=config.SERVICE_NAME)
+        yield {**service_options, **{"package_name": config.PACKAGE_NAME}}
+    finally:
+        sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
 
 
 @pytest.mark.aws
 @pytest.mark.sanity
 @pytest.mark.tls
-@pytest.mark.dcos_min_version('1.10')
-@sdk_utils.dcos_ee_only
-def test_tls_connection(cassandra_service_tls, dcos_ca_bundle):
+def test_tls_connection(cassandra_service, dcos_ca_bundle):
     """
     Tests writing, reading and deleting data over a secure TLS connection.
     """
@@ -117,3 +116,19 @@ def test_tls_connection(cassandra_service_tls, dcos_ca_bundle):
 
         sdk_jobs.run_job(config.get_verify_data_job(dcos_ca_bundle=dcos_ca_bundle))
         sdk_jobs.run_job(config.get_delete_data_job(dcos_ca_bundle=dcos_ca_bundle))
+
+
+@pytest.mark.tls
+@pytest.mark.sanity
+@pytest.mark.recovery
+def test_tls_recovery(cassandra_service, service_account):
+    pod_list = sdk_cmd.svc_cli(cassandra_service["package_name"],
+                               cassandra_service["service"]["name"],
+                               "pod list",
+                               json=True)
+
+    for pod in pod_list:
+        sdk_recovery.check_permanent_recovery(cassandra_service["package_name"],
+                                              cassandra_service["service"]["name"],
+                                              pod,
+                                              recovery_timeout_s=25 * 60)

--- a/frameworks/cassandra/tests/test_tls.py
+++ b/frameworks/cassandra/tests/test_tls.py
@@ -120,7 +120,6 @@ def test_tls_connection(cassandra_service, dcos_ca_bundle):
 
 @pytest.mark.tls
 @pytest.mark.sanity
-@pytest.mark.recovery
 def test_tls_recovery(cassandra_service, service_account):
     pod_list = sdk_cmd.svc_cli(cassandra_service["package_name"],
                                cassandra_service["service"]["name"],
@@ -131,4 +130,5 @@ def test_tls_recovery(cassandra_service, service_account):
         sdk_recovery.check_permanent_recovery(cassandra_service["package_name"],
                                               cassandra_service["service"]["name"],
                                               pod,
-                                              recovery_timeout_s=25 * 60)
+                                              recovery_timeout_s=25 * 60,
+                                              pods_with_updated_tasks=pod_list)

--- a/frameworks/cassandra/tests/test_toggle_tls.py
+++ b/frameworks/cassandra/tests/test_toggle_tls.py
@@ -37,10 +37,7 @@ def dcos_ca_bundle():
     """
     Retrieve DC/OS CA bundle and returns the content.
     """
-    resp = sdk_cmd.cluster_request('GET', '/ca/dcos-ca.crt')
-    cert = resp.content.decode('ascii')
-    assert cert is not None
-    return cert
+    return transport_encryption.fetch_dcos_ca_bundle_contents().decode("ascii")
 
 
 @pytest.fixture(scope='module', autouse=True)

--- a/frameworks/elastic/tests/test_tls.py
+++ b/frameworks/elastic/tests/test_tls.py
@@ -1,9 +1,10 @@
 import pytest
 import shakedown
 
+import sdk_cmd
 import sdk_install
 import sdk_hosts
-import sdk_plan
+import sdk_recovery
 import sdk_utils
 
 from security import transport_encryption
@@ -32,35 +33,39 @@ def service_account(configure_security):
 
 
 @pytest.fixture(scope='module')
-def elastic_service_tls(service_account):
+def elastic_service(service_account):
+    service_options = {
+        "service": {
+            "name": config.SERVICE_NAME,
+            "service_account": service_account["name"],
+            "service_account_secret": service_account["secret"],
+            "security": {
+                "transport_encryption": {
+                    "enabled": True
+                }
+            }
+        },
+        "elasticsearch": {
+            "xpack_enabled": True,
+        }
+    }
+
+    sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
     try:
-        sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
         sdk_install.install(
             config.PACKAGE_NAME,
             service_name=config.SERVICE_NAME,
             expected_running_tasks=config.DEFAULT_TASK_COUNT,
-            additional_options={
-                "service": {
-                    "service_account": service_account["name"],
-                    "service_account_secret": service_account["secret"],
-                    "security": {
-                        "transport_encryption": {
-                            "enabled": True
-                        }
-                    }
-                },
-                "elasticsearch": {
-                    "xpack_enabled": True,
-                }
-            })
+            additional_options=service_options,
+            timeout_seconds=30 * 60)
 
-        yield
+        yield {**service_options, **{"package_name": config.PACKAGE_NAME}}
     finally:
         sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
 
 
 @pytest.fixture(scope='module')
-def kibana_application_tls(elastic_service_tls):
+def kibana_application(elastic_service):
     try:
         elasticsearch_url = "https://" + sdk_hosts.vip_host(config.SERVICE_NAME, "coordinator", 9200)
 
@@ -86,13 +91,13 @@ def kibana_application_tls(elastic_service_tls):
 
 @pytest.mark.tls
 @pytest.mark.smoke
-def test_healthy(elastic_service_tls):
+def test_healthy(elastic_service):
     assert shakedown.service_healthy(config.SERVICE_NAME)
 
 
 @pytest.mark.tls
 @pytest.mark.sanity
-def test_crud_over_tls(elastic_service_tls):
+def test_crud_over_tls(elastic_service):
     config.create_index(
         config.DEFAULT_INDEX_NAME,
         config.DEFAULT_SETTINGS_MAPPINGS,
@@ -119,5 +124,21 @@ def test_crud_over_tls(elastic_service_tls):
 @pytest.mark.sanity
 @pytest.mark.skipif(sdk_utils.dcos_version_at_least('1.12'),
                     reason='MESOS-9008: Mesos Fetcher fails to extract Kibana archive')
-def test_kibana_tls(kibana_application_tls):
+def test_kibana_tls(kibana_application):
     config.check_kibana_adminrouter_integration("service/{}/login".format(config.KIBANA_SERVICE_NAME))
+
+
+@pytest.mark.tls
+@pytest.mark.sanity
+@pytest.mark.recovery
+def test_tls_recovery(elastic_service, service_account):
+    pod_list = sdk_cmd.svc_cli(elastic_service["package_name"],
+                               elastic_service["service"]["name"],
+                               "pod list",
+                               json=True)
+
+    for pod in pod_list:
+        sdk_recovery.check_permanent_recovery(elastic_service["package_name"],
+                                              elastic_service["service"]["name"],
+                                              pod,
+                                              recovery_timeout_s=25 * 60)

--- a/frameworks/hdfs/tests/test_sanity.py
+++ b/frameworks/hdfs/tests/test_sanity.py
@@ -384,8 +384,7 @@ def test_permanently_replace_namenodes():
         sdk_recovery.check_permanent_recovery(config.PACKAGE_NAME,
                                               foldered_name,
                                               pod,
-                                              recovery_timeout_s=25 * 60
-                                              )
+                                              recovery_timeout_s=25 * 60)
 
 
 @pytest.mark.sanity
@@ -398,5 +397,4 @@ def test_permanently_replace_journalnodes():
         sdk_recovery.check_permanent_recovery(config.PACKAGE_NAME,
                                               foldered_name,
                                               pod,
-                                              recovery_timeout_s=25 * 60
-                                              )
+                                              recovery_timeout_s=25 * 60)

--- a/frameworks/helloworld/tests/test_tls.py
+++ b/frameworks/helloworld/tests/test_tls.py
@@ -15,6 +15,8 @@ from cryptography.hazmat.backends import default_backend
 from cryptography.x509.oid import ExtensionOID, NameOID
 from tests import config
 
+from security import transport_encryption
+
 DEFAULT_BACKEND = default_backend()
 
 # Names of VIP aliases defined in examples/tls.yml
@@ -35,6 +37,7 @@ KEYSTORE_APP_CONFIG_NAME = 'integration-test.yml'
 DISCOVERY_TASK_PREFIX = 'discovery-prefix'
 
 log = logging.getLogger(__name__)
+
 
 @pytest.fixture(scope='module', autouse=True)
 def configure_package(configure_security):
@@ -145,7 +148,7 @@ def test_tls_basic_artifacts():
     assert len(sans) == 1
 
     cluster_root_ca_cert = x509.load_pem_x509_certificate(
-        sdk_cmd.cluster_request('GET', '/ca/dcos-ca.crt').content,
+        transport_encryption.fetch_dcos_ca_bundle_contents(),
         DEFAULT_BACKEND)
 
     assert root_ca_cert_in_truststore.signature == cluster_root_ca_cert.signature
@@ -165,12 +168,14 @@ def test_java_keystore():
 
     # Make a curl request from artifacts container to `keystore-app`
     # and make sure that mesos curl can verify certificate served by app
-    curl = (
-        'curl -v -i '
-        '--cacert secure-tls-pod.ca '
-        'https://' + sdk_hosts.vip_host(
-            config.SERVICE_NAME, KEYSTORE_TASK_HTTPS_PORT_NAME) + '/hello-world'
-        )
+    cmd_list = [
+        "curl", "-v", "-i",
+        "--cacert", "secure-tls-pod.ca",
+        "https://{}/hello-world".format(
+            sdk_hosts.vip_host(config.SERVICE_NAME, KEYSTORE_TASK_HTTPS_PORT_NAME)
+        ),
+    ]
+    curl = " ".join(cmd_list)
 
     _, output = sdk_cmd.task_exec(task_id, curl, return_stderr_in_stdout=True)
     # Check that HTTP request was successful with response 200 and make sure
@@ -247,7 +252,7 @@ def test_changing_discovery_replaces_certificate_sans():
         '{name}-0.{service_name}.autoip.dcos.thisdcos.directory'.format(
             name=DISCOVERY_TASK_PREFIX,
             service_name=config.SERVICE_NAME)
-        )
+    )
     assert expected_san in sans
 
     # Run task update with new discovery prefix
@@ -274,7 +279,7 @@ def test_changing_discovery_replaces_certificate_sans():
         '{name}-0.{service_name}.autoip.dcos.thisdcos.directory'.format(
             name=DISCOVERY_TASK_PREFIX + '-new',
             service_name=config.SERVICE_NAME)
-        )
+    )
     assert expected_san in sans
 
 

--- a/frameworks/kafka/tests/config.py
+++ b/frameworks/kafka/tests/config.py
@@ -10,6 +10,7 @@ ZOOKEEPER_SERVICE_NAME = "kafka-zookeeper"
 ZOOKEEPER_TASK_COUNT = 6
 
 DEFAULT_BROKER_COUNT = 3
+DEFAULT_TASK_COUNT = DEFAULT_BROKER_COUNT
 DEFAULT_PARTITION_COUNT = 1
 DEFAULT_REPLICATION_FACTOR = 1
 DEFAULT_PLAN_NAME = "deploy"
@@ -28,7 +29,7 @@ def install(
         expected_running_tasks,
         additional_options={},
         package_version=None,
-        timeout_seconds=25*60,
+        timeout_seconds=25 * 60,
         wait_for_deployment=True):
 
     test_options = {

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluator.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluator.java
@@ -326,6 +326,16 @@ public class OfferEvaluator {
             evaluationStages.add(VolumeEvaluationStage.getNew(volumeSpec, null, useDefaultExecutor));
         }
 
+        // TLS evaluation stages should be added for all tasks regardless of the tasks to launch list to ensure
+        // ExecutorInfo equality when launching new tasks
+        if (tlsStageBuilder.isPresent()) {
+            for (TaskSpec taskSpec : podInstanceRequirement.getPodInstance().getPod().getTasks()) {
+                if (!taskSpec.getTransportEncryption().isEmpty()) {
+                    evaluationStages.add(tlsStageBuilder.get().build(taskSpec.getName()));
+                }
+            }
+        }
+
         String preReservedRole = null;
         String role = null;
         String principal = null;
@@ -363,13 +373,6 @@ public class OfferEvaluator {
                 shouldAddExecutorResources = false;
             }
 
-            // TLS evaluation stages should be added for all tasks regardless of the tasks to launch list to ensure
-            // ExecutorInfo equality when launching new tasks
-            for (TaskSpec taskSpec : podInstanceRequirement.getPodInstance().getPod().getTasks()) {
-                if (!taskSpec.getTransportEncryption().isEmpty()) {
-                    evaluationStages.add(tlsStageBuilder.get().build(taskSpec.getName()));
-                }
-            }
 
             boolean shouldBeLaunched = podInstanceRequirement.getTasksToLaunch().contains(taskName);
             evaluationStages.add(new LaunchEvaluationStage(taskName, shouldBeLaunched, useDefaultExecutor));
@@ -429,9 +432,11 @@ public class OfferEvaluator {
 
         // TLS evaluation stages should be added for all tasks regardless of the tasks to launch list to ensure
         // ExecutorInfo equality when launching new tasks
-        for (TaskSpec taskSpec : podInstanceRequirement.getPodInstance().getPod().getTasks()) {
-            if (!taskSpec.getTransportEncryption().isEmpty()) {
-                evaluationStages.add(tlsStageBuilder.get().build(taskSpec.getName()));
+        if (tlsStageBuilder.isPresent()) {
+            for (TaskSpec taskSpec : podInstanceRequirement.getPodInstance().getPod().getTasks()) {
+                if (!taskSpec.getTransportEncryption().isEmpty()) {
+                    evaluationStages.add(tlsStageBuilder.get().build(taskSpec.getName()));
+                }
             }
         }
 

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluatorTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluatorTest.java
@@ -918,7 +918,10 @@ public class OfferEvaluatorTest extends OfferEvaluatorTestBase {
             );
         }
 
-        PodSpec podSpec = DefaultPodSpec.newBuilder(type, 1, taskSpecs)
+        PodSpec podSpec = DefaultPodSpec.newBuilder("executor-uri")
+                .type(type)
+                .count(1)
+                .tasks(taskSpecs)
                 .preReservedRole(Constants.ANY_ROLE)
                 .build();
 

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluatorTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluatorTest.java
@@ -10,10 +10,8 @@ import com.mesosphere.sdk.scheduler.recovery.FailureUtils;
 import com.mesosphere.sdk.scheduler.recovery.RecoveryType;
 import com.mesosphere.sdk.specification.*;
 import com.mesosphere.sdk.state.PersistentLaunchRecorder;
-import com.mesosphere.sdk.testutils.OfferTestUtils;
-import com.mesosphere.sdk.testutils.ResourceTestUtils;
-import com.mesosphere.sdk.testutils.TaskTestUtils;
-import com.mesosphere.sdk.testutils.TestConstants;
+import com.mesosphere.sdk.testutils.*;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.mesos.Protos;
 import org.apache.mesos.Protos.*;
 import org.apache.mesos.Protos.Offer.Operation;
@@ -22,6 +20,7 @@ import org.junit.Test;
 import org.mockito.Mock;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -868,6 +867,70 @@ public class OfferEvaluatorTest extends OfferEvaluatorTestBase {
         OfferEvaluator.logOutcome(builder, parent, "");
         String log = builder.toString();
         Assert.assertEquals("  PASS(OfferEvaluatorTest): PARENT\n    PASS(OfferEvaluatorTest): CHILD\n", log);
+    }
+
+    @Test
+    public void testEvaluationPipelineGeneratesSingleTLSEvaluationPerTask() throws IOException {
+        Pair<PodInstanceRequirement, List<String>> podInfo = getRequirementWithTransportEncryption(
+                PodInstanceRequirementTestUtils.getCpuResourceSet(1.0),
+                TestConstants.POD_TYPE,
+                0,
+                2);
+
+        List<OfferEvaluationStage> evaluators = evaluator.getEvaluationPipeline(podInfo.getLeft(),
+                                        new ArrayList<>(),
+                                        new HashMap<>());
+
+        List<String> tlsEvaluationTasks = evaluators.stream()
+                .filter(e -> e instanceof TLSEvaluationStage)
+                .map(e -> ((TLSEvaluationStage) e))
+                .map(t -> t.getTaskName())
+                .sorted()
+                .collect(Collectors.toList());
+
+        Assert.assertEquals(podInfo.getRight(), tlsEvaluationTasks);
+
+    }
+
+    private static Pair<PodInstanceRequirement, List<String>> getRequirementWithTransportEncryption(
+            ResourceSet resourceSet, String type, int index, int numberOfTasks) {
+
+        ArrayList<TransportEncryptionSpec> transportEncryptionSpecs = new ArrayList<>();
+        transportEncryptionSpecs.add(new DefaultTransportEncryptionSpec
+                .Builder()
+                .name("test-tls")
+                .type(TransportEncryptionSpec.Type.TLS)
+                .build());
+
+        List<TaskSpec> taskSpecs = new ArrayList<>();
+        for (int i = 0; i < numberOfTasks; ++i) {
+            taskSpecs.add(
+                    DefaultTaskSpec.newBuilder()
+                            .name(String.format("%s%d", TestConstants.TASK_NAME, i))
+                            .commandSpec(
+                                    DefaultCommandSpec.newBuilder(Collections.emptyMap())
+                                            .value(TestConstants.TASK_CMD)
+                                            .build())
+                            .goalState(GoalState.RUNNING)
+                            .resourceSet(resourceSet)
+                            .setTransportEncryption(transportEncryptionSpecs)
+                            .build()
+            );
+        }
+
+        PodSpec podSpec = DefaultPodSpec.newBuilder(type, 1, taskSpecs)
+                .preReservedRole(Constants.ANY_ROLE)
+                .build();
+
+        PodInstance podInstance = new DefaultPodInstance(podSpec, index);
+        List<String> taskNames = podInstance.getPod().getTasks().stream()
+                .map(ts -> ts.getName())
+                .sorted()
+                .collect(Collectors.toList());
+        return Pair.of(
+                PodInstanceRequirement.newBuilder(podInstance, taskNames).build(),
+                taskNames
+        );
     }
 
     private void recordOperations(List<OfferRecommendation> recommendations) throws Exception {

--- a/testing/sdk_recovery.py
+++ b/testing/sdk_recovery.py
@@ -1,4 +1,5 @@
 import logging
+import typing
 
 import sdk_cmd
 import sdk_plan
@@ -13,26 +14,44 @@ def check_permanent_recovery(
     service_name: str,
     pod_name: str,
     recovery_timeout_s: int,
+    pods_with_updated_tasks: typing.List[str] = None,
 ):
     """
-    Perform a replace operation on a specified pod and check that it is replaced
+    Perform a replace (permanent recovery) operation on the specified pod.
 
-    All other pods are checked to see if they remain consistent.
+    The specified pod AND any additional pods in `pods_with_updated_tasks` are
+    checked to ensure that their tasks have been restarted.
+
+    Any remaining pods are checked to ensure that their tasks are not changed.
+
+    For example, performing a pod replace kafka-0 on a Kafka framework should
+    result in ONLY the kafa-0-broker task being restarted. In this case,
+    pods_with_updated_tasks is specified as None.
+
+    When performing a pod replace operation on a Cassandra seed node (node-0),
+    a rolling restart of other nodes is triggered, and
+    pods_with_updated_tasks = ["node-0", "node-1", "node-2"]
+    (assuming a three node Cassandra ring)
     """
     LOG.info("Testing pod replace operation for %s:%s", service_name, pod_name)
 
     sdk_plan.wait_for_completed_deployment(service_name)
     sdk_plan.wait_for_completed_recovery(service_name)
 
-    pod_list = sdk_cmd.svc_cli(package_name, service_name, "pod list", json=True)
+    pod_list = set(sdk_cmd.svc_cli(package_name, service_name, "pod list", json=True))
 
-    tasks_to_replace = set(sdk_tasks.get_task_ids(service_name, pod_name))
+    pods_to_update = set(
+        pods_with_updated_tasks if pods_with_updated_tasks else [] + [pod_name]
+    )
+
+    tasks_to_replace = {}
+    for pod in pods_to_update:
+        tasks_to_replace[pod] = set(sdk_tasks.get_task_ids(service_name, pod_name))
+
     LOG.info("The following tasks will be replaced: %s", tasks_to_replace)
 
     tasks_in_other_pods = {}
-    for pod in pod_list:
-        if pod == pod_name:
-            continue
+    for pod in pod_list - pods_to_update:
         tasks_in_other_pods[pod] = set(sdk_tasks.get_task_ids(service_name, pod))
 
     LOG.info("Tasks in other pods should not be replaced: %s", tasks_in_other_pods)
@@ -43,7 +62,8 @@ def check_permanent_recovery(
     sdk_plan.wait_for_kicked_off_recovery(service_name, recovery_timeout_s)
     sdk_plan.wait_for_completed_recovery(service_name, recovery_timeout_s)
 
-    sdk_tasks.check_tasks_updated(service_name, pod_name, tasks_to_replace)
+    for pod, tasks in tasks_to_replace.items():
+        sdk_tasks.check_tasks_updated(service_name, pod, tasks)
 
     for pod, tasks in tasks_in_other_pods.items():
         sdk_tasks.check_tasks_not_updated(service_name, pod, tasks)

--- a/testing/sdk_recovery.py
+++ b/testing/sdk_recovery.py
@@ -1,0 +1,49 @@
+import logging
+
+import sdk_cmd
+import sdk_plan
+import sdk_tasks
+
+
+LOG = logging.getLogger(__name__)
+
+
+def check_permanent_recovery(
+    package_name: str,
+    service_name: str,
+    pod_name: str,
+    recovery_timeout_s: int,
+):
+    """
+    Perform a replace operation on a specified pod and check that it is replaced
+
+    All other pods are checked to see if they remain consistent.
+    """
+    LOG.info("Testing pod replace operation for %s:%s", service_name, pod_name)
+
+    sdk_plan.wait_for_completed_deployment(service_name)
+    sdk_plan.wait_for_completed_recovery(service_name)
+
+    pod_list = sdk_cmd.svc_cli(package_name, service_name, "pod list", json=True)
+
+    tasks_to_replace = set(sdk_tasks.get_task_ids(service_name, pod_name))
+    LOG.info("The following tasks will be replaced: %s", tasks_to_replace)
+
+    tasks_in_other_pods = {}
+    for pod in pod_list:
+        if pod == pod_name:
+            continue
+        tasks_in_other_pods[pod] = set(sdk_tasks.get_task_ids(service_name, pod))
+
+    LOG.info("Tasks in other pods should not be replaced: %s", tasks_in_other_pods)
+
+    replace_cmd = ["pod", "replace", pod_name]
+    sdk_cmd.svc_cli(package_name, service_name, " ".join(replace_cmd), json=True)
+
+    sdk_plan.wait_for_kicked_off_recovery(service_name, recovery_timeout_s)
+    sdk_plan.wait_for_completed_recovery(service_name, recovery_timeout_s)
+
+    sdk_tasks.check_tasks_updated(service_name, pod_name, tasks_to_replace)
+
+    for pod, tasks in tasks_in_other_pods.items():
+        sdk_tasks.check_tasks_not_updated(service_name, pod, tasks)

--- a/testing/security/transport_encryption.py
+++ b/testing/security/transport_encryption.py
@@ -35,11 +35,11 @@ def setup_service_account(service_name: str,
         sdk_cmd.run_cli("security org groups add_user superusers {name}".format(name=name))
     else:
         acls = [
-                {"rid": "dcos:secrets:default:/{}/*".format(service_name), "action": "full"},
-                {"rid": "dcos:secrets:list:default:/{}".format(service_name), "action": "read"},
-                {"rid": "dcos:adminrouter:ops:ca:rw", "action": "full"},
-                {"rid": "dcos:adminrouter:ops:ca:ro", "action": "full"},
-                ]
+            {"rid": "dcos:secrets:default:/{}/*".format(service_name.strip("/")), "action": "full"},
+            {"rid": "dcos:secrets:list:default:/{}".format(service_name.strip("/")), "action": "read"},
+            {"rid": "dcos:adminrouter:ops:ca:rw", "action": "full"},
+            {"rid": "dcos:adminrouter:ops:ca:ro", "action": "full"},
+        ]
 
         for acl in acls:
             cmd_list = ["security", "org", "users", "grant",
@@ -81,6 +81,16 @@ def fetch_dcos_ca_bundle(task: str) -> str:
     sdk_cmd.task_exec(task, " ".join(cmd))
 
     return local_bundle_file
+
+
+def fetch_dcos_ca_bundle_contents() -> str:
+    resp = sdk_cmd.cluster_request("GET", "/ca/dcos-ca.crt")
+    cert = resp.content
+    if not cert:
+        log.error("Error fetching DC/OS CA bundle")
+        raise Exception("Errot fetching DC/OS CA bundle")
+
+    return cert
 
 
 def create_tls_artifacts(cn: str, task: str) -> str:


### PR DESCRIPTION
This PR is a backport of #2556 and #2576.

This PR addresses an issue where we request multiple mounts of the same secret on TLS enabled data services. This currently only affects HDFS, but could be an issue for any service running multiple tasks with TLS per pod.

The changes included are:
* Modify `TLSEvaluationStage` to not add duplicate volumes to the `PodInfoBuilder`
* Modify `OfferEvaluator` to not add duplicate `TLSEvaluationStages` to the offer evaluation pipeline
* Add `pod replace` integration tests for HDFS, Kafka, Elastic, and Cassandra

(The tests were added first to confirm that this was only affecting HDFS -- after which the fix was implemented).

*Note*: I had originally tried to also run this through a `ServiceTestRunner`, but found that the TLS-handling (especially the Secrets Client) is a bit tightly coupled and I did not want to refactor this further.

## Release Notes
### Bugfix
* Fix an error with duplicate mount operations on TLS-enabled HDFS