### PR TITLE
[BACKPORT][TOOLS] Add -e and --envfile flags to test.sh to pass environment (#2588)

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -10,60 +10,111 @@
 # Exit immediately on errors
 set -e
 
+timestamp="$(date +%d%m%y%H%M%s)"
+# Create a temp file for docker env.
+# When the script exits (successfully or otherwise), clean up the file automatically.
+credsfile="$(mktemp /tmp/sdk-test-creds-${timestamp}.tmp)"
+envfile="$(mktemp /tmp/sdk-test-env-${timestamp}.tmp)"
+function cleanup {
+    rm -f ${credsfile}
+    rm -f ${envfile}
+}
+trap cleanup EXIT
+
 REPO_ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+WORK_DIR="/build" # where REPO_ROOT_DIR is mounted within the image
+
+# Find out what framework(s) are available.
+# - If there's a <REPO>/frameworks directory, get values from there.
+# - Otherwise just use the name of the repo directory.
+# If there's multiple options, the user needs to pick one. If there's only one option then we'll use that automatically.
 if [ -d $REPO_ROOT_DIR/frameworks ]; then
-    FRAMEWORK_LIST=$(ls $REPO_ROOT_DIR/frameworks | sort)
+    # mono-repo (e.g. dcos-commons)
+    FRAMEWORK_LIST=$(ls $REPO_ROOT_DIR/frameworks | sort | xargs echo -n)
 else
-    FRAMEWORK_LIST=$(basename $(pwd))
+    # standalone repo (e.g. spark-build)
+    FRAMEWORK_LIST=$(basename ${REPO_ROOT_DIR})
+fi
+
+
+if [ -n "$AZURE_DEV_CLIENT_ID" -a -n "$AZURE_DEV_CLIENT_SECRET" -a \
+        -n "$AZURE_DEV_TENANT_ID" -a -n "$AZURE_DEV_STORAGE_ACCOUNT" -a \
+        -n "$AZURE_DEV_STORAGE_KEY" ]; then
+    azure_enabled="true"
 fi
 
 # Set default values
 security="permissive"
-pytest_m="sanity and not azure"
-pytest_k=""
-azure_args=""
-gradle_cache="$(pwd)/.gradle_cache"
+if [ -n "$azure_enabled" ]; then
+    pytest_m="sanity"
+else
+    pytest_m="sanity and not azure"
+fi
+gradle_cache="${REPO_ROOT_DIR}/.gradle_cache"
 ssh_path="${HOME}/.ssh/ccm.pem"
-aws_credentials_file="${HOME}/.aws/credentials"
-aws_profile="default"
+aws_creds_path="${HOME}/.aws/credentials"
 enterprise="true"
-interactive="false"
 headless="false"
+interactive="false"
+package_registry="false"
+docker_command=${DOCKER_COMMAND:="bash /build-tools/test_runner.sh $WORK_DIR"}
+docker_image=${DOCKER_IMAGE:-"mesosphere/dcos-commons:latest"}
+env_passthrough=
+envfile_input=
 
 function usage()
 {
-    echo "Usage: $0 [-m MARKEXPR] [-k EXPRESSION] [-p PATH] [-s] [-i|--interactive] [--headless] [--aws|-a PATH] [--aws-profile PROFILE] [all|<framework-name>]"
-    echo "-m passed to pytest directly [default -m \"${pytest_m}\"]"
-    echo "-k passed to pytest directly [default NONE]"
-    echo "   Additional pytest arguments can be passed in the PYTEST_ARGS"
-    echo "   enviroment variable:"
-    echo "      PYTEST_ARGS=$PYTEST_ARGS"
-    echo "-p PATH to cluster SSH key [default ${ssh_path}]"
-    echo "-s run in strict mode (sets \$SECURITY=\"strict\")"
-    echo "--interactive start a docker container in interactive mode"
-    echo "--headless leave STDIN available (mutually exclusive with --interactive)"
-    echo "--gradle-cache PATH sets the gradle cache to the specified path [default ${gradle_cache}]."
-    echo "               Setting PATH to \"\" will disable the cache."
-    echo "--aws-profile PROFILE the AWS profile to use [default ${aws_profile}]"
-    echo "--aws|a PATH to an AWS credentials file [default ${aws_credentials_file}]"
-    echo "        (AWS credentials must be present in this file)"
-    echo "Azure tests will run if these variables are set:"
-    echo "      \$AZURE_CLIENT_ID"
-    echo "      \$AZURE_CLIENT_SECRET"
-    echo "      \$AZURE_TENANT_ID"
-    echo "      \$AZURE_STORAGE_ACCOUNT"
-    echo "      \$AZURE_STORAGE_KEY"
-    echo "  (changes the -m default to \"sanity\")"
+    echo "Usage: $0 [flags] [framework:$(echo $FRAMEWORK_LIST | sed 's/ /,/g')]"
     echo ""
-    echo "Cluster must be created and \$CLUSTER_URL set"
+    echo "Flags:"
+    echo "  -m $pytest_m"
+    echo "  -k <args>"
+    echo "    Test filters passed through to pytest. Other arguments may be passed with PYTEST_ARGS."
+    echo "  -s"
+    echo "    Using a strict mode cluster: configure/use ACLs."
+    echo "  -o"
+    echo "    Using an Open DC/OS cluster: skip Enterprise-only features."
+    echo "  -p $ssh_path"
+    echo "    Path to cluster SSH key."
+    echo "  -e $env_passthrough"
+    echo "    A comma-separated list of environment variables to pass through to the running docker container"
+    echo "  --envfile $envfile_input"
+    echo "    A path to an envfile to pass to the docker container in addition to those required by the test scripts"
+    echo "  -i/--interactive"
+    echo "    Open a shell prompt in the docker container, without actually running any tests. Equivalent to DOCKER_COMMAND=bash"
+    echo "  --headless"
+    echo "    Run docker command in headless mode, without attaching to stdin. Sometimes needed in CI."
+    echo "  --package-registry"
+    echo "    Enables using a package registry to install packages. Requires \$PACKAGE_REGISTRY_STUB_URL."
+    echo "  --dcos-files-path DIR"
+    echo "    Sets the directory to look for .dcos files. If empty, uses stub universe urls to build .dcos file(s)."
+    echo "  --gradle-cache $gradle_cache"
+    echo "    Sets the gradle build cache to the specified path. Setting this to \"\" disables the cache."
+    echo "  -a/--aws $aws_creds_path"
+    echo "    Path to an AWS credentials file. Overrides any AWS_* env credentials."
+    echo "  --aws-profile ${AWS_PROFILE:=NAME}"
+    echo "    The AWS profile to use. Only required when using an AWS credentials file with multiple profiles."
     echo ""
-    echo "Set \$STUB_UNIVERSE_URL to bypass build"
-    echo "  (invalid when building all frameworks)"
-    echo ""
-    echo "Current frameworks:"
-    for framework in $FRAMEWORK_LIST; do
-        echo "       $framework"
-    done
+    echo "Environment:"
+    echo "  CLUSTER_URL"
+    echo "    URL to cluster. If unset then a cluster will be created using dcos-launch"
+    echo "  STUB_UNIVERSE_URL"
+    echo "    One or more comma-separated stub-universe URLs. If unset then a build will be performed internally."
+    echo "  DCOS_LOGIN_USERNAME/DCOS_LOGIN_PASSWORD"
+    echo "    Custom login credentials to use for the cluster."
+    echo "  AZURE_[CLIENT_ID,CLIENT_SECRET,TENANT_ID,STORAGE_ACCOUNT,STORAGE_KEY]"
+    echo "    Enables Azure tests. The -m default is automatically updated to include any Azure tests."
+    echo "  AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY or AWS_DEV_ACCESS_KEY_ID/AWS_DEV_SECRET_ACCESS_KEY"
+    echo "    AWS credentials to use if the credentials file is unavailable."
+    echo "  S3_BUCKET"
+    echo "    S3 bucket to use for testing."
+    echo "  DOCKER_COMMAND=$docker_command"
+    echo "    Command to be run within the docker image (e.g. 'DOCKER_COMMAND=bash' to just get a prompt)"
+    echo "  PYTEST_ARGS"
+    echo "    Additional arguments (other than -m or -k) to pass to pytest."
+    echo "  TEST_SH_*"
+    echo "    Anything starting with TEST_SH_* will be forwarded to the container with that prefix removed."
+    echo "    For example, 'TEST_SH_FOO=BAR' is included as 'FOO=BAR'."
 }
 
 if [ x"${1//-/}" == x"help" -o x"${1//-/}" == x"h" ]; then
@@ -71,33 +122,18 @@ if [ x"${1//-/}" == x"help" -o x"${1//-/}" == x"h" ]; then
     exit 1
 fi
 
-# If AZURE variables are given, change default -m and prepare args for docker
-if [ -n "$AZURE_DEV_CLIENT_ID" -a -n "$AZURE_DEV_CLIENT_SECRET" -a \
-        -n "$AZURE_DEV_TENANT_ID" -a -n "$AZURE_DEV_STORAGE_ACCOUNT" -a \
-        -n "$AZURE_DEV_STORAGE_KEY" ]; then
-azure_args=$(cat<<EOFF
-    -e AZURE_CLIENT_ID=$AZURE_DEV_CLIENT_ID \
-    -e AZURE_CLIENT_SECRET=$AZURE_DEV_CLIENT_SECRET \
-    -e AZURE_TENANT_ID=$AZURE_DEV_TENANT_ID \
-    -e AZURE_STORAGE_ACCOUNT=$AZURE_DEV_STORAGE_ACCOUNT \
-    -e AZURE_STORAGE_KEY=$AZURE_DEV_STORAGE_KEY
-EOFF
-)
-    pytest_m="sanity"
-fi
-
-frameworks=()
+framework=""
 
 while [[ $# -gt 0 ]]; do
 key="$1"
 case $key in
     -m)
     pytest_m="$2"
-    shift # past argument
+    shift
     ;;
     -k)
     pytest_k="$2"
-    shift # past argument
+    shift
     ;;
     -s)
     security="strict"
