### PR TITLE
[TOOLS] Add -e and --envfile flags to test.sh to pass environment

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -58,6 +58,7 @@ headless="false"
 interactive="false"
 package_registry="false"
 docker_command=${DOCKER_COMMAND:="bash /build-tools/test_runner.sh $WORK_DIR"}
+docker_image=${DOCKER_IMAGE:-"mesosphere/dcos-commons:latest"}
 env_passthrough=
 envfile_input=
 
@@ -368,7 +369,7 @@ ${docker_interactive_arg} \
 --env-file $envfile \
 ${volume_args} \
 -w $WORK_DIR \
-mesosphere/dcos-commons:latest \
+${docker_image} \
 ${docker_command}"
 
 echo "==="

--- a/test.sh
+++ b/test.sh
@@ -351,10 +351,10 @@ while read line; do
 done < <(env)
 
 if [ -n "$env_passthrough" ]; then
-    # If the -e flag is specified, the ENVVAR=$ENVVAR lines for the
+    # If the -e flag is specified, add the ENVVAR lines for the
     # comma-separated list of envvars
     for envvar_name in ${env_passthrough//,/ }; do
-        echo "$envvar_name=$(printenv $envvar_name)" >> $envfile
+        echo "$envvar_name" >> $envfile
     done
 fi
 


### PR DESCRIPTION
This PR adds two options to test.sh for better integration into other tooling (such as that used by EdgeLB). This was after a discussion with @vespian today.

The options are:
- `-e ENV_PASSTHROUGH`
- `--envfile ENV_FILE`

Where `ENV_PASSTHROUGH` is a comma-separated list of environment variables and `ENV_FILE` is a path to a local environment file.

In both cases, these options are passed through *in addition* to those already handled by the script. The mechanism for passing the environment to `docker run` command remains a temporary environment file.

Additional improvements:
* A timestamp has also been added to the names of the temporary envfile and credentials file created by the script to allow multiple containers to be run simultaneously.
* Don't require a framework to be specified if `--interactive` mode is selected.
* Allow the docker image to be specified using the `DOCKER_IMAGE` environment variable.