### PR TITLE
test.sh: bugfixes required for integrating the dcos-commons as git submodule into other repo

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -13,8 +13,8 @@ set -e
 timestamp="$(date +%d%m%y%H%M%s)"
 # Create a temp file for docker env.
 # When the script exits (successfully or otherwise), clean up the file automatically.
-credsfile="$(mktemp /tmp/sdk-test-creds-${timestamp}.tmp)"
-envfile="$(mktemp /tmp/sdk-test-env-${timestamp}.tmp)"
+credsfile="$(mktemp /tmp/sdk-test-creds-${timestamp}.XXXXXX.tmp)"
+envfile="$(mktemp /tmp/sdk-test-env-${timestamp}.XXXXXX.tmp)"
 function cleanup {
     rm -f ${credsfile}
     rm -f ${envfile}

--- a/test.sh
+++ b/test.sh
@@ -199,7 +199,7 @@ esac
 shift # past argument or value
 done
 
-if [ -z "$framework" -a x"$interactive" != x"true" ]; then
+if [ -z "$framework" -a x"$interactive" != x"true" -a "x$DOCKER_COMMAND" == "x" ]; then
     # If FRAMEWORK_LIST only has one option, use that. Otherwise complain.
     if [ $(echo $FRAMEWORK_LIST | wc -w) == 1 ]; then
         framework=$FRAMEWORK_LIST

--- a/test.sh
+++ b/test.sh
@@ -21,7 +21,7 @@ function cleanup {
 }
 trap cleanup EXIT
 
-REPO_ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+REPO_ROOT_DIR=${REPO_ROOT_DIR:=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )}
 WORK_DIR="/build" # where REPO_ROOT_DIR is mounted within the image
 
 # Find out what framework(s) are available.
@@ -110,6 +110,8 @@ function usage()
     echo "    S3 bucket to use for testing."
     echo "  DOCKER_COMMAND=$docker_command"
     echo "    Command to be run within the docker image (e.g. 'DOCKER_COMMAND=bash' to just get a prompt)"
+    echo "  REPO_ROOT_DIR"
+    echo "    Allows for overriding the location of the repository's root directory. Autodetected by default."
     echo "  PYTEST_ARGS"
     echo "    Additional arguments (other than -m or -k) to pass to pytest."
     echo "  TEST_SH_*"


### PR DESCRIPTION
### This PR:

This PR fixes few bugs that I found while integrating `test.sh` into edge-lb's CI. Namely:
* mktemp on some distros/Unixes requires XXX+ placeholder to work. On others it will simply be ignored I believe.
* providing framework names for testing should not be required when running `test.sh` with `DOCKER_COMMAND` env var defined
* repository location should not be hardcoded as this prevents other repos (like e.g. edge) to re-use dcos-commons contents and very tightly binds dcos-commons repo's frameworks to it's test tools.

### Related Jiras:
This change is required by Edge-LB's CI refactoring effort in order to integrate dcos-commons tooling into the edge-lb's one and have an easy way to bump dcos-commons without having to commit the tooling into the repo itself (i.e. via git submodules). See:
* https://jira.mesosphere.com/browse/DCOS-38216 `Simplifying the build scripts`
* https://jira.mesosphere.com/browse/DCOS-38215 `Switch edgelb CI to Jenkins Pipelines-based`
* https://jira.mesosphere.com/browse/DCOS-38546 `create a common development container for edgelb`