### PR TITLE
DCOS-39567 Show SDK Plan before performing uninstall.

### DIFF
--- a/testing/sdk_install.py
+++ b/testing/sdk_install.py
@@ -303,7 +303,7 @@ def uninstall(package_name, service_name):
     start = time.time()
 
     log.info("Uninstalling {}".format(service_name))
-   
+
     # Display current SDK Plan before uninstall, helps with debugging stuck uninstalls.
     log.info("Current plan status for {}".format(service_name))
     sdk_cmd.svc_cli(package_name, service_name, check=False)

--- a/testing/sdk_install.py
+++ b/testing/sdk_install.py
@@ -303,6 +303,10 @@ def uninstall(package_name, service_name):
     start = time.time()
 
     log.info("Uninstalling {}".format(service_name))
+   
+    # Display current SDK Plan before uninstall, helps with debugging stuck uninstalls.
+    log.info("Current plan status for {}".format(service_name))
+    sdk_cmd.svc_cli(package_name, service_name, check=False)
 
     try:
         _retried_uninstall_package_and_wait(package_name, service_name)

--- a/testing/sdk_install.py
+++ b/testing/sdk_install.py
@@ -304,7 +304,7 @@ def uninstall(package_name, service_name):
 
     log.info("Uninstalling {}".format(service_name))
 
-    # Display current SDK Plan before uninstall, helps with debugging stuck uninstalls.
+    # Display current SDK Plan before uninstall, helps with debugging stuck uninstalls
     log.info("Current plan status for {}".format(service_name))
     sdk_cmd.svc_cli(package_name, service_name, "plan status deploy", check=False)
 

--- a/testing/sdk_install.py
+++ b/testing/sdk_install.py
@@ -306,7 +306,7 @@ def uninstall(package_name, service_name):
 
     # Display current SDK Plan before uninstall, helps with debugging stuck uninstalls.
     log.info("Current plan status for {}".format(service_name))
-    sdk_cmd.svc_cli(package_name, service_name, check=False)
+    sdk_cmd.svc_cli(package_name, service_name, "plan deploy status", check=False)
 
     try:
         _retried_uninstall_package_and_wait(package_name, service_name)

--- a/testing/sdk_install.py
+++ b/testing/sdk_install.py
@@ -306,7 +306,7 @@ def uninstall(package_name, service_name):
 
     # Display current SDK Plan before uninstall, helps with debugging stuck uninstalls.
     log.info("Current plan status for {}".format(service_name))
-    sdk_cmd.svc_cli(package_name, service_name, "plan deploy status", check=False)
+    sdk_cmd.svc_cli(package_name, service_name, "plan status deploy", check=False)
 
     try:
         _retried_uninstall_package_and_wait(package_name, service_name)


### PR DESCRIPTION
DCOS-39567
Display SDK deploy plan before performing uninstall. This is to help diagnose hanging uninstalls.