### PR TITLE
DCOS-39806 Fix TaskKiller-related flakes

### DIFF
--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/DefaultSchedulerTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/DefaultSchedulerTest.java
@@ -33,8 +33,10 @@ import org.apache.mesos.SchedulerDriver;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.ExpectedSystemExit;
@@ -189,6 +191,26 @@ public class DefaultSchedulerTest {
     private StateStore stateStore;
     private ConfigStore<ServiceSpec> configStore;
     private DefaultScheduler defaultScheduler;
+
+    @BeforeClass
+    public static void beforeAll() {
+        // Disable background TaskKiller thread, to avoid erroneous kill invocations
+        try {
+            TaskKiller.reset(false);
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @AfterClass
+    public static void afterAll() {
+        // Re-enable TaskKiller thread
+        try {
+            TaskKiller.reset(false);
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
 
     @Before
     public void beforeEach() throws Exception {

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/DefaultSchedulerTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/DefaultSchedulerTest.java
@@ -193,23 +193,15 @@ public class DefaultSchedulerTest {
     private DefaultScheduler defaultScheduler;
 
     @BeforeClass
-    public static void beforeAll() {
+    public static void beforeAll() throws InterruptedException {
         // Disable background TaskKiller thread, to avoid erroneous kill invocations
-        try {
-            TaskKiller.reset(false);
-        } catch (Exception e) {
-            throw new IllegalStateException(e);
-        }
+        TaskKiller.reset(false);
     }
 
     @AfterClass
-    public static void afterAll() {
+    public static void afterAll() throws InterruptedException {
         // Re-enable TaskKiller thread
-        try {
-            TaskKiller.reset(false);
-        } catch (Exception e) {
-            throw new IllegalStateException(e);
-        }
+        TaskKiller.reset(true);
     }
 
     @Before


### PR DESCRIPTION
Backport of fix from master: Disable `TaskKiller` background thread so that it doesn't misfire while running these tests

Example flakes:
- https://teamcity.mesosphere.io/viewLog.html?buildId=1138378&tab=buildResultsDiv&buildTypeId=DcosIo_DcosCommons_Sdk_BuildAndTestPr
- https://teamcity.mesosphere.io/viewLog.html?buildId=1136314&tab=buildResultsDiv&buildTypeId=DcosIo_DcosCommons_Sdk_BuildAndTestPr
- https://teamcity.mesosphere.io/viewLog.html?buildId=1136300&tab=buildResultsDiv&buildTypeId=DcosIo_DcosCommons_Sdk_BuildAndTestPr
- https://teamcity.mesosphere.io/viewLog.html?buildId=1135396&tab=buildResultsDiv&buildTypeId=DcosIo_DcosCommons_Sdk_BuildAndTestPr
- https://teamcity.mesosphere.io/viewLog.html?buildId=1135364&tab=buildResultsDiv&buildTypeId=DcosIo_DcosCommons_Sdk_BuildAndTestPr