### PR TITLE
DCOS-40885 Second attempt at fixing 'dcos' deps for extern/sdk-0.40

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,7 @@ RUN pip3 install --upgrade -r test_requirements.txt
 # However external repos using this image currently still need them.
 # Remove these once external repos aren't depending on them anymore.
 RUN pip3 install git+https://github.com/dcos/dcos-cli.git@f1fd38c9e72e1d521cf8120fe4948a789fb40cbc && \
+    pip3 install git+https://github.com/dcos/dcos-cli.git@f1fd38c9e72e1d521cf8120fe4948a789fb40cbc#egg=dcoscli&subdirectory=cli && \
     pip3 install dcos-shakedown==1.4.12
 
 # dcos-cli and lint tooling require this to output cleanly

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,25 +34,17 @@ RUN apt-get update && \
 ENV PATH=$PATH:/usr/local/go/bin
 RUN go version
 
-# Get DC/OS CLI
-RUN curl -O https://downloads.dcos.io/binaries/cli/linux/x86-64/dcos-1.12/dcos && \
-    chmod +x dcos && \
-    mv dcos /usr/local/bin && \
-    dcos --version
-
 # AWS CLI for uploading build artifacts
 RUN pip3 install awscli
 # Install the lint+testing dependencies
 COPY test_requirements.txt test_requirements.txt
 RUN pip3 install --upgrade -r test_requirements.txt
 
-# Deprecated libraries used by external repos.
-# As of PR#2616, these libraries aren't used by dcos-commons anymore.
-# However external repos using this image currently still need them.
-# Remove these once external repos aren't depending on them anymore.
-RUN pip3 install git+https://github.com/dcos/dcos-cli.git@f1fd38c9e72e1d521cf8120fe4948a789fb40cbc && \
-    pip3 install git+https://github.com/dcos/dcos-cli.git@f1fd38c9e72e1d521cf8120fe4948a789fb40cbc#egg=dcoscli&subdirectory=cli && \
-    pip3 install dcos-shakedown==1.4.12
+# Get DC/OS CLI
+RUN curl -O https://downloads.dcos.io/binaries/cli/linux/x86-64/dcos-1.12/dcos && \
+    chmod +x dcos && \
+    mv dcos /usr/local/bin && \
+    dcos --version
 
 # dcos-cli and lint tooling require this to output cleanly
 ENV LC_ALL=C.UTF-8 LANG=C.UTF-8

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,3 +1,13 @@
+# Deprecated libraries which are still used by sdk-0.40 and external repos.
+# dcos-commons master meanwhile doesn't use these anymore as of PR#2616, but we still include them
+# here for now. Remove these once sdk-0.40 and external repos have upgraded their testing/.
+# - required for dcos.servicemanager library, used internally in the dcos library:
+git+https://github.com/dcos/dcos-cli.git@f1fd38c9e72e1d521cf8120fe4948a789fb40cbc#egg=dcoscli&subdirectory=cli
+# - manually select the correct version of the dcos library to avoid a package_manager param count issue in the version declared by shakedown:
+git+https://github.com/dcos/dcos-cli.git@f1fd38c9e72e1d521cf8120fe4948a789fb40cbc
+# - refrain from jumping to 1.5 since we're moving off shakedown anyway:
+dcos-shakedown==1.4.12
+
 # Used by tools/create_testing_volumes.py (and for dcos-launch CLI):
 git+https://github.com/dcos/dcos-test-utils.git@3ebfc18ff9c5a1aa382311474a9192a68c98b0a7
 git+https://github.com/dcos/dcos-launch.git@dc1e116685fba5105f322b007549b7eb104cf441


### PR DESCRIPTION
- The previous method of adding them directly to the Dockerfile doesn't work, they need to be in `test_requirements.txt` or else pip effectively ignores the specified versions.
- The dcoscli dependency is also needed to avoid breaking on an internal `servicemanager` dependency within the `dcos` library.