### PR TITLE
DCOS-42539 Improve recovery config ID selection

### DIFF
--- a/frameworks/kafka/universe/config.json
+++ b/frameworks/kafka/universe/config.json
@@ -949,7 +949,7 @@
         },
         "transaction_max_timeout_ms": {
           "title": "transaction.max.timeout.ms",
-          "description": "The maximum allowed timeout for transactions. If a client's requested transaction time exceed this, then the broker will return an error in InitProducerIdRequest. This prevents a client from too large of a timeout, which can stall consumers reading from topics included in the transaction.",
+          "description": "The maximum allowed timeout for transactions. If a client's requested transaction time exceeds this, then the broker will return an error in InitProducerIdRequest. This prevents a client from too large of a timeout, which can stall consumers reading from topics included in the transaction.",
           "type": "integer",
           "default": 900000,
           "minimum": 1

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluator.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluator.java
@@ -94,7 +94,7 @@ public class OfferEvaluator {
             PodInfoBuilder podInfoBuilder = new PodInfoBuilder(
                     podInstanceRequirement,
                     serviceName,
-                    getTargetConfig(podInstanceRequirement, thisPodTasks.values()),
+                    getTargetConfig(podInstanceRequirement, thisPodTasks),
                     templateUrlFactory,
                     schedulerConfig,
                     thisPodTasks.values(),
@@ -536,30 +536,109 @@ public class OfferEvaluator {
         return null;
     }
 
+    /**
+     * Returns a reasonable configuration ID to be used when launching tasks in a pod.
+     *
+     * @param podInstanceRequirement the pod requirement describing the pod being evaluated and the tasks to be
+     *     launched within the pod
+     * @param thisPodTasksByName all TaskInfos for the pod that currently exist (some may be old)
+     * @return a config UUID to be used for the pod. In a config update this would be the target config, and in a
+     *     recovery operation this would be the pod's/tasks's current config
+     */
     @VisibleForTesting
-    UUID getTargetConfig(PodInstanceRequirement podInstanceRequirement, Collection<Protos.TaskInfo> taskInfos) {
-        if (podInstanceRequirement.getRecoveryType().equals(RecoveryType.NONE) || taskInfos.isEmpty()) {
+    UUID getTargetConfig(
+            PodInstanceRequirement podInstanceRequirement,
+            Map<String, Protos.TaskInfo> thisPodTasksByName) {
+        if (podInstanceRequirement.getRecoveryType().equals(RecoveryType.NONE)) {
+            // This is a config update, the pod should use the new/current target config.
             return targetConfigId;
-        } else {
-            // 1. Recovery always only handles tasks with a goal state of RUNNING
-            // 2. All tasks in a pod should be launched with the same configuration
-            // Therefore it is correct to take the target configuration of one task as being
-            // representative of the whole of the pod. If tasks in the same pod with a goal
-            // state of RUNNING had different target configurations this should be rectified
-            // in any case, so it is doubly proper to choose a single target configuration as
-            // representative of the whole pod's target configuration.
+        }
 
-            Protos.TaskInfo taskInfo = taskInfos.stream().findFirst().get();
+        // This is a recovery operation. Reuse the pod's current configuration, and specifically avoid out-of-band
+        // config updates as part of recovering the pod. Select the correct configuration to use for the recovery:
+        // 1. Filter the pod's tasks to just the ones being recovered in this operation.
+        // 2. If multiple tasks are being recovered, prefer ones that are marked RUNNING, as they are more
+        //    consistently updated to new config ids (workaround for DCOS-42539).
+        // 3. If no tasks are found (shouldn't happen?), fall back to using the target config.
+        Map<String, UUID> runningConfigTargets = new TreeMap<>();
+        Map<String, UUID> otherConfigTargets = new TreeMap<>();
+        sortRecoveryConfigTargets(podInstanceRequirement, thisPodTasksByName, runningConfigTargets, otherConfigTargets);
+
+        // Select a config id from the goal state groups:
+        if (runningConfigTargets.values().stream().distinct().count() > 1) {
+            logger.warn("Multiple goal-running tasks with different target configs. Selecting random config: {}",
+                    runningConfigTargets);
+        }
+        Optional<UUID> selectedConfig = runningConfigTargets.values().stream().findAny();
+        if (!selectedConfig.isPresent()) {
+            if (otherConfigTargets.values().stream().distinct().count() > 1) {
+                logger.warn("Multiple goal-other tasks with different target configs. Selecting random config: {}",
+                        otherConfigTargets);
+            }
+            selectedConfig = otherConfigTargets.values().stream().findAny();
+        }
+        if (!selectedConfig.isPresent()) {
+            // No TaskInfos for the tasks being recovered? Missing target config ids?
+            logger.error("No target configuration could be determined for recovering {}, using scheduler target {} " +
+                    "(goal-running={}, other={})",
+                    podInstanceRequirement.getName(),
+                    targetConfigId,
+                    runningConfigTargets,
+                    otherConfigTargets);
+            return targetConfigId;
+        }
+        logger.info("Recovering {} with config {} (goal-running={}, other={})",
+                podInstanceRequirement.getName(), selectedConfig.get(), runningConfigTargets, otherConfigTargets);
+        return selectedConfig.get();
+    }
+
+    /**
+     * Produces the tasks to be launched in a recovery operation, then groups their config UUIDs according to their goal
+     * states. Tasks whose goal state is RUNNING get priority over other tasks when determining a reasonable target.
+     *
+     * @param podInstanceRequirement the pod requirement describing the pod being recovered and the tasks to be
+     *     relaunched within the pod
+     * @param thisPodTasksByName all TaskInfos for the pod that currently exist (some may be old)
+     * @param runningConfigTargets output where config ids for tasks with a RUNNING GoalState are placed
+     * @param otherConfigTargets output where config ids for tasks with non-RUNNING GoalStates are placed
+     */
+    private void sortRecoveryConfigTargets(
+            PodInstanceRequirement podInstanceRequirement,
+            Map<String, Protos.TaskInfo> thisPodTasksByName,
+            Map<String, UUID> runningConfigTargets,
+            Map<String, UUID> otherConfigTargets) {
+        for (TaskSpec taskSpec : podInstanceRequirement.getPodInstance().getPod().getTasks()) {
+            if (!podInstanceRequirement.getTasksToLaunch().contains(taskSpec.getName())) {
+                // Task isn't included in the recovery operation, skip.
+                logger.info("TODO skipping " + taskSpec.getName() + " vs " + podInstanceRequirement.getTasksToLaunch());
+                continue;
+            }
+            final String taskName = TaskSpec.getInstanceName(podInstanceRequirement.getPodInstance(), taskSpec);
+            Protos.TaskInfo taskInfo = thisPodTasksByName.get(taskName);
+            if (taskInfo == null) {
+                // Task hasn't been launched yet, but is marked to be recovered...
+                logger.warn("TaskInfo not found for recovering task '{}', available tasks are: {}",
+                        taskName, thisPodTasksByName.keySet());
+                continue;
+            }
+
+            final UUID taskTarget;
             try {
-                return new TaskLabelReader(taskInfo).getTargetConfiguration();
+                taskTarget = new TaskLabelReader(taskInfo).getTargetConfiguration();
             } catch (TaskException e) {
-                logger.error(String.format(
-                        "Falling back to current target configuration '%s'. " +
-                                "Failed to determine target configuration for task: %s",
-                                targetConfigId, TextFormat.shortDebugString(taskInfo)), e);
-                return targetConfigId;
+                logger.warn(
+                        String.format("Failed to determine target configuration for task: %s", taskName),
+                        e);
+                continue;
+            }
+
+            if (taskSpec.getGoal().equals(GoalState.RUNNING)) {
+                // Running tasks have first priority: Should contain the more recent config ID.
+                runningConfigTargets.put(taskName, taskTarget);
+            } else {
+                // FINISHED/ONCE tasks have second priority: Not consistently updated with config rollouts.
+                otherConfigTargets.put(taskName, taskTarget);
             }
         }
     }
-
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluator.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluator.java
@@ -556,89 +556,107 @@ public class OfferEvaluator {
 
         // This is a recovery operation. Reuse the pod's current configuration, and specifically avoid out-of-band
         // config updates as part of recovering the pod. Select the correct configuration to use for the recovery:
-        // 1. Filter the pod's tasks to just the ones being recovered in this operation.
-        // 2. If multiple tasks are being recovered, prefer ones that are marked RUNNING, as they are more
-        //    consistently updated to new config ids (workaround for DCOS-42539).
-        // 3. If no tasks are found (shouldn't happen?), fall back to using the target config.
-        Map<String, UUID> runningConfigTargets = new TreeMap<>();
-        Map<String, UUID> otherConfigTargets = new TreeMap<>();
-        sortRecoveryConfigTargets(podInstanceRequirement, thisPodTasksByName, runningConfigTargets, otherConfigTargets);
+        RecoveryConfigIDs recoveryConfigIDs = new RecoveryConfigIDs(logger, podInstanceRequirement, thisPodTasksByName);
 
-        // Select a config id from the goal state groups:
-        if (runningConfigTargets.values().stream().distinct().count() > 1) {
-            logger.warn("Multiple goal-running tasks with different target configs. Selecting random config: {}",
-                    runningConfigTargets);
-        }
-        Optional<UUID> selectedConfig = runningConfigTargets.values().stream().findAny();
+        Optional<UUID> selectedConfig = recoveryConfigIDs.selectRecoveryConfigID();
         if (!selectedConfig.isPresent()) {
-            if (otherConfigTargets.values().stream().distinct().count() > 1) {
-                logger.warn("Multiple goal-other tasks with different target configs. Selecting random config: {}",
-                        otherConfigTargets);
-            }
-            selectedConfig = otherConfigTargets.values().stream().findAny();
+            // Fall back to using the scheduler target config. This shouldn't happen (how are we recovering tasks
+            // that have never been launched before?), but just in case...
+            logger.error("No target configuration could be determined for recovering {}, using scheduler target {}",
+                    podInstanceRequirement.getName(), targetConfigId);
+            selectedConfig = Optional.of(targetConfigId);
         }
-        if (!selectedConfig.isPresent()) {
-            // No TaskInfos for the tasks being recovered? Missing target config ids?
-            logger.error("No target configuration could be determined for recovering {}, using scheduler target {} " +
-                    "(goal-running={}, other={})",
-                    podInstanceRequirement.getName(),
-                    targetConfigId,
-                    runningConfigTargets,
-                    otherConfigTargets);
-            return targetConfigId;
-        }
-        logger.info("Recovering {} with config {} (goal-running={}, other={})",
-                podInstanceRequirement.getName(), selectedConfig.get(), runningConfigTargets, otherConfigTargets);
+        logger.info("Recovering {} with config {} ({})",
+                podInstanceRequirement.getName(), selectedConfig.get(), recoveryConfigIDs);
         return selectedConfig.get();
     }
 
     /**
-     * Produces the tasks to be launched in a recovery operation, then groups their config UUIDs according to their goal
-     * states. Tasks whose goal state is RUNNING get priority over other tasks when determining a reasonable target.
+     * Implementation for selecting the configuration ID to use when recovering task(s) in a pod:
      *
-     * @param podInstanceRequirement the pod requirement describing the pod being recovered and the tasks to be
-     *     relaunched within the pod
-     * @param thisPodTasksByName all TaskInfos for the pod that currently exist (some may be old)
-     * @param runningConfigTargets output where config ids for tasks with a RUNNING GoalState are placed
-     * @param otherConfigTargets output where config ids for tasks with non-RUNNING GoalStates are placed
+     * <ol><li>Filter the pod's tasks to just the ones being recovered in this operation.</li>
+     * <li>If multiple tasks are being recovered, prefer ones that are marked RUNNING, as they are more consistently
+     * updated to new config ids (workaround for DCOS-42539).</li>
+     * <li>If no tasks are found (shouldn't happen?), fall back to using the scheduler's target config.</li></ol>
      */
-    private void sortRecoveryConfigTargets(
-            PodInstanceRequirement podInstanceRequirement,
-            Map<String, Protos.TaskInfo> thisPodTasksByName,
-            Map<String, UUID> runningConfigTargets,
-            Map<String, UUID> otherConfigTargets) {
-        for (TaskSpec taskSpec : podInstanceRequirement.getPodInstance().getPod().getTasks()) {
-            if (!podInstanceRequirement.getTasksToLaunch().contains(taskSpec.getName())) {
-                // Task isn't included in the recovery operation, skip.
-                logger.info("TODO skipping " + taskSpec.getName() + " vs " + podInstanceRequirement.getTasksToLaunch());
-                continue;
-            }
-            final String taskName = TaskSpec.getInstanceName(podInstanceRequirement.getPodInstance(), taskSpec);
-            Protos.TaskInfo taskInfo = thisPodTasksByName.get(taskName);
-            if (taskInfo == null) {
-                // Task hasn't been launched yet, but is marked to be recovered...
-                logger.warn("TaskInfo not found for recovering task '{}', available tasks are: {}",
-                        taskName, thisPodTasksByName.keySet());
-                continue;
-            }
+    private static class RecoveryConfigIDs {
+        private final Logger logger;
+        private final Map<String, UUID> runningConfigIDs = new TreeMap<>();
+        private final Map<String, UUID> otherConfigIDs = new TreeMap<>();
 
-            final UUID taskTarget;
-            try {
-                taskTarget = new TaskLabelReader(taskInfo).getTargetConfiguration();
-            } catch (TaskException e) {
-                logger.warn(
-                        String.format("Failed to determine target configuration for task: %s", taskName),
-                        e);
-                continue;
-            }
+        /**
+         * Selects the tasks to be launched in a recovery operation, then groups their config UUIDs according to their
+         * goal states. Tasks whose goal state is RUNNING get priority over other tasks when determining a reasonable
+         * target.
+         *
+         * @param podInstanceRequirement the pod requirement describing the pod being recovered and the tasks to be
+         *     relaunched within the pod
+         * @param existingPodTasksByName all TaskInfos for the pod that currently exist (some may be defunct)
+         */
+        private RecoveryConfigIDs(
+                Logger logger,
+                PodInstanceRequirement podInstanceRequirement,
+                Map<String, Protos.TaskInfo> existingPodTasksByName) {
+            this.logger = logger;
+            for (TaskSpec taskSpec : podInstanceRequirement.getPodInstance().getPod().getTasks()) {
+                if (!podInstanceRequirement.getTasksToLaunch().contains(taskSpec.getName())) {
+                    // Task isn't included in the recovery operation, skip.
+                    continue;
+                }
+                final String taskName = TaskSpec.getInstanceName(podInstanceRequirement.getPodInstance(), taskSpec);
+                Protos.TaskInfo taskInfo = existingPodTasksByName.get(taskName);
+                if (taskInfo == null) {
+                    // Task hasn't been launched yet, but is marked to be recovered...
+                    logger.warn("TaskInfo not found for recovering task '{}', available tasks are: {}",
+                            taskName, existingPodTasksByName.keySet());
+                    continue;
+                }
 
-            if (taskSpec.getGoal().equals(GoalState.RUNNING)) {
-                // Running tasks have first priority: Should contain the more recent config ID.
-                runningConfigTargets.put(taskName, taskTarget);
-            } else {
-                // FINISHED/ONCE tasks have second priority: Not consistently updated with config rollouts.
-                otherConfigTargets.put(taskName, taskTarget);
+                final UUID taskTarget;
+                try {
+                    taskTarget = new TaskLabelReader(taskInfo).getTargetConfiguration();
+                } catch (TaskException e) {
+                    logger.warn(
+                            String.format("Failed to determine target configuration for task: %s", taskName),
+                            e);
+                    continue;
+                }
+
+                if (GoalState.RUNNING.equals(taskSpec.getGoal())) {
+                    // Running tasks have first priority: Should contain the more recent config ID.
+                    runningConfigIDs.put(taskName, taskTarget);
+                } else {
+                    // Other tasks like FINISHED/ONCE have second priority: Not as consistently updated in rollouts.
+                    otherConfigIDs.put(taskName, taskTarget);
+                }
             }
+        }
+
+        /**
+         * Returns an existing config ID to use for recovering the task(s), or an empty Optional if no valid config ID
+         * could be found.
+         */
+        private Optional<UUID> selectRecoveryConfigID() {
+            // Running tasks have first priority: Should contain the more recent config ID.
+            Optional<UUID> selectedConfig = selectID(runningConfigIDs, "RUNNING");
+            if (selectedConfig.isPresent()) {
+                return selectedConfig;
+            }
+            // Other tasks like FINISHED/ONCE have second priority: Not consistently updated with config rollouts.
+            return selectID(otherConfigIDs, "non-RUNNING");
+        }
+
+        private Optional<UUID> selectID(Map<String, UUID> configIDs, String taskTypeToLog) {
+            if (configIDs.values().stream().distinct().count() > 1) {
+                logger.warn("Multiple {} tasks with different target configs. Selecting random config: {}",
+                        taskTypeToLog, configIDs);
+            }
+            return configIDs.values().stream().findAny();
+        }
+
+        @Override
+        public String toString() {
+            return String.format("goal-running=%s, other=%s", runningConfigIDs, otherConfigIDs);
         }
     }
 }

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluatorTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluatorTest.java
@@ -771,16 +771,21 @@ public class OfferEvaluatorTest extends OfferEvaluatorTestBase {
      * which is used to construct the OfferEvaluator should be used.
      */
     @Test
-    public void testGetTargetconfigRecoveryTypeNone() {
+    public void testGetTargetConfigRecoveryTypeNone() {
         PodInstanceRequirement podInstanceRequirement =
                 PodInstanceRequirement.newBuilder(
-                        PodInstanceRequirementTestUtils.getCpuRequirement(1.0))
+                        PodInstanceRequirementTestUtils.getCpuRequirement(1.0).getPodInstance(),
+                        Collections.singleton(TestConstants.TASK_NAME))
                         .recoveryType(RecoveryType.NONE)
                         .build();
 
         Assert.assertEquals(
                 targetConfig,
-                evaluator.getTargetConfig(podInstanceRequirement, Arrays.asList(TestConstants.TASK_INFO)));
+                evaluator.getTargetConfig(
+                        podInstanceRequirement,
+                        Collections.singletonMap(
+                                TestConstants.POD_TYPE + "-0-" + TestConstants.TASK_NAME,
+                                TestConstants.TASK_INFO)));
     }
 
     /**
@@ -788,7 +793,7 @@ public class OfferEvaluatorTest extends OfferEvaluatorTestBase {
      * the target configuration defined in the ConfigStore which is used to construct the OfferEvaluator should be used.
      */
     @Test
-    public void testGetTargetconfigRecoveryEmptyTaskCollection() {
+    public void testGetTargetConfigRecoveryEmptyTaskCollection() {
         PodInstanceRequirement podInstanceRequirement =
                 PodInstanceRequirement.newBuilder(
                         PodInstanceRequirementTestUtils.getCpuRequirement(1.0))
@@ -797,32 +802,37 @@ public class OfferEvaluatorTest extends OfferEvaluatorTestBase {
 
         Assert.assertEquals(
                 targetConfig,
-                evaluator.getTargetConfig(podInstanceRequirement, Collections.emptyList()));
+                evaluator.getTargetConfig(podInstanceRequirement, Collections.emptyMap()));
     }
 
     /**
-     * If recovery is taking place but a Task has somehow failed to have its target config set, the
-     * ConfigStore / OfferEvaluator's target config should be used.
+     * If recovery is taking place and the task(s) to be recovered lack a config id, the ConfigStore target config
+     * should be used.
      */
     @Test
-    public void testGetTargetconfigRecoveryTypeAnyMissingLabel() {
+    public void testGetTargetConfigRecoveryMissingConfigId() {
         PodInstanceRequirement podInstanceRequirement =
                 PodInstanceRequirement.newBuilder(
-                        PodInstanceRequirementTestUtils.getCpuRequirement(1.0))
+                        PodInstanceRequirementTestUtils.getCpuRequirement(1.0).getPodInstance(),
+                        Collections.singleton(TestConstants.TASK_NAME))
                         .recoveryType(RecoveryType.TRANSIENT)
                         .build();
 
         Assert.assertEquals(
                 targetConfig,
-                evaluator.getTargetConfig(podInstanceRequirement, Arrays.asList(TestConstants.TASK_INFO)));
+                evaluator.getTargetConfig(
+                        podInstanceRequirement,
+                        Collections.singletonMap(
+                                TestConstants.POD_TYPE + "-0-" + TestConstants.TASK_NAME,
+                                TestConstants.TASK_INFO)));
     }
 
     /**
-     * If recovery is taking place and a target config is properly set on the task, its target config should
-     * be used, not the ConfigStore / OfferEvaluator's target config.
+     * If recovery is taking place and the task(s) to be recovered aren't present in the StateStore, the ConfigStore
+     * target config should be used.
      */
     @Test
-    public void testGetTargetconfigRecoveryTypeAny() {
+    public void testGetTargetConfigRecoveryMissingTaskToLaunch() {
         PodInstanceRequirement podInstanceRequirement =
                 PodInstanceRequirement.newBuilder(
                         PodInstanceRequirementTestUtils.getCpuRequirement(1.0))
@@ -836,12 +846,125 @@ public class OfferEvaluatorTest extends OfferEvaluatorTestBase {
                         .toProto())
                 .build();
 
-        Assert.assertNotEquals(
+        Assert.assertEquals(
                 targetConfig,
-                evaluator.getTargetConfig(podInstanceRequirement, Arrays.asList(taskInfo)));
+                evaluator.getTargetConfig(
+                        podInstanceRequirement,
+                        Collections.singletonMap("somethingElse", taskInfo)));
+    }
+
+    /**
+     * If recovery is taking place and a target config is properly set on the task, its target config should
+     * be used, not the ConfigStore / OfferEvaluator's target config.
+     */
+    @Test
+    public void testGetTargetConfigRecoverySingleTask() {
+        PodInstanceRequirement podInstanceRequirement =
+                PodInstanceRequirement.newBuilder(
+                        PodInstanceRequirementTestUtils.getCpuRequirement(1.0).getPodInstance(),
+                        Collections.singleton(TestConstants.TASK_NAME))
+                        .recoveryType(RecoveryType.TRANSIENT)
+                        .build();
+
+        UUID taskConfig = UUID.randomUUID();
+        TaskInfo taskInfo = TestConstants.TASK_INFO.toBuilder().setLabels(
+                new TaskLabelWriter(TestConstants.TASK_INFO)
+                        .setTargetConfiguration(taskConfig)
+                        .toProto())
+                .build();
+
         Assert.assertEquals(
                 taskConfig,
-                evaluator.getTargetConfig(podInstanceRequirement, Arrays.asList(taskInfo)));
+                evaluator.getTargetConfig(
+                        podInstanceRequirement,
+                        Collections.singletonMap(
+                                TestConstants.POD_TYPE + "-0-" + TestConstants.TASK_NAME,
+                                taskInfo)));
+    }
+
+    /**
+     * If a subset of a pod is being recovered, only the config from the tasks to be recovered should be used.
+     */
+    @Test
+    public void testGetTargetConfigRecoveryMixedInclusion() {
+        // Create PodSpec with default and "other" tasks:
+        PodSpec podSpec = PodInstanceRequirementTestUtils.getCpuRequirement(1.0).getPodInstance().getPod();
+        podSpec = DefaultPodSpec.newBuilder(podSpec)
+                .addTask(DefaultTaskSpec.newBuilder(podSpec.getTasks().get(0))
+                        .name("other")
+                        .build())
+                .build();
+        PodInstance podInstance = new DefaultPodInstance(podSpec, 0);
+        PodInstanceRequirement podInstanceRequirement =
+                PodInstanceRequirement.newBuilder(podInstance, Arrays.asList(TestConstants.TASK_NAME))
+                        .recoveryType(RecoveryType.TRANSIENT)
+                        .build();
+
+        UUID recoverTaskConfig = UUID.randomUUID();
+        String recoverTaskFullName = TaskSpec.getInstanceName(podInstance, TestConstants.TASK_NAME);
+        TaskInfo recoverTaskInfo = TestConstants.TASK_INFO.toBuilder()
+                .setName(recoverTaskFullName)
+                .setLabels(new TaskLabelWriter(TestConstants.TASK_INFO)
+                        .setTargetConfiguration(recoverTaskConfig)
+                        .toProto())
+                .build();
+
+        UUID otherTaskConfig = UUID.randomUUID();
+        String otherTaskFullName = TaskSpec.getInstanceName(podInstance, "other");
+        TaskInfo otherTaskInfo = TestConstants.TASK_INFO.toBuilder()
+                .setName(otherTaskFullName)
+                .setLabels(new TaskLabelWriter(TestConstants.TASK_INFO)
+                        .setTargetConfiguration(otherTaskConfig)
+                        .toProto())
+                .build();
+
+        Map<String, TaskInfo> podTasks = new HashMap<>();
+        podTasks.put(recoverTaskFullName, recoverTaskInfo);
+        podTasks.put(otherTaskFullName, otherTaskInfo);
+        Assert.assertEquals(recoverTaskConfig, evaluator.getTargetConfig(podInstanceRequirement, podTasks));
+    }
+
+    /**
+     * If multiple tasks are being recovered, the config on RUNNING task(s) should get priority over non-RUNNING tasks.
+     */
+    @Test
+    public void testGetTargetConfigRecoveryMixedGoalStates() {
+        // Create PodSpec with default=RUNNING and "other"=ONCE tasks:
+        PodSpec podSpec = PodInstanceRequirementTestUtils.getCpuRequirement(1.0).getPodInstance().getPod();
+        podSpec = DefaultPodSpec.newBuilder(podSpec)
+                .addTask(DefaultTaskSpec.newBuilder(podSpec.getTasks().get(0))
+                        .name("other")
+                        .goalState(GoalState.ONCE)
+                        .build())
+                .build();
+        PodInstance podInstance = new DefaultPodInstance(podSpec, 0);
+        PodInstanceRequirement podInstanceRequirement =
+                PodInstanceRequirement.newBuilder(podInstance, Arrays.asList(TestConstants.TASK_NAME, "other"))
+                        .recoveryType(RecoveryType.TRANSIENT)
+                        .build();
+
+        UUID recoverTaskConfig = UUID.randomUUID();
+        String recoverTaskFullName = TaskSpec.getInstanceName(podInstance, TestConstants.TASK_NAME);
+        TaskInfo recoverTaskInfo = TestConstants.TASK_INFO.toBuilder()
+                .setName(recoverTaskFullName)
+                .setLabels(new TaskLabelWriter(TestConstants.TASK_INFO)
+                        .setTargetConfiguration(recoverTaskConfig)
+                        .toProto())
+                .build();
+
+        UUID otherTaskConfig = UUID.randomUUID();
+        String otherTaskFullName = TaskSpec.getInstanceName(podInstance, "other");
+        TaskInfo otherTaskInfo = TestConstants.TASK_INFO.toBuilder()
+                .setName(otherTaskFullName)
+                .setLabels(new TaskLabelWriter(TestConstants.TASK_INFO)
+                        .setTargetConfiguration(otherTaskConfig)
+                        .toProto())
+                .build();
+
+        Map<String, TaskInfo> podTasks = new HashMap<>();
+        podTasks.put(recoverTaskFullName, recoverTaskInfo);
+        podTasks.put(otherTaskFullName, otherTaskInfo);
+        Assert.assertEquals(recoverTaskConfig, evaluator.getTargetConfig(podInstanceRequirement, podTasks));
     }
 
     @Test


### PR DESCRIPTION
Previously, we were selecting a random task in the pod when performing a recovery (restart/replace) operation. This interim fix improves on the existing (lack of) selection logic by making it do the right thing in today's typical cases. A larger change will be made in a following PR to improve the config update flow itself to avoid mixed configs in the same pod unless explicitly needed via e.g. a custom plan.

- Only examine tasks which are being included as part of the recovery operation, rather than all tasks in the pod.
- Among tasks being recovered, prefer the tasks which have a RUNNING goal state, over those with a FINISHED or ONCE goal state.
- Improve logging of the decision itself.