@@ -106,22 +142,45 @@ case $key in
     enterprise="false"
     ;;
     -p)
+    if [[ ! -f "$2" ]]; then echo "File not found: -p $2"; exit 1; fi
     ssh_path="$2"
-    shift # past argument
+    shift
+    ;;
+    -e)
+    env_passthrough="$2"
+    shift
+    ;;
+    --envfile)
+    if [[ ! -f "$2" ]]; then echo "File not found: $key $2"; exit 1; fi
+    envfile_input="$2"
+    shift
     ;;
     -i|--interactive)
+    if [[ x"$headless" == x"true" ]]; then echo "Cannot enable both --headless and --interactive: Disallowing background prompt that runs forever."; exit 1; fi
     interactive="true"
     ;;
     --headless)
+    if [[ x"$interactive" == x"true" ]]; then echo "Cannot enable both --headless and --interactive: Disallowing background prompt that runs forever."; exit 1; fi
     headless="true"
     ;;
+    --package-registry)
+    package_registry="true"
+    ;;
+    --dcos-files-path)
+    if [[ ! -d "$2" ]]; then echo "Directory not found: --dcos-files-path $2"; exit 1; fi
+    # Resolve abs path:
+    dcos_files_path="$( cd "$( dirname "$2" )" && pwd )/$(basename "$2")"
+    shift
+    ;;
     --gradle-cache)
