### PR TITLE
[DCOS-41242] Download bootstrap URI from scheduler for DNS lookup for multiport test.

### DIFF
--- a/frameworks/helloworld/src/main/dist/multiport.yml
+++ b/frameworks/helloworld/src/main/dist/multiport.yml
@@ -5,6 +5,8 @@ scheduler:
 pods:
   multiport:
     count: {{HELLO_COUNT}}
+    uris:
+      - {{BOOTSTRAP_URI}}
     resource-sets:
       multi-port-resources:
         ports:


### PR DESCRIPTION
https://github.com/mesosphere/dcos-commons/pull/2627/files
This PR added bootstrap to cmd to wait for DNS resolution of the pod before trying to do networking. Unfortunately it didn't add the URI for the bootstrap binary, so ./bootstrap was unable to be found. This adds the URI so the binary is pulled into the sandbox, and should fix DCOS-41242.