### PR TITLE
kafka: Add volume profile support

### DIFF
--- a/frameworks/kafka/src/main/dist/svc.yml
+++ b/frameworks/kafka/src/main/dist/svc.yml
@@ -69,6 +69,10 @@ pods:
           path: {{BROKER_DISK_PATH}}
           type: {{BROKER_DISK_TYPE}}
           size: {{BROKER_DISK_SIZE}}
+          {{#BROKER_DISK_PROFILE_ENABLED}}
+          profiles:
+            - {{BROKER_DISK_PROFILE}}
+          {{/BROKER_DISK_PROFILE_ENABLED}}
         env:
           KAFKA_DISK_PATH: "{{BROKER_DISK_PATH}}"
           KAFKA_HEAP_OPTS: "-Xms{{BROKER_JAVA_HEAP}}M -Xmx{{BROKER_JAVA_HEAP}}M"

--- a/frameworks/kafka/universe/config.json
+++ b/frameworks/kafka/universe/config.json
@@ -263,6 +263,10 @@
           "description": "Disk type to be used for storing broker data. See documentation. [ROOT, MOUNT]",
           "default": "ROOT"
         },
+        "disk_profile": {
+          "type": "string",
+          "description": "Disk profile name for storing broker data"
+        },
         "disk_path": {
           "type": "string",
           "description": "Relative path of consistent disk",

--- a/frameworks/kafka/universe/marathon.json.mustache
+++ b/frameworks/kafka/universe/marathon.json.mustache
@@ -63,6 +63,10 @@
     "BROKER_DISK_SIZE": "{{brokers.disk}}",
     "BROKER_DISK_TYPE": "{{brokers.disk_type}}",
     "BROKER_DISK_PATH": "{{brokers.disk_path}}",
+    {{#brokers.disk_profile}}
+    "BROKER_DISK_PROFILE_ENABLED": "true",
+    "BROKER_DISK_PROFILE": "{{brokers.disk_profile}}",
+    {{/brokers.disk_profile}}
     "BROKER_JAVA_HEAP": "{{brokers.heap.size}}",
     "BROKER_PORT": "{{brokers.port}}",
 


### PR DESCRIPTION
This patch adds the volume profile support for kafka brokers. This
allows operator to pick disks based on profile names (see DC/OS storage
service doc: https://docs.mesosphere.com/services/beta-storage/)