### PR TITLE
[DCOS-42770] Wait until no deployments are queued after deletion

### DIFF
--- a/testing/sdk_marathon.py
+++ b/testing/sdk_marathon.py
@@ -166,7 +166,6 @@ def install_app(app_definition: dict, timeout=TIMEOUT_SECONDS) -> None:
         try:
             deployment_response = MarathonDeploymentResponse(response)
         except requests.HTTPError as e:
-            log.error("HTTP error response code while installing: %s", response.json()["message"])
             if e.response.status_code == 409:
                 # App exists already, left over from previous run? Delete and try again.
                 destroy_app(app_name, timeout=timeout)

--- a/testing/sdk_marathon.py
+++ b/testing/sdk_marathon.py
@@ -88,7 +88,7 @@ class MarathonDeploymentResponse:
             deployment_id = response_json["deploymentId"]
         self._apps = [MarathonDeploymentResponse.App(version, deployment_id)]
 
-    def get_apps(self) -> typing.List[App]:
+    def get_apps(self) -> typing.List["App"]:
         return self._apps
 
 

--- a/testing/sdk_marathon.py
+++ b/testing/sdk_marathon.py
@@ -58,7 +58,7 @@ class MarathonDeploymentResponse:
         try:
             response_json = response.json()
         except ValueError:
-            log.error("Failed to parse marathon response as JSON: %s".format(response.text))
+            log.error("Failed to parse marathon response as JSON: %s", response.text)
             raise
         log.info("Marathon deployment response JSON: %s", response_json)
         response.raise_for_status()

--- a/testing/sdk_marathon.py
+++ b/testing/sdk_marathon.py
@@ -246,14 +246,15 @@ def destroy_app(app_name: str, timeout=TIMEOUT_SECONDS) -> None:
         stop_max_delay=timeout * 1000, wait_fixed=2000, retry_on_result=lambda result: not result
     )
     def _wait_for_app_destroyed():
+        if app_exists(app_name, timeout):
+            return False
         running_deployments = sdk_cmd.cluster_request("GET", _api_url("deployments")).json()
         log.info(
             "While waiting to delete %s, currently running marathon deployments: %s",
             deployment_id,
             running_deployments,
         )
-        running_id = next((d for d in running_deployments if d["id"] != deployment_id), None)
-        return running_id is None
+        return deployment_id not in [d["id"] for d in running_deployments]
 
     log.info("Waiting for {} to be removed...".format(app_name))
     _wait_for_app_destroyed()

--- a/testing/sdk_marathon.py
+++ b/testing/sdk_marathon.py
@@ -83,6 +83,8 @@ class MarathonDeploymentResponse:
     def _parse_app_information(self, response_json: dict) -> None:
         version = response_json["version"]
         if self._response.status_code == 201:
+            # Marathon just returns 201 after app creation POST requests including the full
+            # configuration. Therefore we have to parse this case differently.
             deployment_id = response_json["deployments"][0]["id"]
         else:
             deployment_id = response_json["deploymentId"]

--- a/testing/sdk_marathon.py
+++ b/testing/sdk_marathon.py
@@ -6,7 +6,6 @@ SHOULD ALSO BE APPLIED TO sdk_marathon IN ANY OTHER PARTNER REPOS
 ************************************************************************
 """
 import logging
-import re
 import retrying
 import requests
 
@@ -14,7 +13,6 @@ import sdk_cmd
 import sdk_tasks
 
 TIMEOUT_SECONDS = 15 * 60
-APP_EXISTS_ERROR_PATTERN = re.compile(r".*An app with id \[.*\] already exists.*")
 
 log = logging.getLogger(__name__)
 
@@ -65,7 +63,7 @@ class MarathonDeploymentResponse:
 
         self._version = response_json["version"]
         if response.status_code == 201:
-            self.deployment_id = self._parse_deployment_id_on_app_creation(response_json)
+            self._deployment_id = self._parse_deployment_id_on_app_creation(response_json)
         else:
             self._deployment_id = response_json["deploymentId"]
 

--- a/testing/sdk_marathon.py
+++ b/testing/sdk_marathon.py
@@ -238,6 +238,7 @@ def destroy_app(app_name: str, timeout=TIMEOUT_SECONDS) -> None:
         return response.json()
 
     result = _destroy()
+    log.info("DELETE marathon app operation responded with: %s", result)
     deployment_id = result["deploymentId"]
 
     # This check is different from the other deployment checks.


### PR DESCRIPTION
This PR ensures that the `sdk_marathon.destroy_app` call waits until the marathon app is completely removed. Before we only checked if it is still registered.