### PR TITLE
[DCOS-38370] Re-enable Kibana tests.

### DIFF
--- a/frameworks/elastic/tests/test_sanity.py
+++ b/frameworks/elastic/tests/test_sanity.py
@@ -172,10 +172,6 @@ def test_custom_yaml_base64():
 
 @pytest.mark.sanity
 @pytest.mark.timeout(60 * 60)
-@pytest.mark.skipif(
-    sdk_utils.dcos_version_at_least("1.12"),
-    reason="MESOS-9008: Mesos Fetcher fails to extract Kibana archive",
-)
 def test_xpack_toggle_with_kibana(default_populated_index):
     log.info("\n***** Verify X-Pack disabled by default in elasticsearch")
     config.verify_commercial_api_status(False, service_name=foldered_name)

--- a/frameworks/elastic/tests/test_tls.py
+++ b/frameworks/elastic/tests/test_tls.py
@@ -121,10 +121,6 @@ def test_crud_over_tls(elastic_service):
 
 @pytest.mark.tls
 @pytest.mark.sanity
-@pytest.mark.skipif(
-    sdk_utils.dcos_version_at_least("1.12"),
-    reason="MESOS-9008: Mesos Fetcher fails to extract Kibana archive",
-)
 def test_kibana_tls(kibana_application):
     config.check_kibana_adminrouter_integration(
         "service/{}/login".format(config.KIBANA_SERVICE_NAME)


### PR DESCRIPTION
Our TeamCity builds launch DC/OS clusters based off the `testing/master` channel, which means dcos master branch. The dcos master branch is currently [pinning Mesos](https://github.com/dcos/dcos/blob/4961d8182917d102284f7a0ccc29e4c422913565/packages/mesos/buildinfo.json#L11) at [84749967](https://github.com/dcos/dcos/blob/4961d8182917d102284f7a0ccc29e4c422913565/packages/mesos/buildinfo.json#L11), which contains the Mesos Fetcher fix. Given this, we shouldn't see the Kibana failures anymore in our CI builds.

The Mesos Fetcher fix was merged to the Mesos master branch and [will be released on Mesos 1.7.0](https://github.com/apache/mesos/blob/751ef19270ca2a9d82cff5946e1820d28e8e508f/CHANGELOG#L100)