### PR TITLE
Fix bugs in test.sh for edge-lb

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -21,7 +21,7 @@ function cleanup {
 }
 trap cleanup EXIT
 
-REPO_ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+REPO_ROOT_DIR=${REPO_ROOT_DIR:=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )}
 WORK_DIR="/build" # where REPO_ROOT_DIR is mounted within the image
 
 # Find out what framework(s) are available.
@@ -113,6 +113,8 @@ function usage()
     echo "    S3 bucket to use for testing."
     echo "  DOCKER_COMMAND=$docker_command"
     echo "    Command to be run within the docker image (e.g. 'DOCKER_COMMAND=bash' to just get a prompt)"
+    echo "  REPO_ROOT_DIR"
+    echo "    Allows for overriding the location of the repository's root directory. Autodetected by default."
     echo "  PYTEST_ARGS"
     echo "    Additional arguments (other than -m or -k) to pass to pytest."
     echo "  TEST_SH_*"
@@ -206,7 +208,7 @@ esac
 shift # past argument or value
 done
 
-if [ -z "$framework" -a x"$interactive" != x"true" ]; then
+if [ -z "$framework" -a x"$interactive" != x"true" -a x"$DOCKER_COMMAND" == x"" ]; then
     # If FRAMEWORK_LIST only has one option, use that. Otherwise complain.
     if [ $(echo $FRAMEWORK_LIST | wc -w) == 1 ]; then
         framework=$FRAMEWORK_LIST

--- a/test.sh
+++ b/test.sh
@@ -21,7 +21,7 @@ function cleanup {
 }
 trap cleanup EXIT
 
-REPO_ROOT_DIR=${REPO_ROOT_DIR:=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )}
+REPO_ROOT_DIR=${REPO_ROOT_DIR:="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"}
 WORK_DIR="/build" # where REPO_ROOT_DIR is mounted within the image
 
 # Find out what framework(s) are available.
@@ -113,8 +113,9 @@ function usage()
     echo "    S3 bucket to use for testing."
     echo "  DOCKER_COMMAND=$docker_command"
     echo "    Command to be run within the docker image (e.g. 'DOCKER_COMMAND=bash' to just get a prompt)"
-    echo "  REPO_ROOT_DIR"
+    echo "  REPO_ROOT_DIR=${REPO_ROOT_DIR}"
     echo "    Allows for overriding the location of the repository's root directory. Autodetected by default."
+    echo "    Must be an absolute path."
     echo "  PYTEST_ARGS"
     echo "    Additional arguments (other than -m or -k) to pass to pytest."
     echo "  TEST_SH_*"


### PR DESCRIPTION
This PR contains the changes from #2693 for the `master` branch in order to allow `dcos-commons` to be used as a submodule when building edge-lb.

Important changes:
* Allow `REPO_ROOT_DIR` to be overridden.
* Don't require a framework to be specified if a custom `DOCKER_COMMAND` is specified.