### PR TITLE
DCOS-42191 Don't try unreserving pre-reserved resources, fix plan spam

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/ResourceUtils.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/ResourceUtils.java
@@ -59,54 +59,42 @@ public class ResourceUtils {
         return new MesosResource(resource).getRole();
     }
 
-    public static Optional<String> getPrincipal(Protos.Resource resource) {
-        Optional<Protos.Resource.ReservationInfo> reservationInfo = getReservation(resource);
-
-        if (reservationInfo.isPresent()) {
-            return Optional.of(reservationInfo.get().getPrincipal());
-        } else {
-            return Optional.empty();
-        }
-    }
-
     public static Optional<Protos.Resource.ReservationInfo> getReservation(Protos.Resource resource) {
-        if (resource.getReservationsCount() > 0) {
-            return getRefinedReservation(resource);
-        } else {
-            return getLegacyReservation(resource);
-        }
-    }
-
-    private static Optional<Protos.Resource.ReservationInfo> getRefinedReservation(Protos.Resource resource) {
-        if (resource.getReservationsCount() == 0) {
-            return Optional.empty();
-        }
-
-        return Optional.of(resource.getReservations(resource.getReservationsCount() - 1));
-    }
-
-    private static Optional<Protos.Resource.ReservationInfo> getLegacyReservation(Protos.Resource resource) {
-        if (resource.hasReservation()) {
+        int count = resource.getReservationsCount();
+        if (count > 0) {
+            // This is a refined reservation against a pre-reserved resource. Reservation entries should in this order:
+            // 1. STATIC reservation for the pre-reserved role (e.g. slave_public)
+            // 2. DYNAMIC reservation for our refined role (e.g. slave_public/svc-role)
+            return Optional.of(resource.getReservations(count - 1));
+        } else if (resource.hasReservation()) {
+            // "Classic" reservation against a resource that isn't statically reserved.
+            // This is the common case when reserving resources that aren't pre-reserved.
             return Optional.of(resource.getReservation());
         } else {
+            // No reservations present.
             return Optional.empty();
         }
+    }
+
+    public static Optional<String> getPrincipal(Protos.Resource resource) {
+        Optional<Protos.Resource.ReservationInfo> reservationInfo = getReservation(resource);
+        return reservationInfo.isPresent()
+                ? Optional.of(reservationInfo.get().getPrincipal())
+                : Optional.empty();
     }
 
     public static Optional<String> getNamespace(Protos.Resource resource) {
         Optional<Protos.Resource.ReservationInfo> reservationInfo = getReservation(resource);
-        if (!reservationInfo.isPresent()) {
-            return Optional.empty();
-        }
-        return AuxLabelAccess.getResourceNamespace(reservationInfo.get());
+        return reservationInfo.isPresent()
+                ? AuxLabelAccess.getResourceNamespace(reservationInfo.get())
+                : Optional.empty();
     }
 
     public static Optional<String> getResourceId(Protos.Resource resource) {
         Optional<Protos.Resource.ReservationInfo> reservationInfo = getReservation(resource);
-        if (!reservationInfo.isPresent()) {
-            return Optional.empty();
-        }
-        return AuxLabelAccess.getResourceId(reservationInfo.get());
+        return reservationInfo.isPresent()
+                ? AuxLabelAccess.getResourceId(reservationInfo.get())
+                : Optional.empty();
     }
 
     public static boolean hasResourceId(Protos.Resource resource) {

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/ResourceUtils.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/ResourceUtils.java
@@ -77,24 +77,15 @@ public class ResourceUtils {
     }
 
     public static Optional<String> getPrincipal(Protos.Resource resource) {
-        Optional<Protos.Resource.ReservationInfo> reservationInfo = getReservation(resource);
-        return reservationInfo.isPresent()
-                ? Optional.of(reservationInfo.get().getPrincipal())
-                : Optional.empty();
+        return getReservation(resource).map(Protos.Resource.ReservationInfo::getPrincipal);
     }
 
     public static Optional<String> getNamespace(Protos.Resource resource) {
-        Optional<Protos.Resource.ReservationInfo> reservationInfo = getReservation(resource);
-        return reservationInfo.isPresent()
-                ? AuxLabelAccess.getResourceNamespace(reservationInfo.get())
-                : Optional.empty();
+        return getReservation(resource).flatMap(AuxLabelAccess::getResourceNamespace);
     }
 
     public static Optional<String> getResourceId(Protos.Resource resource) {
-        Optional<Protos.Resource.ReservationInfo> reservationInfo = getReservation(resource);
-        return reservationInfo.isPresent()
-                ? AuxLabelAccess.getResourceId(reservationInfo.get())
-                : Optional.empty();
+        return getReservation(resource).flatMap(AuxLabelAccess::getResourceId);
     }
 
     public static boolean hasResourceId(Protos.Resource resource) {

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/recovery/DefaultRecoveryPlanManager.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/recovery/DefaultRecoveryPlanManager.java
@@ -96,7 +96,8 @@ public class DefaultRecoveryPlanManager implements PlanManager {
     protected void setPlanInternal(Plan plan) {
         synchronized (planLock) {
             this.plan = plan;
-            if (!plan.getChildren().isEmpty()) {
+            // Avoid logging for non-empty completed plan, as is the case when a previous recovery had occurred:
+            if (!plan.getChildren().isEmpty() && !plan.isComplete()) {
                 try {
                     logger.info("Recovery plan set to: {}",
                             SerializationUtils.toShortJsonString(PlanInfo.forPlan(plan)));

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/uninstall/UninstallScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/uninstall/UninstallScheduler.java
@@ -214,8 +214,11 @@ public class UninstallScheduler extends AbstractScheduler {
     public UnexpectedResourcesResponse getUnexpectedResources(Collection<Protos.Offer> unusedOffers) {
         Collection<OfferResources> unexpected = unusedOffers.stream()
                 .map(offer -> new OfferResources(offer).addAll(offer.getResourcesList().stream()
-                        // Omit unreserved resources:
-                        .filter(resource -> ResourceUtils.getReservation(resource).isPresent())
+                        // Omit any unreserved resources, and any unrefined pre-reserved resources.
+                        // In addition, checking for a valid resource_id label is a good sanity check to avoid
+                        // potentially unreserving any resources that weren't originally created by the SDK.
+                        // This is in addition to separate filtering in FrameworkScheduler of reserved Marathon volumes.
+                        .filter(resource -> ResourceUtils.hasResourceId(resource))
                         .collect(Collectors.toList())))
                 .collect(Collectors.toList());
         try {


### PR DESCRIPTION
- Check for a `resource_id` label when examining resources during uninstall. The immediate issue is a no-op where the scheduler tries to unreserve resources which are only statically pre-reserved, but it doesn't hurt to be conservative and always check for the `resource_id` label before unreserving. This should avoid the possibility of attempting to unreserve an offered resource that wasn't created by the SDK. Note that there are already upstream filters in FrameworkScheduler for filtering out Marathon volumes, so this check is effectively redundant in that case.
- Avoid (repeated) logging of the recovery plan when it's currently complete. It can be non-empty but complete in the case when prior recoveries had occurred within the lifespan of the scheduler process.

To be clear, neither of these issues should result in any problems for end users. The ultimate effect of this PR should just be a reduction in log noise and avoiding a Mesos noop.