### PR TITLE
DCOS-43083 : Decommision Task Kills

### DIFF
--- a/frameworks/helloworld/src/test/java/com/mesosphere/sdk/helloworld/scheduler/ServiceTest.java
+++ b/frameworks/helloworld/src/test/java/com/mesosphere/sdk/helloworld/scheduler/ServiceTest.java
@@ -389,10 +389,6 @@ public class ServiceTest {
         ticks.add(Send.taskStatus("world-0-server", Protos.TaskState.TASK_RUNNING).setReadinessCheckExitCode(0).build());
         ticks.add(Send.taskStatus("world-1-server", Protos.TaskState.TASK_RUNNING).setReadinessCheckExitCode(0).build());
 
-        // An initial kill is sent early on for the decommissioned tasks:
-        ticks.add(Expect.taskNameKilled("world-0-server", 1));
-        ticks.add(Expect.taskNameKilled("world-1-server", 1));
-
         // Now, we expect there to be the following plan state:
         // - a deploy plan that's COMPLETE, with only hello-0 (empty world phase)
         // - a recovery plan that's COMPLETE
@@ -413,7 +409,7 @@ public class ServiceTest {
         // Check plan state after an offer came through: world-1-server killed
         ticks.add(new ExpectDecommissionPlanProgress(Arrays.asList(
                 new StepCount("world-1", stepCount - 1, 0, 1), new StepCount("world-0", stepCount, 0, 0))));
-        ticks.add(Expect.taskNameKilled("world-1-server", 2));
+        ticks.add(Expect.taskNameKilled("world-1-server", 1));
 
         // Offer world-0 resources and check that nothing happens (haven't gotten there yet):
         ticks.add(Send.offerBuilder("world").setPodIndexToReoffer(0).build());
@@ -440,7 +436,7 @@ public class ServiceTest {
         ticks.add(Send.offerBuilder("world").setPodIndexToReoffer(0).build());
         ticks.add(new ExpectDecommissionPlanProgress(Arrays.asList(
                 new StepCount("world-1", 0, 0, stepCount), new StepCount("world-0", 1, 0, stepCount - 1))));
-        ticks.add(Expect.taskNameKilled("world-0-server", 2));
+        ticks.add(Expect.taskNameKilled("world-0-server", 1));
         ticks.add(new ExpectEmptyResources(result.getPersister(), "world-0-server"));
 
         // Turn the crank once again to erase the world-0 stub:

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/DefaultScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/DefaultScheduler.java
@@ -182,7 +182,12 @@ public class DefaultScheduler extends AbstractScheduler {
             activeTasks.addAll(decommissionedTasks);
         }
 
-        killUnneededTasks(stateStore, activeTasks);
+        if (schedulerConfig.useLegacyUnneededTaskKills()) {
+            //This case is turned off by default.
+            legacyKillUnneededTasks(stateStore, activeTasks, logger);
+        } else {
+            killUnneededTasks(stateStore, activeTasks);
+        }
     }
 
     @Override
@@ -269,24 +274,55 @@ public class DefaultScheduler extends AbstractScheduler {
                 .map(taskInfo -> taskInfo.getTaskId())
                 .collect(Collectors.toSet());
 
+        taskIdsToKill.forEach(taskID -> TaskKiller.killTask(taskID));
+    }
+
+    private static void legacyKillUnneededTasks(StateStore stateStore, Set<String> taskToDeployNames, Logger logger) {
+
+        //This method is retained to understand why we're cleaning out TaskInfo's and why
+        //a global kill was issued to pending tasks. This method can be invoked in frameworks
+        //that do not have require extensive cleanup via decommissioning. The environment
+        //variable USE_LEGACY_KILL_UNNEEDED_TASKS should be set to invoke this method at runtime.
+
+        Set<Protos.TaskInfo> unneededTaskInfos = stateStore.fetchTasks().stream()
+                .filter(taskInfo -> !taskToDeployNames.contains(taskInfo.getName()))
+                .collect(Collectors.toSet());
+
+        Set<Protos.TaskID> taskIdsToKill = unneededTaskInfos.stream()
+                .map(taskInfo -> taskInfo.getTaskId())
+                .collect(Collectors.toSet());
+
         // Clear the TaskIDs from the TaskInfos so we drop all future TaskStatus Messages
+        //TODO: Investigate why this is needed anymore.
         Set<Protos.TaskInfo> cleanedTaskInfos = unneededTaskInfos.stream()
                 .map(taskInfo -> taskInfo.toBuilder())
                 .map(builder -> builder.setTaskId(Protos.TaskID.newBuilder().setValue("")).build())
                 .collect(Collectors.toSet());
 
         // Remove both TaskInfo and TaskStatus, then store the cleaned TaskInfo one at a time to limit damage in the
-        // event of an untimely scheduler crash
+        // event of an untimely scheduler crash.
+        //TODO: Investigate why this is needed anymore.
         for (Protos.TaskInfo taskInfo : cleanedTaskInfos) {
             stateStore.clearTask(taskInfo.getName());
             stateStore.storeTasks(Arrays.asList(taskInfo));
         }
 
+        unneededTaskInfos.stream().forEach(taskInfo ->
+                logger.info("Enqueued kill of taskName: {} taskId: {} due to unneeded taskinfos!",
+                        taskInfo.getName(),
+                        taskInfo.getTaskId()));
+
         taskIdsToKill.forEach(taskID -> TaskKiller.killTask(taskID));
 
+        //WARNING: This is a global kill of pending tasks. This can interfere with
+        //decommission steps which may have started up in pending state.
+        //Some frameworks like k8s need decommission steps to execute correctly for cleanup.
         for (Protos.TaskInfo taskInfo : stateStore.fetchTasks()) {
             GoalStateOverride.Status overrideStatus = stateStore.fetchGoalOverrideStatus(taskInfo.getName());
             if (overrideStatus.progress == GoalStateOverride.Progress.PENDING) {
+                logger.warn("Enqueued kill of taskName: {} taskId: {} due to GoalStateOverride PENDING!",
+                        taskInfo.getName(),
+                        taskInfo.getTaskId());
                 // Enabling or disabling an override was triggered, but the task kill wasn't processed so that the
                 // change in override could take effect. Kill the task so that it can enter (or exit) the override. The
                 // override status will then be marked IN_PROGRESS once we have received the terminal TaskStatus.

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerConfig.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerConfig.java
@@ -197,6 +197,11 @@ public class SchedulerConfig {
     private static final String LIBPROCESS_IP_ENV = "LIBPROCESS_IP";
 
     /**
+     * Environment variable to control use of legacy killUnneededTasks sematics. By default this is disabled.
+     */
+    private static final String USE_LEGACY_UNNEEDED_TASK_KILLS = "USE_LEGACY_KILL_UNNEEDED_TASKS";
+
+    /**
      * We print the build info here because this is likely to be a very early point in the service's execution. In a
      * multi-service situation, however, this code may be getting invoked multiple times, so only print if we haven't
      * printed before.
@@ -310,6 +315,10 @@ public class SchedulerConfig {
 
     public boolean isUninstallEnabled() {
         return envStore.isPresent(SDK_UNINSTALL);
+    }
+
+    public boolean useLegacyUnneededTaskKills() {
+        return envStore.isPresent(USE_LEGACY_UNNEEDED_TASK_KILLS);
     }
 
     /**


### PR DESCRIPTION
k8s uses custom decommissioners to perform cleanup. Currently on a scheduler restart, we're prematurely killing off the decommission related tasks.
    
In this patch:
- Remove global kills of tasks with GoalStateOverride of PENDING as default behaviour.
- Move current semantics into legacyKillUnneededTasks() and use environment variable USE_LEGACY_KILL_UNNEEDED_TASKS to toggle previous functionality at runtime.

Update hello-world unit test ServiceTest.testWorldDecommission to reflect the following changes
- Initial task kill has been removed, tasks will be killed during TriggerDecommisionStep.
- Update counts to reflect that world-1-server and world-0-server are only killed once.