### PR TITLE
[DCOS-39326] Bump Gradle Versions Plugin to 0.20.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
 }
 
 plugins {
-    id 'com.github.ben-manes.versions' version '0.17.0'
+    id 'com.github.ben-manes.versions' version '0.20.0'
     id 'com.github.ksoichiro.console.reporter' version '0.5.0'
 }
 


### PR DESCRIPTION
Our CI sometimes fails due to the `com.github.ben-manes.versions` plugin. This PR bumps it to the latest version.