### PR TITLE
[DCOS-38688] Add custom rack upgrade test (#2591)

### DIFF
--- a/frameworks/cassandra/tests/test_racks.py
+++ b/frameworks/cassandra/tests/test_racks.py
@@ -1,8 +1,7 @@
 import logging
 import pytest
-import shakedown
 import sdk_install
-import sdk_tasks
+import sdk_upgrade
 import sdk_utils
 
 from tests import config
@@ -11,7 +10,7 @@ from tests import nodetool
 log = logging.getLogger(__name__)
 
 
-@pytest.fixture(scope='module', autouse=True)
+@pytest.fixture(scope="module", autouse=True)
 def configure_package(configure_security):
     try:
         sdk_install.uninstall(config.PACKAGE_NAME, config.get_foldered_service_name())
@@ -21,7 +20,7 @@ def configure_package(configure_security):
         sdk_install.uninstall(config.PACKAGE_NAME, config.get_foldered_service_name())
 
 
-@pytest.mark.dcos_min_version('1.11')
+@pytest.mark.dcos_min_version("1.11")
 @sdk_utils.dcos_ee_only
 @pytest.mark.sanity
 def test_rack():
@@ -30,15 +29,13 @@ def test_rack():
         config.get_foldered_service_name(),
         3,
         additional_options={
-            "service": {
-                "name": config.get_foldered_service_name()
-            },
-            "nodes": {
-                "placement_constraint": "[[\"@zone\", \"GROUP_BY\", \"1\"]]"
-            }
-        })
+            "service": {"name": config.get_foldered_service_name()},
+            "nodes": {"placement_constraint": '[["@zone", "GROUP_BY", "1"]]'},
+        },
+    )
 
-    raw_status = nodetool.cmd('node-0', 'status')
+    raw_status = nodetool.cmd("node-0", "status")
+
     log.info("raw_status: {}".format(raw_status))
     stdout = raw_status[1]
     log.info("stdout: {}".format(stdout))
@@ -46,5 +43,17 @@ def test_rack():
     node = nodetool.parse_status(stdout)[0]
     log.info("node: {}".format(node))
 
-    assert node.get_rack() != 'rack1'
-    assert 'us-west' in node.get_rack()
+    assert node.get_rack() != "rack1"
+    assert "us-west" in node.get_rack()
+
+
+@pytest.mark.sanity
+def test_custom_rack_upgrade():
+    foldered_service_name = config.get_foldered_service_name()
+    service_options = {"service": {"name": foldered_service_name, "rack": "not-rack1"}}
+    sdk_upgrade.test_upgrade(
+        config.PACKAGE_NAME,
+        foldered_service_name,
+        config.DEFAULT_TASK_COUNT,
+        additional_options=service_options,
+    )


### PR DESCRIPTION
This is a backport of #2591 adding a custom rack upgrade test.

This also adjusted the arguments to the `nodetool.cmd` function to align with the state in the `sdk-0.40` branch.