### PR TITLE
[DCOS-29502] Add default principal pattern for HDFS

### DIFF
--- a/frameworks/hdfs/src/main/dist/core-site.xml
+++ b/frameworks/hdfs/src/main/dist/core-site.xml
@@ -531,7 +531,7 @@
     <property>
         <name>hadoop.security.auth_to_local</name>
         <value>
-            {{DECODED_AUTH_TO_LOCAL}}
+            {{{DECODED_AUTH_TO_LOCAL}}}
         </value>
     </property>
 

--- a/frameworks/hdfs/src/main/java/com/mesosphere/sdk/hdfs/scheduler/HDFSAuthEnvContainer.java
+++ b/frameworks/hdfs/src/main/java/com/mesosphere/sdk/hdfs/scheduler/HDFSAuthEnvContainer.java
@@ -1,0 +1,74 @@
+package com.mesosphere.sdk.hdfs.scheduler;
+
+import com.mesosphere.sdk.config.TaskEnvRouter;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Map;
+
+/**
+ * This class captures the needed environment variables which are used for the kerberos authentication.
+ **/
+public class HDFSAuthEnvContainer {
+    private static final String AUTH_TO_LOCAL = "AUTH_TO_LOCAL";
+    public static final String PRIMARY_ENV_KEY = "TASKCFG_ALL_SECURITY_KERBEROS_PRIMARY";
+    public static final String REALM_ENV_KEY = "TASKCFG_ALL_SECURITY_KERBEROS_REALM";
+    public static final String FRAMEWORK_USER_ENV_KEY = "TASKCFG_ALL_TASK_USER";
+    public static final String DECODED_AUTH_TO_LOCAL = "DECODED_" + AUTH_TO_LOCAL;
+    public static final String TASKCFG_ALL_AUTH_TO_LOCAL = TaskEnvRouter.TASKCFG_GLOBAL_ENV_PREFIX + AUTH_TO_LOCAL;
+    private static final String[] REQUIRED_ENV_KEYS = {PRIMARY_ENV_KEY, REALM_ENV_KEY, FRAMEWORK_USER_ENV_KEY};
+
+    private final String primary;
+    private final String realm;
+    private final String frameworkUser;
+    private final String envAuthMapping;
+
+    public String getPrimary() {
+        return primary;
+    }
+
+    public String getEnvAuthMapping() {
+        return envAuthMapping;
+    }
+
+    public String getRealm() {
+        return realm;
+    }
+
+    public String getFrameworkUser() {
+        return frameworkUser;
+    }
+
+    private void checkEnvHasRequiredKeys(Map<String, String> env) {
+        ArrayList<String> missingKeys = new ArrayList<>();
+        for (String envKey : REQUIRED_ENV_KEYS) {
+            if (env.containsKey(envKey)) {
+                continue;
+            }
+            missingKeys.add(envKey);
+        }
+        if (!missingKeys.isEmpty()) {
+            String msg = String.format("The following environment keys are missing %s", String.join(", ", missingKeys));
+            throw new RuntimeException(msg);
+        }
+    }
+
+    public HDFSAuthEnvContainer(Map<String, String> env) {
+        checkEnvHasRequiredKeys(env);
+        this.envAuthMapping = getAuthMappingFromEnv(env);
+        this.primary = env.get(PRIMARY_ENV_KEY);
+        this.frameworkUser = env.get(FRAMEWORK_USER_ENV_KEY);
+        this.realm = env.get(REALM_ENV_KEY);
+    }
+
+    private String getAuthMappingFromEnv(Map<String, String> env) {
+        if (!env.containsKey(TASKCFG_ALL_AUTH_TO_LOCAL)) {
+            return "";
+        }
+        Base64.Decoder decoder = Base64.getDecoder();
+        String base64Mappings = env.get(TASKCFG_ALL_AUTH_TO_LOCAL);
+        byte[] hdfsUserAuthMappingsBytes = decoder.decode(base64Mappings);
+        return new String(hdfsUserAuthMappingsBytes, StandardCharsets.UTF_8);
+    }
+}

