### PR TITLE
[DCOS-41674] Add test to check envvars under restart (#2677)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,7 @@
 .*
 
 !test_requirements.txt
+!frozen_requirements.txt
 !test_runner.sh
 !/tools/ci
 !test.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,10 +39,7 @@ COPY frozen_requirements.txt frozen_requirements.txt
 RUN pip3 install --upgrade -r frozen_requirements.txt
 
 # Get DC/OS CLI
-RUN curl -O https://downloads.dcos.io/binaries/cli/linux/x86-64/dcos-1.12/dcos && \
-    chmod +x dcos && \
-    mv dcos /usr/local/bin && \
-    dcos --version
+COPY dep-snapshots/dcos /usr/local/bin
 
 # dcos-cli and lint tooling require this to output cleanly
 ENV LC_ALL=C.UTF-8 LANG=C.UTF-8

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,11 +34,9 @@ RUN apt-get update && \
 ENV PATH=$PATH:/usr/local/go/bin
 RUN go version
 
-# AWS CLI for uploading build artifacts
-RUN pip3 install awscli
-# Install the lint+testing dependencies
-COPY test_requirements.txt test_requirements.txt
-RUN pip3 install --upgrade -r test_requirements.txt
+# Install the lint+testing dependencies and AWS CLI for uploading build artifacts
+COPY frozen_requirements.txt frozen_requirements.txt
+RUN pip3 install --upgrade -r frozen_requirements.txt
 
 # Get DC/OS CLI
 RUN curl -O https://downloads.dcos.io/binaries/cli/linux/x86-64/dcos-1.12/dcos && \

--- a/frameworks/cassandra/tests/test_sanity.py
+++ b/frameworks/cassandra/tests/test_sanity.py
@@ -1,4 +1,6 @@
 import pytest
+import logging
+
 import sdk_cmd
 import sdk_hosts
 import sdk_install
@@ -13,7 +15,10 @@ import sdk_utils
 from tests import config
 
 
-@pytest.fixture(scope='module', autouse=True)
+log = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="module", autouse=True)
 def configure_package(configure_security):
     test_jobs = []
     try:
@@ -123,3 +128,50 @@ def test_metrics():
         config.DEFAULT_CASSANDRA_TIMEOUT,
         expected_metrics_exist
     )
+
+
+@pytest.mark.sanity
+def test_config_update_across_restart():
+    foldered_service_name = config.get_foldered_service_name()
+
+    batch_size_warn_threshold_in_kb = 15
+    sdk_upgrade.update_or_upgrade_or_downgrade(
+        config.PACKAGE_NAME,
+        foldered_service_name,
+        to_package_version=None,
+        additional_options={
+            "service": {"name": foldered_service_name},
+            "cassandra": {"batch_size_warn_threshold_in_kb": batch_size_warn_threshold_in_kb},
+        },
+        expected_running_tasks=config.DEFAULT_TASK_COUNT,
+        wait_for_deployment=True,
+        timeout_seconds=config.DEFAULT_CASSANDRA_TIMEOUT,
+    )
+
+    for _ in range(3):
+        cmd_list = ["pod", "restart", "node-0"]
+        sdk_cmd.svc_cli(config.PACKAGE_NAME, foldered_service_name, " ".join(cmd_list))
+
+        sdk_plan.wait_for_kicked_off_recovery(foldered_service_name)
+        sdk_plan.wait_for_completed_recovery(
+            foldered_service_name, timeout_seconds=config.DEFAULT_CASSANDRA_TIMEOUT
+        )
+
+        _, stdout, _ = sdk_cmd.service_task_exec(foldered_service_name, "node-0-server", "env")
+
+        envvar = "CASSANDRA_BATCH_SIZE_WARN_THRESHOLD_IN_KB="
+        envvar_pos = stdout.find(envvar)
+        if envvar_pos < 0:
+            raise Exception("Required envvar not found")
+
+        if not stdout[envvar_pos + len(envvar) :].startswith(
+            "{}".format(batch_size_warn_threshold_in_kb)
+        ):
+            found_string = stdout[envvar_pos + len(envvar) : envvar_pos + len(envvar) + 15]
+            log.error(
+                "Looking for %s%d but found: %s",
+                envvar,
+                batch_size_warn_threshold_in_kb,
+                found_string,
+            )
+            raise Exception("Envvar not set to required value")

