### PR TITLE
[DCOS-40636][TOOLS] Add interactive testing note to TESTING.md

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -79,6 +79,49 @@ The detected frameworks would be:
 
 If no `frameworks` folder exists, the current folder is assumed to be the root of a single framework. Note that the name of the framework displayed in this case (and above) is purely cosmetic, and the package name for the framework is determined from the catalog definition files.
 
+#### Running tests interactively
+
+The default when invoking `test.sh` is to run all tests defined for a given framework. It may, however be desirable to run a subset of tests interactively while developing a feature or the related tests themselves.
+
+The following command:
+```bash
+CLUSTER_URL=$(dcos config show core.dcos_url) ./test.sh -i
+```
+starts an interactive shell in a Docker container with the requirements for running the tests installed. The folder from which `./test.sh` was started is mounted into the container as `/build` and the default (or specified) SSH key is mounted at `/ssh/key`.
+
+**Note:** In order to run tests against a strict mode cluster and additional `-s` flag is required when starting the container.
+
+##### Setting up
+Before running test we perform the following steps inside the container:
+* Connect to the cluster: `dcos cluster setup ${CLUSTER_URL}`
+* Add the SSH key to the SSH agent: `eval $(ssh-agent -s); ssh-add /ssh/key`
+* Set the `PYTHONPATH` environment variable: `export PYTHONPATH=testing`
+
+Most system integration tests rely on a stub-universe being set up allowing us to install the version of the framework under test. Thus it is required to run:
+```bash
+export STUB_UNIVERSE_URL="https://universe-converter.mesosphere.com/transform?url=https://infinity-artifacts.s3.amazonaws.com/autodelete7d/my-framework/20180806-125351-sdEdQ7mRfHFXQzmT/stub-universe-my-framework.json
+```
+The stub-universe URL can be optained from an earlier build, or by building the framework (`my-framework` in this case) in the container by running the following command:
+```bash
+./frameworks/my-framwork/build.sh aws
+```
+(where this assumes a multi-framework repository)
+or simply:
+```bash
+./build.sh aws
+```
+for a single framework repository.
+
+##### Interacting with tests
+At this point, we are able to interactively run the tests using `py.test`. For example to check the tests available we could run we pass the `--collect-only` flag to the `py.test` command:
+```bash
+py.test -vv -s -m "sanity" --collect-only frameworks/my-framework/tests
+```
+
+If we're happy with the tests that will be run, we can drop the `--collect-only` flag and run the tests.
+
+**Note:** The tooling included with SDK-based projects includes collecting task logs for failed tests. This is useful for CI jobs, but does add quite a bit of verbosity when running interactively. In order to disable this, run `export INTEGRATION_TEST_LOG_COLLECTION=False` before running the tests.
+
 #### Advanced usage
 Running
 ```bash

--- a/TESTING.md
+++ b/TESTING.md
@@ -95,7 +95,11 @@ starts an interactive shell in a Docker container with the requirements for runn
 Before running test we perform the following steps inside the container:
 * Connect to the cluster: `dcos cluster setup ${CLUSTER_URL}`
 * Add the SSH key to the SSH agent: `eval $(ssh-agent -s); ssh-add /ssh/key`
-* Set the `PYTHONPATH` environment variable: `export PYTHONPATH=testing`
+
+It may also be required to set the `PYTHONPATH` environment variable:
+```bash
+export PYTHONPATH=/build/testing
+```
 
 Most system integration tests rely on a stub-universe being set up allowing us to install the version of the framework under test. Thus it is required to run:
 ```bash

--- a/TESTING.md
+++ b/TESTING.md
@@ -85,7 +85,7 @@ The default when invoking `test.sh` is to run all tests defined for a given fram
 
 The following command:
 ```bash
-CLUSTER_URL=$(dcos config show core.dcos_url) ./test.sh -i
+./test.sh -i
 ```
 starts an interactive shell in a Docker container with the requirements for running the tests installed. The folder from which `./test.sh` was started is mounted into the container as `/build` and the default (or specified) SSH key is mounted at `/ssh/key`.
 

--- a/test.sh
+++ b/test.sh
@@ -13,10 +13,10 @@ set -e
 timestamp="$(date +%y%m%d-%H%M%S)"
 # Create a temp file for docker env.
 # When the script exits (successfully or otherwise), clean up the file automatically.
-tmp_credsfile="$(mktemp /tmp/sdk-test-creds-${timestamp}-XXXX.tmp)"
+tmp_aws_creds_path="$(mktemp /tmp/sdk-test-creds-${timestamp}-XXXX.tmp)"
 envfile="$(mktemp /tmp/sdk-test-env-${timestamp}-XXXX.tmp)"
 function cleanup {
-    rm -f ${tmp_credsfile}
+    rm -f ${tmp_aws_creds_path}
     rm -f ${envfile}
 }
 trap cleanup EXIT
