### PR TITLE
Wait for deploy plan to kick off before checking for task state.

### DIFF
--- a/frameworks/helloworld/tests/test_taskcfg.py
+++ b/frameworks/helloworld/tests/test_taskcfg.py
@@ -43,7 +43,7 @@ def test_deploy():
     # wait for new TASK_FAILEDs to appear:
     @retrying.retry(
         wait_fixed=1000,
-        stop_max_delay=1000*wait_time_in_seconds,
+        stop_max_delay=1000 * wait_time_in_seconds,
         retry_on_result=lambda res: not res)
     def wait_for_new_failures():
         new_state_history = _get_state_history(task_name)


### PR DESCRIPTION
https://jira.mesosphere.com/browse/DCOS-40376
https://jira.mesosphere.com/browse/DCOS-39468

Bumped up wait timeout to last through the schedulers DNS resolution. 
Also added sdk_plan.wait_for_kicked_off_deployment which should wait until the apiServer is up and responding. 