### PR TITLE
DCOS-43083 : Decommission task kills.

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerConfig.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerConfig.java
@@ -199,7 +199,7 @@ public class SchedulerConfig {
     /**
      * Environment variable to control use of legacy killUnneededTasks sematics. By default this is disabled.
      */
-    private static final String USE_LEGACY_UNNEEDED_TASK_KILLS= "USE_LEGACY_KILL_UNEEDED_TASKS"
+    private static final String USE_LEGACY_UNNEEDED_TASK_KILLS= "USE_LEGACY_KILL_UNEEDED_TASKS";
 
     /**
      * We print the build info here because this is likely to be a very early point in the service's execution. In a

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerConfig.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerConfig.java
@@ -197,6 +197,11 @@ public class SchedulerConfig {
     private static final String LIBPROCESS_IP_ENV = "LIBPROCESS_IP";
 
     /**
+     * Environment variable to control use of legacy killUnneededTasks sematics. By default this is disabled.
+     */
+    private static final String USE_LEGACY_UNNEEDED_TASK_KILLS= "USE_LEGACY_KILL_UNEEDED_TASKS"
+
+    /**
      * We print the build info here because this is likely to be a very early point in the service's execution. In a
      * multi-service situation, however, this code may be getting invoked multiple times, so only print if we haven't
      * printed before.
@@ -310,6 +315,10 @@ public class SchedulerConfig {
 
     public boolean isUninstallEnabled() {
         return envStore.isPresent(SDK_UNINSTALL);
+    }
+
+    public boolean useLegacyUnneededTaskKills() {
+        return envStore.isPresent(USE_LEGACY_UNNEEDED_TASK_KILLS);
     }
 
     /**


### PR DESCRIPTION
k8s uses custom decomissioners to perform cleanup. Currently on a scheduler restart,
we're prematurely killing off the decommission related tasks.

In this patch:
- Remove global kills of tasks with GoalStateOverride of PENDING as default behaviour.
- Move current semantics into legacyKillUnneededTasks() and use environment variable
USE_LEGACY_KILL_UNEEDED_TASKS to toggle previous functionality at runtime.