### PR TITLE
[DCOS-41824] Enforce data service version under test

### DIFF
--- a/frameworks/kafka/tests/config.py
+++ b/frameworks/kafka/tests/config.py
@@ -25,7 +25,6 @@ def install(
     service_name,
     expected_running_tasks,
     additional_options={},
-    package_version=None,
     timeout_seconds=25 * 60,
     wait_for_deployment=True,
 ):
@@ -37,7 +36,6 @@ def install(
         expected_running_tasks=expected_running_tasks,
         service_name=service_name,
         additional_options=sdk_utils.merge_dictionaries(test_options, additional_options),
-        package_version=package_version,
         timeout_seconds=timeout_seconds,
         wait_for_deployment=wait_for_deployment,
     )

--- a/frameworks/kafka/tests/test_zookeeper_auth.py
+++ b/frameworks/kafka/tests/test_zookeeper_auth.py
@@ -97,6 +97,7 @@ def zookeeper_service(kerberos):
             config.ZOOKEEPER_PACKAGE_NAME,
             config.ZOOKEEPER_SERVICE_NAME,
             config.ZOOKEEPER_TASK_COUNT,
+            package_version=None,
             additional_options=service_options,
             timeout_seconds=30 * 60,
             insert_strict_options=False,

--- a/frameworks/kafka/tests/test_zookeeper_auth.py
+++ b/frameworks/kafka/tests/test_zookeeper_auth.py
@@ -97,7 +97,7 @@ def zookeeper_service(kerberos):
             config.ZOOKEEPER_PACKAGE_NAME,
             config.ZOOKEEPER_SERVICE_NAME,
             config.ZOOKEEPER_TASK_COUNT,
-            package_version=sdk_install.PackageVersion.LATEST_UNIVERSE.value,
+            package_version=sdk_install.PackageVersion.LATEST_UNIVERSE,
             additional_options=service_options,
             timeout_seconds=30 * 60,
             insert_strict_options=False,

--- a/frameworks/kafka/tests/test_zookeeper_auth.py
+++ b/frameworks/kafka/tests/test_zookeeper_auth.py
@@ -97,7 +97,7 @@ def zookeeper_service(kerberos):
             config.ZOOKEEPER_PACKAGE_NAME,
             config.ZOOKEEPER_SERVICE_NAME,
             config.ZOOKEEPER_TASK_COUNT,
-            package_version=None,
+            package_version=sdk_install.PackageVersion.LATEST_UNIVERSE.value,
             additional_options=service_options,
             timeout_seconds=30 * 60,
             insert_strict_options=False,

--- a/frameworks/kafka/tests/test_zookeeper_authz.py
+++ b/frameworks/kafka/tests/test_zookeeper_authz.py
@@ -101,6 +101,7 @@ def zookeeper_service(kerberos):
             config.ZOOKEEPER_PACKAGE_NAME,
             config.ZOOKEEPER_SERVICE_NAME,
             config.ZOOKEEPER_TASK_COUNT,
+            package_version=None,
             additional_options=service_options,
             timeout_seconds=30 * 60,
             insert_strict_options=False,

--- a/frameworks/kafka/tests/test_zookeeper_authz.py
+++ b/frameworks/kafka/tests/test_zookeeper_authz.py
@@ -101,7 +101,7 @@ def zookeeper_service(kerberos):
             config.ZOOKEEPER_PACKAGE_NAME,
             config.ZOOKEEPER_SERVICE_NAME,
             config.ZOOKEEPER_TASK_COUNT,
-            package_version=sdk_install.PackageVersion.LATEST_UNIVERSE.value,
+            package_version=sdk_install.PackageVersion.LATEST_UNIVERSE,
             additional_options=service_options,
             timeout_seconds=30 * 60,
             insert_strict_options=False,

--- a/frameworks/kafka/tests/test_zookeeper_authz.py
+++ b/frameworks/kafka/tests/test_zookeeper_authz.py
@@ -101,7 +101,7 @@ def zookeeper_service(kerberos):
             config.ZOOKEEPER_PACKAGE_NAME,
             config.ZOOKEEPER_SERVICE_NAME,
             config.ZOOKEEPER_TASK_COUNT,
-            package_version=None,
+            package_version=sdk_install.PackageVersion.LATEST_UNIVERSE.value,
             additional_options=service_options,
             timeout_seconds=30 * 60,
             insert_strict_options=False,

--- a/testing/sdk_install.py
+++ b/testing/sdk_install.py
@@ -10,6 +10,7 @@ import logging
 import time
 import retrying
 import tempfile
+from enum import Enum
 
 import sdk_cmd
 import sdk_marathon
@@ -35,15 +36,20 @@ def get_installed_service_names() -> set:
     return _installed_service_names
 
 
