### PR TITLE
[DCOS-40696] log if scheduler is about to hit a null reference

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/AbstractScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/AbstractScheduler.java
@@ -2,6 +2,7 @@ package com.mesosphere.sdk.scheduler;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.TextFormat;
+import com.mesosphere.sdk.framework.ProcessExit;
 import com.mesosphere.sdk.http.types.EndpointProducer;
 import com.mesosphere.sdk.offer.LoggingUtils;
 import com.mesosphere.sdk.scheduler.plan.Plan;
@@ -132,6 +133,7 @@ public abstract class AbstractScheduler implements MesosEventClient {
             workSetTracker.updateWorkSet(activeWorkSet);
         } catch (NullPointerException e) {
             logger.warn("workset tracker is uninitialized, scheduler has his a null reference and is exiting.");
+            ProcessExit.exit(ProcessExit.ERROR, e);
 
         }
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/AbstractScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/AbstractScheduler.java
@@ -127,10 +127,13 @@ public abstract class AbstractScheduler implements MesosEventClient {
                     inProgressSteps.stream().map(step -> step.getMessage()).collect(Collectors.toList()));
         }
         activeWorkSet.addAll(inProgressSteps);
-        if (workSetTracker == null) {
-            logger.warn("workset tracker is uninitialized, scheduler will hit a null reference and exit.");
+
+        try {
+            workSetTracker.updateWorkSet(activeWorkSet);
+        } catch (NullPointerException e) {
+            logger.warn("workset tracker is uninitialized, scheduler has his a null reference and is exiting.");
+
         }
-        workSetTracker.updateWorkSet(activeWorkSet);
 
         return getStatus();
     }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/AbstractScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/AbstractScheduler.java
@@ -128,7 +128,7 @@ public abstract class AbstractScheduler implements MesosEventClient {
         }
         activeWorkSet.addAll(inProgressSteps);
         if (workSetTracker == null) {
-            logger.warn("workset tracker is uninitialized, scheduler will hit a null reference");
+            logger.warn("workset tracker is uninitialized, scheduler will hit a null reference and exit.");
         }
         workSetTracker.updateWorkSet(activeWorkSet);
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/AbstractScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/AbstractScheduler.java
@@ -127,6 +127,9 @@ public abstract class AbstractScheduler implements MesosEventClient {
                     inProgressSteps.stream().map(step -> step.getMessage()).collect(Collectors.toList()));
         }
         activeWorkSet.addAll(inProgressSteps);
+        if (workSetTracker == null) {
+            logger.warn("workset tracker is uninitialized, scheduler will hit a null reference");
+        }
         workSetTracker.updateWorkSet(activeWorkSet);
 
         return getStatus();


### PR DESCRIPTION
Log if the scheduler is about to hit a nullref

this is to help us detect the bug in https://jira.mesosphere.com/browse/DCOS-40696

if we determine this is the correct null ref we can work backwords to detect why it was null in that case.