### PR TITLE
DCOS-38256 Fixed bug where if Port env-key was defined, env based secrets were empty.

### DIFF
--- a/frameworks/helloworld/src/main/dist/secrets.yml
+++ b/frameworks/helloworld/src/main/dist/secrets.yml
@@ -26,6 +26,10 @@ pods:
                echo hello >> hello-container-path/output && sleep $SLEEP_DURATION
         cpus: {{HELLO_CPUS}}
         memory: {{HELLO_MEM}}
+          ports:
+            test:
+              port: 0
+              env-key: PORT_ENV_VAR
         volume:
           path: hello-container-path
           type: ROOT

--- a/frameworks/helloworld/src/main/dist/secrets.yml
+++ b/frameworks/helloworld/src/main/dist/secrets.yml
@@ -26,10 +26,10 @@ pods:
                echo hello >> hello-container-path/output && sleep $SLEEP_DURATION
         cpus: {{HELLO_CPUS}}
         memory: {{HELLO_MEM}}
-          ports:
-            test:
-              port: 0
-              env-key: PORT_ENV_VAR
+        ports:
+          test:
+            port: 0
+            env-key: PORT_ENV_VAR
         volume:
           path: hello-container-path
           type: ROOT

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/taskdata/EnvUtils.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/taskdata/EnvUtils.java
@@ -23,11 +23,11 @@ public class EnvUtils {
      * In the event of duplicate labels, the last duplicate wins.
      * This is the inverse of {@link #toProto(Map)}.
      */
-    public static Map<String, String> toMap(Environment environment) {
+    public static Map<String, Environment.Variable> toMap(Environment environment) {
         // sort labels alphabetically for convenience in debugging/logging:
-        Map<String, String> map = new TreeMap<>();
+        Map<String, Environment.Variable> map = new TreeMap<>();
         for (Environment.Variable variable : environment.getVariablesList()) {
-            map.put(variable.getName(), variable.getValue());
+            map.put(variable.getName(), variable);
         }
         return map;
     }
@@ -40,8 +40,8 @@ public class EnvUtils {
         Environment.Builder envBuilder = Environment.newBuilder();
         for (Map.Entry<String, String> entry : environmentMap.entrySet()) {
             envBuilder.addVariablesBuilder()
-                .setName(entry.getKey())
-                .setValue(entry.getValue());
+                    .setName(entry.getKey())
+                    .setValue(entry.getValue());
         }
         return envBuilder.build();
     }
@@ -50,9 +50,16 @@ public class EnvUtils {
      * Adds or updates the provided environment variable entry in the provided command builder.
      */
     public static Environment withEnvVar(Environment environment, String key, String value) {
-        Map<String, String> envMap = toMap(environment);
-        envMap.put(key, value);
-        return toProto(envMap);
+        Map<String, Environment.Variable> envMap = toMap(environment);
+        envMap.put(key, Environment.Variable.newBuilder()
+                .setName(key)
+                .setValue(value)
+                .build());
+        Environment.Builder envBuilder = Environment.newBuilder();
+        for (Map.Entry<String, Environment.Variable> entry : envMap.entrySet()) {
+            envBuilder.addVariables(entry.getValue());
+        }
+        return envBuilder.build();
     }
 
     /**

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/LaunchEvaluationStageTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/LaunchEvaluationStageTest.java
@@ -88,9 +88,9 @@ public class LaunchEvaluationStageTest extends DefaultCapabilitiesTestSuite {
         stage.evaluate(new MesosResourcePool(offer, Optional.of(Constants.ANY_ROLE)), podInfoBuilder);
         Protos.TaskInfo.Builder taskBuilder = podInfoBuilder.getTaskBuilder(TestConstants.TASK_NAME);
 
-        Map<String, String> env = EnvUtils.toMap(taskBuilder.getCommand().getEnvironment());
-        Assert.assertEquals(TestConstants.LOCAL_REGION, env.get(EnvConstants.REGION_TASKENV));
-        Assert.assertEquals(TestConstants.ZONE, env.get(EnvConstants.ZONE_TASKENV));
+        Map<String, Protos.Environment.Variable> env = EnvUtils.toMap(taskBuilder.getCommand().getEnvironment());
+        Assert.assertEquals(TestConstants.LOCAL_REGION, env.get(EnvConstants.REGION_TASKENV).getValue());
+        Assert.assertEquals(TestConstants.ZONE, env.get(EnvConstants.ZONE_TASKENV).getValue());
     }
 
     @Test
@@ -98,7 +98,7 @@ public class LaunchEvaluationStageTest extends DefaultCapabilitiesTestSuite {
         stage.evaluate(new MesosResourcePool(offer, Optional.of(Constants.ANY_ROLE)), podInfoBuilder);
         Protos.TaskInfo.Builder taskBuilder = podInfoBuilder.getTaskBuilder(TestConstants.TASK_NAME);
 
-        Map<String, String> env = EnvUtils.toMap(taskBuilder.getCommand().getEnvironment());
+        Map<String, Protos.Environment.Variable> env = EnvUtils.toMap(taskBuilder.getCommand().getEnvironment());
         Assert.assertNull(env.get(EnvConstants.REGION_TASKENV));
         Assert.assertNull(env.get(EnvConstants.ZONE_TASKENV));
     }

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluatorPortsTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluatorPortsTest.java
@@ -44,8 +44,8 @@ public class OfferEvaluatorPortsTest extends OfferEvaluatorTestBase {
         Protos.Resource fulfilledPortResource = taskInfo.getResources(0);
         Assert.assertFalse(getResourceId(fulfilledPortResource).isEmpty());
 
-        Map<String, String> envvars = EnvUtils.toMap(taskInfo.getCommand().getEnvironment());
-        Assert.assertEquals(String.valueOf(555), envvars.get(TestConstants.PORT_ENV_NAME + "_555"));
+        Map<String, Protos.Environment.Variable> envvars = EnvUtils.toMap(taskInfo.getCommand().getEnvironment());
+        Assert.assertEquals(String.valueOf(555), envvars.get(TestConstants.PORT_ENV_NAME + "_555").getValue());
     }
 
 
@@ -128,9 +128,9 @@ public class OfferEvaluatorPortsTest extends OfferEvaluatorTestBase {
         Protos.Resource fulfilledPortResource = taskInfo.getResources(0);
         Assert.assertFalse(getResourceId(fulfilledPortResource).isEmpty());
 
-        Map<String, String> envvars = EnvUtils.toMap(taskInfo.getCommand().getEnvironment());
+        Map<String, Protos.Environment.Variable> envvars = EnvUtils.toMap(taskInfo.getCommand().getEnvironment());
         Assert.assertEquals(envvars.toString(),
-                String.valueOf(10000), envvars.get(TestConstants.PORT_ENV_NAME + "_0"));
+                String.valueOf(10000), envvars.get(TestConstants.PORT_ENV_NAME + "_0").getValue());
     }
 
 
@@ -161,8 +161,8 @@ public class OfferEvaluatorPortsTest extends OfferEvaluatorTestBase {
         Operation launchOperation = recommendations.get(2).getOperation();
         TaskInfo taskInfo = launchOperation.getLaunchGroup().getTaskGroup().getTasks(0);
 
-        Map<String, String> envvars = EnvUtils.toMap(taskInfo.getCommand().getEnvironment());
-        Assert.assertEquals(String.valueOf(666), envvars.get(TestConstants.PORT_ENV_NAME + "_666"));
+        Map<String, Protos.Environment.Variable> envvars = EnvUtils.toMap(taskInfo.getCommand().getEnvironment());
+        Assert.assertEquals(String.valueOf(666), envvars.get(TestConstants.PORT_ENV_NAME + "_666").getValue());
     }
 
 
@@ -194,8 +194,8 @@ public class OfferEvaluatorPortsTest extends OfferEvaluatorTestBase {
         Operation launchOperation = recommendations.get(2).getOperation();
         TaskInfo taskInfo = launchOperation.getLaunchGroup().getTaskGroup().getTasks(0);
 
-        Map<String, String> envvars = EnvUtils.toMap(taskInfo.getCommand().getEnvironment());
-        Assert.assertEquals(String.valueOf(666), envvars.get(TestConstants.PORT_ENV_NAME + "_666"));
+        Map<String, Protos.Environment.Variable> envvars = EnvUtils.toMap(taskInfo.getCommand().getEnvironment());
+        Assert.assertEquals(String.valueOf(666), envvars.get(TestConstants.PORT_ENV_NAME + "_666").getValue());
     }
 
     @Test
@@ -260,9 +260,9 @@ public class OfferEvaluatorPortsTest extends OfferEvaluatorTestBase {
         Assert.assertEquals(getResourceId(taskInfo.getResources(0)), getResourceId(fulfilledPortResource1));
         Assert.assertEquals(getResourceId(taskInfo.getResources(1)), getResourceId(fulfilledPortResource2));
 
-        Map<String, String> envvars = EnvUtils.toMap(taskInfo.getCommand().getEnvironment());
-        Assert.assertEquals(String.valueOf(10000), envvars.get(portenv0));
-        Assert.assertEquals(String.valueOf(10001), envvars.get(portenv1));
+        Map<String, Protos.Environment.Variable> envvars = EnvUtils.toMap(taskInfo.getCommand().getEnvironment());
+        Assert.assertEquals(String.valueOf(10000), envvars.get(portenv0).getValue());
+        Assert.assertEquals(String.valueOf(10001), envvars.get(portenv1).getValue());
 
         Assert.assertEquals(10000, taskInfo.getResources(0).getRanges().getRange(0).getBegin());
         Assert.assertEquals(10000, taskInfo.getResources(0).getRanges().getRange(0).getEnd());
@@ -297,8 +297,8 @@ public class OfferEvaluatorPortsTest extends OfferEvaluatorTestBase {
         Assert.assertTrue(vipLabel.getKey().startsWith("VIP_"));
         Assert.assertEquals(vipLabel.getValue(), TestConstants.VIP_NAME + "-10000:80");
 
-        Map<String, String> envvars = EnvUtils.toMap(taskInfo.getCommand().getEnvironment());
-        Assert.assertEquals(String.valueOf(10000), envvars.get(TestConstants.PORT_ENV_NAME + "_VIP_10000"));
+        Map<String, Protos.Environment.Variable> envvars = EnvUtils.toMap(taskInfo.getCommand().getEnvironment());
+        Assert.assertEquals(String.valueOf(10000), envvars.get(TestConstants.PORT_ENV_NAME + "_VIP_10000").getValue());
     }
 
     @SuppressWarnings("PMD.AvoidUsingHardCodedIP")
@@ -328,8 +328,8 @@ public class OfferEvaluatorPortsTest extends OfferEvaluatorTestBase {
         Assert.assertTrue(vipLabel.getKey().startsWith("VIP_"));
         Assert.assertEquals(vipLabel.getValue(), TestConstants.VIP_NAME + "-0:80");
 
-        Map<String, String> envvars = EnvUtils.toMap(taskInfo.getCommand().getEnvironment());
-        Assert.assertEquals(String.valueOf(10000), envvars.get(TestConstants.PORT_ENV_NAME + "_VIP_0"));
+        Map<String, Protos.Environment.Variable> envvars = EnvUtils.toMap(taskInfo.getCommand().getEnvironment());
+        Assert.assertEquals(String.valueOf(10000), envvars.get(TestConstants.PORT_ENV_NAME + "_VIP_0").getValue());
     }
 
     private Collection<Resource> getExpectedExecutorResources(Protos.ExecutorInfo executorInfo) {

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/taskdata/EnvUtilsTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/taskdata/EnvUtilsTest.java
@@ -9,11 +9,11 @@ import org.junit.Test;
  */
 public class EnvUtilsTest {
 
-    private final String SECRET_KEY = "SECRET_KEY";
-    private final String SECRET_PATH = "SECRET_PATH";
-    private final String TEST_ENV_KEY = "TEST_KEY";
-    private final String TEST_ENV_VALUE = "TEST_VALUE";
-    private final String TEST_REPLACE_ENV_VALUE = "TEST_NEW_VALUE";
+    private final static String SECRET_KEY = "SECRET_KEY";
+    private final static String SECRET_PATH = "SECRET_PATH";
+    private final static String TEST_ENV_KEY = "TEST_KEY";
+    private final static String TEST_ENV_VALUE = "TEST_VALUE";
+    private final static String TEST_REPLACE_ENV_VALUE = "TEST_NEW_VALUE";
 
     /*
         Make sure that withEnvVar does not accidentally strip secrets.

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/taskdata/EnvUtilsTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/taskdata/EnvUtilsTest.java
@@ -1,0 +1,64 @@
+package com.mesosphere.sdk.offer.taskdata;
+
+import org.apache.mesos.Protos;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests for {@link EnvUtils}.
+ */
+public class EnvUtilsTest {
+
+    private final String SECRET_KEY = "SECRET_KEY";
+    private final String SECRET_PATH = "SECRET_PATH";
+    private final String TEST_ENV_KEY = "TEST_KEY";
+    private final String TEST_ENV_VALUE = "TEST_VALUE";
+    private final String TEST_REPLACE_ENV_VALUE = "TEST_NEW_VALUE";
+
+    /*
+        Make sure that withEnvVar does not accidentally strip secrets.
+        DCOS-38256
+     */
+    @Test
+    public void addEnvVarToEnvironmentWithSecret() {
+        Protos.Environment.Builder envBuilder = Protos.Environment.newBuilder();
+        envBuilder.addVariablesBuilder()
+                .setName(SECRET_KEY)
+                .setType(Protos.Environment.Variable.Type.SECRET)
+                .setSecret(getReferenceSecret(SECRET_PATH));
+        Protos.Environment newEnv = EnvUtils.withEnvVar(envBuilder.build(), TEST_ENV_KEY, TEST_ENV_VALUE);
+        Assert.assertEquals(newEnv.getVariablesCount(), 2);
+        for(Protos.Environment.Variable envVar : newEnv.getVariablesList()) {
+            if (envVar.getName().equals(SECRET_KEY)) {
+                Assert.assertEquals(envVar.getSecret(), getReferenceSecret(SECRET_PATH));
+            }
+            if (envVar.getName().equals(TEST_ENV_KEY)) {
+                Assert.assertEquals(envVar.getValue(), TEST_ENV_VALUE);
+            }
+
+        }
+    }
+
+    /*
+        Make sure withEnvVar overwrites an existing key's value, instead of adding a new one.
+    */
+    @Test
+    public void overwriteExistingEnvVarKey() {
+        Protos.Environment.Builder envBuilder = Protos.Environment.newBuilder();
+        envBuilder.addVariablesBuilder()
+                .setName(TEST_ENV_KEY)
+                .setValue(TEST_ENV_VALUE)
+                .build();
+        Protos.Environment newEnv = EnvUtils.withEnvVar(envBuilder.build(), TEST_ENV_KEY, TEST_REPLACE_ENV_VALUE);
+        Assert.assertEquals(newEnv.getVariablesCount(), 1);
+        Protos.Environment.Variable envVar = newEnv.getVariables(0);
+        Assert.assertEquals(envVar.getValue(), TEST_REPLACE_ENV_VALUE);
+    }
+
+    private static Protos.Secret getReferenceSecret(String secretPath) {
+        return Protos.Secret.newBuilder()
+                .setType(Protos.Secret.Type.REFERENCE)
+                .setReference(Protos.Secret.Reference.newBuilder().setName(secretPath))
+                .build();
+    }
+}


### PR DESCRIPTION
I added a port env-key to the secrets test to test this as an integration in the future, and wrote some unit tests for withEnvVar.