### PR TITLE
DCOS-29474 Detect leftover frameworks after uninstalls

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -38,16 +38,19 @@ for noise_source in [
 
 log = logging.getLogger(__name__)
 
+
+def is_env_var_set(key: str, default: str) -> bool:
+    return str(os.environ.get(key, default)).lower() in ["true", "1"]
+
+
 # The following environment variable allows for log collection to be turned off.
 # This is useful, for example in testing.
-INTEGRATION_TEST_LOG_COLLECTION = sdk_utils.is_env_var_set(
-    'INTEGRATION_TEST_LOG_COLLECTION', default=str(True)
-)
+INTEGRATION_TEST_LOG_COLLECTION = is_env_var_set('INTEGRATION_TEST_LOG_COLLECTION', default=str(True))
 
 
 @pytest.fixture(scope='session', autouse=True)
 def configure_universe(tmpdir_factory):
-    if sdk_utils.is_env_var_set('PACKAGE_REGISTRY_ENABLED', default=''):
+    if is_env_var_set('PACKAGE_REGISTRY_ENABLED', default=''):
         yield from sdk_package_registry.package_registry_session(tmpdir_factory)
     else:
         yield from sdk_repository.universe_session()

--- a/frameworks/helloworld/tests/test_custom_service_tld.py
+++ b/frameworks/helloworld/tests/test_custom_service_tld.py
@@ -1,8 +1,6 @@
 import logging
 
 import pytest
-import shakedown
-import time
 
 import sdk_hosts
 import sdk_install
@@ -19,7 +17,7 @@ def configure_package(configure_security):
     try:
         sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
 
-        yield # let the test session execute
+        yield  # let the test session execute
     finally:
         sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
 

--- a/frameworks/helloworld/tests/test_zzzrecovery.py
+++ b/frameworks/helloworld/tests/test_zzzrecovery.py
@@ -337,6 +337,9 @@ def test_shutdown_host():
 
     # Instead of partitioning or reconnecting, we shut down the host permanently
     sdk_cmd.shutdown_agent(replace_hostname)
+    # Reserved resources on this agent are expected to appear as orphaned in Mesos state.
+    # Tell our uninstall validation to ignore orphaned resources coming from this agent.
+    sdk_install.ignore_dead_agent(replace_hostname)
 
     # Get pod name from task name: "hello-0-server" => "hello-0"
     replace_pods = set([task.name[:-len('-server')] for task in replace_tasks])
@@ -364,6 +367,7 @@ def test_shutdown_host():
                  'old={}\nnew={}'.format(replaced_task, new_task))
         assert replaced_task.agent != new_task.agent
 