+class PackageVersion(Enum):
+    STUB_UNIVERSE = "stub-universe"
+    LATEST_UNIVERSE = ""
+
+
 @retrying.retry(stop_max_attempt_number=3, retry_on_exception=lambda e: isinstance(e, Exception))
 def _retried_install_impl(
-    package_name,
-    service_name,
-    expected_running_tasks,
-    options={},
-    package_version=None,
-    timeout_seconds=TIMEOUT_SECONDS,
-):
+    package_name: str,
+    service_name: str,
+    expected_running_tasks: int,
+    package_version: str,
+    options: dict,
+    timeout_seconds: int,
+) -> None:
     log.info(
         "Installing package={} service={} with options={} version={}".format(
             package_name, service_name, options, package_version
@@ -82,15 +88,15 @@ def _retried_install_impl(
 
 
 def install(
-    package_name,
-    service_name,
-    expected_running_tasks,
-    additional_options={},
-    package_version="stub-universe",
-    timeout_seconds=TIMEOUT_SECONDS,
-    wait_for_deployment=True,
-    insert_strict_options=True,
-):
+    package_name: str,
+    service_name: str,
+    expected_running_tasks: int,
+    additional_options: dict = {},
+    package_version: str = PackageVersion.STUB_UNIVERSE.value,
+    timeout_seconds: int = TIMEOUT_SECONDS,
+    wait_for_deployment: bool = True,
+    insert_strict_options: bool = True,
+) -> None:
     start = time.time()
 
     # If the package is already installed at this point, fail immediately.
@@ -119,8 +125,8 @@ def install(
         package_name,
         service_name,
         expected_running_tasks,
-        options,
         package_version,
+        options,
         timeout_seconds,
     )
 

--- a/testing/sdk_install.py
+++ b/testing/sdk_install.py
@@ -86,7 +86,7 @@ def install(
     service_name,
     expected_running_tasks,
     additional_options={},
-    package_version=None,
+    package_version="stub-universe",
     timeout_seconds=TIMEOUT_SECONDS,
     wait_for_deployment=True,
     insert_strict_options=True,

--- a/testing/sdk_install.py
+++ b/testing/sdk_install.py
@@ -92,7 +92,7 @@ def install(
     service_name: str,
     expected_running_tasks: int,
     additional_options: dict = {},
-    package_version: str = PackageVersion.STUB_UNIVERSE.value,
+    package_version: PackageVersion = PackageVersion.STUB_UNIVERSE,
     timeout_seconds: int = TIMEOUT_SECONDS,
     wait_for_deployment: bool = True,
     insert_strict_options: bool = True,
@@ -125,7 +125,7 @@ def install(
         package_name,
         service_name,
         expected_running_tasks,
-        package_version,
+        package_version.value if isinstance(package_version, PackageVersion) else package_version,
         options,
         timeout_seconds,
     )

--- a/testing/sdk_package_registry.py
+++ b/testing/sdk_package_registry.py
@@ -48,6 +48,7 @@ def install_package_registry(service_secret_path: str) -> Dict:
         PACKAGE_REGISTRY_NAME,
         PACKAGE_REGISTRY_SERVICE_NAME,
         expected_running_tasks=0,
+        package_version=None,
         additional_options={"registry": {"service-account-secret-path": service_secret_path}},
         wait_for_deployment=False,
         insert_strict_options=False,

--- a/testing/sdk_package_registry.py
+++ b/testing/sdk_package_registry.py
@@ -48,7 +48,7 @@ def install_package_registry(service_secret_path: str) -> Dict:
         PACKAGE_REGISTRY_NAME,
         PACKAGE_REGISTRY_SERVICE_NAME,
         expected_running_tasks=0,
-        package_version=None,
+        package_version=sdk_install.PackageVersion.LATEST_UNIVERSE.value,
         additional_options={"registry": {"service-account-secret-path": service_secret_path}},
         wait_for_deployment=False,
         insert_strict_options=False,

--- a/testing/sdk_package_registry.py
+++ b/testing/sdk_package_registry.py
@@ -48,7 +48,7 @@ def install_package_registry(service_secret_path: str) -> Dict:
         PACKAGE_REGISTRY_NAME,
         PACKAGE_REGISTRY_SERVICE_NAME,
         expected_running_tasks=0,
-        package_version=sdk_install.PackageVersion.LATEST_UNIVERSE.value,
+        package_version=sdk_install.PackageVersion.LATEST_UNIVERSE,
         additional_options={"registry": {"service-account-secret-path": service_secret_path}},
         wait_for_deployment=False,
         insert_strict_options=False,

--- a/testing/sdk_upgrade.py
+++ b/testing/sdk_upgrade.py
@@ -64,6 +64,7 @@ def test_upgrade(
             package_name,
             service_name,
             expected_running_tasks,
+            package_version=universe_version,
             additional_options=additional_options,
             timeout_seconds=timeout_seconds,
             wait_for_deployment=wait_for_deployment,
@@ -175,7 +176,9 @@ def update_or_upgrade_or_downgrade(
     if (to_package_version and not is_cli_supports_service_version_upgrade()) or (
         additional_options and not is_cli_supports_service_options_update()
     ):
-        log.info("Using marathon flow to upgrade %s to version [%s]", service_name, to_package_version)
+        log.info(
+            "Using marathon flow to upgrade %s to version [%s]", service_name, to_package_version
+        )
         sdk_marathon.destroy_app(service_name)
         sdk_install.install(
             package_name,


### PR DESCRIPTION
This PR sets the installed version of a package during testing to `stub-universe`. It ensures that we always test the newly built version and not by accident the universe version.