--- a/frameworks/hdfs/src/main/java/com/mesosphere/sdk/hdfs/scheduler/HDFSUserAuthMapperBuilder.java
+++ b/frameworks/hdfs/src/main/java/com/mesosphere/sdk/hdfs/scheduler/HDFSUserAuthMapperBuilder.java
@@ -1,0 +1,41 @@
+package com.mesosphere.sdk.hdfs.scheduler;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * This class helps to generate user auth mappings for the HDFS setup with kerberos.
+ */
+public class HDFSUserAuthMapperBuilder {
+    private static final String authToLocalDefaultTemplate = "RULE:[2:$1/$2@$0](%s/%s.%s@%s)s/.*/%s/";
+    private final ArrayList<String> authMappings = new ArrayList<>();
+    private final String frameworkHost;
+    private final HDFSAuthEnvContainer envContainer;
+
+    public HDFSUserAuthMapperBuilder(Map<String, String> env, String frameworkHost) {
+        this.frameworkHost = frameworkHost;
+        this.envContainer = new HDFSAuthEnvContainer(env);
+    }
+
+    public HDFSUserAuthMapperBuilder addUserAuthMappingFromEnv() {
+        authMappings.add(envContainer.getEnvAuthMapping());
+        return this;
+    }
+
+    public HDFSUserAuthMapperBuilder addDefaultUserAuthMapping(String hostPrefix, String hostPostfix, int nodeCount) {
+        for (int i = 0; i < nodeCount; i++) {
+            String taskName = String.format("%s-%s-%s", hostPrefix, i, hostPostfix);
+            String authMapping = String.format(authToLocalDefaultTemplate, envContainer.getPrimary(), taskName,
+                    frameworkHost, envContainer.getRealm(), envContainer.getFrameworkUser());
+            authMappings.add(authMapping);
+        }
+        return this;
+    }
+
+    public String build() {
+        return authMappings.stream().filter(StringUtils::isNotBlank).collect(Collectors.joining("\n"));
+    }
+}

