### PR TITLE
[DCOS-38379][TESTS] Remove all multiservice dynamic tests from smoke

### DIFF
--- a/frameworks/helloworld/tests/test_multiservice_dynamic.py
+++ b/frameworks/helloworld/tests/test_multiservice_dynamic.py
@@ -49,7 +49,7 @@ def check_scheduler_relaunched(service_name: str, old_scheduler_task_id: str,
     """
     @retrying.retry(
         wait_fixed=1000,
-        stop_max_delay=timeout_seconds*1000,
+        stop_max_delay=timeout_seconds * 1000,
         retry_on_result=lambda res: not res)
     def fn():
         try:
@@ -111,7 +111,6 @@ def test_add_deploy_restart_remove():
 
 
 @pytest.mark.sanity
-@pytest.mark.smoke
 def test_add_multiple_uninstall():
     # add two services:
     svc1 = 'test1'
@@ -172,7 +171,7 @@ def get_service_list():
 
 @retrying.retry(
     wait_fixed=1000,
-    stop_max_delay=5*60*1000)
+    stop_max_delay=5 * 60 * 1000)
 def wait_for_service_count(count):
     services = get_service_list()
     log.info('Waiting for scheduler to have {} services, got {}: {}'.format(


### PR DESCRIPTION
This PR removes an additional `test_multiservice_dynamic` test from the set of smoke tests. The original was removed in a68699864f5e6da65f325993ba5098d8a1e1e05d.