### PR TITLE
DCOS-42539 Fix how TaskInfos are updated with sidecar tasks and resource sets

### DIFF
--- a/frameworks/cassandra/tests/test_sanity.py
+++ b/frameworks/cassandra/tests/test_sanity.py
@@ -9,7 +9,6 @@ import sdk_metrics
 import sdk_networks
 import sdk_plan
 import sdk_upgrade
-import sdk_utils
 
 from tests import config
 
@@ -79,12 +78,7 @@ def test_repair_cleanup_plans_complete():
 
 
 @pytest.mark.sanity
-@pytest.mark.metrics
 @pytest.mark.dcos_min_version("1.9")
-@pytest.mark.skipif(
-    sdk_utils.dcos_version_at_least("1.12"),
-    reason="Metrics are not working on 1.12. Reenable once this is fixed",
-)
 def test_metrics():
     expected_metrics = [
         "org.apache.cassandra.metrics.Table.CoordinatorReadLatency.system.hints.p999",

--- a/frameworks/cassandra/universe/marathon.json.mustache
+++ b/frameworks/cassandra/universe/marathon.json.mustache
@@ -15,6 +15,15 @@
     "DCOS_SERVICE_SCHEME": "http"
   },
   {{#service.service_account_secret}}
+  "container": {
+    "type": "MESOS",
+    "volumes": [
+      {
+        "containerPath": "secrets/service-account.json",
+        "secret": "serviceCredential"
+      }
+    ]
+  },
   "secrets": {
     "serviceCredential": {
       "source": "{{service.service_account_secret}}"
@@ -34,8 +43,8 @@
     "S3CLI_VERSION": "s3cli-0.0.55-linux-amd64",
 
     {{#service.service_account_secret}}
-    "DCOS_SERVICE_ACCOUNT_CREDENTIAL": { "secret": "serviceCredential" },
-    "MESOS_MODULES": "{\"libraries\":[{\"file\":\"libmesos-bundle\/lib\/mesos\/libdcos_security.so\",\"modules\":[{\"name\": \"com_mesosphere_dcos_ClassicRPCAuthenticatee\"},{\"name\":\"com_mesosphere_dcos_http_Authenticatee\",\"parameters\":[{\"key\":\"jwt_exp_timeout\",\"value\":\"5mins\"},{\"key\":\"preemptive_refresh_duration\",\"value\":\"30mins\"}]}]}]}",
+    "DCOS_SERVICE_ACCOUNT_CREDENTIAL": "secrets/service-account.json",
+    "MESOS_MODULES": "{\"libraries\":[{\"file\":\"libmesos-bundle\/lib\/mesos\/libdcos_security.so\",\"modules\":[{\"name\": \"com_mesosphere_dcos_ClassicRPCAuthenticatee\"},{\"name\":\"com_mesosphere_dcos_http_Authenticatee\",\"parameters\":[{\"key\":\"service_account_credential\",\"value\":\"file://secrets/service-account.json\"},{\"key\":\"jwt_exp_timeout\",\"value\":\"5mins\"},{\"key\":\"preemptive_refresh_duration\",\"value\":\"30mins\"}]}]}]}",
     "MESOS_AUTHENTICATEE": "com_mesosphere_dcos_ClassicRPCAuthenticatee",
     "MESOS_HTTP_AUTHENTICATEE": "com_mesosphere_dcos_http_Authenticatee",
     {{/service.service_account_secret}}

--- a/frameworks/elastic/tests/test_sanity.py
+++ b/frameworks/elastic/tests/test_sanity.py
@@ -87,9 +87,7 @@ def test_pod_replace_then_immediate_config_update():
 def test_endpoints():
     # check that we can reach the scheduler via admin router, and that returned endpoints are sanitized:
     for endpoint in config.ENDPOINT_TYPES:
-        endpoints = sdk_networks.get_endpoint(
-            config.PACKAGE_NAME, foldered_name, endpoint
-        )
+        endpoints = sdk_networks.get_endpoint(config.PACKAGE_NAME, foldered_name, endpoint)
         host = endpoint.split("-")[0]  # 'coordinator-http' => 'coordinator'
         assert endpoints["dns"][0].startswith(
             sdk_hosts.autoip_host(foldered_name, host + "-0-node")
@@ -116,12 +114,7 @@ def test_indexing(default_populated_index):
 
 
 @pytest.mark.sanity
-@pytest.mark.metrics
 @pytest.mark.dcos_min_version("1.9")
-@pytest.mark.skipif(
-    sdk_utils.dcos_version_at_least("1.12"),
-    reason="Metrics are not working on 1.12. Reenable once this is fixed",
-)
 def test_metrics():
     expected_metrics = [
         "node.data-0-node.fs.total.total_in_bytes",

--- a/frameworks/elastic/universe/marathon.json.mustache
+++ b/frameworks/elastic/universe/marathon.json.mustache
@@ -15,6 +15,15 @@
     "DCOS_SERVICE_SCHEME": "http"
   },
   {{#service.service_account_secret}}
+  "container": {
+    "type": "MESOS",
+    "volumes": [
+      {
+        "containerPath": "secrets/service-account.json",
+        "secret": "serviceCredential"
+      }
+    ]
+  },
   "secrets": {
     "serviceCredential": {
       "source": "{{service.service_account_secret}}"
@@ -43,8 +52,8 @@
     "FRAMEWORK_LOG_LEVEL": "{{service.log_level}}",
 
     {{#service.service_account_secret}}
-    "DCOS_SERVICE_ACCOUNT_CREDENTIAL": { "secret": "serviceCredential" },
-    "MESOS_MODULES": "{\"libraries\":[{\"file\":\"libmesos-bundle\/lib\/mesos\/libdcos_security.so\",\"modules\":[{\"name\": \"com_mesosphere_dcos_ClassicRPCAuthenticatee\"},{\"name\":\"com_mesosphere_dcos_http_Authenticatee\",\"parameters\":[{\"key\":\"jwt_exp_timeout\",\"value\":\"5mins\"},{\"key\":\"preemptive_refresh_duration\",\"value\":\"30mins\"}]}]}]}",
+    "DCOS_SERVICE_ACCOUNT_CREDENTIAL": "secrets/service-account.json",
+    "MESOS_MODULES": "{\"libraries\":[{\"file\":\"libmesos-bundle\/lib\/mesos\/libdcos_security.so\",\"modules\":[{\"name\": \"com_mesosphere_dcos_ClassicRPCAuthenticatee\"},{\"name\":\"com_mesosphere_dcos_http_Authenticatee\",\"parameters\":[{\"key\":\"service_account_credential\",\"value\":\"file://secrets/service-account.json\"},{\"key\":\"jwt_exp_timeout\",\"value\":\"5mins\"},{\"key\":\"preemptive_refresh_duration\",\"value\":\"30mins\"}]}]}]}",
     "MESOS_AUTHENTICATEE": "com_mesosphere_dcos_ClassicRPCAuthenticatee",
     "MESOS_HTTP_AUTHENTICATEE": "com_mesosphere_dcos_http_Authenticatee",
     {{/service.service_account_secret}}

--- a/frameworks/hdfs/tests/test_sanity.py
+++ b/frameworks/hdfs/tests/test_sanity.py
@@ -58,9 +58,7 @@ def pre_test_setup():
 def test_endpoints():
     # check that we can reach the scheduler via admin router, and that returned endpoints are sanitized:
     core_site = etree.fromstring(
-        sdk_networks.get_endpoint_string(
-            config.PACKAGE_NAME, foldered_name, "core-site.xml"
-        )
+        sdk_networks.get_endpoint_string(config.PACKAGE_NAME, foldered_name, "core-site.xml")
     )
     check_properties(
         core_site,
@@ -68,9 +66,7 @@ def test_endpoints():
     )
 
     hdfs_site = etree.fromstring(
-        sdk_networks.get_endpoint_string(
-            config.PACKAGE_NAME, foldered_name, "hdfs-site.xml"
-        )
+        sdk_networks.get_endpoint_string(config.PACKAGE_NAME, foldered_name, "hdfs-site.xml")
     )
     expect = {
         "dfs.namenode.shared.edits.dir": "qjournal://{}/hdfs".format(
@@ -357,12 +353,7 @@ def test_modify_app_config_rollback():
 
 
 @pytest.mark.sanity
-@pytest.mark.metrics
 @pytest.mark.dcos_min_version("1.9")
-@pytest.mark.skipif(
-    sdk_utils.dcos_version_at_least("1.12"),
-    reason="Metrics are not working on 1.12. Reenable once this is fixed",
-)
 def test_metrics():
     expected_metrics = [
         "JournalNode.jvm.JvmMetrics.ThreadsRunnable",

--- a/frameworks/hdfs/universe/marathon.json.mustache
+++ b/frameworks/hdfs/universe/marathon.json.mustache
@@ -15,6 +15,15 @@
     "DCOS_SERVICE_SCHEME": "http"
   },
   {{#service.service_account_secret}}
+  "container": {
+    "type": "MESOS",
+    "volumes": [
+      {
+        "containerPath": "secrets/service-account.json",
+        "secret": "serviceCredential"
+      }
+    ]
+  },
   "secrets": {
     "serviceCredential": {
       "source": "{{service.service_account_secret}}"
@@ -66,8 +75,8 @@
     {{/service.virtual_network_enabled}}
 
     {{#service.service_account_secret}}
-    "DCOS_SERVICE_ACCOUNT_CREDENTIAL": { "secret": "serviceCredential" },
-    "MESOS_MODULES": "{\"libraries\":[{\"file\":\"libmesos-bundle\/lib\/mesos\/libdcos_security.so\",\"modules\":[{\"name\": \"com_mesosphere_dcos_ClassicRPCAuthenticatee\"},{\"name\":\"com_mesosphere_dcos_http_Authenticatee\",\"parameters\":[{\"key\":\"jwt_exp_timeout\",\"value\":\"5mins\"},{\"key\":\"preemptive_refresh_duration\",\"value\":\"30mins\"}]}]}]}",
+    "DCOS_SERVICE_ACCOUNT_CREDENTIAL": "secrets/service-account.json",
+    "MESOS_MODULES": "{\"libraries\":[{\"file\":\"libmesos-bundle\/lib\/mesos\/libdcos_security.so\",\"modules\":[{\"name\": \"com_mesosphere_dcos_ClassicRPCAuthenticatee\"},{\"name\":\"com_mesosphere_dcos_http_Authenticatee\",\"parameters\":[{\"key\":\"service_account_credential\",\"value\":\"file://secrets/service-account.json\"},{\"key\":\"jwt_exp_timeout\",\"value\":\"5mins\"},{\"key\":\"preemptive_refresh_duration\",\"value\":\"30mins\"}]}]}]}",
     "MESOS_AUTHENTICATEE": "com_mesosphere_dcos_ClassicRPCAuthenticatee",
     "MESOS_HTTP_AUTHENTICATEE": "com_mesosphere_dcos_http_Authenticatee",
     {{/service.service_account_secret}}

--- a/frameworks/helloworld/tests/test_sanity.py
+++ b/frameworks/helloworld/tests/test_sanity.py
@@ -7,10 +7,12 @@ import retrying
 import sdk_cmd
 import sdk_install
 import sdk_marathon
+import sdk_metrics
 import sdk_plan
 import sdk_tasks
 import sdk_upgrade
 import sdk_utils
+
 from tests import config
 
 
@@ -21,17 +23,68 @@ foldered_name = sdk_utils.get_foldered_name(config.SERVICE_NAME)
 @pytest.fixture(scope="module", autouse=True)
 def configure_package(configure_security):
     try:
+        service_options = {"service": {"name": foldered_name}}
         sdk_install.uninstall(config.PACKAGE_NAME, foldered_name)
         sdk_upgrade.test_upgrade(
             config.PACKAGE_NAME,
             foldered_name,
             config.DEFAULT_TASK_COUNT,
-            additional_options={"service": {"name": foldered_name}},
+            additional_options=service_options,
         )
 
-        yield  # let the test session execute
+        yield {"package_name": config.PACKAGE_NAME, **service_options}
     finally:
         sdk_install.uninstall(config.PACKAGE_NAME, foldered_name)
+
+
+@pytest.mark.sanity
+@pytest.mark.smoke
+@pytest.mark.dcos_min_version("1.9")
+def test_metrics_cli_for_scheduler_metrics(configure_package):
+    scheduler_task_prefix = sdk_marathon.get_scheduler_task_prefix(
+        configure_package["service"]["name"]
+    )
+    scheduler_task_id = sdk_tasks.get_task_ids("marathon", scheduler_task_prefix).pop()
+    scheduler_metrics = sdk_metrics.wait_for_metrics_from_cli(scheduler_task_id, timeout_seconds=60)
+
+    assert scheduler_metrics, "Expecting a non-empty set of metrics"
+
+
+@pytest.mark.sanity
+@pytest.mark.smoke
+@pytest.mark.dcos_min_version("1.9")
+def test_metrics_for_task_metrics(configure_package):
+
+    def write_metric_to_statsd_counter(metric_name: str, value: int):
+        """
+        Write a metric with the specified value to statsd.
+
+        This is done by echoing the statsd string through ncat to the statsd host an port.
+        """
+        metric_echo = 'echo \\"{}:{}|c\\"'.format(metric_name, value)
+        ncat_command = 'ncat -w 1 -u \\$STATSD_UDP_HOST \\$STATSD_UDP_PORT'
+        pipe = " | "
+
+        bash_command = sdk_cmd.get_bash_command(
+            metric_echo + pipe + ncat_command,
+            environment=None,
+        )
+        sdk_cmd.service_task_exec(configure_package["service"]["name"], "hello-0-server", bash_command)
+
+    metric_name = "test.metrics.CamelCaseMetric"
+    write_metric_to_statsd_counter(metric_name, 1)
+
+    def expected_metrics_exist(emitted_metrics) -> bool:
+        return sdk_metrics.check_metrics_presence(emitted_metrics, [metric_name])
+
+    sdk_metrics.wait_for_service_metrics(
+        configure_package["package_name"],
+        configure_package["service"]["name"],
+        "hello-0",
+        "hello-0-server",
+        timeout=5 * 60,
+        expected_metrics_callback=expected_metrics_exist,
+    )
 
 
 @pytest.mark.sanity
@@ -217,15 +270,13 @@ def test_config_cli():
     configs = json.loads(stdout)
     assert len(configs) >= 1  # refrain from breaking this test if earlier tests did a config update
 
-    assert (
-        0
-        == sdk_cmd.svc_cli(
-            config.PACKAGE_NAME,
-            foldered_name,
-            "debug config show {}".format(configs[0]),
-            print_output=False,  # noisy output
-        )[0]
+    rc, _, _ = sdk_cmd.svc_cli(
+        config.PACKAGE_NAME,
+        foldered_name,
+        "debug config show {}".format(configs[0]),
+        print_output=False,  # noisy output
     )
+    assert rc == 0
     _check_json_output(foldered_name, "debug config target")
     _check_json_output(foldered_name, "debug config target_id")
 
@@ -236,33 +287,25 @@ def test_plan_cli():
     plan_name = "deploy"
     phase_name = "world"
     _check_json_output(foldered_name, "plan list")
-    assert (
-        0
-        == sdk_cmd.svc_cli(config.PACKAGE_NAME, foldered_name, "plan show {}".format(plan_name))[0]
-    )
+    rc, _, _ = sdk_cmd.svc_cli(config.PACKAGE_NAME, foldered_name, "plan show {}".format(plan_name))
+    assert rc == 0
     _check_json_output(foldered_name, "plan show --json {}".format(plan_name))
     _check_json_output(foldered_name, "plan show {} --json".format(plan_name))
 
     # trigger a restart so that the plan is in a non-complete state.
     # the 'interrupt' command will fail if the plan is already complete:
-    assert (
-        0
-        == sdk_cmd.svc_cli(
-            config.PACKAGE_NAME, foldered_name, "plan force-restart {}".format(plan_name)
-        )[0]
+    rc, _, _ = sdk_cmd.svc_cli(
+        config.PACKAGE_NAME, foldered_name, "plan force-restart {}".format(plan_name)
     )
-    assert (
-        0
-        == sdk_cmd.svc_cli(
-            config.PACKAGE_NAME, foldered_name, "plan interrupt {} {}".format(plan_name, phase_name)
-        )[0]
+    assert rc == 0
+    rc, _, _ = sdk_cmd.svc_cli(
+        config.PACKAGE_NAME, foldered_name, "plan interrupt {} {}".format(plan_name, phase_name)
     )
-    assert (
-        0
-        == sdk_cmd.svc_cli(
-            config.PACKAGE_NAME, foldered_name, "plan continue {} {}".format(plan_name, phase_name)
-        )[0]
+    assert rc == 0
+    rc, _, _ = sdk_cmd.svc_cli(
+        config.PACKAGE_NAME, foldered_name, "plan continue {} {}".format(plan_name, phase_name)
     )
+    assert rc == 0
 
     # now wait for plan to finish before continuing to other tests:
     assert sdk_plan.wait_for_completed_plan(foldered_name, plan_name)

--- a/frameworks/helloworld/universe/config.json
+++ b/frameworks/helloworld/universe/config.json
@@ -130,6 +130,12 @@
           },
           "description": "Placement constraint for the hello-world scheduler",
           "default": []
+        },
+        "verbose_mesos_logging": {
+          "description": "Sets the value of GLOG_v env-var used by Mesos. Enabled by default, set to 0 to disable.",
+          "type": "integer",
+          "enum": [0, 1],
+          "default": 1
         }
       }
     },

--- a/frameworks/helloworld/universe/marathon.json.mustache
+++ b/frameworks/helloworld/universe/marathon.json.mustache
@@ -16,6 +16,15 @@
     "DCOS_SERVICE_SCHEME": "http"
   },
   {{#service.service_account_secret}}
+  "container": {
+    "type": "MESOS",
+    "volumes": [
+      {
+        "containerPath": "secrets/service-account.json",
+        "secret": "serviceCredential"
+      }
+    ]
+  },
   "secrets": {
     "serviceCredential": {
       "source": "{{service.service_account_secret}}"
@@ -60,8 +69,8 @@
     "BOOTSTRAP_URI": "{{resource.assets.uris.bootstrap-zip}}",
     "LIBMESOS_URI": "{{resource.assets.uris.libmesos-bundle-tar-gz}}",
     {{#service.service_account_secret}}
-    "DCOS_SERVICE_ACCOUNT_CREDENTIAL": { "secret": "serviceCredential" },
-    "MESOS_MODULES": "{\"libraries\":[{\"file\":\"libmesos-bundle\/lib\/mesos\/libdcos_security.so\",\"modules\":[{\"name\": \"com_mesosphere_dcos_ClassicRPCAuthenticatee\"},{\"name\":\"com_mesosphere_dcos_http_Authenticatee\",\"parameters\":[{\"key\":\"jwt_exp_timeout\",\"value\":\"5mins\"},{\"key\":\"preemptive_refresh_duration\",\"value\":\"30mins\"}]}]}]}",
+    "DCOS_SERVICE_ACCOUNT_CREDENTIAL": "secrets/service-account.json",
+    "MESOS_MODULES": "{\"libraries\":[{\"file\":\"libmesos-bundle\/lib\/mesos\/libdcos_security.so\",\"modules\":[{\"name\": \"com_mesosphere_dcos_ClassicRPCAuthenticatee\"},{\"name\":\"com_mesosphere_dcos_http_Authenticatee\",\"parameters\":[{\"key\":\"service_account_credential\",\"value\":\"file://secrets/service-account.json\"},{\"key\":\"jwt_exp_timeout\",\"value\":\"5mins\"},{\"key\":\"preemptive_refresh_duration\",\"value\":\"30mins\"}]}]}]}",
     "MESOS_AUTHENTICATEE": "com_mesosphere_dcos_ClassicRPCAuthenticatee",
     "MESOS_HTTP_AUTHENTICATEE": "com_mesosphere_dcos_http_Authenticatee",
     {{/service.service_account_secret}}
@@ -94,7 +103,8 @@
     "TEST_BOOLEAN": "{{service.test_boolean}}",
     "SCENARIOS": "{{service.scenario}}",
     "ALLOW_REGION_AWARENESS": "{{service.allow_region_awareness}}",
-    "HELLO_PORT_ONE": "{{hello.port_one}}"
+    "HELLO_PORT_ONE": "{{hello.port_one}}",
+    "GLOG_v":"{{service.verbose_mesos_logging}}"
   },
   "fetch": [
     { "uri": "{{resource.assets.uris.bootstrap-zip}}", "cache": true },

--- a/frameworks/kafka/tests/test_sanity.py
+++ b/frameworks/kafka/tests/test_sanity.py
@@ -126,7 +126,7 @@ def test_broker_invalid():
         config.PACKAGE_NAME, FOLDERED_NAME, "broker get {}".format(config.DEFAULT_BROKER_COUNT + 1)
     )
     assert rc != 0, "Invalid broker id should have failed"
-    assert "Got 404" in stderr
+    assert "error" in stderr
 
 
 # --------- Pods -------------

--- a/frameworks/kafka/tests/test_sanity.py
+++ b/frameworks/kafka/tests/test_sanity.py
@@ -153,12 +153,7 @@ def test_pod_replace(kafka_client: client.KafkaClient):
 
 
 @pytest.mark.sanity
-@pytest.mark.metrics
 @pytest.mark.dcos_min_version("1.9")
-@pytest.mark.skipif(
-    sdk_utils.dcos_version_at_least("1.12"),
-    reason="Metrics are not working on 1.12. Reenable once this is fixed",
-)
 def test_metrics():
     expected_metrics = [
         "kafka.network.RequestMetrics.ResponseQueueTimeMs.max",

--- a/frameworks/kafka/universe/marathon.json.mustache
+++ b/frameworks/kafka/universe/marathon.json.mustache
@@ -15,6 +15,15 @@
     "DCOS_SERVICE_SCHEME": "http"
   },
   {{#service.service_account_secret}}
+  "container": {
+    "type": "MESOS",
+    "volumes": [
+      {
+        "containerPath": "secrets/service-account.json",
+        "secret": "serviceCredential"
+      }
+    ]
+  },
   "secrets": {
     "serviceCredential": {
       "source": "{{service.service_account_secret}}"
@@ -67,8 +76,8 @@
     "BROKER_PORT": "{{brokers.port}}",
 
     {{#service.service_account_secret}}
-    "DCOS_SERVICE_ACCOUNT_CREDENTIAL": { "secret": "serviceCredential" },
-    "MESOS_MODULES": "{\"libraries\":[{\"file\":\"libmesos-bundle\/lib\/mesos\/libdcos_security.so\",\"modules\":[{\"name\": \"com_mesosphere_dcos_ClassicRPCAuthenticatee\"},{\"name\":\"com_mesosphere_dcos_http_Authenticatee\",\"parameters\":[{\"key\":\"jwt_exp_timeout\",\"value\":\"5mins\"},{\"key\":\"preemptive_refresh_duration\",\"value\":\"30mins\"}]}]}]}",
+    "DCOS_SERVICE_ACCOUNT_CREDENTIAL": "secrets/service-account.json",
+    "MESOS_MODULES": "{\"libraries\":[{\"file\":\"libmesos-bundle\/lib\/mesos\/libdcos_security.so\",\"modules\":[{\"name\": \"com_mesosphere_dcos_ClassicRPCAuthenticatee\"},{\"name\":\"com_mesosphere_dcos_http_Authenticatee\",\"parameters\":[{\"key\":\"service_account_credential\",\"value\":\"file://secrets/service-account.json\"},{\"key\":\"jwt_exp_timeout\",\"value\":\"5mins\"},{\"key\":\"preemptive_refresh_duration\",\"value\":\"30mins\"}]}]}]}",
     "MESOS_AUTHENTICATEE": "com_mesosphere_dcos_ClassicRPCAuthenticatee",
     "MESOS_HTTP_AUTHENTICATEE": "com_mesosphere_dcos_http_Authenticatee",
     {{/service.service_account_secret}}

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerConfig.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerConfig.java
@@ -467,8 +467,6 @@ public final class SchedulerConfig {
       throw new IllegalArgumentException(e);
     } catch (NoSuchAlgorithmException e) {
       throw new IllegalStateException(e);
-    } finally {
-      pemReader.close();
     }
   }
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerConfig.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerConfig.java
@@ -12,6 +12,7 @@ import com.mesosphere.sdk.offer.LoggingUtils;
 import com.mesosphere.sdk.state.GoalStateOverride;
 
 import com.auth0.jwt.algorithms.Algorithm;
+import org.apache.commons.io.IOUtils;
 import org.apache.http.impl.client.LaxRedirectStrategy;
 import org.apache.mesos.Protos;
 import org.apache.mesos.Protos.Credential;
@@ -19,8 +20,11 @@ import org.bouncycastle.util.io.pem.PemReader;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.StringReader;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
 import java.security.interfaces.RSAPrivateKey;
@@ -421,18 +425,28 @@ public final class SchedulerConfig {
   }
 
   /**
-   * Returns a token provider which may be used to retrieve DC/OS JWT auth tokens, or throws an exception if the local
-   * environment doesn't provide the needed information (e.g. on a DC/OS Open cluster)
+   * Returns a token provider which may be used to retrieve DC/OS JWT auth tokens, or throws an
+   * exception if the local environment doesn't provide the needed information (e.g. on a DC/OS
+   * Open cluster)
    */
   public TokenProvider getDcosAuthTokenProvider() throws IOException {
-    JSONObject serviceAccountObject = new JSONObject(envStore.getRequired(SIDECHANNEL_AUTH_ENV));
-    PemReader pemReader = new PemReader(
-        new StringReader(serviceAccountObject.getString("private_key")));
-    try {
-      RSAPrivateKey privateKey = (RSAPrivateKey) KeyFactory.getInstance("RSA").generatePrivate(
-          new PKCS8EncodedKeySpec(pemReader.readPemObject().getContent()));
-      RSAPublicKey publicKey = (RSAPublicKey) KeyFactory.getInstance("RSA").generatePublic(
-          new RSAPublicKeySpec(privateKey.getModulus(), privateKey.getPrivateExponent()));
+    JSONObject serviceAccountObject = loadFileOrEnvSecret();
+    try (PemReader pemReader = new PemReader(
+        new StringReader(serviceAccountObject.getString("private_key"))
+    ))
+    {
+      RSAPrivateKey privateKey = (RSAPrivateKey) KeyFactory
+          .getInstance("RSA")
+          .generatePrivate(new PKCS8EncodedKeySpec(pemReader.readPemObject().getContent()));
+
+      RSAPublicKey publicKey = (RSAPublicKey) KeyFactory
+          .getInstance("RSA")
+          .generatePublic(
+              new RSAPublicKeySpec(
+                  privateKey.getModulus(),
+                  privateKey.getPrivateExponent()
+              )
+          );
 
       ServiceAccountIAMTokenClient serviceAccountIAMTokenProvider =
           new ServiceAccountIAMTokenClient(
@@ -456,6 +470,19 @@ public final class SchedulerConfig {
     } finally {
       pemReader.close();
     }
+  }
+
+  private JSONObject loadFileOrEnvSecret() throws IOException {
+    String content = envStore.getRequired(SIDECHANNEL_AUTH_ENV);
+    JSONObject serviceAccountObject;
+    if (Files.isRegularFile(Paths.get(content))) {
+      LOGGER.info("Reading file {} to load secrets", content);
+      serviceAccountObject = new JSONObject(IOUtils.toString(new FileInputStream(content)));
+    } else {
+      LOGGER.info("Reading service account information from {}", SIDECHANNEL_AUTH_ENV);
+      serviceAccountObject = new JSONObject(content);
+    }
+    return serviceAccountObject;
   }
 
   /**

--- a/testing/sdk_cmd.py
+++ b/testing/sdk_cmd.py
@@ -567,3 +567,9 @@ def _get_task_info(task_id_prefix: str) -> dict:
         ",".join([t.get("id", "NO-ID") for t in tasks]),
     )
     return {}
+
+
+def get_bash_command(cmd: str, environment: str) -> str:
+    env_str = "{} && ".format(environment) if environment else ""
+
+    return 'bash -c "{}{}"'.format(env_str, cmd)

--- a/tools/diagnostics/create_service_diagnostics_bundle.sh
+++ b/tools/diagnostics/create_service_diagnostics_bundle.sh
@@ -31,7 +31,7 @@ else
   readonly CONTAINER_DCOS_COMMONS_VOLUME_MOUNT=
 fi
 
-readonly VERSION='v0.1.0'
+readonly VERSION='v0.2.0-snapshot'
 
 function version () {
   echo "${VERSION}"

--- a/tools/diagnostics/full_bundle.py
+++ b/tools/diagnostics/full_bundle.py
@@ -30,17 +30,14 @@ def get_dcos_services() -> (bool, str):
         return (True, stdout)
 
 
-def to_dcos_service_name(service_name: str) -> str:
-    """DC/OS service names don't contain the first slash.
-    i.e.: |     SDK service name     |   DC/OS service name    |
+def is_service_named(service_name: str, service: dict) -> bool:
+    """Handles a case where DC/OS service names sometimes don't contain the first slash.
+    e.g.: |     SDK service name     |   DC/OS service name    |
           |--------------------------+-------------------------|
           | /data-services/cassandra | data-services/cassandra |
+          | /production/cassandra    | /production/cassandra   |
     """
-    return service_name.lstrip("/")
-
-
-def is_service_named(service_name: str, service: dict) -> bool:
-    return service.get("name") == to_dcos_service_name(service_name)
+    return service.get("name") in [service_name, service_name.lstrip("/")]
 
 
 def is_service_active(service: dict) -> bool:
@@ -63,9 +60,7 @@ def is_service_scheduler_task(package_name: str, service_name: str, task: dict) 
     dcos_service_name = next(
         iter([l.get("value") for l in labels if l.get("key") == "DCOS_SERVICE_NAME"]), ""
     )
-    return dcos_package_name == package_name and dcos_service_name == to_dcos_service_name(
-        service_name
-    )
+    return dcos_package_name == package_name and dcos_service_name == service_name
 
 
 def directory_date_string() -> str:


### PR DESCRIPTION
Updates the task refresh logic to explicitly update the StateStore TaskInfos for ALL tasks sharing a ResourceSet when any task in that set is updated. This avoids the possibility of hitting mismatches between TaskInfos, and makes it easier to track down what resources a given task is expected to be using at any given time, and avoids the current problems around TaskInfo data (config IDs) potentially being out of date in sidecar tasks. The new logic explicitly treats resource evaluation as per-ResourceSet, and then applies the resulting changes to the paired TaskInfo(s). See comments in OfferEvaluator for more info.

Other unrelated fixes for this last PR:
- Allow overriding the executor resource "overhead" via scheduler envvars
- Remove the long-deprecated FINISHED goalstate, which was long ago renamed to ONCE. YAML files will raise an error at build time, while serialzed ServiceSpecs will automatically convert FINISHED to ONCE to ensure compatibility during upgrade/downgrade.
- Clarify and add more information to evaluation logs, in particular log when resource ids are generated and be much clearer about when they are required.
- In recovery logic, avoid repeatedly refetching the full list of TaskInfos from the StateStore, which would involve reparsing large protobufs each time. Instead fetch the list only once and reuse that copy where needed.
- Add internal support for the added mesos task states (breaking up TASK_LOST). Note that these won't effectively be enabled until the scheduler explicitly opts in by setting the PARTITION_AWARE flag in the FrameworkInfo (in SchedulerDriverFactory)