### PR TITLE
Disable metrics test due to changed container metrics structure

### DIFF
--- a/frameworks/cassandra/tests/test_sanity.py
+++ b/frameworks/cassandra/tests/test_sanity.py
@@ -9,6 +9,7 @@ import sdk_metrics
 import sdk_networks
 import sdk_plan
 import sdk_upgrade
+import sdk_utils
 
 from tests import config
 
@@ -80,6 +81,10 @@ def test_repair_cleanup_plans_complete():
 @pytest.mark.sanity
 @pytest.mark.metrics
 @pytest.mark.dcos_min_version("1.9")
+@pytest.mark.skipif(
+    sdk_utils.dcos_version_at_least("1.12"),
+    reason="Metrics are not working on 1.12. Reenable once this is fixed",
+)
 def test_metrics():
     expected_metrics = [
         "org.apache.cassandra.metrics.Table.CoordinatorReadLatency.system.hints.p999",

--- a/frameworks/elastic/tests/test_sanity.py
+++ b/frameworks/elastic/tests/test_sanity.py
@@ -118,6 +118,10 @@ def test_indexing(default_populated_index):
 @pytest.mark.sanity
 @pytest.mark.metrics
 @pytest.mark.dcos_min_version("1.9")
+@pytest.mark.skipif(
+    sdk_utils.dcos_version_at_least("1.12"),
+    reason="Metrics are not working on 1.12. Reenable once this is fixed",
+)
 def test_metrics():
     expected_metrics = [
         "node.data-0-node.fs.total.total_in_bytes",

--- a/frameworks/hdfs/tests/test_sanity.py
+++ b/frameworks/hdfs/tests/test_sanity.py
@@ -359,6 +359,10 @@ def test_modify_app_config_rollback():
 @pytest.mark.sanity
 @pytest.mark.metrics
 @pytest.mark.dcos_min_version("1.9")
+@pytest.mark.skipif(
+    sdk_utils.dcos_version_at_least("1.12"),
+    reason="Metrics are not working on 1.12. Reenable once this is fixed",
+)
 def test_metrics():
     expected_metrics = [
         "JournalNode.jvm.JvmMetrics.ThreadsRunnable",

--- a/frameworks/kafka/tests/test_sanity.py
+++ b/frameworks/kafka/tests/test_sanity.py
@@ -151,6 +151,10 @@ def test_pod_replace():
 @pytest.mark.sanity
 @pytest.mark.metrics
 @pytest.mark.dcos_min_version("1.9")
+@pytest.mark.skipif(
+    sdk_utils.dcos_version_at_least("1.12"),
+    reason="Metrics are not working on 1.12. Reenable once this is fixed",
+)
 def test_metrics():
     expected_metrics = [
         "kafka.network.RequestMetrics.ResponseQueueTimeMs.max",


### PR DESCRIPTION
The metrics container structure probably has changed slightly so even with the newer changes the test fail. As follow-up https://jira.mesosphere.com/browse/DCOS-43546 is created.