### PR TITLE
Preheat docker image with jar dependencies + pre-commit env

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,7 +2,6 @@
 /**/build
 /**/__pycache__
 *.pyc
-.*
 
 !test_requirements.txt
 !test_runner.sh

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: stable
     hooks:
     - id: black
-      args: [--check]
+      args: [--diff]
       language_version: python3
     - id: black
       name: black-format

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,15 +36,26 @@ RUN go version
 
 # AWS CLI for uploading build artifacts
 RUN pip3 install awscli
-# Install the testing dependencies
+# Install the lint+testing dependencies
 COPY test_requirements.txt test_requirements.txt
 RUN pip3 install --upgrade -r test_requirements.txt
-# shakedown and dcos-cli require this to output cleanly
+
+# dcos-cli and lint tooling require this to output cleanly
 ENV LC_ALL=C.UTF-8 LANG=C.UTF-8
 # use an arbitrary path for temporary build artifacts
 ENV GOPATH=/go-tmp
 # make a dir for holding the SSH key in tests
 RUN mkdir /root/.ssh
+
+# Copy all of the repo into the image, then run some build/lint commands against the copy to heat up caches. Then delete the copy.
+RUN mkdir /tmp/repo/
+COPY / /tmp/repo/
+# gradlew: Heat up jar cache. pre-commit: Heat up lint tooling cache.
+RUN cd /tmp/repo/ && \
+    ./gradlew classes && \
+    pre-commit && \
+    cd / && \
+    rm -rf /tmp/repo/
 
 # Create a build-tool directory:
 RUN mkdir /build-tools
@@ -56,7 +67,6 @@ COPY tools/ci/launch_cluster.sh /build-tools/
 
 # Create a folder to store the distributed artefacts
 RUN mkdir /dcos-commons-dist
-
 ENV DCOS_COMMONS_DIST_ROOT /dcos-commons-dist
 
 COPY tools/distribution/* ${DCOS_COMMONS_DIST_ROOT}/


### PR DESCRIPTION
This should greatly speed up local builds, as `docker run` commands won't need to download everything from scratch.
Worst case, if the cache is out of date, then a subset of the dependencies will need to be redownloaded.

Before:
```
$ time docker run --rm -t -i -v /home/nick/code/dcos-commons:/build -w /build mesosphere/dcos-commons:latest ./gradlew classes
[... download jars, build code ...]

BUILD SUCCESSFUL in 56s
17 actionable tasks: 15 executed, 2 up-to-date

real    0m58.432s
user    0m0.109s
sys     0m0.088s

$ time docker run --rm -t -i -v /home/nick/code/dcos-commons:/build -w /build mesosphere/dcos-commons:latest pre-commit
[INFO] Initializing environment for https://github.com/ambv/black.
[INFO] Initializing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Installing environment for https://github.com/ambv/black.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
black................................................(no files to check)Skipped
Flake8...............................................(no files to check)Skipped
pylint...............................................(no files to check)Skipped

real	0m14.128s
user	0m0.046s
sys	0m0.029s
```

After:
```
$ time docker run --rm -t -i -v /home/nick/code/dcos-commons:/build -w /build nick-test ./gradlew classes
[... build code ...]

BUILD SUCCESSFUL in 10s
17 actionable tasks: 11 executed, 6 up-to-date

real    0m12.157s
user    0m0.063s
sys     0m0.014s

$ time docker run --rm -t -i -v /home/nick/code/dcos-commons:/build -w /build nick-test pre-commit
black................................................(no files to check)Skipped
Flake8...............................................(no files to check)Skipped
pylint...............................................(no files to check)Skipped

real	0m1.417s
user	0m0.057s
sys	0m0.015s
```