### PR TITLE
[DCOS 39710] Investigate kafka acl test failures

### DIFF
--- a/frameworks/kafka/tests/auth.py
+++ b/frameworks/kafka/tests/auth.py
@@ -170,6 +170,10 @@ def write_to_topic(
             if "LEADER_NOT_AVAILABLE" in stderr:
                 LOG.warning("Write failed with LEADER_NOT_AVAILABLE")
                 return True
+            if not is_not_authorized(output):
+                LOG.warning("Write failed with AuthorizationException")
+                return False
+            raise Exception("Not yet captured error while sending")
 
         LOG.info("Write appears to have succeeded")
         return False

--- a/frameworks/kafka/tests/test_zookeeper_authz.py
+++ b/frameworks/kafka/tests/test_zookeeper_authz.py
@@ -3,6 +3,7 @@ This module tests the interaction of Kafka with Zookeeper with authorization ena
 """
 import logging
 import pytest
+import typing
 
 import sdk_auth
 import sdk_cmd
@@ -120,113 +121,12 @@ def kafka_client(kerberos):
         kafka_client.uninstall()
 
 
-@pytest.mark.dcos_min_version("1.10")
-@sdk_utils.dcos_ee_only
-@pytest.mark.sanity
-def test_authz_acls_required(kafka_client: client.KafkaClient, zookeeper_server, kerberos):
-    try:
-        zookeeper_dns = sdk_networks.get_endpoint(
-            zookeeper_server["package_name"], zookeeper_server["service"]["name"], "clientport"
-        )["dns"]
-
-        sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
-        service_options = {
-            "service": {
-                "name": config.SERVICE_NAME,
-                "security": {
-                    "kerberos": {
-                        "enabled": True,
-                        "enabled_for_zookeeper": True,
-                        "kdc": {"hostname": kerberos.get_host(), "port": int(kerberos.get_port())},
-                        "realm": kerberos.get_realm(),
-                        "keytab_secret": kerberos.get_keytab_path(),
-                    },
-                    "authorization": {"enabled": True, "super_users": "User:{}".format("super")},
-                },
-            },
-            "kafka": {"kafka_zookeeper_uri": ",".join(zookeeper_dns)},
-        }
-        config.install(
-            config.PACKAGE_NAME,
-            config.SERVICE_NAME,
-            config.DEFAULT_BROKER_COUNT,
-            additional_options=service_options,
-        )
-
-        kafka_server = {**service_options, **{"package_name": config.PACKAGE_NAME}}
-
-        topic_name = "authz.test"
-        sdk_cmd.svc_cli(
-            kafka_server["package_name"],
-            kafka_server["service"]["name"],
-            "topic create {}".format(topic_name),
-        )
-
-        kafka_client.connect(kafka_server)
-
-        # Clear the ACLs
-        kafka_client.remove_acls("authorized", kafka_server, topic_name)
-
-        # Since no ACLs are specified, only the super user can read and write
-        for user in ["super"]:
-            log.info("Checking write / read permissions for user=%s", user)
-            write_success, read_successes, _ = kafka_client.can_write_and_read(
-                user, kafka_server, topic_name, kerberos
-            )
-            assert write_success, "Write failed (user={})".format(user)
-            assert read_successes, (
-                "Read failed (user={}): "
-                "MESSAGES={} "
-                "read_successes={}".format(user, kafka_client.MESSAGES, read_successes)
-            )
-
-        for user in ["authorized", "unauthorized"]:
-            log.info("Checking lack of write / read permissions for user=%s", user)
-            write_success, _, read_messages = kafka_client.can_write_and_read(
-                user, kafka_server, topic_name, kerberos
-            )
-            assert not write_success, "Write not expected to succeed (user={})".format(user)
-            assert auth.is_not_authorized(read_messages), "Unauthorized expected (user={}".format(
-                user
-            )
-
-        log.info("Writing and reading: Adding acl for authorized user")
-        kafka_client.add_acls("authorized", kafka_server, topic_name)
-
-        # After adding ACLs the authorized user and super user should still have access to the topic.
-        for user in ["authorized", "super"]:
-            log.info("Checking write / read permissions for user=%s", user)
-            write_success, read_successes, _ = kafka_client.can_write_and_read(
-                user, kafka_server, topic_name, kerberos
-            )
-            assert write_success, "Write failed (user={})".format(user)
-            assert read_successes, (
-                "Read failed (user={}): "
-                "MESSAGES={} "
-                "read_successes={}".format(user, kafka_client.MESSAGES, read_successes)
-            )
-
-        for user in ["unauthorized"]:
-            log.info("Checking lack of write / read permissions for user=%s", user)
-            write_success, _, read_messages = kafka_client.can_write_and_read(
-                user, kafka_server, topic_name, kerberos
-            )
-            assert not write_success, "Write not expected to succeed (user={})".format(user)
-            assert auth.is_not_authorized(read_messages), "Unauthorized expected (user={}".format(
-                user
-            )
-
-    finally:
-        # Ensure that we clean up the ZK state.
-        kafka_client.remove_acls("authorized", kafka_server, topic_name)
-
-        sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
-
-
-@pytest.mark.dcos_min_version("1.10")
-@pytest.mark.ee_only
-@pytest.mark.sanity
-def test_authz_acls_not_required(kafka_client: client.KafkaClient, zookeeper_server, kerberos):
+@pytest.fixture(autouse=True)
+def kafka_client_setup(
+    kafka_client: client.KafkaClient,
+    zookeeper_server: typing.Dict,
+    kerberos: sdk_auth.KerberosEnvironment,
+):
     try:
         zookeeper_dns = sdk_networks.get_endpoint(
             zookeeper_server["package_name"], zookeeper_server["service"]["name"], "clientport"
@@ -274,48 +174,85 @@ def test_authz_acls_not_required(kafka_client: client.KafkaClient, zookeeper_ser
 
         # Clear the ACLs
         kafka_client.remove_acls("authorized", kafka_server, topic_name)
+        yield Permissions(kerberos, kafka_server, kafka_client, topic_name)
+    finally:
+        # Ensure that we clean up the ZK state.
+        kafka_client.remove_acls("authorized", kafka_server, topic_name)
 
-        # Since no ACLs are specified, all users can read and write.
-        for user in ["authorized", "unauthorized", "super"]:
-            log.info("Checking write / read permissions for user=%s", user)
-            write_success, read_successes, _ = kafka_client.can_write_and_read(
-                user, kafka_server, topic_name, kerberos
-            )
-            assert write_success, "Write failed (user={})".format(user)
-            assert read_successes, (
-                "Read failed (user={}): "
-                "MESSAGES={} "
-                "read_successes={}".format(user, kafka_client.MESSAGES, read_successes)
-            )
+        sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
 
-        log.info("Writing and reading: Adding acl for authorized user")
-        kafka_client.add_acls("authorized", kafka_server, topic_name)
 
-        # After adding ACLs the authorized user and super user should still have access to the topic.
-        for user in ["authorized", "super"]:
-            log.info("Checking write / read permissions for user=%s", user)
-            write_success, read_successes, _ = kafka_client.can_write_and_read(
-                user, kafka_server, topic_name, kerberos
-            )
-            assert write_success, "Write failed (user={})".format(user)
-            assert read_successes, (
-                "Read failed (user={}): "
-                "MESSAGES={} "
-                "read_successes={}".format(user, kafka_client.MESSAGES, read_successes)
-            )
+class Permissions:
+    def __init__(
+        self,
+        kerberos: sdk_auth.KerberosEnvironment,
+        kafka_server: typing.Dict,
+        kafka_client: client.KafkaClient,
+        topic_name: str,
+    ) -> None:
+        self.kerberos = kerberos
+        self.kafka_server = kafka_server
+        self.kafka_client = kafka_client
+        self.topic_name = topic_name
 
-        for user in ["unauthorized"]:
+    def check_lack_of_permissions(self, users: typing.List[str]) -> None:
+        for user in users:
             log.info("Checking lack of write / read permissions for user=%s", user)
-            write_success, _, read_messages = kafka_client.can_write_and_read(
-                user, kafka_server, topic_name, kerberos
+            write_success, _, read_messages = self.kafka_client.can_write_and_read(
+                user, self.kafka_server, self.topic_name, self.kerberos
             )
             assert not write_success, "Write not expected to succeed (user={})".format(user)
             assert auth.is_not_authorized(read_messages), "Unauthorized expected (user={}".format(
                 user
             )
 
-    finally:
-        # Ensure that we clean up the ZK state.
-        kafka_client.remove_acls("authorized", kafka_server, topic_name)
+    def check_grant_of_permissions(self, users: typing.List[str]) -> None:
+        for user in users:
+            log.info("Checking write / read permissions for user=%s", user)
+            write_success, read_successes, _ = self.kafka_client.can_write_and_read(
+                user, self.kafka_server, self.topic_name, self.kerberos
+            )
+            assert write_success, "Write failed (user={})".format(user)
+            assert read_successes, (
+                "Read failed (user={}): "
+                "MESSAGES={} "
+                "read_successes={}".format(user, self.kafka_client.MESSAGES, read_successes)
+            )
 
-        sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
+
+@pytest.mark.dcos_min_version("1.10")
+@sdk_utils.dcos_ee_only
+@pytest.mark.sanity
+@pytest.mark.acl_auth
+def test_authz_acls_required(kafka_client_setup: Permissions):
+    # Since no ACLs are specified, only the super user can read and write
+    kafka_client_setup.check_grant_of_permissions(["super"])
+    kafka_client_setup.check_lack_of_permissions(["authorized", "unauthorized"])
+
+    log.info("Writing and reading: Adding acl for authorized user")
+    kafka_client_setup.kafka_client.add_acls(
+        "authorized", kafka_client_setup.kafka_server, kafka_client_setup.topic_name
+    )
+
+    # After adding ACLs the authorized user and super user should still have access to the topic.
+    kafka_client_setup.check_grant_of_permissions(["authorized", "super"])
+    kafka_client_setup.check_lack_of_permissions(["unauthorized"])
+
+
+@pytest.mark.dcos_min_version("1.10")
+@pytest.mark.ee_only
+@pytest.mark.sanity
+@pytest.mark.acl_auth
+def test_authz_acls_not_required(kafka_client_setup: Permissions):
+
+    # Since no ACLs are specified, all users can read and write.
+    kafka_client_setup.check_grant_of_permissions(["authorized", "unauthorized", "super"])
+
+    log.info("Writing and reading: Adding acl for authorized user")
+    kafka_client_setup.kafka_client.add_acls(
+        "authorized", kafka_client_setup.kafka_server, kafka_client_setup.topic_name
+    )
+
+    # After adding ACLs the authorized user and super user should still have access to the topic.
+    kafka_client_setup.check_grant_of_permissions(["authorized", "super"])
+    kafka_client_setup.check_lack_of_permissions(["unauthorized"])


### PR DESCRIPTION
The initial issue stated problems with writing to Kafka while acls are applied.  Currently, this behaviour is hard to reproduce due to missing log files in TeamCity. I have added the following things to help to track it in the future.

- Raise exception on kafka write if not seen exception occurs
- Reduced code duplication in`test_zookeeper_authz.py`