+
 def install_options_helper(kill_grace_period=0):
     options = {
         "world": {
@@ -374,4 +378,3 @@ def install_options_helper(kill_grace_period=0):
 
     sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
     sdk_install.install(config.PACKAGE_NAME, config.SERVICE_NAME, config.DEFAULT_TASK_COUNT + 1, additional_options=options)
-

--- a/frameworks/kafka/tests/client.py
+++ b/frameworks/kafka/tests/client.py
@@ -6,8 +6,8 @@ import uuid
 
 import sdk_auth
 import sdk_cmd
-import sdk_install
 import sdk_marathon
+import sdk_utils
 
 from tests import auth
 from tests import test_utils
@@ -111,7 +111,7 @@ class KafkaClient:
 
         if kerberos is not None:
             self._is_kerberos = True
-            options = sdk_install.merge_dictionaries(options, self._get_kerberos_options(kerberos))
+            options = sdk_utils.merge_dictionaries(options, self._get_kerberos_options(kerberos))
 
         sdk_marathon.install_app(options)
 

--- a/frameworks/kafka/tests/config.py
+++ b/frameworks/kafka/tests/config.py
@@ -39,7 +39,7 @@ def install(
     sdk_install.install(package_name=package_name,
                         expected_running_tasks=expected_running_tasks,
                         service_name=service_name,
-                        additional_options=sdk_install.merge_dictionaries(test_options, additional_options),
+                        additional_options=sdk_utils.merge_dictionaries(test_options, additional_options),
                         package_version=package_version,
                         timeout_seconds=timeout_seconds,
                         wait_for_deployment=wait_for_deployment)

--- a/frameworks/kafka/tests/test_tls.py
+++ b/frameworks/kafka/tests/test_tls.py
@@ -132,11 +132,11 @@ def test_tls_ciphers(kafka_service):
 
     sdk_cmd.service_task_exec(config.SERVICE_NAME, task_name, 'openssl version')  # Output OpenSSL version.
     log.warning("\n%s OpenSSL ciphers missing from the cipher_suites module:", len(missing_openssl_ciphers))
-    log.warning("\n".join(sdk_utils.sort(list(missing_openssl_ciphers))))
+    log.warning("\n".join(to_sorted(list(missing_openssl_ciphers))))
     log.info("\n%s expected ciphers:", len(expected_ciphers))
-    log.info("\n".join(sdk_utils.sort(list(expected_ciphers))))
+    log.info("\n".join(to_sorted(list(expected_ciphers))))
     log.info("\n%s ciphers will be checked:", len(possible_openssl_ciphers))
-    for openssl_cipher in sdk_utils.sort(list(possible_openssl_ciphers)):
+    for openssl_cipher in to_sorted(list(possible_openssl_ciphers)):
         log.info("%s (%s)", cipher_suites.rfc_name(openssl_cipher), openssl_cipher)
 
     for openssl_cipher in possible_openssl_ciphers:
@@ -144,9 +144,15 @@ def test_tls_ciphers(kafka_service):
             enabled_ciphers.add(cipher_suites.rfc_name(openssl_cipher))
 
     log.info('%s ciphers enabled out of %s:', len(enabled_ciphers), len(possible_openssl_ciphers))
-    log.info("\n".join(sdk_utils.sort(list(enabled_ciphers))))
+    log.info("\n".join(to_sorted(list(enabled_ciphers))))
 
     assert expected_ciphers == enabled_ciphers, "Enabled ciphers should match expected ciphers"
+
+
+def to_sorted(coll):
+    """ Sorts a collection and returns it. """
+    coll.sort()
+    return coll
 
 
 @pytest.mark.tls

--- a/frameworks/kafka/tests/test_zookeeper.py
+++ b/frameworks/kafka/tests/test_zookeeper.py
@@ -28,7 +28,7 @@ def zookeeper_server(configure_security):
     try:
         sdk_install.uninstall(config.ZOOKEEPER_PACKAGE_NAME, config.ZOOKEEPER_SERVICE_NAME)
         if sdk_utils.is_strict_mode():
-            service_options = sdk_install.merge_dictionaries({
+            service_options = sdk_utils.merge_dictionaries({
                 'service': {
                     'service_account': zk_account,
                     'service_account_secret': zk_secret,

--- a/frameworks/kafka/tests/test_zookeeper_auth.py
+++ b/frameworks/kafka/tests/test_zookeeper_auth.py
@@ -83,7 +83,7 @@ def zookeeper_server(kerberos):
     zk_secret = "kakfa-zookeeper-secret"
 
     if sdk_utils.is_strict_mode():
-        service_options = sdk_install.merge_dictionaries({
+        service_options = sdk_utils.merge_dictionaries({
             'service': {
                 'service_account': zk_account,
                 'service_account_secret': zk_secret,

--- a/frameworks/kafka/tests/test_zookeeper_authz.py
+++ b/frameworks/kafka/tests/test_zookeeper_authz.py
@@ -83,7 +83,7 @@ def zookeeper_server(kerberos):
     zk_secret = "kakfa-zookeeper-secret"
 
     if sdk_utils.is_strict_mode():
-        service_options = sdk_install.merge_dictionaries({
+        service_options = sdk_utils.merge_dictionaries({
             'service': {
                 'service_account': zk_account,
                 'service_account_secret': zk_secret,

--- a/test.sh
+++ b/test.sh
@@ -10,11 +10,11 @@
 # Exit immediately on errors
 set -e
 
-timestamp="$(date +%d%m%y%H%M%s)"
+timestamp="$(date +%y%m%d-%H%M%S)"
 # Create a temp file for docker env.
 # When the script exits (successfully or otherwise), clean up the file automatically.
-credsfile="$(mktemp /tmp/sdk-test-creds-${timestamp}.tmp)"
-envfile="$(mktemp /tmp/sdk-test-env-${timestamp}.tmp)"
+credsfile="$(mktemp /tmp/sdk-test-creds-${timestamp}-XXXX.tmp)"
+envfile="$(mktemp /tmp/sdk-test-env-${timestamp}-XXXX.tmp)"
 function cleanup {
     rm -f ${credsfile}
     rm -f ${envfile}

--- a/testing/sdk_cmd.py
+++ b/testing/sdk_cmd.py
@@ -336,7 +336,7 @@ def _task_exec(task_id_prefix: str, cmd: str) -> tuple:
     return run_raw_cli("task exec {} {}".format(task_id_prefix, cmd))
 
 
-def resolve_hosts(marathon_task_name: str, hosts: list, bootstrap_cmd: str='./bootstrap') -> bool:
+def resolve_hosts(marathon_task_name: str, hosts: list, bootstrap_cmd: str = './bootstrap') -> bool:
     """
     Use bootstrap to resolve the specified list of hosts
     """

--- a/testing/sdk_diag.py
+++ b/testing/sdk_diag.py
@@ -390,7 +390,7 @@ def _select_log_files(item: pytest.Item, task_id: str, file_infos: list, source:
 
     Results are placed in the 'selected' param.
     '''
-    logfile_pattern = re.compile('^.*/(stdout|stderr)(\.[0-9]+)?$')
+    logfile_pattern = re.compile(r'^.*/(stdout|stderr)(\.[0-9]+)?$')
     for file_info in file_infos:
         if not logfile_pattern.match(file_info['path']):
             continue

--- a/testing/sdk_utils.py
+++ b/testing/sdk_utils.py
@@ -4,6 +4,7 @@ FOR THE TIME BEING WHATEVER MODIFICATIONS ARE APPLIED TO THIS FILE
 SHOULD ALSO BE APPLIED TO sdk_utils IN ANY OTHER PARTNER REPOS
 ************************************************************************
 '''
+import collections
 import functools
 import logging
 import operator
@@ -57,6 +58,10 @@ def get_task_id_prefix(service_name, task_name):
 def get_deslashed_service_name(service_name):
     # Foldered services have slashes removed: '/test/integration/foo' => 'test__integration__foo'.
     return service_name.lstrip('/').replace('/', '__')
+
+
+def get_role(service_name):
+    return '{}-role'.format(get_deslashed_service_name(service_name))
 
 
 def get_zk_path(service_name):
@@ -149,3 +154,17 @@ def get_in(keys, coll, default=None):
         return functools.reduce(operator.getitem, keys, coll)
     except (KeyError, IndexError, TypeError):
         return default
+
+
+def merge_dictionaries(dict1, dict2):
+    if (not isinstance(dict2, dict)):
+        return dict1
+    ret = {}
+    for k, v in dict1.items():
+        ret[k] = v
+    for k, v in dict2.items():
+        if (k in dict1 and isinstance(dict1[k], dict) and isinstance(dict2[k], collections.Mapping)):
+            ret[k] = merge_dictionaries(dict1[k], dict2[k])
+        else:
+            ret[k] = dict2[k]
+    return ret

--- a/testing/security/cipher_suites.py
+++ b/testing/security/cipher_suites.py
@@ -1,5 +1,3 @@
-import sdk_utils
-
 OPENSSL_TO_RFC_NAMES = {
     'ADH-AES128-GCM-SHA256': 'TLS_DH_anon_WITH_AES_128_GCM_SHA256',
     'ADH-AES128-SHA': 'TLS_DH_anon_WITH_AES_128_CBC_SHA',
@@ -256,7 +254,8 @@ OPENSSL_TO_RFC_NAMES = {
     'TLS_FALLBACK_SCSV': 'TLS_FALLBACK_SCSV'
 }
 
-RFC_TO_OPENSSL_NAMES = sdk_utils.invert_dict(OPENSSL_TO_RFC_NAMES)
+# Inverted:
+RFC_TO_OPENSSL_NAMES = dict((v, k) for k, v in OPENSSL_TO_RFC_NAMES.items())
 
 
 def missing_openssl_ciphers(openssl_ciphers: set) -> set:


### PR DESCRIPTION
We're occasionally seeing flakes in `test_srv_records` which were traced down to frameworks not being correctly unregistered. After uninstall, validate that the framework was correctly unregistered, and throw an exception (triggering log collection) if the check fails.

Other misc fixes:
- Also throw if dangling resources are found. We were previously logging them but not throwing, so it's not clear if this is actually a thing. We should check this though, as any issues here imply an uninstall bug.
- Fix error produced by linux `mktemp` when running `test.sh`, and prettify the timestamp used: `mktemp: too few X's in template`
- Misc python lint fixes, and cleanup of lightly-used functions in `sdk_utils`.