### PR TITLE
Add .pre-commit-config.yaml to Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,3 +9,4 @@
 !test.sh
 !TESTING.md
 !/tools/**/*.py
+!.pre-commit-config.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,6 +78,7 @@ COPY conftest.py ${DCOS_COMMONS_DIST_ROOT}/
 
 COPY testing ${DCOS_COMMONS_DIST_ROOT}/testing
 COPY tools ${DCOS_COMMONS_DIST_ROOT}/tools
+COPY .pre-commit-config.yaml ${DCOS_COMMONS_DIST_ROOT}/
 
 COPY build.gradle ${DCOS_COMMONS_DIST_ROOT}/build.gradle
 RUN grep -oE "version = '.*?'" ${DCOS_COMMONS_DIST_ROOT}/build.gradle | sed 's/version = //' > ${DCOS_COMMONS_DIST_ROOT}/.version


### PR DESCRIPTION
This adds `.pre-commit-config.yaml` to the Docker image to allow the same checks to be easily used in other projects.