### PR TITLE
Disable flaky hello-world recovery tests in 0.40

### DIFF
--- a/frameworks/helloworld/tests/test_zzzrecovery.py
+++ b/frameworks/helloworld/tests/test_zzzrecovery.py
@@ -212,8 +212,7 @@ def test_zk_killed():
 
 
 @pytest.mark.recovery
-@pytest.mark.skipif(sdk_utils.dcos_version_less_than("1.10"),
-                    reason="BLOCKED-INFINITY-3203: Skipping recovery tests on 1.9")
+@pytest.mark.skip(reason="disabled due to DCOS-39848")
 def test_config_update_then_kill_task_in_node():
     # kill 1 of 2 world tasks
     world_ids = sdk_tasks.get_task_ids(config.SERVICE_NAME, 'world')
@@ -224,8 +223,7 @@ def test_config_update_then_kill_task_in_node():
 
 
 @pytest.mark.recovery
-@pytest.mark.skipif(sdk_utils.dcos_version_less_than("1.10"),
-                    reason="BLOCKED-INFINITY-3203: Skipping recovery tests on 1.9")
+@pytest.mark.skip(reason="disabled due to DCOS-39848")
 def test_config_update_then_kill_all_task_in_node():
     #  kill both world tasks
     world_ids = sdk_tasks.get_task_ids(config.SERVICE_NAME, 'world')
@@ -237,8 +235,7 @@ def test_config_update_then_kill_all_task_in_node():
 
 
 @pytest.mark.recovery
-@pytest.mark.skipif(sdk_utils.dcos_version_less_than("1.10"),
-                    reason="BLOCKED-INFINITY-3203: Skipping recovery tests on 1.9")
+@pytest.mark.skip(reason="disabled due to DCOS-39848")
 def test_config_update_then_scheduler_died():
     world_ids = sdk_tasks.get_task_ids(config.SERVICE_NAME, 'world')
     host = sdk_marathon.get_scheduler_host(config.SERVICE_NAME)
@@ -249,8 +246,7 @@ def test_config_update_then_scheduler_died():
 
 
 @pytest.mark.recovery
-@pytest.mark.skipif(sdk_utils.dcos_version_less_than("1.10"),
-                    reason="BLOCKED-INFINITY-3203: Skipping recovery tests on 1.9")
+@pytest.mark.skip(reason="disabled due to DCOS-39848")
 def test_config_update_then_executor_killed():
     world_ids = sdk_tasks.get_task_ids(config.SERVICE_NAME, 'world')
     config.bump_world_cpus()
@@ -260,8 +256,7 @@ def test_config_update_then_executor_killed():
 
 
 @pytest.mark.recovery
-@pytest.mark.skipif(sdk_utils.dcos_version_less_than("1.10"),
-                    reason="BLOCKED-INFINITY-3203: Skipping recovery tests on 1.9")
+@pytest.mark.skip(reason="disabled due to DCOS-39848")
 def test_config_updates_then_all_executors_killed():
     world_ids = sdk_tasks.get_task_ids(config.SERVICE_NAME, 'world')
     hosts = shakedown.get_service_ips(config.SERVICE_NAME)
@@ -304,8 +299,7 @@ def test_pod_replace():
 
 
 @pytest.mark.recovery
-@pytest.mark.skipif(sdk_utils.dcos_version_less_than("1.10"),
-                    reason="BLOCKED-INFINITY-3203: Skipping recovery tests on 1.9")
+@pytest.mark.skip(reason="disabled due to DCOS-39848")
 def test_config_update_while_partitioned():
     world_ids = sdk_tasks.get_task_ids(config.SERVICE_NAME, 'world')
     host = sdk_hosts.system_host(config.SERVICE_NAME, "world-0-server")
@@ -330,8 +324,7 @@ def test_config_update_while_partitioned():
 # WARNING: THIS MUST BE THE LAST TEST IN THIS FILE. ANY TEST THAT FOLLOWS WILL BE FLAKY.
 # @@@@@@@
 @pytest.mark.sanity
-@pytest.mark.skipif(sdk_utils.dcos_version_less_than("1.10"),
-                    reason="BLOCKED-INFINITY-3203: Skipping recovery tests on 1.9")
+@pytest.mark.skip(reason="disabled due to DCOS-39848")
 def test_shutdown_host():
     candidate_tasks = sdk_tasks.get_tasks_avoiding_scheduler(
         config.SERVICE_NAME, re.compile('^(hello|world)-[0-9]+-server$'))

--- a/tools/ci/checks/run_pylint_checks.sh
+++ b/tools/ci/checks/run_pylint_checks.sh
@@ -8,4 +8,4 @@ docker run --rm -t \
     -v $(pwd):/build:ro \
     -w /build \
         ${DOCKER_IMAGE} \
-            pylint -E "$@"
+            pylint -E -j4 --disable=invalid-sequence-index --disable=no-member --disable=no-name-in-module "$@"


### PR DESCRIPTION
We disabled these in 0.50, backporting the disable to 0.40. 