### PR TITLE
[DCOS-40654] When listing reserved resources, fail test if we leaked some.

### DIFF
--- a/testing/sdk_install.py
+++ b/testing/sdk_install.py
@@ -234,9 +234,9 @@ def _uninstall(
             if 'marathon' in str(e):
                 log.info('Detected a probable marathon flake. Raising so retry will trigger.')
                 raise
-            sdk_utils.list_reserved_resources(service_name)
+            sdk_utils.list_reserved_resources_after_uninstall(service_name)
         else:
-            if sdk_utils.list_reserved_resources(service_name):
+            if sdk_utils.list_reserved_resources_after_uninstall(service_name):
                 raise dcos.errors.DCOSException('Leaked resource reservations found.')
 
 

--- a/testing/sdk_install.py
+++ b/testing/sdk_install.py
@@ -234,8 +234,10 @@ def _uninstall(
             if 'marathon' in str(e):
                 log.info('Detected a probable marathon flake. Raising so retry will trigger.')
                 raise
-        finally:
-            sdk_utils.list_reserved_resources()
+            sdk_utils.list_reserved_resources(service_name)
+        else:
+            if sdk_utils.list_reserved_resources(service_name):
+                raise dcos.errors.DCOSException('Leaked resource reservations found.')
 
 
 def merge_dictionaries(dict1, dict2):

--- a/testing/sdk_utils.py
+++ b/testing/sdk_utils.py
@@ -25,18 +25,30 @@ def get_service_name(default: str) -> str:
     return os.environ.get("INTEGRATION_TEST__SERVICE_NAME") or default
 
 
-def list_reserved_resources():
-    '''Displays the currently reserved resources on all agents via state.json;
-       Currently for INFINITY-1881 where we believe uninstall may not be
-       always doing its job correctly.'''
-    state_json_slaveinfo = dcos.mesos.DCOSClient().get_state_summary()['slaves']
+def list_reserved_resources(service_name: str) -> bool:
+    """
+    Logs all reserved resources and returns a true value if there are some for this service's role.
 
-    for slave in state_json_slaveinfo:
+    The reservations are retrieved from state.json.
+    This is for debugging DCOS-40654.
+    """
+    service_role = service_name.strip("/").replace("/", "__") + "-role"
+    state_json_slave_info = dcos.mesos.DCOSClient().get_state_summary()['slaves']
+    reserved_resources_messages = []
+    found_for_this_service = False
+    msg = 'on slaveid=%s hostname=%s reserved resources: %s'
+    for slave in state_json_slave_info:
         reserved_resources = slave['reserved_resources']
-        if reserved_resources == {}:
+        if not reserved_resources:
             continue
-        msg = 'on slaveid=%s hostname=%s reserved resources: %s'
-        log.info(msg % (slave['id'], slave['hostname'], reserved_resources))
+        reserved_resources_messages.append(msg % (slave['id'], slave['hostname'], reserved_resources))
+        if service_role in reserved_resources:
+            found_for_this_service = True
+    if reserved_resources_messages:
+        log.info('Found following reserved resources post uninstall.')
+        for reserved_resources_message in reserved_resources_messages:
+            log.info(reserved_resources_message)
+    return found_for_this_service
 
 
 def get_foldered_name(service_name):

--- a/testing/sdk_utils.py
+++ b/testing/sdk_utils.py
@@ -25,7 +25,7 @@ def get_service_name(default: str) -> str:
     return os.environ.get("INTEGRATION_TEST__SERVICE_NAME") or default
 
 
-def list_reserved_resources(service_name: str) -> bool:
+def list_reserved_resources_after_uninstall(service_name: str) -> bool:
     """
     Logs all reserved resources and returns a true value if there are some for this service's role.
 
@@ -45,7 +45,7 @@ def list_reserved_resources(service_name: str) -> bool:
         if service_role in reserved_resources:
             found_for_this_service = True
     if reserved_resources_messages:
-        log.info('Found following reserved resources post uninstall.')
+        log.info('Found following reserved resources after uninstalling %s.', service_name)
         for reserved_resources_message in reserved_resources_messages:
             log.info(reserved_resources_message)
     return found_for_this_service


### PR DESCRIPTION
This should let sdk_diag get the log for uninstall scheduler to help us
establish the cause for those leaks.

This is already implemented on master in a different way.