@@ -266,8 +266,8 @@ else
     fi
     # Check AWS_* envvars for credentials, create temp creds file using those credentials:
     if [ -n "${AWS_ACCESS_KEY_ID}" -a -n "${AWS_SECRET_ACCESS_KEY}}" ]; then
-        echo "Writing AWS env credentials to temporary file: $tmp_credsfile"
-        cat > $tmp_credsfile <<EOF
+        echo "Writing AWS env credentials to temporary file: $tmp_aws_creds_path"
+        cat > $tmp_aws_creds_path <<EOF
 [${aws_profile}]
 aws_access_key_id = ${AWS_ACCESS_KEY_ID}
 aws_secret_access_key = ${AWS_SECRET_ACCESS_KEY}
@@ -276,7 +276,7 @@ EOF
         echo "Missing AWS credentials file (${aws_creds_path}) and AWS env (AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY)"
         exit 1
     fi
-    aws_credential_file_mount_target="${tmp_credsfile}"
+    aws_credential_file_mount_target="${tmp_aws_creds_path}"
 fi
 volume_args="$volume_args -v $aws_credential_file_mount_target:/root/.aws/credentials:ro"
 

--- a/test.sh
+++ b/test.sh
@@ -13,10 +13,10 @@ set -e
 timestamp="$(date +%y%m%d-%H%M%S)"
 # Create a temp file for docker env.
 # When the script exits (successfully or otherwise), clean up the file automatically.
-credsfile="$(mktemp /tmp/sdk-test-creds-${timestamp}-XXXX.tmp)"
+tmp_credsfile="$(mktemp /tmp/sdk-test-creds-${timestamp}-XXXX.tmp)"
 envfile="$(mktemp /tmp/sdk-test-env-${timestamp}-XXXX.tmp)"
 function cleanup {
-    rm -f ${credsfile}
+    rm -f ${tmp_credsfile}
     rm -f ${envfile}
 }
 trap cleanup EXIT
@@ -214,6 +214,11 @@ fi
 
 volume_args="-v ${REPO_ROOT_DIR}:$WORK_DIR"
 
+if [ -z "$CLUSTER_URL" -a x"$interactive" == x"true" ]; then
+    CLUSTER_URL="$(dcos config show core.dcos_url)"
+    echo "CLUSTER_URL not specified. Using attached cluster ${CLUSTER_URL} in interactive mode"
+fi
+
 # Configure SSH key for getting into the cluster during tests
 if [ -f "$ssh_path" ]; then
     volume_args="$volume_args -v $ssh_path:/ssh/key" # pass provided key into docker env
@@ -252,7 +257,7 @@ fi
 
 # Write the AWS credential file (deleted on script exit)
 if [ -f "${aws_creds_path}" ]; then
-    aws_credential_file_path="${aws_creds_path}"
+    aws_credential_file_mount_target="${aws_creds_path}"
 else
     # CI environments may have creds in AWS_DEV_* envvars, map them to AWS_*:
     if [ -n "${AWS_DEV_ACCESS_KEY_ID}" -a -n "${AWS_DEV_SECRET_ACCESS_KEY}}" ]; then
@@ -261,8 +266,8 @@ else
     fi
     # Check AWS_* envvars for credentials, create temp creds file using those credentials:
     if [ -n "${AWS_ACCESS_KEY_ID}" -a -n "${AWS_SECRET_ACCESS_KEY}}" ]; then
-        echo "Writing AWS env credentials to temporary file: $credsfile"
-        cat > $credsfile <<EOF
+        echo "Writing AWS env credentials to temporary file: $tmp_credsfile"
+        cat > $tmp_credsfile <<EOF
 [${aws_profile}]
 aws_access_key_id = ${AWS_ACCESS_KEY_ID}
 aws_secret_access_key = ${AWS_SECRET_ACCESS_KEY}
@@ -271,10 +276,9 @@ EOF
         echo "Missing AWS credentials file (${aws_creds_path}) and AWS env (AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY)"
         exit 1
     fi
-    chmod 500 "${credsfile}"
-    aws_credential_file_path="${credsfile}"
+    aws_credential_file_mount_target="${tmp_credsfile}"
 fi
-volume_args="$volume_args -v $aws_credential_file_path:/root/.aws/credentials:ro"
+volume_args="$volume_args -v $aws_credential_file_mount_target:/root/.aws/credentials:ro"
 
 if [ -n "$gradle_cache" ]; then
     echo "Setting Gradle cache to ${gradle_cache}"


### PR DESCRIPTION
This PR:
* Adds a section on interactive testing to `TESTING.md`
* Improves interactive mode for `test.sh` by using an existing AWS credentials file if it exists. This allows credentials to be refreshed without having to restart the docker container.