+    if [[ ! -d "$2" ]]; then echo "Directory not found: --gradle-cache $2"; exit 1; fi
     gradle_cache="$2"
     shift
     ;;
     -a|--aws)
-    aws_credentials_file="$2"
-    shift # past argument
+    if [[ ! -f "$2" ]]; then echo "File not found: -a/--aws $2"; exit 1; fi
+    aws_creds_path="$2"
+    shift
     ;;
     --aws-profile)
     aws_profile="$2"
@@ -133,98 +192,100 @@ case $key in
     exit 1
     ;;
     *)
-    frameworks+=("$key")
+    if [[ -n "$framework" ]]; then echo "Multiple frameworks specified, please only specify one at a time: $framework $@"; exit 1; fi
+    framework=$key
     ;;
 esac
 shift # past argument or value
 done
 
-if [ ! -f "$ssh_path" ]; then
-    echo "The specified CCM key ($ssh_path) does not exist or is not a file"
-    exit 1
-fi
-
-
-if [ ! -f "${aws_credentials_file}" ]; then
-    echo "The required AWS credentials file ${aws_credentials_file} was not found"
-    echo "Try running 'maws' to log in"
-    exit 1
-else
-    PROFILES=$( grep -oE "^\[\S+\]" $aws_credentials_file )
-    if [ "$( echo "$PROFILES" | grep "\[${aws_profile}\]" )" != "[${aws_profile}]" ]; then
-        echo "The specified profile (${aws_profile}) was not found in the file $aws_credentials_file"
-
-        if [ $( echo "$PROFILES" | wc -l ) == "1" ]; then
-            PROFILES="${PROFILES/#[/}"
-            aws_profile="${PROFILES/%]/}"
-            echo "Using single profile: ${aws_profile}"
-        elif [ -n $AWS_PROFILE ]; then
-            echo "Use AWS_PROFILE"
-            aws_profile=$AWS_PROFILE
-        else
-            echo "Found:"
-            echo "$PROFILES"
-            echo ""
-            echo "Specify the correct profile using the --aws-profile command line option"
-            exit 1
-        fi
-    fi
-fi
-
-echo "interactive=$interactive"
-echo "headless=$headless"
-echo "security=$security"
-echo "enterprise=$enterprise"
-
-DOCKER_ARGS=
-if [ -n $gradle_cache ]; then
-    echo "Setting Gradle cache to ${gradle_cache}"
-    DOCKER_ARGS="${DOCKER_ARGS} -v ${gradle_cache}:/root/.gradle"
-else
-    echo "Disabling Gradle cache"
-fi
-
-# Some automation contexts (e.g. Jenkins) will be unhappy
-# if STDIN is not available. The --headless command accomodates
-# such contexts.
-if [ x"$headless" == x"true" ]; then
-    if [ x"$interactive" == "true" ]; then
-        echo "Both --headless and -i|--interactive cannot be used at the same time."
-        exit 1
-    fi
-    DOCKER_INTERACTIVE_FLAGS=""
-else
-    DOCKER_INTERACTIVE_FLAGS="-i"
-fi
-
-
-WORK_DIR="/build"
-
-if [ x"$interactive" == x"false" ]; then
-    if [ -z "$CLUSTER_URL" ]; then
-        echo "Cluster not found. Create and configure one then set \$CLUSTER_URL."
-        exit 1
+if [ -z "$framework" -a x"$interactive" != x"true" ]; then
+    # If FRAMEWORK_LIST only has one option, use that. Otherwise complain.
+    if [ $(echo $FRAMEWORK_LIST | wc -w) == 1 ]; then
+        framework=$FRAMEWORK_LIST
     else
