### PR TITLE
[TOOLS] Also persist KDC when deploying

### DIFF
--- a/tools/kdc/kdc.py
+++ b/tools/kdc/kdc.py
@@ -90,7 +90,7 @@ def parse_principals(principals_file: str) -> list:
 def deploy(args: dict):
     log.info("Deploying KDC")
 
-    kerberos = sdk_auth.KerberosEnvironment()
+    kerberos = sdk_auth.KerberosEnvironment(persist=True)
 
     if args.principals_file:
         create_keytab_secret(args, kerberos)


### PR DESCRIPTION
This PR ensures that the `persist=True` flag is passed to the KDC when running the `deploy` subcommand. If this is not done, the installed KDC will be torn-down. This is not favourable, for example, in Soak.