### PR TITLE
[DCOS-41166] Use UNKNOWN as git sha for scheduler JAR in case of error

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,3 +10,4 @@
 !test.sh
 !TESTING.md
 !/tools/**/*.py
+!.pre-commit-config.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,19 @@
-FROM ubuntu:16.04
-RUN apt-get update && apt-get install -y \
-    git \
+FROM ubuntu:18.04
+
+ENV GO_VERSION=1.10.2
+
+# Install JDK via PPA: https://github.com/franzwong/til/blob/master/java/silent-install-oracle-jdk8-ubuntu.md
+RUN apt-get update && \
+    apt-get install -y python3-software-properties software-properties-common && \
+    add-apt-repository -y ppa:webupd8team/java && \
+    apt-get update && \
+    echo "oracle-java8-installer shared/accepted-oracle-license-v1-1 select true" | debconf-set-selections && \
+    apt-get install -y \
     curl \
+    git \
     jq \
-    default-jdk \
+    libssl-dev \
+    oracle-java8-installer \
     python-pip \
     python3 \
     python3-dev \
@@ -11,35 +21,52 @@ RUN apt-get update && apt-get install -y \
     rsync \
     tox \
     software-properties-common \
-    python-software-properties \
-    libssl-dev \
     upx-ucl \
     wget \
     zip && \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/* && \
+    java -version && \
+    curl -O https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz && \
+    tar -xf go${GO_VERSION}.linux-amd64.tar.gz && \
+    mv go /usr/local && \
+    rm -f go${GO_VERSION}.linux-amd64.tar.gz
 
-# Install go 1.8.5
-RUN curl -O https://storage.googleapis.com/golang/go1.8.5.linux-amd64.tar.gz && \
-    tar -xf go1.8.5.linux-amd64.tar.gz && \
-    mv go /usr/local
 ENV PATH=$PATH:/usr/local/go/bin
 RUN go version
 
 # AWS CLI for uploading build artifacts
 RUN pip3 install awscli
-# Install the testing dependencies
+# Install the lint+testing dependencies
 COPY test_requirements.txt test_requirements.txt
-RUN pip3 install -r test_requirements.txt
-# shakedown and dcos-cli require this to output cleanly
+RUN pip3 install --upgrade -r test_requirements.txt
+
+# Get DC/OS CLI
+RUN curl -O https://downloads.dcos.io/binaries/cli/linux/x86-64/dcos-1.12/dcos && \
+    chmod +x dcos && \
+    mv dcos /usr/local/bin && \
+    dcos --version
+
+# dcos-cli and lint tooling require this to output cleanly
 ENV LC_ALL=C.UTF-8 LANG=C.UTF-8
 # use an arbitrary path for temporary build artifacts
 ENV GOPATH=/go-tmp
 # make a dir for holding the SSH key in tests
 RUN mkdir /root/.ssh
 
+# Copy all of the repo into the image, then run some build/lint commands against the copy to heat up caches. Then delete the copy.
+RUN mkdir /tmp/repo/
+COPY / /tmp/repo/
+# gradlew: Heat up jar cache. pre-commit: Heat up lint tooling cache.
+RUN cd /tmp/repo/ && \
+    ./gradlew testClasses && \
+    git init && \
+    pre-commit install-hooks && \
+    cd / && \
+    rm -rf /tmp/repo/
+
 # Create a build-tool directory:
 RUN mkdir /build-tools
-ENV PATH /build-tools:$PATH
+ENV PATH=/build-tools:$PATH
 
 COPY tools/distribution/init /build-tools/
 COPY tools/ci/test_runner.sh /build-tools/
@@ -47,7 +74,6 @@ COPY tools/ci/launch_cluster.sh /build-tools/
 
 # Create a folder to store the distributed artefacts
 RUN mkdir /dcos-commons-dist
-
 ENV DCOS_COMMONS_DIST_ROOT /dcos-commons-dist
 
 COPY tools/distribution/* ${DCOS_COMMONS_DIST_ROOT}/
@@ -59,6 +85,7 @@ COPY conftest.py ${DCOS_COMMONS_DIST_ROOT}/
 
 COPY testing ${DCOS_COMMONS_DIST_ROOT}/testing
 COPY tools ${DCOS_COMMONS_DIST_ROOT}/tools
+COPY .pre-commit-config.yaml ${DCOS_COMMONS_DIST_ROOT}/
 
 COPY build.gradle ${DCOS_COMMONS_DIST_ROOT}/build.gradle
 RUN grep -oE "version = '.*?'" ${DCOS_COMMONS_DIST_ROOT}/build.gradle | sed 's/version = //' > ${DCOS_COMMONS_DIST_ROOT}/.version

--- a/sdk/common/build.gradle
+++ b/sdk/common/build.gradle
@@ -22,17 +22,23 @@ task sourceJar(type: Jar) {
 
 // Configure the SDKBuildInfo class generator
 def getGitHash = { ->
+    def valueOnFailure = "UNKNOWN"
     def stdout = new ByteArrayOutputStream()
-    exec {
-        commandLine 'git', 'rev-parse', '--short', 'HEAD'
-        standardOutput = stdout
+    try {
+        exec {
+            commandLine 'git', 'rev-parse', '--short', 'HEAD'
+            standardOutput = stdout
+        }
+        exec {
+            // Teamcity workaround: using 'git describe' to determine dirty status doesn't work there.
+            commandLine '/bin/sh', '-c', 'if [ -n "$(git diff --name-only HEAD)" ]; then echo -dirty; fi'
+            standardOutput = stdout
+        }
+        return stdout.toString().replace("\n", "")
+    } catch(Exception ex) {
+        logger.error("An error occurred while calculating the git hash. Using {}", valueOnFailure)
     }
-    exec {
-        // Teamcity workaround: using 'git describe' to determine dirty status doesn't work there.
-        commandLine '/bin/sh', '-c', 'if [ -n "$(git diff --name-only HEAD)" ]; then echo -dirty; fi'
-        standardOutput = stdout
-    }
-    return stdout.toString().replace("\n", "")
+    return valueOnFailure
 }
 buildConfig {
     packageName = 'com.mesosphere.sdk.generated'

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,10 +1,22 @@
-botocore
-py==1.5.1
+# Deprecated libraries which are still used by sdk-0.40 and external repos.
+# dcos-commons master meanwhile doesn't use these anymore as of PR#2616, but we still include them
+# here for now. Remove these once sdk-0.40 and external repos have upgraded their testing/.
+# - required for dcos.servicemanager library, used internally in the dcos library:
 git+https://github.com/dcos/dcos-cli.git@f1fd38c9e72e1d521cf8120fe4948a789fb40cbc#egg=dcoscli&subdirectory=cli
+# - manually select the correct version of the dcos library to avoid a package_manager param count issue in the version declared by shakedown:
 git+https://github.com/dcos/dcos-cli.git@f1fd38c9e72e1d521cf8120fe4948a789fb40cbc
+# - refrain from jumping to 1.5 since we're moving off shakedown anyway:
 dcos-shakedown==1.4.12
-git+https://github.com/dcos/dcos-test-utils.git@c9a4fc583a4a0bca18040ad4c7772e187e51aa74
-git+https://github.com/dcos/dcos-launch.git@e44c5cb521925cd6efd71da343a806ce2f22b496
+
+# Used by tools/create_testing_volumes.py (and for dcos-launch CLI):
+git+https://github.com/dcos/dcos-test-utils.git@3ebfc18ff9c5a1aa382311474a9192a68c98b0a7
+git+https://github.com/dcos/dcos-launch.git@dc1e116685fba5105f322b007549b7eb104cf441
+
+# CI:
 teamcity-messages
+
+# Lint:
+pre-commit
 flake8
 pylint
+black


### PR DESCRIPTION
Makes a change equivalent to the Gradle change in #2645 to the `sdk-0.40` branch. This is required to unblock #2644 which in-turn unblocks #2639