-        if [[ x"$security" == x"strict" ]] && [[ $CLUSTER_URL != https* ]]; then
-            echo $CLUSTER_URL
-            echo "CLUSTER_URL must be https in strict mode"
-            exit 1
-        fi
-    fi
-
-    framework="$frameworks"
-    if [ "$framework" = "all" -a -n "$STUB_UNIVERSE_URL" ]; then
-        echo "Cannot set \$STUB_UNIVERSE_URL when building all frameworks"
+        echo "Multiple frameworks in $(basename $REPO_ROOT_DIR)/frameworks/, please specify one to test: $FRAMEWORK_LIST"
         exit 1
     fi
-    FRAMEWORK_ARGS="-e FRAMEWORK=$framework"
-    DOCKER_COMMAND="bash /build-tools/test_runner.sh $WORK_DIR"
+elif [ "$framework" = "all" ]; then
+    echo "'all' is no longer supported. Please specify one framework to test: $FRAMEWORK_LIST"
+    exit 1
+fi
+
+volume_args="-v ${REPO_ROOT_DIR}:$WORK_DIR"
+
+# Configure SSH key for getting into the cluster during tests
+if [ -f "$ssh_path" ]; then
+    volume_args="$volume_args -v $ssh_path:/ssh/key" # pass provided key into docker env
 else
