### PR TITLE
DCOS-38256 Backport Fixed bug where if Port env-key was defined, env based secrets were empty.

### DIFF
--- a/frameworks/helloworld/src/main/dist/secrets.yml
+++ b/frameworks/helloworld/src/main/dist/secrets.yml
@@ -26,6 +26,10 @@ pods:
                echo hello >> hello-container-path/output && sleep $SLEEP_DURATION
         cpus: {{HELLO_CPUS}}
         memory: {{HELLO_MEM}}
+        ports:
+          test:
+            port: 0
+            env-key: PORT_ENV_VAR
         volume:
           path: hello-container-path
           type: ROOT

--- a/sdk/common/src/main/java/com/mesosphere/sdk/offer/taskdata/EnvUtils.java
+++ b/sdk/common/src/main/java/com/mesosphere/sdk/offer/taskdata/EnvUtils.java
@@ -23,11 +23,11 @@ public class EnvUtils {
      * In the event of duplicate labels, the last duplicate wins.
      * This is the inverse of {@link #toProto(Map)}.
      */
-    public static Map<String, String> toMap(Environment environment) {
+    public static Map<String, Environment.Variable> toMap(Environment environment) {
         // sort labels alphabetically for convenience in debugging/logging:
-        Map<String, String> map = new TreeMap<>();
+        Map<String, Environment.Variable> map = new TreeMap<>();
         for (Environment.Variable variable : environment.getVariablesList()) {
-            map.put(variable.getName(), variable.getValue());
+            map.put(variable.getName(), variable);
         }
         return map;
     }
@@ -40,8 +40,8 @@ public class EnvUtils {
         Environment.Builder envBuilder = Environment.newBuilder();
         for (Map.Entry<String, String> entry : environmentMap.entrySet()) {
             envBuilder.addVariablesBuilder()
-                .setName(entry.getKey())
-                .setValue(entry.getValue());
+                    .setName(entry.getKey())
+                    .setValue(entry.getValue());
         }
         return envBuilder.build();
     }
@@ -50,9 +50,16 @@ public class EnvUtils {
      * Adds or updates the provided environment variable entry in the provided command builder.
      */
     public static Environment withEnvVar(Environment environment, String key, String value) {
-        Map<String, String> envMap = toMap(environment);
-        envMap.put(key, value);
-        return toProto(envMap);
+        Map<String, Environment.Variable> envMap = toMap(environment);
+        envMap.put(key, Environment.Variable.newBuilder()
+                .setName(key)
+                .setValue(value)
+                .build());
+        Environment.Builder envBuilder = Environment.newBuilder();
+        for (Map.Entry<String, Environment.Variable> entry : envMap.entrySet()) {
+            envBuilder.addVariables(entry.getValue());
+        }
+        return envBuilder.build();
     }
 
     /**

--- a/sdk/common/src/main/java/com/mesosphere/sdk/offer/taskdata/EnvUtils.java
+++ b/sdk/common/src/main/java/com/mesosphere/sdk/offer/taskdata/EnvUtils.java
@@ -40,8 +40,8 @@ public class EnvUtils {
         Environment.Builder envBuilder = Environment.newBuilder();
         for (Map.Entry<String, String> entry : environmentMap.entrySet()) {
             envBuilder.addVariablesBuilder()
-                    .setName(entry.getKey())
-                    .setValue(entry.getValue());
+                .setName(entry.getKey())
+                .setValue(entry.getValue());
         }
         return envBuilder.build();
     }

--- a/sdk/executor/src/main/java/com/mesosphere/sdk/offer/taskdata/ProcessBuilderUtils.java
+++ b/sdk/executor/src/main/java/com/mesosphere/sdk/offer/taskdata/ProcessBuilderUtils.java
@@ -1,6 +1,7 @@
 package com.mesosphere.sdk.offer.taskdata;
 
 import java.util.Map;
+import java.util.TreeMap;
 
 import org.apache.mesos.Protos;
 
@@ -13,11 +14,24 @@ public class ProcessBuilderUtils {
     }
 
     /**
+     * Returns a Map representation of the provided {@link Protos.Environment}.
+     * In the event of duplicate labels, the last duplicate wins.
+     */
+    public static Map<String, String> toMap(Protos.Environment environment) {
+        // sort labels alphabetically for convenience in debugging/logging:
+        Map<String, String> map = new TreeMap<>();
+        for (Protos.Environment.Variable variable : environment.getVariablesList()) {
+            map.put(variable.getName(), variable.getValue());
+        }
+        return map;
+    }
+
+    /**
      * Returns a {@link ProcessBuilder} instance which has been initialized with the provided
      * {@link Protos.CommandInfo}'s command and environment.
      */
     public static ProcessBuilder buildProcess(Protos.CommandInfo cmd) {
-        return buildProcess(cmd.getValue(), EnvUtils.toMap(cmd.getEnvironment()));
+        return buildProcess(cmd.getValue(), toMap(cmd.getEnvironment()));
     }
 
     /**

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/LaunchEvaluationStageTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/LaunchEvaluationStageTest.java
@@ -93,9 +93,9 @@ public class LaunchEvaluationStageTest extends DefaultCapabilitiesTestSuite {
                 podInfoBuilder);
         Protos.TaskInfo.Builder taskBuilder = podInfoBuilder.getTaskBuilder(TestConstants.TASK_NAME);
 
-        Map<String, String> env = EnvUtils.toMap(taskBuilder.getCommand().getEnvironment());
-        Assert.assertEquals(TestConstants.LOCAL_REGION, env.get(EnvConstants.REGION_TASKENV));
-        Assert.assertEquals(TestConstants.ZONE, env.get(EnvConstants.ZONE_TASKENV));
+        Map<String, Protos.Environment.Variable> env = EnvUtils.toMap(taskBuilder.getCommand().getEnvironment());
+        Assert.assertEquals(TestConstants.LOCAL_REGION, env.get(EnvConstants.REGION_TASKENV).getValue());
+        Assert.assertEquals(TestConstants.ZONE, env.get(EnvConstants.ZONE_TASKENV).getValue());
     }
 
     @Test
@@ -105,7 +105,7 @@ public class LaunchEvaluationStageTest extends DefaultCapabilitiesTestSuite {
                 podInfoBuilder);
         Protos.TaskInfo.Builder taskBuilder = podInfoBuilder.getTaskBuilder(TestConstants.TASK_NAME);
 
-        Map<String, String> env = EnvUtils.toMap(taskBuilder.getCommand().getEnvironment());
+        Map<String, Protos.Environment.Variable> env = EnvUtils.toMap(taskBuilder.getCommand().getEnvironment());
         Assert.assertNull(env.get(EnvConstants.REGION_TASKENV));
         Assert.assertNull(env.get(EnvConstants.ZONE_TASKENV));
     }

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluatorPortsTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluatorPortsTest.java
@@ -46,8 +46,8 @@ public class OfferEvaluatorPortsTest extends OfferEvaluatorTestBase {
         Assert.assertFalse(getResourceId(fulfilledPortResource).isEmpty());
 
         Protos.CommandInfo command = TaskPackingUtils.unpack(taskInfo).getCommand();
-        Map<String, String> envvars = EnvUtils.toMap(command.getEnvironment());
-        Assert.assertEquals(String.valueOf(555), envvars.get(TestConstants.PORT_ENV_NAME + "_555"));
+        Map<String, Protos.Environment.Variable> envvars = EnvUtils.toMap(command.getEnvironment());
+        Assert.assertEquals(String.valueOf(555), envvars.get(TestConstants.PORT_ENV_NAME + "_555").getValue());
     }
 
     @Test
@@ -67,8 +67,8 @@ public class OfferEvaluatorPortsTest extends OfferEvaluatorTestBase {
         Assert.assertFalse(getResourceId(fulfilledPortResource).isEmpty());
 
         Protos.CommandInfo command = TaskPackingUtils.unpack(taskInfo).getCommand();
-        Map<String, String> envvars = EnvUtils.toMap(command.getEnvironment());
-        Assert.assertEquals(String.valueOf(555), envvars.get(TestConstants.PORT_ENV_NAME + "_555"));
+        Map<String, Protos.Environment.Variable> envvars = EnvUtils.toMap(command.getEnvironment());
+        Assert.assertEquals(String.valueOf(555), envvars.get(TestConstants.PORT_ENV_NAME + "_555").getValue());
     }
 
     @Test
@@ -196,10 +196,10 @@ public class OfferEvaluatorPortsTest extends OfferEvaluatorTestBase {
         Protos.Resource fulfilledPortResource = taskInfo.getResources(0);
         Assert.assertFalse(getResourceId(fulfilledPortResource).isEmpty());
 
-        Map<String, String> envvars = EnvUtils.toMap(
+        Map<String, Protos.Environment.Variable> envvars = EnvUtils.toMap(
                 TaskPackingUtils.unpack(taskInfo).getCommand().getEnvironment());
         Assert.assertEquals(envvars.toString(),
-                String.valueOf(10000), envvars.get(TestConstants.PORT_ENV_NAME + "_0"));
+                String.valueOf(10000), envvars.get(TestConstants.PORT_ENV_NAME + "_0").getValue());
     }
 
     @Test
@@ -218,10 +218,10 @@ public class OfferEvaluatorPortsTest extends OfferEvaluatorTestBase {
         Protos.Resource fulfilledPortResource = taskInfo.getResources(0);
         Assert.assertFalse(getResourceId(fulfilledPortResource).isEmpty());
 
-        Map<String, String> envvars = EnvUtils.toMap(
+        Map<String, Protos.Environment.Variable> envvars = EnvUtils.toMap(
                 TaskPackingUtils.unpack(taskInfo).getCommand().getEnvironment());
         Assert.assertEquals(envvars.toString(),
-                String.valueOf(10000), envvars.get(TestConstants.PORT_ENV_NAME + "_0"));
+                String.valueOf(10000), envvars.get(TestConstants.PORT_ENV_NAME + "_0").getValue());
     }
 
     @Test
@@ -251,9 +251,9 @@ public class OfferEvaluatorPortsTest extends OfferEvaluatorTestBase {
         Operation launchOperation = recommendations.get(2).getOperation();
         TaskInfo taskInfo = launchOperation.getLaunchGroup().getTaskGroup().getTasks(0);
 
-        Map<String, String> envvars = EnvUtils.toMap(
+        Map<String, Protos.Environment.Variable> envvars = EnvUtils.toMap(
                 TaskPackingUtils.unpack(taskInfo).getCommand().getEnvironment());
-        Assert.assertEquals(String.valueOf(666), envvars.get(TestConstants.PORT_ENV_NAME + "_666"));
+        Assert.assertEquals(String.valueOf(666), envvars.get(TestConstants.PORT_ENV_NAME + "_666").getValue());
     }
 
     @Test
@@ -281,9 +281,9 @@ public class OfferEvaluatorPortsTest extends OfferEvaluatorTestBase {
         Operation launchOperation = recommendations.get(2).getOperation();
         TaskInfo taskInfo = launchOperation.getLaunch().getTaskInfos(0);
 
-        Map<String, String> envvars = EnvUtils.toMap(
+        Map<String, Protos.Environment.Variable> envvars = EnvUtils.toMap(
                 TaskPackingUtils.unpack(taskInfo).getCommand().getEnvironment());
-        Assert.assertEquals(String.valueOf(666), envvars.get(TestConstants.PORT_ENV_NAME + "_666"));
+        Assert.assertEquals(String.valueOf(666), envvars.get(TestConstants.PORT_ENV_NAME + "_666").getValue());
     }
 
     @Test
@@ -313,9 +313,9 @@ public class OfferEvaluatorPortsTest extends OfferEvaluatorTestBase {
         Operation launchOperation = recommendations.get(2).getOperation();
         TaskInfo taskInfo = launchOperation.getLaunchGroup().getTaskGroup().getTasks(0);
 
-        Map<String, String> envvars = EnvUtils.toMap(
+        Map<String, Protos.Environment.Variable> envvars = EnvUtils.toMap(
                 TaskPackingUtils.unpack(taskInfo).getCommand().getEnvironment());
-        Assert.assertEquals(String.valueOf(666), envvars.get(TestConstants.PORT_ENV_NAME + "_666"));
+        Assert.assertEquals(String.valueOf(666), envvars.get(TestConstants.PORT_ENV_NAME + "_666").getValue());
     }
 
     @Test
@@ -343,9 +343,9 @@ public class OfferEvaluatorPortsTest extends OfferEvaluatorTestBase {
         Operation launchOperation = recommendations.get(2).getOperation();
         TaskInfo taskInfo = launchOperation.getLaunch().getTaskInfos(0);
 
-        Map<String, String> envvars = EnvUtils.toMap(
+        Map<String, Protos.Environment.Variable> envvars = EnvUtils.toMap(
                 TaskPackingUtils.unpack(taskInfo).getCommand().getEnvironment());
-        Assert.assertEquals(String.valueOf(666), envvars.get(TestConstants.PORT_ENV_NAME + "_666"));
+        Assert.assertEquals(String.valueOf(666), envvars.get(TestConstants.PORT_ENV_NAME + "_666").getValue());
     }
 
     @Test
@@ -438,10 +438,10 @@ public class OfferEvaluatorPortsTest extends OfferEvaluatorTestBase {
         Assert.assertEquals(getResourceId(taskInfo.getResources(0)), getResourceId(fulfilledPortResource1));
         Assert.assertEquals(getResourceId(taskInfo.getResources(1)), getResourceId(fulfilledPortResource2));
 
-        Map<String, String> envvars = EnvUtils.toMap(
+        Map<String, Protos.Environment.Variable> envvars = EnvUtils.toMap(
                 TaskPackingUtils.unpack(taskInfo).getCommand().getEnvironment());
-        Assert.assertEquals(String.valueOf(10000), envvars.get(portenv0));
-        Assert.assertEquals(String.valueOf(10001), envvars.get(portenv1));
+        Assert.assertEquals(String.valueOf(10000), envvars.get(portenv0).getValue());
+        Assert.assertEquals(String.valueOf(10001), envvars.get(portenv1).getValue());
 
         Assert.assertEquals(10000, taskInfo.getResources(0).getRanges().getRange(0).getBegin());
         Assert.assertEquals(10000, taskInfo.getResources(0).getRanges().getRange(0).getEnd());
@@ -478,10 +478,10 @@ public class OfferEvaluatorPortsTest extends OfferEvaluatorTestBase {
         Assert.assertEquals(getResourceId(taskInfo.getResources(0)), getResourceId(fulfilledPortResource1));
         Assert.assertEquals(getResourceId(taskInfo.getResources(1)), getResourceId(fulfilledPortResource2));
 
-        Map<String, String> envvars = EnvUtils.toMap(
+        Map<String, Protos.Environment.Variable> envvars = EnvUtils.toMap(
                 TaskPackingUtils.unpack(taskInfo).getCommand().getEnvironment());
-        Assert.assertEquals(String.valueOf(10000), envvars.get(portenv0));
-        Assert.assertEquals(String.valueOf(10001), envvars.get(portenv1));
+        Assert.assertEquals(String.valueOf(10000), envvars.get(portenv0).getValue());
+        Assert.assertEquals(String.valueOf(10001), envvars.get(portenv1).getValue());
 
         Assert.assertEquals(10000, taskInfo.getResources(0).getRanges().getRange(0).getBegin());
         Assert.assertEquals(10000, taskInfo.getResources(0).getRanges().getRange(0).getEnd());
@@ -517,9 +517,9 @@ public class OfferEvaluatorPortsTest extends OfferEvaluatorTestBase {
         Assert.assertTrue(vipLabel.getKey().startsWith("VIP_"));
         Assert.assertEquals(vipLabel.getValue(), TestConstants.VIP_NAME + "-10000:80");
 
-        Map<String, String> envvars = EnvUtils.toMap(
+        Map<String, Protos.Environment.Variable> envvars = EnvUtils.toMap(
                 TaskPackingUtils.unpack(taskInfo).getCommand().getEnvironment());
-        Assert.assertEquals(String.valueOf(10000), envvars.get(TestConstants.PORT_ENV_NAME + "_VIP_10000"));
+        Assert.assertEquals(String.valueOf(10000), envvars.get(TestConstants.PORT_ENV_NAME + "_VIP_10000").getValue());
     }
 
     @SuppressWarnings("PMD.AvoidUsingHardCodedIP")
@@ -549,9 +549,9 @@ public class OfferEvaluatorPortsTest extends OfferEvaluatorTestBase {
         Assert.assertTrue(vipLabel.getKey().startsWith("VIP_"));
         Assert.assertEquals(vipLabel.getValue(), TestConstants.VIP_NAME + "-0:80");
 
-        Map<String, String> envvars = EnvUtils.toMap(
+        Map<String, Protos.Environment.Variable> envvars = EnvUtils.toMap(
                 TaskPackingUtils.unpack(taskInfo).getCommand().getEnvironment());
-        Assert.assertEquals(String.valueOf(10000), envvars.get(TestConstants.PORT_ENV_NAME + "_VIP_0"));
+        Assert.assertEquals(String.valueOf(10000), envvars.get(TestConstants.PORT_ENV_NAME + "_VIP_0").getValue());
     }
 
     private Collection<Resource> getExpectedExecutorResources(Protos.ExecutorInfo executorInfo) {
@@ -612,8 +612,8 @@ public class OfferEvaluatorPortsTest extends OfferEvaluatorTestBase {
         Assert.assertTrue(vipLabel.getKey().startsWith("VIP_"));
         Assert.assertEquals(vipLabel.getValue(), TestConstants.VIP_NAME + "-0:80");
 
-        Map<String, String> envvars = EnvUtils.toMap(
+        Map<String, Protos.Environment.Variable> envvars = EnvUtils.toMap(
                 TaskPackingUtils.unpack(taskInfo).getCommand().getEnvironment());
-        Assert.assertEquals(String.valueOf(10000), envvars.get(TestConstants.PORT_ENV_NAME + "_VIP_0"));
+        Assert.assertEquals(String.valueOf(10000), envvars.get(TestConstants.PORT_ENV_NAME + "_VIP_0").getValue());
     }
 }

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/taskdata/EnvUtilsTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/taskdata/EnvUtilsTest.java
@@ -1,0 +1,64 @@
+package com.mesosphere.sdk.offer.taskdata;
+
+import org.apache.mesos.Protos;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests for {@link EnvUtils}.
+ */
+public class EnvUtilsTest {
+
+    private final static String SECRET_KEY = "SECRET_KEY";
+    private final static String SECRET_PATH = "SECRET_PATH";
+    private final static String TEST_ENV_KEY = "TEST_KEY";
+    private final static String TEST_ENV_VALUE = "TEST_VALUE";
+    private final static String TEST_REPLACE_ENV_VALUE = "TEST_NEW_VALUE";
+
+    /*
+        Make sure that withEnvVar does not accidentally strip secrets.
+        DCOS-38256
+     */
+    @Test
+    public void addEnvVarToEnvironmentWithSecret() {
+        Protos.Environment.Builder envBuilder = Protos.Environment.newBuilder();
+        envBuilder.addVariablesBuilder()
+                .setName(SECRET_KEY)
+                .setType(Protos.Environment.Variable.Type.SECRET)
+                .setSecret(getReferenceSecret(SECRET_PATH));
+        Protos.Environment newEnv = EnvUtils.withEnvVar(envBuilder.build(), TEST_ENV_KEY, TEST_ENV_VALUE);
+        Assert.assertEquals(newEnv.getVariablesCount(), 2);
+        for(Protos.Environment.Variable envVar : newEnv.getVariablesList()) {
+            if (envVar.getName().equals(SECRET_KEY)) {
+                Assert.assertEquals(envVar.getSecret(), getReferenceSecret(SECRET_PATH));
+            }
+            if (envVar.getName().equals(TEST_ENV_KEY)) {
+                Assert.assertEquals(envVar.getValue(), TEST_ENV_VALUE);
+            }
+
+        }
+    }
+
+    /*
+        Make sure withEnvVar overwrites an existing key's value, instead of adding a new one.
+    */
+    @Test
+    public void overwriteExistingEnvVarKey() {
+        Protos.Environment.Builder envBuilder = Protos.Environment.newBuilder();
+        envBuilder.addVariablesBuilder()
+                .setName(TEST_ENV_KEY)
+                .setValue(TEST_ENV_VALUE)
+                .build();
+        Protos.Environment newEnv = EnvUtils.withEnvVar(envBuilder.build(), TEST_ENV_KEY, TEST_REPLACE_ENV_VALUE);
+        Assert.assertEquals(newEnv.getVariablesCount(), 1);
+        Protos.Environment.Variable envVar = newEnv.getVariables(0);
+        Assert.assertEquals(envVar.getValue(), TEST_REPLACE_ENV_VALUE);
+    }
+
+    private static Protos.Secret getReferenceSecret(String secretPath) {
+        return Protos.Secret.newBuilder()
+                .setType(Protos.Secret.Type.REFERENCE)
+                .setReference(Protos.Secret.Reference.newBuilder().setName(secretPath))
+                .build();
+    }
+}


### PR DESCRIPTION
Backport to 0.40

* DCOS-38256 Fixed bug where if Port env-key was defined, env based
secrets had an empty string value.
