### PR TITLE
[DCOS-41166] Make getGitSHA robust for use in non-git folders

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@
 /**/build
 /**/__pycache__
 *.pyc
+.*
 
 !test_requirements.txt
 !test_runner.sh

--- a/sdk/scheduler/build.gradle
+++ b/sdk/scheduler/build.gradle
@@ -5,17 +5,23 @@ plugins {
 
 // Configure the SDKBuildInfo class generator
 def getGitHash = { ->
+    def valueOnFailure = "UNKNOWN"
     def stdout = new ByteArrayOutputStream()
-    exec {
-        commandLine 'git', 'rev-parse', '--short', 'HEAD'
-        standardOutput = stdout
+    try {
+        exec {
+            commandLine 'git', 'rev-parse', '--short', 'HEAD'
+            standardOutput = stdout
+        }
+        exec {
+            // Teamcity workaround: using 'git describe' to determine dirty status doesn't work there.
+            commandLine '/bin/sh', '-c', 'if [ -n "$(git diff --name-only HEAD)" ]; then echo -dirty; fi'
+            standardOutput = stdout
+        }
+        return stdout.toString().replace("\n", "")
+    } catch(Exception ex) {
+        logger.error("An error occurred while calculating the git hash. Using {}", valueOnFailure)
     }
-    exec {
-        // Teamcity workaround: using 'git describe' to determine dirty status doesn't work there.
-        commandLine '/bin/sh', '-c', 'if [ -n "$(git diff --name-only HEAD)" ]; then echo -dirty; fi'
-        standardOutput = stdout
-    }
-    return stdout.toString().replace("\n", "")
+    return valueOnFailure
 }
 buildConfig {
     packageName = 'com.mesosphere.sdk.generated'


### PR DESCRIPTION
* Use UNKNOWN as git sha for scheduler JAR in case of error
* Don't pass `.*` to Docker context by default

When executing in a non-git folder or when building the docker image we now see:
```bash
./gradlew testClasses
Parallel execution is an incubating feature.

> Configure project :scheduler
fatal: Not a git repository (or any of the parent directories): .git
An error occurred while calculating the git hash. Using %s
```

See related PRs:
* #2623 where the implicit requirement that this support a non-git repo folder was introduced.
* #2644 where this caused issues