### PR TITLE
[TESTS] Disable metrics tests on 1.12

### DIFF
--- a/frameworks/cassandra/tests/test_sanity.py
+++ b/frameworks/cassandra/tests/test_sanity.py
@@ -75,8 +75,10 @@ def test_repair_cleanup_plans_complete():
 @pytest.mark.sanity
 @pytest.mark.metrics
 @pytest.mark.dcos_min_version("1.9")
-@pytest.mark.skipif(sdk_utils.dcos_version() == "1.12",
-                    reason="Metrics are not working on 1.12. Reenable once this is fixed")
+@pytest.mark.skipif(
+    sdk_utils.dcos_version_at_least("1.12"),
+    reason="Metrics are not working on 1.12. Reenable once this is fixed",
+)
 def test_metrics():
     expected_metrics = [
         "org.apache.cassandra.metrics.Table.CoordinatorReadLatency.system.hints.p999",

--- a/frameworks/cassandra/tests/test_sanity.py
+++ b/frameworks/cassandra/tests/test_sanity.py
@@ -6,6 +6,7 @@ import sdk_metrics
 import sdk_networks
 import sdk_plan
 import sdk_upgrade
+import sdk_utils
 
 from tests import config
 
@@ -74,6 +75,8 @@ def test_repair_cleanup_plans_complete():
 @pytest.mark.sanity
 @pytest.mark.metrics
 @pytest.mark.dcos_min_version("1.9")
+@pytest.mark.skipif(sdk_utils.dcos_version() == "1.12",
+                    reason="Metrics are not working on 1.12. Reenable once this is fixed")
 def test_metrics():
     expected_metrics = [
         "org.apache.cassandra.metrics.Table.CoordinatorReadLatency.system.hints.p999",

--- a/frameworks/elastic/tests/test_sanity.py
+++ b/frameworks/elastic/tests/test_sanity.py
@@ -118,6 +118,10 @@ def test_indexing(default_populated_index):
 @pytest.mark.sanity
 @pytest.mark.metrics
 @pytest.mark.dcos_min_version("1.9")
+@pytest.mark.skipif(
+    sdk_utils.dcos_version() == "1.12",
+    reason="Metrics are not working on 1.12. Reenable once this is fixed",
+)
 def test_metrics():
     expected_metrics = [
         "node.data-0-node.fs.total.total_in_bytes",

--- a/frameworks/elastic/tests/test_sanity.py
+++ b/frameworks/elastic/tests/test_sanity.py
@@ -119,7 +119,7 @@ def test_indexing(default_populated_index):
 @pytest.mark.metrics
 @pytest.mark.dcos_min_version("1.9")
 @pytest.mark.skipif(
-    sdk_utils.dcos_version() == "1.12",
+    sdk_utils.dcos_version_at_least("1.12"),
     reason="Metrics are not working on 1.12. Reenable once this is fixed",
 )
 def test_metrics():

--- a/frameworks/hdfs/tests/test_sanity.py
+++ b/frameworks/hdfs/tests/test_sanity.py
@@ -358,6 +358,10 @@ def test_modify_app_config_rollback():
 @pytest.mark.sanity
 @pytest.mark.metrics
 @pytest.mark.dcos_min_version("1.9")
+@pytest.mark.skipif(
+    sdk_utils.dcos_version() == "1.12",
+    reason="Metrics are not working on 1.12. Reenable once this is fixed",
+)
 def test_metrics():
     expected_metrics = [
         "JournalNode.jvm.JvmMetrics.ThreadsRunnable",

--- a/frameworks/hdfs/tests/test_sanity.py
+++ b/frameworks/hdfs/tests/test_sanity.py
@@ -359,7 +359,7 @@ def test_modify_app_config_rollback():
 @pytest.mark.metrics
 @pytest.mark.dcos_min_version("1.9")
 @pytest.mark.skipif(
-    sdk_utils.dcos_version() == "1.12",
+    sdk_utils.dcos_version_at_least("1.12"),
     reason="Metrics are not working on 1.12. Reenable once this is fixed",
 )
 def test_metrics():

--- a/frameworks/kafka/tests/test_sanity.py
+++ b/frameworks/kafka/tests/test_sanity.py
@@ -152,7 +152,7 @@ def test_pod_replace():
 @pytest.mark.metrics
 @pytest.mark.dcos_min_version("1.9")
 @pytest.mark.skipif(
-    sdk_utils.dcos_version() == "1.12",
+    sdk_utils.dcos_version_at_least("1.12"),
     reason="Metrics are not working on 1.12. Reenable once this is fixed",
 )
 def test_metrics():

--- a/frameworks/kafka/tests/test_sanity.py
+++ b/frameworks/kafka/tests/test_sanity.py
@@ -151,6 +151,10 @@ def test_pod_replace():
 @pytest.mark.sanity
 @pytest.mark.metrics
 @pytest.mark.dcos_min_version("1.9")
+@pytest.mark.skipif(
+    sdk_utils.dcos_version() == "1.12",
+    reason="Metrics are not working on 1.12. Reenable once this is fixed",
+)
 def test_metrics():
     expected_metrics = [
         "kafka.network.RequestMetrics.ResponseQueueTimeMs.max",


### PR DESCRIPTION
This PR just disables the metrics tests (which are failing) on 1.12.

For the record, I also have #2664 to add a hello-world smoke test for this so that we can easily test alternative fixes.