### PR TITLE
Wait for deployment to finish before checking taskcfg.

### DIFF
--- a/frameworks/helloworld/tests/test_taskcfg.py
+++ b/frameworks/helloworld/tests/test_taskcfg.py
@@ -20,7 +20,7 @@ def configure_package(configure_security):
             config.SERVICE_NAME,
             0,
             {"service": {"yaml": "taskcfg"}},
-            wait_for_deployment=False,
+            wait_for_deployment=True,
         )
 
         yield  # let the test session execute


### PR DESCRIPTION
https://jira.mesosphere.com/browse/DCOS-39468
https://jira.mesosphere.com/browse/DCOS-40376
Previously we weren't waiting for deployment to finish before checking if tasks had finished running in the taskcfg tests. Since we added a possible 30 second delay to schedulers coming up due to DNS checks, we've introduced a race condition in the test where we no longer are fast enough to pass.