### PR TITLE
[DCOS-38379] fixing flaky multi service test

### DIFF
--- a/frameworks/helloworld/tests/test_multiservice_dynamic.py
+++ b/frameworks/helloworld/tests/test_multiservice_dynamic.py
@@ -53,7 +53,7 @@ def check_scheduler_relaunched(service_name: str, old_scheduler_task_id: str,
         retry_on_result=lambda res: not res)
     def fn():
         try:
-            task_ids = set([t['id'] for t in shakedown.get_tasks(completed=True) if t['name'].startswith(service_name)])
+            task_ids = set([t['id'] for t in shakedown.get_tasks(completed=False) if t['name'] == service_name])
             log.info('found the following task ids {}'.format(task_ids))
         except dcos.errors.DCOSHTTPException:
             log.info('Failed to get task ids. service_name=%s', service_name)


### PR DESCRIPTION
task name will be the same, it is the id that will be different. Also the old task id will always show up if we query for completed tasks. 