### PR TITLE
sdk_cmd: Added check for 'verify' key

### DIFF
--- a/testing/sdk_cmd.py
+++ b/testing/sdk_cmd.py
@@ -112,7 +112,7 @@ def cluster_request(
         start = time.time()
 
         # check if we have verify key already exists.
-        if kwargs is not None and kwargs['verify'] is not None:
+        if kwargs is not None and kwargs.get('verify') is not None:
             kwargs['verify'] = False
             response = requests.request(method, url, auth=auth, timeout=timeout_seconds, **kwargs)
         else:

--- a/testing/sdk_cmd.py
+++ b/testing/sdk_cmd.py
@@ -110,9 +110,14 @@ def cluster_request(
 
     def _cluster_request():
         start = time.time()
-        response = requests.request(
-            method, url, auth=auth, verify=False, timeout=timeout_seconds, **kwargs
-        )
+
+        # check if we have verify key already exists.
+        if kwargs is not None and kwargs['verify'] is not None:
+            kwargs['verify'] = False
+            response = requests.request(method, url, auth=auth, timeout=timeout_seconds, **kwargs)
+        else:
+            response = requests.request(method, url, auth=auth, verify=False, timeout=timeout_seconds, **kwargs)
+
         end = time.time()
 
         log_msg = "(HTTP {}) {}".format(method.upper(), cluster_path)


### PR DESCRIPTION
The key verify sometimes exists in kwargs causing errors in _get_cluster, an example of this from dcos-kubernetes-cluster:


`
[2018-10-11 06:08:26,861|tests.conftest|ERROR]: Test test_disk_pressure failed in call phase, dumping state
[06:09:26][2018-10-11 06:09:26,930|tests.conftest|ERROR]: Mesos state collection failed!
[06:09:26]Traceback (most recent call last):
[06:09:26]  File "/go/src/github.com/mesosphere/dcos-kubernetes-1.x/kubernetes/tests/conftest.py", line 163, in pytest_runtest_makereport
[06:09:26]    get_mesos_state_on_failure(item.name)
[06:09:26]  File "/go/src/github.com/mesosphere/dcos-kubernetes-1.x/kubernetes/tests/conftest.py", line 213, in get_mesos_state_on_failure
[06:09:26]    r = sdk_cmd.cluster_request('GET', '/mesos/{}'.format(name), verify=False, raise_on_error=False)
[06:09:26]  File "/go/src/github.com/mesosphere/dcos-kubernetes-1.x/kubernetes/testing/sdk_cmd.py", line 147, in cluster_request
[06:09:26]    return retry_fn()
[06:09:26]  File "/go/src/github.com/mesosphere/dcos-kubernetes-1.x/env/lib/python3.6/site-packages/retrying.py", line 49, in wrapped_f
[06:09:26]    return Retrying(*dargs, **dkw).call(f, *args, **kw)
[06:09:26]  File "/go/src/github.com/mesosphere/dcos-kubernetes-1.x/env/lib/python3.6/site-packages/retrying.py", line 212, in call
[06:09:26]    raise attempt.get()
[06:09:26]  File "/go/src/github.com/mesosphere/dcos-kubernetes-1.x/env/lib/python3.6/site-packages/retrying.py", line 247, in get
[06:09:26]    six.reraise(self.value[0], self.value[1], self.value[2])
[06:09:26]  File "/go/src/github.com/mesosphere/dcos-kubernetes-1.x/env/lib/python3.6/site-packages/six.py", line 693, in reraise
[06:09:26]    raise value
[06:09:26]  File "/go/src/github.com/mesosphere/dcos-kubernetes-1.x/env/lib/python3.6/site-packages/retrying.py", line 200, in call
[06:09:26]    attempt = Attempt(fn(*args, **kwargs), attempt_number, False)
[06:09:26]  File "/go/src/github.com/mesosphere/dcos-kubernetes-1.x/kubernetes/testing/sdk_cmd.py", line 145, in retry_fn
[06:09:26]    return _cluster_request()
[06:09:26]  File "/go/src/github.com/mesosphere/dcos-kubernetes-1.x/kubernetes/testing/sdk_cmd.py", line 114, in _cluster_request
[06:09:26]    method, url, auth=auth, verify=False, timeout=timeout_seconds, **kwargs
[06:09:26]TypeError: request() got multiple values for keyword argument 'verify'
[07:07:00]make: *** [shakedown-run] Error 1
[07:07:00]make: *** [ci-shakedown] Error 2
`