### PR TITLE
[DCOS-38688] Add custom rack upgrade test

### DIFF
--- a/frameworks/cassandra/tests/test_racks.py
+++ b/frameworks/cassandra/tests/test_racks.py
@@ -50,10 +50,11 @@ def test_rack():
 
 @pytest.mark.sanity
 def test_custom_rack_upgrade():
-    service_options = {"service": {"rack": "not-rack1"}}
+    foldered_service_name = config.get_foldered_service_name()
+    service_options = {"service": {"name": foldered_service_name, "rack": "not-rack1"}}
     sdk_upgrade.test_upgrade(
         config.PACKAGE_NAME,
-        config.get_foldered_service_name(),
+        foldered_service_name,
         config.DEFAULT_TASK_COUNT,
         additional_options=service_options,
     )

--- a/frameworks/cassandra/tests/test_racks.py
+++ b/frameworks/cassandra/tests/test_racks.py
@@ -1,6 +1,7 @@
 import logging
 import pytest
 import sdk_install
+import sdk_upgrade
 import sdk_utils
 
 from tests import config
@@ -9,7 +10,7 @@ from tests import nodetool
 log = logging.getLogger(__name__)
 
 
-@pytest.fixture(scope='module', autouse=True)
+@pytest.fixture(scope="module", autouse=True)
 def configure_package(configure_security):
     try:
         sdk_install.uninstall(config.PACKAGE_NAME, config.get_foldered_service_name())
@@ -19,7 +20,7 @@ def configure_package(configure_security):
         sdk_install.uninstall(config.PACKAGE_NAME, config.get_foldered_service_name())
 
 
-@pytest.mark.dcos_min_version('1.11')
+@pytest.mark.dcos_min_version("1.11")
 @sdk_utils.dcos_ee_only
 @pytest.mark.sanity
 def test_rack():
@@ -28,15 +29,14 @@ def test_rack():
         config.get_foldered_service_name(),
         3,
         additional_options={
-            "service": {
-                "name": config.get_foldered_service_name()
-            },
-            "nodes": {
-                "placement_constraint": "[[\"@zone\", \"GROUP_BY\", \"1\"]]"
-            }
-        })
+            "service": {"name": config.get_foldered_service_name()},
+            "nodes": {"placement_constraint": '[["@zone", "GROUP_BY", "1"]]'},
+        },
+    )
 
-    raw_status = nodetool.cmd(config.get_foldered_service_name(), 'node-0-server', 'status')
+    raw_status = nodetool.cmd(
+        config.get_foldered_service_name(), "node-0-server", "status"
+    )
     log.info("raw_status: {}".format(raw_status))
     stdout = raw_status[1]
     log.info("stdout: {}".format(stdout))
@@ -44,5 +44,16 @@ def test_rack():
     node = nodetool.parse_status(stdout)[0]
     log.info("node: {}".format(node))
 
-    assert node.get_rack() != 'rack1'
-    assert 'us-west' in node.get_rack()
+    assert node.get_rack() != "rack1"
+    assert "us-west" in node.get_rack()
+
+
+@pytest.mark.sanity
+def test_custom_rack_upgrade():
+    service_options = {"service": {"rack": "not-rack1"}}
+    sdk_upgrade.test_upgrade(
+        config.PACKAGE_NAME,
+        config.get_foldered_service_name(),
+        config.DEFAULT_TASK_COUNT,
+        additional_options=service_options,
+    )


### PR DESCRIPTION
This PR adds an upgrade test for custom racks in Cassandra.

@nickbp we could probably rather add a Unit Test that ensures that the property is present in the Cassandra racks configuration file, but that would not really test upgrade.