--- a/frameworks/helloworld/src/main/dist/sidecar.yml
+++ b/frameworks/helloworld/src/main/dist/sidecar.yml
@@ -25,6 +25,7 @@ pods:
           # Note, this is very high so that the test test_sidecar.test_toxic_sidecar_doesnt_trigger_recovery
           # will always have an empty recovery plan.
           SLEEP_DURATION: 10000
+          CONFIG_SLEEP_DURATION: {{SLEEP_DURATION}}
       once:
         goal: ONCE
         cmd: "echo 'I run only once' >> hello-container-path/output"

--- a/frameworks/helloworld/tests/test_sidecar.py
+++ b/frameworks/helloworld/tests/test_sidecar.py
@@ -7,7 +7,9 @@ import sdk_cmd
 import sdk_install
 import sdk_marathon
 import sdk_plan
+import sdk_upgrade
 import sdk_utils
+
 from tests import config
 
 log = logging.getLogger(__name__)
@@ -30,6 +32,42 @@ def configure_package(configure_security):
         yield  # let the test session execute
     finally:
         sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
+
+
+@pytest.mark.sanity
+def test_envvar_accross_restarts():
+    sleep_duration = 9999
+    sdk_upgrade.update_or_upgrade_or_downgrade(
+        config.PACKAGE_NAME,
+        config.SERVICE_NAME,
+        to_package_version=None,
+        additional_options={
+            "service": {"name": config.SERVICE_NAME, "sleep": sleep_duration, "yaml": "sidecar"}
+        },
+        expected_running_tasks=2,
+        wait_for_deployment=True,
+    )
+
+    for attempt in range(3):
+        cmd_list = ["pod", "restart", "hello-0"]
+        sdk_cmd.svc_cli(config.PACKAGE_NAME, config.SERVICE_NAME, " ".join(cmd_list))
+
+        sdk_plan.wait_for_kicked_off_recovery(config.SERVICE_NAME)
+        sdk_plan.wait_for_completed_recovery(config.SERVICE_NAME)
+
+        _, stdout, _ = sdk_cmd.service_task_exec(config.SERVICE_NAME, "hello-0-server", "env")
+
+        envvar = "CONFIG_SLEEP_DURATION="
+        envvar_pos = stdout.find(envvar)
+        if envvar_pos < 0:
+            raise Exception("Required envvar not found")
+
+        if not stdout[envvar_pos + len(envvar) :].startswith("{}".format(sleep_duration)):
+            found_string = stdout[envvar_pos + len(envvar) : envvar_pos + len(envvar) + 15]
+            log.error(
+                "(%d) Looking for %s%d but found: %s", attempt, envvar, sleep_duration, found_string
+            )
+            raise Exception("Envvar not set to required value")
 
 
 @pytest.mark.sanity