-# interactive mode
-    # FRAMEWORK_ARGS="-u $(id -u):$(id -g) -e DCOS_DIR=/build/.dcos-in-docker"
-    FRAMEWORK_ARGS=""
-    framework="NOT_SPECIFIED"
-    DOCKER_COMMAND="bash"
+    if [ -n "$CLUSTER_URL" ]; then
+        # If the user is providing us with a cluster, we require the SSH key for that cluster.
+        echo "SSH key not found at $ssh_path. Use -p <path/to/id_rsa> to customize this path."
+        echo "An SSH key is required for communication with the provided CLUSTER_URL=$CLUSTER_URL"
+        exit 1
+    fi
+    # Don't need ssh key now: test_runner.sh will extract the key after cluster launch
+fi
+
+# Configure the AWS credentials profile
+if [ -n "${aws_profile}" ]; then
+    echo "Using provided --aws-profile: ${aws_profile}"
+elif [ -n "$AWS_PROFILE" ]; then
+    echo "Using provided AWS_PROFILE: $AWS_PROFILE"
+    aws_profile=$AWS_PROFILE
+elif [ -f "${aws_creds_path}" ]; then
+    # Check the creds file. If there's exactly one profile, then use that profile.
+    available_profiles=$(grep -oE '^\[\S+\]' $aws_creds_path | tr -d '[]') # find line(s) that look like "[profile]", remove "[]"
+    available_profile_count=$(echo "$available_profiles" | wc -l)
+    if [ "$available_profile_count" == "1" ]; then
+        aws_profile=$available_profiles
+        echo "Using sole profile in $aws_creds_path: $aws_profile"
+    else
+        echo "Expected 1 profile in $aws_creds_path, found $available_profile_count: ${available_profiles}"
+        echo "Please specify --aws-profile or \$AWS_PROFILE to select a profile"
+        exit 1
+    fi
+else
+    echo "No AWS profile specified, using 'default'"
+    aws_profile="default"
+fi
+
+# Write the AWS credential file (deleted on script exit)
+if [ -f "${aws_creds_path}" ]; then
+    cat $aws_creds_path > $credsfile
+else
+    # CI environments may have creds in AWS_DEV_* envvars, map them to AWS_*:
+    if [ -n "${AWS_DEV_ACCESS_KEY_ID}" -a -n "${AWS_DEV_SECRET_ACCESS_KEY}}" ]; then
+	AWS_ACCESS_KEY_ID=${AWS_DEV_ACCESS_KEY_ID}
+        AWS_SECRET_ACCESS_KEY=${AWS_DEV_SECRET_ACCESS_KEY}
+    fi
+    # Check AWS_* envvars for credentials, create temp creds file using those credentials:
+    if [ -n "${AWS_ACCESS_KEY_ID}" -a -n "${AWS_SECRET_ACCESS_KEY}}" ]; then
+	echo "Writing AWS env credentials to temporary file: $credsfile"
+        cat > $credsfile <<EOF
+[${aws_profile}]
+aws_access_key_id = ${AWS_ACCESS_KEY_ID}
+aws_secret_access_key = ${AWS_SECRET_ACCESS_KEY}
+EOF
+    else
+        echo "Missing AWS credentials file (${aws_creds_path}) and AWS env (AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY)"
+        exit 1
+    fi
+fi
+volume_args="$volume_args -v $credsfile:/root/.aws/credentials:ro"
+
+if [ -n "$gradle_cache" ]; then
+    echo "Setting Gradle cache to ${gradle_cache}"
+    volume_args="$volume_args -v ${gradle_cache}:/root/.gradle"
+fi
+
+if [ x"$interactive" == x"true" ]; then
+    docker_command="bash"
+fi
+
+# Some automation contexts (e.g. Jenkins) will be unhappy if STDIN is not available. The --headless command accomodates such contexts.
+if [ x"$headless" != x"true" ]; then
+    docker_interactive_arg="-i"
 fi
 
 if [ -n "$pytest_k" ]; then
@@ -233,7 +294,6 @@ if [ -n "$pytest_k" ]; then
     fi
     PYTEST_ARGS="$PYTEST_ARGS-k \"$pytest_k\""
 fi
-
 if [ -n "$pytest_m" ]; then
     if [ -n "$PYTEST_ARGS" ]; then
         PYTEST_ARGS="$PYTEST_ARGS "
@@ -241,25 +301,85 @@ if [ -n "$pytest_m" ]; then
     PYTEST_ARGS="$PYTEST_ARGS-m \"$pytest_m\""
 fi
 
+if [ x"$package_registry" == x"true" ]; then
+    if [ -z "$PACKAGE_REGISTRY_STUB_URL" ]; then
+        echo "PACKAGE_REGISTRY_STUB_URL not found in environment. Exiting..."
+        exit 1
+    fi
+fi
 
