### PR TITLE
DCOS-40402 Wait for DNS resolution in multiport yml

### DIFF
--- a/frameworks/helloworld/src/main/dist/multiport.yml
+++ b/frameworks/helloworld/src/main/dist/multiport.yml
@@ -18,6 +18,7 @@ pods:
         goal: ONCE
         resource-set: multi-port-resources
         cmd: |
+          ./bootstrap -verbose -resolve=true
           nc_alias=""
           if which ncat 2>/dev/null; then
               nc_alias=ncat


### PR DESCRIPTION
We should always wait for DNS resolution before using the hostnames.