--- a/frameworks/hdfs/src/main/java/com/mesosphere/sdk/hdfs/scheduler/Main.java
+++ b/frameworks/hdfs/src/main/java/com/mesosphere/sdk/hdfs/scheduler/Main.java
@@ -30,12 +30,11 @@ import java.util.*;
  */
 public class Main {
     private static final Logger LOGGER = LoggerFactory.getLogger(Main.class);
-    private static final String AUTH_TO_LOCAL = "AUTH_TO_LOCAL";
-    private static final String DECODED_AUTH_TO_LOCAL = "DECODED_" + AUTH_TO_LOCAL;
-    private static final String TASKCFG_ALL_AUTH_TO_LOCAL = TaskEnvRouter.TASKCFG_GLOBAL_ENV_PREFIX + AUTH_TO_LOCAL;
     private static final String JOURNAL_POD_TYPE = "journal";
     private static final String NAME_POD_TYPE = "name";
     private static final String DATA_POD_TYPE = "data";
+    private static final int JOURNAL_NODE_COUNT = 3;
+    private static final int NAME_NODE_COUNT = 2;
 
     static final String SERVICE_ZK_ROOT_TASKENV = "SERVICE_ZK_ROOT";
     static final String HDFS_SITE_XML = "hdfs-site.xml";
@@ -54,33 +53,52 @@ public class Main {
         RawServiceSpec rawServiceSpec = RawServiceSpec.newBuilder(yamlSpecFile).build();
         File configDir = yamlSpecFile.getParentFile();
 
-        Map<String, String> env = new HashMap<>(System.getenv());
-        env.put("ALLOW_REGION_AWARENESS", "true");
-        SchedulerConfig schedulerConfig = SchedulerConfig.fromMap(env);
+        SchedulerConfig schedulerConfig = SchedulerConfig.fromEnv();
+
+        Map<String, String> env = System.getenv();
+
+        String userAuthMapping;
+
+        if (Boolean.valueOf(env.get("TASKCFG_ALL_SECURITY_KERBEROS_ENABLED"))) {
+            String frameworkHost = EndpointUtils.toAutoIpDomain(rawServiceSpec.getName(), schedulerConfig);
+            userAuthMapping = new HDFSUserAuthMapperBuilder(env, frameworkHost)
+                    .addUserAuthMappingFromEnv()
+                    .addDefaultUserAuthMapping(JOURNAL_POD_TYPE, "node", JOURNAL_NODE_COUNT)
+                    .addDefaultUserAuthMapping(NAME_POD_TYPE, "zkfc", NAME_NODE_COUNT)
+                    .addDefaultUserAuthMapping(NAME_POD_TYPE, "node", NAME_NODE_COUNT)
+                    .addDefaultUserAuthMapping(DATA_POD_TYPE, "node", Integer.parseInt(env.get("DATA_COUNT")))
+                    .build();
+        } else {
+            userAuthMapping = "";
+        }
+
+
 
         DefaultServiceSpec serviceSpec = DefaultServiceSpec.newGenerator(rawServiceSpec, schedulerConfig, configDir)
 
                 // Used by 'zkfc' and 'zkfc-format' tasks within this pod:
                 .setPodEnv("name", SERVICE_ZK_ROOT_TASKENV, CuratorUtils.getServiceRootPath(rawServiceSpec.getName()))
-                .setAllPodsEnv(DECODED_AUTH_TO_LOCAL,
-                                getHDFSUserAuthMappings(System.getenv(), TASKCFG_ALL_AUTH_TO_LOCAL))
+                .setAllPodsEnv(HDFSAuthEnvContainer.DECODED_AUTH_TO_LOCAL, userAuthMapping)
                 .build();
-
 
         return DefaultScheduler.newBuilder(setPlacementRules(serviceSpec), schedulerConfig)
                 .setRecoveryManagerFactory(new HdfsRecoveryPlanOverriderFactory())
                 .setPlansFrom(rawServiceSpec)
                 .setEndpointProducer(HDFS_SITE_XML, EndpointProducer.constant(
-                        renderTemplate(new File(configDir, HDFS_SITE_XML), serviceSpec.getName(), schedulerConfig)))
+                        renderTemplate(new File(configDir, HDFS_SITE_XML), serviceSpec.getName(), schedulerConfig,
+                                userAuthMapping)))
                 .setEndpointProducer(CORE_SITE_XML, EndpointProducer.constant(
-                        renderTemplate(new File(configDir, CORE_SITE_XML), serviceSpec.getName(), schedulerConfig)))
+                        renderTemplate(new File(configDir, CORE_SITE_XML), serviceSpec.getName(), schedulerConfig,
+                                userAuthMapping)))
                 .setCustomConfigValidators(Arrays.asList(new HDFSZoneValidator()))
                 .withSingleRegionConstraint();
     }
 