--- a/frozen_requirements.txt
+++ b/frozen_requirements.txt
@@ -1,0 +1,119 @@
+# This file was created from test_requirements.txt in the following way in
+# order to work around build breakage: https://jira.mesosphere.com/browse/DCOS-43889
+# 1. s/frozen_/test_/g in Dockerfile
+# 2. docker build .
+# [...]
+# Successfully built IMAGE-ID
+# 3. docker run -ti IMAGE-ID pip3 freeze > frozen_requirements.txt
+# 4. Manually edit the file to:
+#    - replace the references to dcoscli, dcos, dcos-test-utils and dcos-launch with the four git+http URIs below
+#    - replace urllib 1.24 with 1.23 
+#    - add this comment
+# 5. git checkout Dockerfile
+git+https://github.com/dcos/dcos-cli.git@f1fd38c9e72e1d521cf8120fe4948a789fb40cbc#egg=dcoscli&subdirectory=cli
+git+https://github.com/dcos/dcos-cli.git@f1fd38c9e72e1d521cf8120fe4948a789fb40cbc
+git+https://github.com/dcos/dcos-test-utils.git@3ebfc18ff9c5a1aa382311474a9192a68c98b0a7
+git+https://github.com/dcos/dcos-launch.git@dc1e116685fba5105f322b007549b7eb104cf441
+adal==1.1.0
+altgraph==0.16.1
+appdirs==1.4.3
+asn1crypto==0.24.0
+aspy.yaml==1.1.1
+astroid==2.0.4
+atomicwrites==1.2.1
+attrs==18.2.0
+awscli==1.16.33
+azure-common==1.1.16
+azure-mgmt-network==2.0.0
+azure-mgmt-nspkg==3.0.2
+azure-mgmt-resource==2.0.0
+azure-monitor==0.3.1
+azure-nspkg==3.0.2
+azure-storage==0.36.0
+bcrypt==3.1.4
+black==18.9b0
+boto3==1.9.23
+botocore==1.12.23
+cached-property==1.5.1
+cachetools==2.1.0
+Cerberus==1.2
+certifi==2018.10.15
+cffi==1.11.5
+cfgv==1.1.0
+chardet==3.0.4
+Click==7.0
+colorama==0.3.9
+cryptography==2.0.2
+dcos-shakedown==1.4.12
+docopt==0.6.2
+docutils==0.14
+entrypoints==0.2.3
+flake8==3.5.0
+future==0.16.0
+google-api-python-client==1.7.4
+google-auth==1.5.1
+google-auth-httplib2==0.0.3
+httplib2==0.11.3
+identify==1.1.7
+idna==2.7
+isodate==0.6.0
+isort==4.3.4
+jeepney==0.4
+jmespath==0.9.3
+jsonschema==2.6.0
+keyring==15.1.0
+keyrings.alt==3.0
+lazy-object-proxy==1.3.1
+macholib==1.11
+mccabe==0.6.1
+more-itertools==4.3.0
+msrest==0.6.0
+msrestazure==0.4.34
+nodeenv==1.3.2
+oauth2client==3.0.0
+oauthlib==2.1.0
+pager==3.3
+paramiko==2.4.2
+pefile==2018.8.8
+pkginfo==1.2.1
+pluggy==0.7.1
+pre-commit==1.11.2
+prettytable==0.7.2
+py==1.7.0
+pyasn1==0.4.4
+pyasn1-modules==0.2.2
+pycodestyle==2.3.1
+pycparser==2.19
+pycrypto==2.6.1
+pyflakes==1.6.0
+Pygments==2.2.0
+pygobject==3.26.1
+PyInstaller==3.3
+PyJWT==1.4.2
+pylint==2.1.1
+PyNaCl==1.3.0
+pytest==3.8.2
+pytest-timeout==1.3.2
+python-apt==1.6.2
+python-dateutil==2.7.3
+pyxdg==0.25
+PyYAML==3.13
+requests==2.19.1
+requests-oauthlib==1.0.0
+retrying==1.3.3
+rsa==4.0
+s3transfer==0.1.13
+scp==0.12.1
+SecretStorage==3.1.0
+six==1.11.0
+sseclient==0.0.14
+teamcity-messages==1.21
+toml==0.10.0
+toolz==0.9.0
+tox==2.5.0
+typed-ast==1.1.0
+unattended-upgrades==0.1
+uritemplate==3.0.0
+urllib3==1.23
+virtualenv==15.2.0
+wrapt==1.10.11

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -12,6 +12,9 @@ dcos-shakedown==1.4.12
 git+https://github.com/dcos/dcos-test-utils.git@3ebfc18ff9c5a1aa382311474a9192a68c98b0a7
 git+https://github.com/dcos/dcos-launch.git@dc1e116685fba5105f322b007549b7eb104cf441
 
+# AWS CLI for uploading build artifacts
+awscli
+
 # CI:
 teamcity-messages
 

--- a/tools/ci/checks/get_applicable_changes.py
+++ b/tools/ci/checks/get_applicable_changes.py
@@ -8,7 +8,7 @@ from typing import List
 
 
 BUILD_FOLDERS = ["cli/", "clivendor/", "govendor/", "sdk/", "testing/", "tools/"]
-BUILD_FILES = ["conftest.py", "test_requirements.txt", "Dockerfile"]
+BUILD_FILES = ["conftest.py", "test_requirements.txt", "frozen_requirements.txt", "Dockerfile"]
 
 
 def get_changed_files(git_reference: str) -> List[str]:


### PR DESCRIPTION
This is a backport of #2677

* Add tests for Cassandra and HelloWorld to check envvars under restart

* Update docker-specific files to skip rebuild of docker image in CI.