### PR TITLE
[TOOLS] Fix release with multiple "upgradeFrom"s.

### DIFF
--- a/tools/release_builder.py
+++ b/tools/release_builder.py
@@ -416,7 +416,7 @@ Upgrades from:   {}
         pkgdir = self._unpack_stub_universe(stub_universe_json, scratchdir)
         try:
             return publisher.publish(scratchdir, pkgdir)
-        except:
+        except Exception:
             log.error(
                 'Failed to create PR. '
                 'Note that any release artifacts were already uploaded to {}, '

--- a/tools/release_builder.py
+++ b/tools/release_builder.py
@@ -112,7 +112,7 @@ class UniverseReleaseBuilder(object):
             http_release_server, release_dir_path, self._pkg_version)
 
         self._release_docker_image = release_docker_image or None
-        self._upgrades_from = upgrades_from
+        self._upgrades_from = list(map(str.strip, upgrades_from.split(',')))
 
         log.info('''###
 Source URL:      {}
@@ -211,8 +211,8 @@ Upgrades from:   {}
         package_json['version'] = self._pkg_version
 
         if self._upgrades_from is not None:
-            package_json['upgradesFrom'] = [self._upgrades_from]
-            package_json['downgradesTo'] = [self._upgrades_from]
+            package_json['upgradesFrom'] = [*self._upgrades_from]
+            package_json['downgradesTo'] = [*self._upgrades_from]
         elif self._stub_universe_pkg_name != self._pkg_name and \
             (package_json.get('upgradesFrom', ['*']) != ['*'] or
              package_json.get('downgradesTo', ['*']) != ['*']):


### PR DESCRIPTION
Split value coming from ENV var by comma and strip whitespace.

Without this change there doesn't seem to be a way to specify multiple versions in "upgradeFrom".

Example with multiple versions:
```
$ export UPGRADES_FROM='2.0.3-3.0.14, 2.1.0-3.0.16'
$ AWS_ACCESS_KEY_ID=<...> AWS_SECRET_ACCESS_KEY=<...> DRY_RUN=true FORCE_ARTIFACT_UPLOAD=true ./tools/release_builder.py move 2.3.0-3.0.16-rc3 <...>
Read PACKAGE_NAME=
Getting package name from stub universe URL
Got package name %s from stub universe URL
Using non-beta package name cassandra
Uploading assets for cassandra to cassandra/assets
aws-cli/1.11.179 Python/2.7.10 Darwin/17.6.0 botocore/1.7.37
###
Source URL:      https://infinity-artifacts.s3.amazonaws.com/autodelete7d/cassandra/20180711-105725-7AFU7b6yktt4sIgP/stub-universe-cassandra.json
Package name:    cassandra
Package version: 2.3.0-3.0.16-rc3
Artifact output: https://downloads.mesosphere.com/cassandra/assets/2.3.0-3.0.16-rc3
Upgrades from:   ['2.0.3-3.0.14', '2.1.0-3.0.16']
###
Updated package.json:
---
+++
@@ -1,14 +1,16 @@
 {
   "packagingVersion": "4.0",
   "upgradesFrom": [
-    "2.2.0-3.0.16"
+    "2.0.3-3.0.14",
+    "2.1.0-3.0.16"
   ],
   "downgradesTo": [
-    "2.2.0-3.0.16"
+    "2.0.3-3.0.14",
+    "2.1.0-3.0.16"
   ],
<...>
```

You can see that it still works for single values:
```
$ export UPGRADES_FROM=2.0.3-3.0.14
$ AWS_ACCESS_KEY_ID=<...> AWS_SECRET_ACCESS_KEY=<...> DRY_RUN=true FORCE_ARTIFACT_UPLOAD=true ./tools/release_builder.py move 2.3.0-3.0.16-rc3 <...>
Read PACKAGE_NAME=
Getting package name from stub universe URL
Got package name %s from stub universe URL
Using non-beta package name cassandra
Uploading assets for cassandra to cassandra/assets
aws-cli/1.11.179 Python/2.7.10 Darwin/17.6.0 botocore/1.7.37
###
Source URL:      https://infinity-artifacts.s3.amazonaws.com/autodelete7d/cassandra/20180711-105725-7AFU7b6yktt4sIgP/stub-universe-cassandra.json
Package name:    cassandra
Package version: 2.3.0-3.0.16-rc3
Artifact output: https://downloads.mesosphere.com/cassandra/assets/2.3.0-3.0.16-rc3
Upgrades from:   ['2.0.3-3.0.14']
###
Updated package.json:
---
+++
@@ -1,14 +1,14 @@
 {
   "packagingVersion": "4.0",
   "upgradesFrom": [
-    "2.2.0-3.0.16"
+    "2.0.3-3.0.14"
   ],
   "downgradesTo": [
-    "2.2.0-3.0.16"
+    "2.0.3-3.0.14"
   ],
<...>
```