### PR TITLE
[TOOLS] Default upgrades_from to an empty string.

### DIFF
--- a/tools/release_builder.py
+++ b/tools/release_builder.py
@@ -85,7 +85,7 @@ class UniverseReleaseBuilder(object):
             release_docker_image=os.environ.get('RELEASE_DOCKER_IMAGE'),
             release_dir_path=os.environ.get('RELEASE_DIR_PATH', ''),
             beta_release=os.environ.get('BETA', 'False'),
-            upgrades_from=os.environ.get('UPGRADES_FROM')):
+            upgrades_from=os.environ.get('UPGRADES_FROM', '')):
         self._dry_run = os.environ.get('DRY_RUN', '')
         self._force_upload = os.environ.get('FORCE_ARTIFACT_UPLOAD', '').lower() == 'true'
         self._beta_release = beta_release.lower() == 'true'


### PR DESCRIPTION
When this script is run from `make-stub-permanent` the ENV variable is an empty string. When it's run from `release-framework-to-universe` the ENV variable isn't set, so `os.environ.get('UPGRADES_FROM')` returns `None`.