+
     private static String renderTemplate(File configFile,
                                          String serviceName,
-                                         SchedulerConfig schedulerConfig) throws Exception {
+                                         SchedulerConfig schedulerConfig,
+                                         String userAuthMapping) {
         byte[] bytes;
         try {
             bytes = Files.readAllBytes(configFile.toPath());
@@ -98,13 +116,13 @@ public class Main {
         env.put(EnvConstants.SCHEDULER_API_HOSTNAME_TASKENV, EndpointUtils.toSchedulerApiVipHostname(serviceName));
         env.put("MESOS_SANDBOX", "sandboxpath");
         env.put(SERVICE_ZK_ROOT_TASKENV, CuratorUtils.getServiceRootPath(serviceName));
-        env.put(DECODED_AUTH_TO_LOCAL, getHDFSUserAuthMappings(env, AUTH_TO_LOCAL));
+        env.put(HDFSAuthEnvContainer.DECODED_AUTH_TO_LOCAL, userAuthMapping);
 
         String fileStr = new String(bytes, StandardCharsets.UTF_8);
         return TemplateUtils.renderMustacheThrowIfMissing(configFile.getName(), fileStr, env);
     }
 
-    private static ServiceSpec setPlacementRules(DefaultServiceSpec serviceSpec) throws Exception {
+    private static ServiceSpec setPlacementRules(DefaultServiceSpec serviceSpec) {
         PodSpec journal = getJournalPodSpec(serviceSpec);
         PodSpec name = getNamePodSpec(serviceSpec);
         PodSpec data = getDataPodSpec(serviceSpec);
@@ -123,14 +141,6 @@ public class Main {
                     "Missing required pod named '%s' in service spec", podName));
         }
         return match.get();
-    }
-
-    private static String getHDFSUserAuthMappings(Map<String, String> env, String envVarKeyName) throws Exception {
-        Base64.Decoder decoder = Base64.getDecoder();
-        String base64Mappings = env.get(envVarKeyName);
-        byte[] hdfsUserAuthMappingsBytes = decoder.decode(base64Mappings);
-        String authMappings = new String(hdfsUserAuthMappingsBytes, "UTF-8");
-        return authMappings;
     }
 
     private static PodSpec getJournalPodSpec(ServiceSpec serviceSpec) {

--- a/frameworks/hdfs/src/test/java/com/mesosphere/sdk/hdfs/scheduler/HDFSUserAuthMapperBuilderTest.java
+++ b/frameworks/hdfs/src/test/java/com/mesosphere/sdk/hdfs/scheduler/HDFSUserAuthMapperBuilderTest.java
@@ -1,0 +1,167 @@
+package com.mesosphere.sdk.hdfs.scheduler;
+
+import com.mesosphere.sdk.config.TaskEnvRouter;
+import com.mesosphere.sdk.offer.taskdata.EnvConstants;
+import com.mesosphere.sdk.specification.yaml.TemplateUtils;
+import com.mesosphere.sdk.testing.CosmosRenderer;
+import com.mesosphere.sdk.testing.ServiceTestRunner;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.*;
+
+public class HDFSUserAuthMapperBuilderTest {
+    private static final String frameworkHost = "host";
+    private static final Map<String, String> ENV;
+    static {
+        ENV = new HashMap<>();
+        ENV.put(HDFSAuthEnvContainer.PRIMARY_ENV_KEY, "primary");
+        ENV.put(HDFSAuthEnvContainer.FRAMEWORK_USER_ENV_KEY, "user");
+        ENV.put(HDFSAuthEnvContainer.REALM_ENV_KEY, "realm");
+    }
+
+
+    @Test(expected = RuntimeException.class)
+    public void testThrowExceptionOnEnvWithoutAllRequiredKeys() {
+        Map<String, String> env = new HashMap<>();
+        new HDFSUserAuthMapperBuilder(env, frameworkHost);
+    }
+
+    @Test
+    public void testNoAuthToLocalProvidedByEnv() {
+        String authMappings =  new HDFSUserAuthMapperBuilder(ENV, frameworkHost)
+                .addUserAuthMappingFromEnv()
+                .build();
+        Assert.assertEquals("", authMappings);
+    }
+
+    @Test
+    public void testAddUserAuthMappingFromEnv() {
+        String expected = "value";
+        Map<String, String> env = getEnvWithEncodedAuthToLocal(expected);
+        String authMappings = new HDFSUserAuthMapperBuilder(env, frameworkHost)
+                .addUserAuthMappingFromEnv()
+                .build();
+        Assert.assertEquals(expected, authMappings);
+    }
+
+    @Test
+    public void testAddDefaultUserAuthMapping() {
+        String authMappings = new HDFSUserAuthMapperBuilder(ENV, frameworkHost)
+                .addDefaultUserAuthMapping("data", "node", 1)
+                .build();
+        String expected = "RULE:[2:$1/$2@$0](primary/data-0-node.host@realm)s/.*/user/";
+        Assert.assertEquals(expected, authMappings);
+    }
+
+    @Test
+    public void testEnvAuthToLocalIsNotOverwritten() {
+        String expected = "authToLocal";
+        Map<String, String> env = getEnvWithEncodedAuthToLocal(expected);
+        String authMappings = new HDFSUserAuthMapperBuilder(env, frameworkHost)
+                .addUserAuthMappingFromEnv()
+                .addDefaultUserAuthMapping("data", "node", 1)
+                .build();
+        Assert.assertTrue(Arrays.asList(authMappings.split("\n")).contains(expected));
+    }
+
+    @Test
+    public void testMultipleDefaultUserAuthMappings() {
+        String authMappings = new HDFSUserAuthMapperBuilder(ENV, frameworkHost)
+                .addDefaultUserAuthMapping("data", "node", 2)
+                .build();
+        String expected = "RULE:[2:$1/$2@$0](primary/data-0-node.host@realm)s/.*/user/\nRULE:[2:$1/$2@$0](primary/data-1-node.host@realm)s/.*/user/";
+        Assert.assertEquals(expected, authMappings);
+    }
+
+    @Test
+    public void testUserAuthMappingSeparation() {
+        String expected = "value";
+        Map<String, String> env = getEnvWithEncodedAuthToLocal(expected);
+        String authMappings = new HDFSUserAuthMapperBuilder(env, frameworkHost)
+                .addUserAuthMappingFromEnv()
+                .addDefaultUserAuthMapping("data", "node", 1)
+                .build();
+        Assert.assertEquals(2, authMappings.split("\n").length);
+    }
+
+    @Test
+    public void testFilterEmptyAuthMappingLines() {
+        Map<String, String> env = getEnvWithEncodedAuthToLocal("");
+        String authMappings = new HDFSUserAuthMapperBuilder(env, frameworkHost)
+                .addUserAuthMappingFromEnv()
+                .addUserAuthMappingFromEnv()
+                .build();
+        Assert.assertEquals(1, authMappings.split("\n").length);
+    }
+
+    @Test
+    public void testAuthMapperTemplating() throws Exception {
+        File template = ServiceTestRunner.getDistFile(Main.CORE_SITE_XML);
+        String templateContent = new String(Files.readAllBytes(template.toPath()), StandardCharsets.UTF_8);
+
+        String realm = ENV.get(HDFSAuthEnvContainer.REALM_ENV_KEY);
+        String primary = ENV.get(HDFSAuthEnvContainer.PRIMARY_ENV_KEY);
+
+        Map<String, String> schedulerEnv =
+                CosmosRenderer.renderSchedulerEnvironment(Collections.emptyMap(), Collections.emptyMap());
+        Map<String, String> taskEnv = new TaskEnvRouter(schedulerEnv).getConfig("ALL");
+        taskEnv.put(EnvConstants.FRAMEWORK_HOST_TASKENV, "hdfs.on.some.cluster");
+        taskEnv.put("MESOS_SANDBOX", "/mnt/sandbox");
+        taskEnv.put(Main.SERVICE_ZK_ROOT_TASKENV, "/dcos-service-path__to__hdfs");
+        taskEnv.put("SECURITY_KERBEROS_ENABLED", "true");
+        taskEnv.put("SECURITY_KERBEROS_PRIMARY", primary);
+        taskEnv.put("SECURITY_KERBEROS_REALM", realm);
+        taskEnv.put("SECURITY_KERBEROS_PRIMARY_HTTP", "primHttp");
+        taskEnv.put("SCHEDULER_API_HOSTNAME", "schedulerHostname");
+
+        String authMappings = new HDFSUserAuthMapperBuilder(ENV, frameworkHost)
+                .addDefaultUserAuthMapping("data", "node", 2)
+                .build();
+
+        taskEnv.put("DECODED_AUTH_TO_LOCAL", authMappings);
+
+
+        String filledTemplate = TemplateUtils.renderMustacheThrowIfMissing(template.getName(), templateContent, taskEnv);
+        Assert.assertEquals(findAuthMappings(filledTemplate), authMappings);
+    }
+
+    private static String findAuthMappings(String config) throws IOException {
+        BufferedReader bufReader = new BufferedReader(new StringReader(config));
+        String line;
+        boolean started = false;
+
+        ArrayList<String> mappings = new ArrayList<>();
+        while ((line=bufReader.readLine()) != null) {
+            line = line.trim();
+            if (line.equals("<name>hadoop.security.auth_to_local</name>")) {
+                started = true;
+                continue;
+            }
+            if (!started || line.startsWith("<value")) {
+                continue;
+            }
+            if (line.startsWith("</")) {
+                break;
+            }
+            mappings.add(line);
+        }
+        return String.join("\n", mappings);
+    }
+
+    private static Map<String, String> getEnvWithEncodedAuthToLocal(String authToLocal) {
+        Map<String, String> env = new HashMap<>();
+        env.put(HDFSAuthEnvContainer.TASKCFG_ALL_AUTH_TO_LOCAL, Base64.getEncoder()
+                .encodeToString(authToLocal.getBytes(StandardCharsets.UTF_8)));
+        env.putAll(ENV);
+        return env;
+    }
+
+
+}

--- a/frameworks/hdfs/tests/auth.py
+++ b/frameworks/hdfs/tests/auth.py
@@ -56,10 +56,7 @@ def get_principal_to_user_mapping() -> str:
     we need to create an appropriate mapping to test authorization functionality.
     :return: A base64-encoded string of principal->user mappings
     """
-    rules = [
-        "RULE:[2:$1@$0](^hdfs@.*$)s/.*/hdfs/",
-        "RULE:[1:$1@$0](^nobody@.*$)s/.*/nobody/"
-    ]
+    rules = ["RULE:[2:$1@$0](^hdfs@.*$)s/.*/hdfs/"]
 
     for user in USERS:
         rules.append("RULE:[1:$1@$0](^{user}@.*$)s/.*/{user}/".format(user=user))

--- a/frameworks/hdfs/tests/test_default_kerberos_setup.py
+++ b/frameworks/hdfs/tests/test_default_kerberos_setup.py
@@ -1,0 +1,77 @@
+import pytest
+
+import sdk_utils
+import sdk_auth
+import sdk_install
+
+from security import transport_encryption
+
+from tests import config, auth
+
+foldered_name = config.FOLDERED_SERVICE_NAME
+
+pytestmark = [
+    sdk_utils.dcos_ee_only,
+    pytest.mark.skipif(
+        sdk_utils.dcos_version_less_than("1.10"),
+        reason="Kerberos tests require DC/OS 1.10 or higher",
+    ),
+]
+
+
+@pytest.fixture(scope="module", autouse=True)
+def service_account(configure_security):
+    """
+    Sets up a service account for use with TLS.
+    """
+    try:
+        service_account_info = transport_encryption.setup_service_account(foldered_name)
+        yield service_account_info
+    finally:
+        transport_encryption.cleanup_service_account(foldered_name, service_account_info)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def kerberos(configure_security):
+    try:
+        principals = auth.get_service_principals(foldered_name, sdk_auth.REALM)
+
+        kerberos_env = sdk_auth.KerberosEnvironment()
+        kerberos_env.add_principals(principals)
+        kerberos_env.finalize()
+
+        yield kerberos_env
+
+    finally:
+        kerberos_env.cleanup()
+
+
+@pytest.mark.auth
+@pytest.mark.sanity
+def test_install_without_additional_principal_to_user_mapping(kerberos, service_account):
+    service_options = {
+        "service": {
+            "name": foldered_name,
+            "service_account": service_account["name"],
+            "service_account_secret": service_account["secret"],
+            "security": {
+                "kerberos": {
+                    "enabled": True,
+                    "debug": True,
+                    "kdc": {"hostname": kerberos.get_host(), "port": int(kerberos.get_port())},
+                    "realm": kerberos.get_realm(),
+                    "keytab_secret": kerberos.get_keytab_path(),
+                }
+            },
+        }
+    }
+
+    sdk_install.uninstall(config.PACKAGE_NAME, foldered_name)
+    sdk_install.install(
+        config.PACKAGE_NAME,
+        foldered_name,
+        config.DEFAULT_TASK_COUNT,
+        additional_options=service_options,
+        timeout_seconds=30 * 60,
+    )
+    sdk_install.uninstall(config.PACKAGE_NAME, foldered_name)


### PR DESCRIPTION
This PR is a backport of #2682 and adds a sane default for the HDFS auth-to-local mapping that allows HDFS with Kerberos to be installed with the default options.