### PR TITLE
Add support for Arbitrary Task Labels to Service Spec YAML

### DIFF
--- a/docs/pages/developer-guide.md
+++ b/docs/pages/developer-guide.md
@@ -1053,6 +1053,28 @@ Specifying that pods join a virtual network has the following indirect effects:
     * This was done so that you do not have to remove all of the port resource requirements just to deploy a service on the virtual network.
   * A caveat of this is that the SDK does not allow the configuation of a pod to change from the virtual network to the host network or vice-versa.
 
+## Label-Based Discovery
+
+Some external tools such as [Taefik](https://docs.traefik.io) require tasks to be configured with custom labels which are accessed by reading Mesos state. Below is an example of specifying labels for a task in your service spec YAML:
+
+```
+name: "hello-world"
+pods:
+  hello:
+    count: 1
+    tasks:
+      server:
+        goal: RUNNING
+        cmd: "echo hello >> hello-container-path/output && sleep 1000"
+        cpus: 0.2
+        memory: 256
+        labels: "traefik.enable:true,traefik.frontend.entryPoints:http,traefik.frontend.rule:PathPrefix:/"
+        ports:
+          http:
+          port: 8080
+          advertise: true
+```
+
 # Metrics
 ## Default
 Schedulers generate a set of default metrics.  Metrics are reported in three main categories: offers, operations, and status messages.
@@ -1084,57 +1106,57 @@ The JSON representation of the metrics is available at the `/v1/metrics` endpoin
 ###### JSON
 ```json
 {
-	"version": "3.1.3",
-	"gauges": {},
-	"counters": {
-		"declines.long": {
-			"count": 15
-		},
-		"offers.processed": {
-			"count": 18
-		},
-		"offers.received": {
-			"count": 18
-		},
-		"operation.create": {
-			"count": 5
-		},
-		"operation.launch_group": {
-			"count": 3
-		},
-		"operation.reserve": {
-			"count": 20
-		},
-		"revives": {
-			"count": 3
-		},
-		"task_status.task_running": {
-			"count": 6
-		}
-	},
-	"histograms": {},
-	"meters": {},
-	"timers": {
-		"offers.process": {
-			"count": 10,
-			"max": 0.684745927,
-			"mean": 0.15145255818999337,
-			"min": 5.367950000000001E-4,
-			"p50": 0.0035879090000000002,
-			"p75": 0.40317217800000005,
-			"p95": 0.684745927,
-			"p98": 0.684745927,
-			"p99": 0.684745927,
-			"p999": 0.684745927,
-			"stddev": 0.24017017290826104,
-			"m15_rate": 0.5944843686231079,
-			"m1_rate": 0.5250565015924039,
-			"m5_rate": 0.583689104996544,
-			"mean_rate": 0.3809369986002824,
-			"duration_units": "seconds",
-			"rate_units": "calls/second"
-		}
-	}
+    "version": "3.1.3",
+    "gauges": {},
+    "counters": {
+        "declines.long": {
+            "count": 15
+        },
+        "offers.processed": {
+            "count": 18
+        },
+        "offers.received": {
+            "count": 18
+        },
+        "operation.create": {
+            "count": 5
+        },
+        "operation.launch_group": {
+            "count": 3
+        },
+        "operation.reserve": {
+            "count": 20
+        },
+        "revives": {
+            "count": 3
+        },
+        "task_status.task_running": {
+            "count": 6
+        }
+    },
+    "histograms": {},
+    "meters": {},
+    "timers": {
+        "offers.process": {
+            "count": 10,
+            "max": 0.684745927,
+            "mean": 0.15145255818999337,
+            "min": 5.367950000000001E-4,
+            "p50": 0.0035879090000000002,
+            "p75": 0.40317217800000005,
+            "p95": 0.684745927,
+            "p98": 0.684745927,
+            "p99": 0.684745927,
+            "p999": 0.684745927,
+            "stddev": 0.24017017290826104,
+            "m15_rate": 0.5944843686231079,
+            "m1_rate": 0.5250565015924039,
+            "m5_rate": 0.583689104996544,
+            "mean_rate": 0.3809369986002824,
+            "duration_units": "seconds",
+            "rate_units": "calls/second"
+        }
+    }
 }
 ```
 

--- a/docs/pages/yaml-reference.md
+++ b/docs/pages/yaml-reference.md
@@ -468,6 +468,10 @@ This documentation effectively reflects the Java object tree under [RawServiceSp
 
         The default visibility for the discovery information. May be `FRAMEWORK`, `CLUSTER`, or `EXTERNAL`. If unset this defaults to `CLUSTER`. See [Mesos documentation](http://mesos.apache.org/documentation/latest/app-framework-development-guide/) on service discovery for more information on these visibility values.
 
+    * `labels`
+
+        This may be used to define custom task labels which will be present in the Mesos state.
+
     * `transport-encryption`
 
       A task may optionally ask for a X.509 TLS certificate with private key and CA certificate bundle. A certificate can be used by service to enable secure communication.

--- a/frameworks/helloworld/src/main/dist/svc.yml
+++ b/frameworks/helloworld/src/main/dist/svc.yml
@@ -25,6 +25,7 @@ pods:
           delay: 0
           timeout: 10
           max-consecutive-failures: 3
+        labels: {{HELLO_LABELS}}
   world:
     count: {{WORLD_COUNT}}
     allow-decommission: true

--- a/frameworks/helloworld/src/test/java/com/mesosphere/sdk/helloworld/scheduler/ServiceTest.java
+++ b/frameworks/helloworld/src/test/java/com/mesosphere/sdk/helloworld/scheduler/ServiceTest.java
@@ -999,6 +999,8 @@ public class ServiceTest {
                 "DEPLOY_STEPS", "[[first, second, third]]"));
         schedulerEnvForExamples.put("pod-profile-mount-volume.yml", toMap(
                 "HELLO_VOLUME_PROFILE", "xfs"));
+        schedulerEnvForExamples.put("svc.yml", toMap(
+                "HELLO_LABELS", "label1:label-value1"));
 
         // Iterate over yml files in dist/examples/, run sanity check for each:
         File[] exampleFiles = ServiceTestRunner.getDistDir().listFiles();

--- a/frameworks/helloworld/universe/config.json
+++ b/frameworks/helloworld/universe/config.json
@@ -200,6 +200,11 @@
           "description": "any arbitrary port can be used",
           "type": "integer",
           "default": 1729
+        },
+        "labels": {
+          "description": "labels",
+          "type": "string",
+          "default": ""
         }
       },
       "required": [

--- a/frameworks/helloworld/universe/marathon.json.mustache
+++ b/frameworks/helloworld/universe/marathon.json.mustache
@@ -52,6 +52,7 @@
     {{#hello.kill_grace_period}}
     "HELLO_KILL_GRACE_PERIOD": "{{hello.kill_grace_period}}",
     {{/hello.kill_grace_period}}
+    "HELLO_LABELS": "{{hello.labels}}",
     "WORLD_COUNT": "{{world.count}}",
     "WORLD_CPUS": "{{world.cpus}}",
     "WORLD_MEM": "{{world.mem}}",

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/TaskUtils.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/TaskUtils.java
@@ -207,8 +207,8 @@ public final class TaskUtils {
 
     // Labels
 
-    Map<String, String> oldLabels = oldTaskSpec.getLabels();
-    Map<String, String> newLabels = newTaskSpec.getLabels();
+    Map<String, String> oldLabels = oldTaskSpec.getTaskLabels();
+    Map<String, String> newLabels = newTaskSpec.getTaskLabels();
     if (!Objects.equals(oldLabels, newLabels)) {
       LOGGER.debug("Task labels '{}' and '{}' are different.", oldLabels, newLabels);
       return true;

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/TaskUtils.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/TaskUtils.java
@@ -205,6 +205,15 @@ public final class TaskUtils {
       return true;
     }
 
+    // Labels
+
+    Map<String, String> oldLabels = oldTaskSpec.getLabels();
+    Map<String, String> newLabels = newTaskSpec.getLabels();
+    if (!Objects.equals(oldLabels, newLabels)) {
+      LOGGER.debug("Task labels '{}' and '{}' are different.", oldLabels, newLabels);
+      return true;
+    }
+
     // CommandSpecs
 
     Optional<CommandSpec> oldCommand = oldTaskSpec.getCommand();

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/PodInfoBuilder.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/PodInfoBuilder.java
@@ -261,7 +261,7 @@ public class PodInfoBuilder {
         .setTargetConfiguration(targetConfigurationId)
         .setType(podInstance.getPod().getType())
         .setIndex(podInstance.getIndex())
-        .setAdditionalLabels(taskSpec.getLabels())
+        .setAdditionalLabels(taskSpec.getTaskLabels())
         .toProto());
 
     if (taskSpec.getCommand().isPresent()) {

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/PodInfoBuilder.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/PodInfoBuilder.java
@@ -261,6 +261,7 @@ public class PodInfoBuilder {
         .setTargetConfiguration(targetConfigurationId)
         .setType(podInstance.getPod().getType())
         .setIndex(podInstance.getIndex())
+        .setAdditionalLabels(taskSpec.getLabels())
         .toProto());
 
     if (taskSpec.getCommand().isPresent()) {

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/taskdata/TaskLabelWriter.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/taskdata/TaskLabelWriter.java
@@ -11,6 +11,7 @@ import org.apache.mesos.Protos.Labels;
 import org.apache.mesos.Protos.Offer;
 import org.apache.mesos.Protos.TaskInfo;
 
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -33,6 +34,16 @@ public class TaskLabelWriter {
    */
   public TaskLabelWriter(TaskInfo.Builder taskInfoBuilder) {
     writer = new LabelWriter(taskInfoBuilder.getLabels());
+  }
+
+  /**
+   * Sets additional arbitrary labels.
+   */
+  public TaskLabelWriter setAdditionalLabels(Map<String, String> labels) {
+    for (Map.Entry<String, String> entry : labels.entrySet()) {
+      writer.put(entry.getKey(), entry.getValue());
+    }
+    return this;
   }
 
   /**

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultNetworkSpec.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultNetworkSpec.java
@@ -31,8 +31,8 @@ public final class DefaultNetworkSpec implements NetworkSpec {
       @JsonProperty("network-labels") Map<String, String> labels)
   {
     this.networkName = networkName;
-    this.portMappings = portMappings == null ? Collections.emptyMap() : portMappings;
-    this.labels = labels == null ? Collections.emptyMap() : labels;
+    this.portMappings = (portMappings != null) ? portMappings : Collections.emptyMap();
+    this.labels = (labels != null) ? labels : Collections.emptyMap();
   }
 
   private DefaultNetworkSpec(Builder builder) {

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultTaskSpec.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultTaskSpec.java
@@ -36,7 +36,7 @@ public final class DefaultTaskSpec implements TaskSpec {
 
   private final CommandSpec commandSpec;
 
-  private final Map<String, String> labels;
+  private final Map<String, String> taskLabels;
 
   private final HealthCheckSpec healthCheckSpec;
 
@@ -60,7 +60,7 @@ public final class DefaultTaskSpec implements TaskSpec {
       @JsonProperty("essential") Boolean essential,
       @JsonProperty("resource-set") ResourceSet resourceSet,
       @JsonProperty("command-spec") CommandSpec commandSpec,
-      @JsonProperty("task-labels") Map<String, String> labels,
+      @JsonProperty("task-labels") Map<String, String> taskLabels,
       @JsonProperty("health-check-spec") HealthCheckSpec healthCheckSpec,
       @JsonProperty("readiness-check-spec") ReadinessCheckSpec readinessCheckSpec,
       @JsonProperty("config-files") Collection<ConfigFileSpec> configFiles,
@@ -74,7 +74,7 @@ public final class DefaultTaskSpec implements TaskSpec {
     this.essential = (essential != null) ? essential : true;
     this.resourceSet = resourceSet;
     this.commandSpec = commandSpec;
-    this.labels = (labels != null) ? labels : Collections.emptyMap();
+    this.taskLabels = (taskLabels != null) ? taskLabels : Collections.emptyMap();
     this.healthCheckSpec = healthCheckSpec;
     this.readinessCheckSpec = readinessCheckSpec;
     this.configFiles = (configFiles != null) ? configFiles : Collections.emptyList();
@@ -94,7 +94,7 @@ public final class DefaultTaskSpec implements TaskSpec {
         builder.essential,
         builder.resourceSet,
         builder.commandSpec,
-        builder.labels,
+        builder.taskLabels,
         builder.healthCheckSpec,
         builder.readinessCheckSpec,
         builder.configFiles,
@@ -141,7 +141,7 @@ public final class DefaultTaskSpec implements TaskSpec {
     builder.essential = copy.isEssential();
     builder.resourceSet = copy.getResourceSet();
     builder.commandSpec = copy.getCommand().orElse(null);
-    builder.labels = copy.getLabels();
+    builder.taskLabels = copy.getTaskLabels();
     builder.readinessCheckSpec(copy.getReadinessCheck().orElse(null));
     builder.healthCheckSpec = copy.getHealthCheck().orElse(null);
     builder.readinessCheckSpec = copy.getReadinessCheck().orElse(null);
@@ -178,8 +178,8 @@ public final class DefaultTaskSpec implements TaskSpec {
   }
 
   @Override
-  public Map<String, String> getLabels() {
-    return labels;
+  public Map<String, String> getTaskLabels() {
+    return taskLabels;
   }
 
   @Override
@@ -245,7 +245,7 @@ public final class DefaultTaskSpec implements TaskSpec {
 
     private CommandSpec commandSpec;
 
-    private Map<String, String> labels;
+    private Map<String, String> taskLabels;
 
     private HealthCheckSpec healthCheckSpec;
 
@@ -322,14 +322,14 @@ public final class DefaultTaskSpec implements TaskSpec {
     }
 
     /**
-     * Sets the {@code labels} and returns a reference to this Builder so that the methods can be
+     * Sets the {@code taskLabels} and returns a reference to this Builder so that the methods can be
      * chained together.
      *
-     * @param labels the {@code labels} to set
+     * @param taskLabels the {@code taskLabels} to set
      * @return a reference to this Builder
      */
-    public Builder taskLabels(Map<String, String> labels) {
-      this.labels = labels;
+    public Builder taskLabels(Map<String, String> taskLabels) {
+      this.taskLabels = taskLabels;
       return this;
     }
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultTaskSpec.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultTaskSpec.java
@@ -11,8 +11,8 @@ import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Optional;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Default implementation of a {@link TaskSpec}.

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultTaskSpec.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultTaskSpec.java
@@ -12,6 +12,7 @@ import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Optional;
+import java.util.Map;
 
 /**
  * Default implementation of a {@link TaskSpec}.
@@ -35,6 +36,8 @@ public final class DefaultTaskSpec implements TaskSpec {
 
   private final CommandSpec commandSpec;
 
+  private final Map<String, String> labels;
+
   private final HealthCheckSpec healthCheckSpec;
 
   private final ReadinessCheckSpec readinessCheckSpec;
@@ -57,6 +60,7 @@ public final class DefaultTaskSpec implements TaskSpec {
       @JsonProperty("essential") Boolean essential,
       @JsonProperty("resource-set") ResourceSet resourceSet,
       @JsonProperty("command-spec") CommandSpec commandSpec,
+      @JsonProperty("task-labels") Map<String, String> labels,
       @JsonProperty("health-check-spec") HealthCheckSpec healthCheckSpec,
       @JsonProperty("readiness-check-spec") ReadinessCheckSpec readinessCheckSpec,
       @JsonProperty("config-files") Collection<ConfigFileSpec> configFiles,
@@ -70,6 +74,7 @@ public final class DefaultTaskSpec implements TaskSpec {
     this.essential = (essential != null) ? essential : true;
     this.resourceSet = resourceSet;
     this.commandSpec = commandSpec;
+    this.labels = (labels != null) ? labels : Collections.emptyMap();
     this.healthCheckSpec = healthCheckSpec;
     this.readinessCheckSpec = readinessCheckSpec;
     this.configFiles = (configFiles != null) ? configFiles : Collections.emptyList();
@@ -89,6 +94,7 @@ public final class DefaultTaskSpec implements TaskSpec {
         builder.essential,
         builder.resourceSet,
         builder.commandSpec,
+        builder.labels,
         builder.healthCheckSpec,
         builder.readinessCheckSpec,
         builder.configFiles,
@@ -135,6 +141,7 @@ public final class DefaultTaskSpec implements TaskSpec {
     builder.essential = copy.isEssential();
     builder.resourceSet = copy.getResourceSet();
     builder.commandSpec = copy.getCommand().orElse(null);
+    builder.labels = copy.getLabels();
     builder.readinessCheckSpec(copy.getReadinessCheck().orElse(null));
     builder.healthCheckSpec = copy.getHealthCheck().orElse(null);
     builder.readinessCheckSpec = copy.getReadinessCheck().orElse(null);
@@ -168,6 +175,11 @@ public final class DefaultTaskSpec implements TaskSpec {
   @Override
   public Optional<CommandSpec> getCommand() {
     return Optional.ofNullable(commandSpec);
+  }
+
+  @Override
+  public Map<String, String> getLabels() {
+    return labels;
   }
 
   @Override
@@ -232,6 +244,8 @@ public final class DefaultTaskSpec implements TaskSpec {
     private ResourceSet resourceSet;
 
     private CommandSpec commandSpec;
+
+    private Map<String, String> labels;
 
     private HealthCheckSpec healthCheckSpec;
 
@@ -304,6 +318,18 @@ public final class DefaultTaskSpec implements TaskSpec {
      */
     public Builder commandSpec(CommandSpec commandSpec) {
       this.commandSpec = commandSpec;
+      return this;
+    }
+
+    /**
+     * Sets the {@code labels} and returns a reference to this Builder so that the methods can be
+     * chained together.
+     *
+     * @param labels the {@code labels} to set
+     * @return a reference to this Builder
+     */
+    public Builder taskLabels(Map<String, String> labels) {
+      this.labels = labels;
       return this;
     }
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/TaskSpec.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/TaskSpec.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 import java.util.Collection;
 import java.util.Optional;
+import java.util.Map;
 
 /**
  * Specification for a Task.
@@ -33,6 +34,9 @@ public interface TaskSpec {
 
   @JsonProperty("command-spec")
   Optional<CommandSpec> getCommand();
+
+  @JsonProperty("task-labels")
+  Map<String, String> getLabels();
 
   @JsonProperty("health-check-spec")
   Optional<HealthCheckSpec> getHealthCheck();

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/TaskSpec.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/TaskSpec.java
@@ -4,8 +4,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 import java.util.Collection;
-import java.util.Optional;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Specification for a Task.

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/TaskSpec.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/TaskSpec.java
@@ -36,7 +36,7 @@ public interface TaskSpec {
   Optional<CommandSpec> getCommand();
 
   @JsonProperty("task-labels")
-  Map<String, String> getLabels();
+  Map<String, String> getTaskLabels();
 
   @JsonProperty("health-check-spec")
   Optional<HealthCheckSpec> getHealthCheck();

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/RawNetwork.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/RawNetwork.java
@@ -3,10 +3,8 @@ package com.mesosphere.sdk.specification.yaml;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * Raw YAML network.
@@ -60,22 +58,5 @@ public final class RawNetwork {
 
   public String getLabelsCsv() {
     return labelsCsv;
-  }
-
-  public List<String[]> getValidatedLabels() throws IllegalArgumentException {
-    List<String[]> kvs = Arrays.stream(labelsCsv.split(","))
-        .map(s -> s.split(":", 2))
-        .collect(Collectors.toList());
-    kvs.forEach(kv -> {
-      if (kv.length != 2) {
-        throw new IllegalArgumentException(String.format(
-            "Illegal label string, got %s, should be " +
-                "comma-seperated key value pairs (seperated by colons)." +
-                " For example: k_0:v_0,k_1:v_1,...,k_n:v_n",
-            labelsCsv
-        ));
-      }
-    });
-    return kvs;
   }
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/RawNetwork.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/RawNetwork.java
@@ -64,7 +64,7 @@ public final class RawNetwork {
 
   public List<String[]> getValidatedLabels() throws IllegalArgumentException {
     List<String[]> kvs = Arrays.stream(labelsCsv.split(","))
-        .map(s -> s.split(":"))
+        .map(s -> s.split(":", 2))
         .collect(Collectors.toList());
     kvs.forEach(kv -> {
       if (kv.length != 2) {
@@ -79,4 +79,3 @@ public final class RawNetwork {
     return kvs;
   }
 }
-

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/RawTask.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/RawTask.java
@@ -2,9 +2,11 @@ package com.mesosphere.sdk.specification.yaml;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Raw YAML task.
@@ -16,6 +18,8 @@ public final class RawTask {
   private final Boolean essential;
 
   private final String cmd;
+
+  private final String labelsCsv;
 
   private final Map<String, String> env;
 
@@ -49,6 +53,7 @@ public final class RawTask {
       @JsonProperty("goal") String goal,
       @JsonProperty("essential") Boolean essential,
       @JsonProperty("cmd") String cmd,
+      @JsonProperty("labels") String labels,
       @JsonProperty("env") Map<String, String> env,
       @JsonProperty("configs") WriteOnceLinkedHashMap<String, RawConfig> configs,
       @JsonProperty("cpus") Double cpus,
@@ -67,6 +72,7 @@ public final class RawTask {
     this.goal = goal;
     this.essential = essential;
     this.cmd = cmd;
+    this.labelsCsv = labels;
     this.env = env;
     this.configs = configs;
     this.cpus = cpus;
@@ -125,6 +131,27 @@ public final class RawTask {
 
   public String getCmd() {
     return cmd;
+  }
+
+  public String getLabelsCsv() {
+    return labelsCsv;
+  }
+
+  public List<String[]> getValidatedLabels() throws IllegalArgumentException {
+    List<String[]> kvs = Arrays.stream(labelsCsv.split(","))
+      .map(s -> s.split(":", 2))
+      .collect(Collectors.toList());
+    kvs.forEach(kv -> {
+      if (kv.length != 2) {
+        throw new IllegalArgumentException(String.format(
+            "Illegal label string, got %s, should be " +
+                "comma-seperated key value pairs (seperated by colons)." +
+                " For example: k_0:v_0,k_1:v_1,...,k_n:v_n",
+            labelsCsv
+        ));
+      }
+    });
+    return kvs;
   }
 
   public Map<String, String> getEnv() {

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/RawTask.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/RawTask.java
@@ -139,8 +139,8 @@ public final class RawTask {
 
   public List<String[]> getValidatedLabels() throws IllegalArgumentException {
     List<String[]> kvs = Arrays.stream(labelsCsv.split(","))
-      .map(s -> s.split(":", 2))
-      .collect(Collectors.toList());
+        .map(s -> s.split(":", 2))
+        .collect(Collectors.toList());
     kvs.forEach(kv -> {
       if (kv.length != 2) {
         throw new IllegalArgumentException(String.format(

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/RawTask.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/RawTask.java
@@ -2,11 +2,9 @@ package com.mesosphere.sdk.specification.yaml;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 /**
  * Raw YAML task.
@@ -135,23 +133,6 @@ public final class RawTask {
 
   public String getLabelsCsv() {
     return labelsCsv;
-  }
-
-  public List<String[]> getValidatedLabels() throws IllegalArgumentException {
-    List<String[]> kvs = Arrays.stream(labelsCsv.split(","))
-        .map(s -> s.split(":", 2))
-        .collect(Collectors.toList());
-    kvs.forEach(kv -> {
-      if (kv.length != 2) {
-        throw new IllegalArgumentException(String.format(
-            "Illegal label string, got %s, should be " +
-                "comma-seperated key value pairs (seperated by colons)." +
-                " For example: k_0:v_0,k_1:v_1,...,k_n:v_n",
-            labelsCsv
-        ));
-      }
-    });
-    return kvs;
   }
 
   public Map<String, String> getEnv() {

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/YAMLToInternalMappers.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/YAMLToInternalMappers.java
@@ -479,8 +479,7 @@ public final class YAMLToInternalMappers {
         .name(taskName);
 
     if (!Strings.isNullOrEmpty(rawTask.getLabelsCsv())) {
-      builder.taskLabels(rawTask.getValidatedLabels()
-          .stream().collect(Collectors.toMap(s -> s[0], s -> s[1])));
+      builder.taskLabels(convertLabels(rawTask.getLabelsCsv()));
     }
 
     if (StringUtils.isNotBlank(rawTask.getResourceSet())) {
@@ -621,6 +620,26 @@ public final class YAMLToInternalMappers {
         principal);
   }
 
+  private static Map<String, String> convertLabels(
+      String rawLabelsCsv) throws IllegalArgumentException
+  {
+    List<String[]> kvs = Arrays.stream(rawLabelsCsv.split(","))
+        .map(s -> s.split(":", 2))
+        .collect(Collectors.toList());
+    kvs.forEach(kv -> {
+      if (kv.length != 2) {
+        throw new IllegalArgumentException(String.format(
+            "Illegal label string, got %s, should be " +
+                "comma-seperated key value pairs (seperated by colons)." +
+                " For example: k_0:v_0,k_1:v_1,...,k_n:v_n",
+            rawLabelsCsv
+        ));
+      }
+    });
+
+    return kvs.stream().collect(Collectors.toMap(s -> s[0], s -> s[1]));
+  }
+
   private static DefaultNetworkSpec convertNetwork(
       String networkName,
       RawNetwork rawNetwork,
@@ -652,8 +671,7 @@ public final class YAMLToInternalMappers {
     }
 
     if (!Strings.isNullOrEmpty(rawNetwork.getLabelsCsv())) {
-      builder.networkLabels(rawNetwork.getValidatedLabels()
-          .stream().collect(Collectors.toMap(s -> s[0], s -> s[1])));
+      builder.networkLabels(convertLabels(rawNetwork.getLabelsCsv()));
     }
 
     return builder.build();

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/YAMLToInternalMappers.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/YAMLToInternalMappers.java
@@ -478,6 +478,11 @@ public final class YAMLToInternalMappers {
         .setTransportEncryption(transportEncryption)
         .name(taskName);
 
+    if (!Strings.isNullOrEmpty(rawTask.getLabelsCsv())) {
+      builder.taskLabels(rawTask.getValidatedLabels()
+          .stream().collect(Collectors.toMap(s -> s[0], s -> s[1])));
+    }
+
     if (StringUtils.isNotBlank(rawTask.getResourceSet())) {
       // Use resource set content:
       builder.resourceSet(

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/LaunchEvaluationStageTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/LaunchEvaluationStageTest.java
@@ -53,7 +53,7 @@ public class LaunchEvaluationStageTest extends DefaultCapabilitiesTestSuite {
         stage.evaluate(new MesosResourcePool(offer, Optional.of(Constants.ANY_ROLE)), podInfoBuilder);
         Protos.TaskInfo.Builder taskBuilder = podInfoBuilder.getTaskBuilder(TestConstants.TASK_NAME);
 
-        Assert.assertEquals(5, taskBuilder.getLabels().getLabelsCount());
+        Assert.assertEquals(6, taskBuilder.getLabels().getLabelsCount());
 
         // labels are sorted alphabetically (see LabelUtils):
         Protos.Label label = taskBuilder.getLabels().getLabels(0);
@@ -61,18 +61,22 @@ public class LaunchEvaluationStageTest extends DefaultCapabilitiesTestSuite {
         Assert.assertEquals(Integer.toString(TestConstants.TASK_INDEX), label.getValue());
 
         label = taskBuilder.getLabels().getLabels(1);
+        Assert.assertEquals(label.getKey(), "label1");
+        Assert.assertEquals("label1-value", label.getValue());
+
+        label = taskBuilder.getLabels().getLabels(2);
         Assert.assertEquals("offer_attributes", label.getKey());
         Assert.assertEquals("", label.getValue());
 
-        label = taskBuilder.getLabels().getLabels(2);
+        label = taskBuilder.getLabels().getLabels(3);
         Assert.assertEquals("offer_hostname", label.getKey());
         Assert.assertEquals(TestConstants.HOSTNAME, label.getValue());
 
-        label = taskBuilder.getLabels().getLabels(3);
+        label = taskBuilder.getLabels().getLabels(4);
         Assert.assertEquals("target_configuration", label.getKey());
         Assert.assertEquals(36, label.getValue().length());
 
-        label = taskBuilder.getLabels().getLabels(4);
+        label = taskBuilder.getLabels().getLabels(5);
         Assert.assertEquals(label.getKey(), "task_type");
         Assert.assertEquals(TestConstants.POD_TYPE, label.getValue());
     }

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/taskdata/TaskLabelReaderWriterTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/taskdata/TaskLabelReaderWriterTest.java
@@ -8,7 +8,9 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -105,6 +107,18 @@ public class TaskLabelReaderWriterTest {
         builder = getTestTaskInfo().toBuilder();
         builder.setLabels(new TaskLabelWriter(builder).setType("").toProto());
         Assert.assertEquals("", new TaskLabelReader(builder).getType());
+    }
+
+    @Test
+    public void testAdditionalLabels() throws TaskException {
+        Map<String, String> labels = new HashMap<String, String>();
+        labels.put("label1", "label1-value");
+        labels.put("label2", "label2-value");
+
+        Protos.TaskInfo.Builder builder = getTestTaskInfo().toBuilder();
+        builder.setLabels(new TaskLabelWriter(builder).setAdditionalLabels(labels).toProto());
+        Assert.assertEquals("label1-value", new LabelReader("", builder.getLabels()).getOrThrow("label1"));
+        Assert.assertEquals("label2-value", new LabelReader("", builder.getLabels()).getOrThrow("label2"));
     }
 
     @Test

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/plan/PodInstanceRequirementTestUtils.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/plan/PodInstanceRequirementTestUtils.java
@@ -172,6 +172,7 @@ public class PodInstanceRequirementTestUtils {
                                 .build())
                 .goalState(GoalState.RUNNING)
                 .resourceSet(resourceSet)
+                .taskLabels(TestConstants.LABELS)
                 .build();
 
         PodSpec podSpec = DefaultPodSpec.newBuilder(type, 1, Arrays.asList(taskSpec))

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/specification/DefaultServiceSpecTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/specification/DefaultServiceSpecTest.java
@@ -412,17 +412,30 @@ public class DefaultServiceSpecTest {
     }
 
     @Test
-    public void validLabels() throws Exception {
+    public void validTaskLabels() throws Exception {
         ClassLoader classLoader = getClass().getClassLoader();
-        File file = new File(classLoader.getResource("valid-labels.yml").getFile());
+        File file = new File(classLoader.getResource("valid-task-labels.yml").getFile());
         DefaultServiceSpec defaultServiceSpec = DefaultServiceSpec.newGenerator(file, SCHEDULER_CONFIG).build();
-        Assert.assertEquals("label1-value", defaultServiceSpec.getPods().get(0).getTasks().get(0).getLabels().get("label1"));
+        PodSpec podSpec = defaultServiceSpec.getPods().get(0);
+        Assert.assertTrue("", Iterables.get(podSpec.getTasks(), 0).getTaskLabels().containsKey("label1"));
+        Assert.assertTrue("", Iterables.get(podSpec.getTasks(), 0).getTaskLabels()
+                          .get("label1").equals("label1-value"));
+        Assert.assertTrue("", Iterables.get(podSpec.getTasks(), 0).getTaskLabels().containsKey("label2"));
+        Assert.assertTrue("", Iterables.get(podSpec.getTasks(), 0).getTaskLabels()
+                          .get("label2").equals("path:/"));
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void invalidLabels() throws Exception {
+    public void invalidTaskLabelsFormat() throws Exception {
         ClassLoader classLoader = getClass().getClassLoader();
-        File file = new File(classLoader.getResource("invalid-labels.yml").getFile());
+        File file = new File(classLoader.getResource("invalid-task-labels-format.yml").getFile());
+        DefaultServiceSpec.newGenerator(file, SCHEDULER_CONFIG).build();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void invalidTaskLabelsBlank() throws Exception {
+        ClassLoader classLoader = getClass().getClassLoader();
+        File file = new File(classLoader.getResource("invalid-task-labels-blank.yml").getFile());
         DefaultServiceSpec.newGenerator(file, SCHEDULER_CONFIG).build();
     }
 
@@ -452,7 +465,7 @@ public class DefaultServiceSpecTest {
                 .get("key1").equals("val1"));
         Assert.assertTrue("", Iterables.get(podSpec.getNetworks(), 0).getLabels().containsKey("key2"));
         Assert.assertTrue("", Iterables.get(podSpec.getNetworks(), 0).getLabels()
-                .get("key2").equals("val2"));
+                .get("key2").equals("val2a:val2b"));
     }
 
     @Test
@@ -481,13 +494,26 @@ public class DefaultServiceSpecTest {
         }
     }
 
-
     @Test(expected = IllegalArgumentException.class)
     public void invalidNetworks() throws Exception {
         ClassLoader classLoader = getClass().getClassLoader();
         // this service spec contains specifies an overlay network that doesn't support port mapping, but contains
         // port mapping requests
         File file = new File(classLoader.getResource("invalid-network.yml").getFile());
+        DefaultServiceSpec.newGenerator(file, SCHEDULER_CONFIG).build();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void invalidNetworkLabelsFormat() throws Exception {
+        ClassLoader classLoader = getClass().getClassLoader();
+        File file = new File(classLoader.getResource("invalid-network-labels-format.yml").getFile());
+        DefaultServiceSpec.newGenerator(file, SCHEDULER_CONFIG).build();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void invalidNetworkLabelsBlank() throws Exception {
+        ClassLoader classLoader = getClass().getClassLoader();
+        File file = new File(classLoader.getResource("invalid-network-labels-blank.yml").getFile());
         DefaultServiceSpec.newGenerator(file, SCHEDULER_CONFIG).build();
     }
 

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/specification/DefaultServiceSpecTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/specification/DefaultServiceSpecTest.java
@@ -411,6 +411,21 @@ public class DefaultServiceSpecTest {
         Assert.assertEquals("group/image", defaultServiceSpec.getPods().get(0).getImage().get());
     }
 
+    @Test
+    public void validLabels() throws Exception {
+        ClassLoader classLoader = getClass().getClassLoader();
+        File file = new File(classLoader.getResource("valid-labels.yml").getFile());
+        DefaultServiceSpec defaultServiceSpec = DefaultServiceSpec.newGenerator(file, SCHEDULER_CONFIG).build();
+        Assert.assertEquals("label1-value", defaultServiceSpec.getPods().get(0).getTasks().get(0).getLabels().get("label1"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void invalidLabels() throws Exception {
+        ClassLoader classLoader = getClass().getClassLoader();
+        File file = new File(classLoader.getResource("invalid-labels.yml").getFile());
+        DefaultServiceSpec.newGenerator(file, SCHEDULER_CONFIG).build();
+    }
+
     @Test(expected = IllegalArgumentException.class)
     public void invalidImageNull() throws Exception {
         ClassLoader classLoader = getClass().getClassLoader();

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/specification/DefaultTaskSpecTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/specification/DefaultTaskSpecTest.java
@@ -61,6 +61,7 @@ public class DefaultTaskSpecTest {
                         .visibility(Protos.DiscoveryInfo.Visibility.CLUSTER)
                         .build())
                 .taskKillGracePeriodSeconds(DefaultTaskSpec.TASK_KILL_GRACE_PERIOD_SECONDS_DEFAULT)
+                .taskLabels(TestConstants.LABELS)
                 .build();
 
         DefaultTaskSpec clone = DefaultTaskSpec.newBuilder(original).build();

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/testutils/TestConstants.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/testutils/TestConstants.java
@@ -4,6 +4,9 @@ import org.apache.mesos.Protos;
 
 import com.mesosphere.sdk.offer.CommonIdUtils;
 
+import java.util.Map;
+import java.util.HashMap;
+
 /**
  * This class encapsulates constants for tests.
  */
@@ -47,6 +50,9 @@ public class TestConstants {
                     .setMount(Protos.Resource.DiskInfo.Source.Mount.newBuilder().setRoot("/mnt/source"))
                     .build();
     public static final String IP_ADDRESS = "localhost";
+    public static final Map<String, String> LABELS = getDefaultLabels();
+
+
 
     // CNI port mapping constants
     public static final int HOST_PORT = 4040;
@@ -107,5 +113,11 @@ public class TestConstants {
                         .setZone(Protos.DomainInfo.FaultDomain.ZoneInfo.newBuilder().setName(TestConstants.ZONE))
                         .setRegion(Protos.DomainInfo.FaultDomain.RegionInfo.newBuilder().setName(region)))
                 .build();
+    }
+
+    private static final Map<String, String> getDefaultLabels() {
+        Map<String, String> labels = new HashMap<String, String>();
+        labels.put("label1", "label1-value");
+        return labels;
     }
 }

--- a/sdk/scheduler/src/test/resources/invalid-labels.yml
+++ b/sdk/scheduler/src/test/resources/invalid-labels.yml
@@ -1,0 +1,11 @@
+name: "invalid-labels-test"
+pods:
+  server:
+    count: 1
+    tasks:
+      server:
+        goal: RUNNING
+        cmd: "cmd"
+        cpus: 1
+        memory: 1024
+        labels: "label1,label1-value"

--- a/sdk/scheduler/src/test/resources/invalid-network-labels-blank.yml
+++ b/sdk/scheduler/src/test/resources/invalid-network-labels-blank.yml
@@ -1,10 +1,10 @@
-name: "valid-container-network-test"
+name: "invalid-network-labels-blank-test"
 pods:
   server:
     count: 1
     networks:
       dcos:
-        labels: "key1:val1,key2:val2a:val2b"
+        labels: "   "
     tasks:
       server:
         goal: RUNNING

--- a/sdk/scheduler/src/test/resources/invalid-network-labels-format.yml
+++ b/sdk/scheduler/src/test/resources/invalid-network-labels-format.yml
@@ -1,10 +1,10 @@
-name: "valid-container-network-test"
+name: "invalid-network-labels-format-test"
 pods:
   server:
     count: 1
     networks:
       dcos:
-        labels: "key1:val1,key2:val2a:val2b"
+        labels: "key1,val1"
     tasks:
       server:
         goal: RUNNING

--- a/sdk/scheduler/src/test/resources/invalid-task-labels-blank.yml
+++ b/sdk/scheduler/src/test/resources/invalid-task-labels-blank.yml
@@ -1,0 +1,11 @@
+name: "invalid-task-labels-blank-test"
+pods:
+  server:
+    count: 1
+    tasks:
+      server:
+        goal: RUNNING
+        cmd: "cmd"
+        cpus: 1
+        memory: 1024
+        labels: "   "

--- a/sdk/scheduler/src/test/resources/invalid-task-labels-format.yml
+++ b/sdk/scheduler/src/test/resources/invalid-task-labels-format.yml
@@ -1,4 +1,4 @@
-name: "invalid-labels-test"
+name: "invalid-task-labels-format-test"
 pods:
   server:
     count: 1

--- a/sdk/scheduler/src/test/resources/valid-exhaustive.yml
+++ b/sdk/scheduler/src/test/resources/valid-exhaustive.yml
@@ -44,6 +44,7 @@ pods:
         goal: RUNNING
         cmd: "echo $TASK_NAME >> $TASK_NAME$CONTAINER_PATH_SUFFIX/output && sleep $SLEEP_DURATION"
         resource-set: meta-data-resources
+        labels: "label1:label1-value,label2:label2-value"
         env:
           TASK_NAME: "meta-data"
           CONTAINER_PATH_SUFFIX: "-container-path"

--- a/sdk/scheduler/src/test/resources/valid-exhaustive.yml
+++ b/sdk/scheduler/src/test/resources/valid-exhaustive.yml
@@ -9,6 +9,7 @@ pods:
     count: 2
     networks:
       dcos:
+        labels: "key1:value1"
     rlimits:
       RLIMIT_AS:
         soft: 5

--- a/sdk/scheduler/src/test/resources/valid-labels.yml
+++ b/sdk/scheduler/src/test/resources/valid-labels.yml
@@ -1,0 +1,11 @@
+name: "valid-labels-test"
+pods:
+  server:
+    count: 1
+    tasks:
+      server:
+        goal: RUNNING
+        cmd: "cmd"
+        cpus: 1
+        memory: 1024
+        labels: "label1:label1-value,label2:path:/"

--- a/sdk/scheduler/src/test/resources/valid-task-labels.yml
+++ b/sdk/scheduler/src/test/resources/valid-task-labels.yml
@@ -1,4 +1,4 @@
-name: "valid-labels-test"
+name: "valid-task-labels-test"
 pods:
   server:
     count: 1


### PR DESCRIPTION
Some external tools such as [Traefik](https://docs.traefik.io) require tasks to be configured with custom labels which are accessed by reading Mesos state. This change allows for functionality like the following to be defined in a service spec YAML:

```
pods:
  hello:
    tasks:
      server:
        ...
        labels: "traefik.enable:true,traefik.frontend.entryPoints:http,traefik.frontend.rule:PathPrefix:/"
        ports:
          http:
          port: 8080
          advertise: true
```