### PR TITLE
DCOS-42539 (backport) Improve recovery config ID selection

### DIFF
--- a/frameworks/kafka/universe/config.json
+++ b/frameworks/kafka/universe/config.json
@@ -958,7 +958,7 @@
         },
         "transaction_max_timeout_ms": {
           "title": "transaction.max.timeout.ms",
-          "description": "The maximum allowed timeout for transactions. If a client\u2019s requested transaction time exceed this, then the broker will return an error in InitProducerIdRequest. This prevents a client from too large of a timeout, which can stall consumers reading from topics included in the transaction.",
+          "description": "The maximum allowed timeout for transactions. If a client's requested transaction time exceeds this, then the broker will return an error in InitProducerIdRequest. This prevents a client from too large of a timeout, which can stall consumers reading from topics included in the transaction.",
           "type": "integer",
           "default": 900000,
           "minimum": 1

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluator.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluator.java
@@ -87,7 +87,7 @@ public class OfferEvaluator {
             PodInfoBuilder podInfoBuilder = new PodInfoBuilder(
                     podInstanceRequirement,
                     serviceName,
-                    getTargetConfig(podInstanceRequirement, thisPodTasks.values()),
+                    getTargetConfig(podInstanceRequirement, thisPodTasks),
                     schedulerConfig,
                     thisPodTasks.values(),
                     stateStore.fetchFrameworkId().get(),
@@ -511,30 +511,109 @@ public class OfferEvaluator {
         return null;
     }
 
+    /**
+     * Returns a reasonable configuration ID to be used when launching tasks in a pod.
+     *
+     * @param podInstanceRequirement the pod requirement describing the pod being evaluated and the tasks to be
+     *     launched within the pod
+     * @param thisPodTasksByName all TaskInfos for the pod that currently exist (some may be old)
+     * @return a config UUID to be used for the pod. In a config update this would be the target config, and in a
+     *     recovery operation this would be the pod's/tasks's current config
+     */
     @VisibleForTesting
-    UUID getTargetConfig(PodInstanceRequirement podInstanceRequirement, Collection<Protos.TaskInfo> taskInfos) {
-        if (podInstanceRequirement.getRecoveryType().equals(RecoveryType.NONE) || taskInfos.isEmpty()) {
+    UUID getTargetConfig(
+            PodInstanceRequirement podInstanceRequirement,
+            Map<String, Protos.TaskInfo> thisPodTasksByName) {
+        if (podInstanceRequirement.getRecoveryType().equals(RecoveryType.NONE)) {
+            // This is a config update, the pod should use the new/current target config.
             return targetConfigId;
-        } else {
-            // 1. Recovery always only handles tasks with a goal state of RUNNING
-            // 2. All tasks in a pod should be launched with the same configuration
-            // Therefore it is correct to take the target configuration of one task as being
-            // representative of the whole of the pod. If tasks in the same pod with a goal
-            // state of RUNNING had different target configurations this should be rectified
-            // in any case, so it is doubly proper to choose a single target configuration as
-            // representative of the whole pod's target configuration.
+        }
 
-            Protos.TaskInfo taskInfo = taskInfos.stream().findFirst().get();
+        // This is a recovery operation. Reuse the pod's current configuration, and specifically avoid out-of-band
+        // config updates as part of recovering the pod. Select the correct configuration to use for the recovery:
+        // 1. Filter the pod's tasks to just the ones being recovered in this operation.
+        // 2. If multiple tasks are being recovered, prefer ones that are marked RUNNING, as they are more
+        //    consistently updated to new config ids (workaround for DCOS-42539).
+        // 3. If no tasks are found (shouldn't happen?), fall back to using the target config.
+        Map<String, UUID> runningConfigTargets = new TreeMap<>();
+        Map<String, UUID> otherConfigTargets = new TreeMap<>();
+        sortRecoveryConfigTargets(podInstanceRequirement, thisPodTasksByName, runningConfigTargets, otherConfigTargets);
+
+        // Select a config id from the goal state groups:
+        if (runningConfigTargets.values().stream().distinct().count() > 1) {
+            logger.warn("Multiple goal-running tasks with different target configs. Selecting random config: {}",
+                    runningConfigTargets);
+        }
+        Optional<UUID> selectedConfig = runningConfigTargets.values().stream().findAny();
+        if (!selectedConfig.isPresent()) {
+            if (otherConfigTargets.values().stream().distinct().count() > 1) {
+                logger.warn("Multiple goal-other tasks with different target configs. Selecting random config: {}",
+                        otherConfigTargets);
+            }
+            selectedConfig = otherConfigTargets.values().stream().findAny();
+        }
+        if (!selectedConfig.isPresent()) {
+            // No TaskInfos for the tasks being recovered? Missing target config ids?
+            logger.error("No target configuration could be determined for recovering {}, using scheduler target {} " +
+                    "(goal-running={}, other={})",
+                    podInstanceRequirement.getName(),
+                    targetConfigId,
+                    runningConfigTargets,
+                    otherConfigTargets);
+            return targetConfigId;
+        }
+        logger.info("Recovering {} with config {} (goal-running={}, other={})",
+                podInstanceRequirement.getName(), selectedConfig.get(), runningConfigTargets, otherConfigTargets);
+        return selectedConfig.get();
+    }
+
+    /**
+     * Produces the tasks to be launched in a recovery operation, then groups their config UUIDs according to their goal
+     * states. Tasks whose goal state is RUNNING get priority over other tasks when determining a reasonable target.
+     *
+     * @param podInstanceRequirement the pod requirement describing the pod being recovered and the tasks to be
+     *     relaunched within the pod
+     * @param thisPodTasksByName all TaskInfos for the pod that currently exist (some may be old)
+     * @param runningConfigTargets output where config ids for tasks with a RUNNING GoalState are placed
+     * @param otherConfigTargets output where config ids for tasks with non-RUNNING GoalStates are placed
+     */
+    private static void sortRecoveryConfigTargets(
+            PodInstanceRequirement podInstanceRequirement,
+            Map<String, Protos.TaskInfo> thisPodTasksByName,
+            Map<String, UUID> runningConfigTargets,
+            Map<String, UUID> otherConfigTargets) {
+        for (TaskSpec taskSpec : podInstanceRequirement.getPodInstance().getPod().getTasks()) {
+            if (!podInstanceRequirement.getTasksToLaunch().contains(taskSpec.getName())) {
+                // Task isn't included in the recovery operation, skip.
+                logger.info("TODO skipping " + taskSpec.getName() + " vs " + podInstanceRequirement.getTasksToLaunch());
+                continue;
+            }
+            final String taskName = TaskSpec.getInstanceName(podInstanceRequirement.getPodInstance(), taskSpec);
+            Protos.TaskInfo taskInfo = thisPodTasksByName.get(taskName);
+            if (taskInfo == null) {
+                // Task hasn't been launched yet, but is marked to be recovered...
+                logger.warn("TaskInfo not found for recovering task '{}', available tasks are: {}",
+                        taskName, thisPodTasksByName.keySet());
+                continue;
+            }
+
+            final UUID taskTarget;
             try {
-                return new TaskLabelReader(taskInfo).getTargetConfiguration();
+                taskTarget = new TaskLabelReader(taskInfo).getTargetConfiguration();
             } catch (TaskException e) {
-                logger.error(String.format(
-                        "Falling back to current target configuration '%s'. " +
-                                "Failed to determine target configuration for task: %s",
-                                targetConfigId, TextFormat.shortDebugString(taskInfo)), e);
-                return targetConfigId;
+                logger.warn(
+                        String.format("Failed to determine target configuration for task: %s", taskName),
+                        e);
+                continue;
+            }
+
+            if (taskSpec.getGoal().equals(GoalState.RUNNING)) {
+                // Running tasks have first priority: Should contain the more recent config ID.
+                runningConfigTargets.put(taskName, taskTarget);
+            } else {
+                // FINISHED/ONCE tasks have second priority: Not consistently updated with config rollouts.
+                otherConfigTargets.put(taskName, taskTarget);
             }
         }
     }
-
 }

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/plan/PodInstanceRequirementTestUtils.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/plan/PodInstanceRequirementTestUtils.java
@@ -163,7 +163,7 @@ public class PodInstanceRequirementTestUtils {
         PodSpec podSpec = DefaultPodSpec.newBuilder("executor-uri")
                 .type(type)
                 .count(1)
-                .tasks(Arrays.asList(taskSpec))
+                .addTask(taskSpec)
                 .preReservedRole(Constants.ANY_ROLE)
                 .build();
 
@@ -194,7 +194,7 @@ public class PodInstanceRequirementTestUtils {
         PodSpec podSpec = DefaultPodSpec.newBuilder("executor-uri")
                 .type(type)
                 .count(1)
-                .tasks(Arrays.asList(taskSpec))
+                .addTask(taskSpec)
                 .volumes(executorVolumes)
                 .build();
 


### PR DESCRIPTION
Previously, we were selecting a random task in the pod when performing a recovery (restart/replace) operation. This interim fix improves on the existing (lack of) selection logic by making it do the right thing in today's typical cases. A larger change will be made in sdk-0.50+ to improve the config update flow itself to avoid mixed configs in the same pod unless explicitly needed via e.g. a custom plan.

- Only examine tasks which are being included as part of the recovery operation, rather than all tasks in the pod.
- Among tasks being recovered, prefer the tasks which have a RUNNING goal state, over those with a FINISHED or ONCE goal state.
- Improve logging of the decision itself.

... and while we're in sdk-0.40, this PR also fixes an encoding issue in Kafka's config options for DCOS-42473