-docker run --rm \
-    -v ${aws_credentials_file}:/root/.aws/credentials:ro \
-    -e AWS_PROFILE="${aws_profile}" \
-    -e DCOS_ENTERPRISE="$enterprise" \
-    -e DCOS_LOGIN_USERNAME="$DCOS_LOGIN_USERNAME" \
-    -e DCOS_LOGIN_PASSWORD="$DCOS_LOGIN_PASSWORD" \
-    -e CLUSTER_URL="$CLUSTER_URL" \
-    -e S3_BUCKET="$S3_BUCKET" \
-    $azure_args \
-    -e SECURITY="$security" \
-    -e PYTEST_ARGS="$PYTEST_ARGS" \
-    $FRAMEWORK_ARGS \
-    -e STUB_UNIVERSE_URL="$STUB_UNIVERSE_URL" \
-    -v $(pwd):$WORK_DIR \
-    -v $ssh_path:/ssh/key \
-    -w $WORK_DIR \
-    -t \
-    $DOCKER_INTERACTIVE_FLAGS \
-    $DOCKER_ARGS \
-    mesosphere/dcos-commons:latest \
-    $DOCKER_COMMAND
+if [ -n "$dcos_files_path" ]; then
+    volume_args="$volume_args -v \"${dcos_files_path}\":\"${dcos_files_path}\""
+fi
+
+if [ -n "$TEAMCITY_VERSION" ]; then
+    # The teamcity python module treats present-but-empty as enabled.
+    # We must therefore completely omitted this envvar to disable teamcity handling.
+    echo "TEAMCITY_VERSION=\"${TEAMCITY_VERSION}\"" >> $envfile
+fi
+
+if [ -n "$azure_enabled" ]; then
+    cat >> $envfile <<EOF
+AZURE_CLIENT_ID=$AZURE_DEV_CLIENT_ID
+AZURE_CLIENT_SECRET=$AZURE_DEV_CLIENT_SECRET
+AZURE_TENANT_ID=$AZURE_DEV_TENANT_ID
+AZURE_STORAGE_ACCOUNT=$AZURE_DEV_STORAGE_ACCOUNT
+AZURE_STORAGE_KEY=$AZURE_DEV_STORAGE_KEY
+EOF
+fi
+
+cat >> $envfile <<EOF
+AWS_PROFILE=$aws_profile
+CLUSTER_URL=$CLUSTER_URL
+DCOS_ENTERPRISE=$enterprise
+DCOS_FILES_PATH=$dcos_files_path
+DCOS_LOGIN_PASSWORD=$DCOS_LOGIN_PASSWORD
+DCOS_LOGIN_USERNAME=$DCOS_LOGIN_USERNAME
+FRAMEWORK=$framework
+PACKAGE_REGISTRY_ENABLED=$package_registry
+PACKAGE_REGISTRY_STUB_URL=$PACKAGE_REGISTRY_STUB_URL
+PYTEST_ARGS=$PYTEST_ARGS
+S3_BUCKET=$S3_BUCKET
+SECURITY=$security
+STUB_UNIVERSE_URL=$STUB_UNIVERSE_URL
+EOF
+
+while read line; do
+    # Prefix match, then strip prefix in envfile:
+    if [[ "${line:0:8}" = "TEST_SH_" ]]; then
+        echo ${line#TEST_SH_} >> $envfile
+    fi
+done < <(env)
+
+if [ -n "$env_passthrough" ]; then
+    # If the -e flag is specified, add the ENVVAR lines for the
+    # comma-separated list of envvars
+    for envvar_name in ${env_passthrough//,/ }; do
+        echo "$envvar_name" >> $envfile
+    done
+fi
+
+if [ -n "$envfile_input" ]; then
+    cat "${envfile_input}" >> $envfile
+fi
+
+CMD="docker run --rm \
+-t \
+${docker_interactive_arg} \
+--env-file $envfile \
+${volume_args} \
+-w $WORK_DIR \
+${docker_image} \
+${docker_command}"
+
+echo "==="
+echo "Docker command:"
+echo "  $CMD"
+echo ""
+echo "Environment:"
+while read line; do
+    echo "  $line"
+done <$envfile
+echo "==="
+
+$CMD


### PR DESCRIPTION
This is a backport of #2588 and updates `test.sh` to that of `master`.

The changes from #2588 include:
* Add -e and --envfile flags to test.sh to pass environment
* Also allow the docker image to be overridden

This is required to cut the new SDK release.