### PR TITLE
[DCOS-43889] Freeze all pip depencies to recover from build breakage.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,6 +7,7 @@
 /logs
 
 !test_requirements.txt
+!frozen_requirements.txt
 !test_runner.sh
 !/tools/ci
 !test.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,11 +34,9 @@ RUN apt-get update && \
 ENV PATH=$PATH:/usr/local/go/bin
 RUN go version
 
-# AWS CLI for uploading build artifacts
-RUN pip3 install awscli
-# Install the lint+testing dependencies
-COPY test_requirements.txt test_requirements.txt
-RUN pip3 install --upgrade -r test_requirements.txt
+# Install the lint+testing dependencies and AWS CLI for uploading build artifacts
+COPY frozen_requirements.txt frozen_requirements.txt
+RUN pip3 install --upgrade -r frozen_requirements.txt
 
 # Get DC/OS CLI
 RUN curl -O https://downloads.dcos.io/binaries/cli/linux/x86-64/dcos-1.12/dcos && \

--- a/frozen_requirements.txt
+++ b/frozen_requirements.txt
@@ -1,0 +1,119 @@
+# This file was created from test_requirements.txt in the following way in
+# order to work around build breakage: https://jira.mesosphere.com/browse/DCOS-43889
+# 1. s/frozen_/test_/g in Dockerfile
+# 2. docker build .
+# [...]
+# Successfully built IMAGE-ID
+# 3. docker run -ti IMAGE-ID pip3 freeze > frozen_requirements.txt
+# 4. Manually edit the file to:
+#    - replace the references to dcoscli, dcos, dcos-test-utils and dcos-launch with the four git+http URIs below
+#    - replace urllib 1.24 with 1.23 
+#    - add this comment
+# 5. git checkout Dockerfile
+git+https://github.com/dcos/dcos-cli.git@f1fd38c9e72e1d521cf8120fe4948a789fb40cbc#egg=dcoscli&subdirectory=cli
+git+https://github.com/dcos/dcos-cli.git@f1fd38c9e72e1d521cf8120fe4948a789fb40cbc
+git+https://github.com/dcos/dcos-test-utils.git@3ebfc18ff9c5a1aa382311474a9192a68c98b0a7
+git+https://github.com/dcos/dcos-launch.git@dc1e116685fba5105f322b007549b7eb104cf441
+adal==1.1.0
+altgraph==0.16.1
+appdirs==1.4.3
+asn1crypto==0.24.0
+aspy.yaml==1.1.1
+astroid==2.0.4
+atomicwrites==1.2.1
+attrs==18.2.0
+awscli==1.16.33
+azure-common==1.1.16
+azure-mgmt-network==2.0.0
+azure-mgmt-nspkg==3.0.2
+azure-mgmt-resource==2.0.0
+azure-monitor==0.3.1
+azure-nspkg==3.0.2
+azure-storage==0.36.0
+bcrypt==3.1.4
+black==18.9b0
+boto3==1.9.23
+botocore==1.12.23
+cached-property==1.5.1
+cachetools==2.1.0
+Cerberus==1.2
+certifi==2018.10.15
+cffi==1.11.5
+cfgv==1.1.0
+chardet==3.0.4
+Click==7.0
+colorama==0.3.9
+cryptography==2.0.2
+dcos-shakedown==1.4.12
+docopt==0.6.2
+docutils==0.14
+entrypoints==0.2.3
+flake8==3.5.0
+future==0.16.0
+google-api-python-client==1.7.4
+google-auth==1.5.1
+google-auth-httplib2==0.0.3
+httplib2==0.11.3
+identify==1.1.7
+idna==2.7
+isodate==0.6.0
+isort==4.3.4
+jeepney==0.4
+jmespath==0.9.3
+jsonschema==2.6.0
+keyring==15.1.0
+keyrings.alt==3.0
+lazy-object-proxy==1.3.1
+macholib==1.11
+mccabe==0.6.1
+more-itertools==4.3.0
+msrest==0.6.0
+msrestazure==0.4.34
+nodeenv==1.3.2
+oauth2client==3.0.0
+oauthlib==2.1.0
+pager==3.3
+paramiko==2.4.2
+pefile==2018.8.8
+pkginfo==1.2.1
+pluggy==0.7.1
+pre-commit==1.11.2
+prettytable==0.7.2
+py==1.7.0
+pyasn1==0.4.4
+pyasn1-modules==0.2.2
+pycodestyle==2.3.1
+pycparser==2.19
+pycrypto==2.6.1
+pyflakes==1.6.0
+Pygments==2.2.0
+pygobject==3.26.1
+PyInstaller==3.3
+PyJWT==1.4.2
+pylint==2.1.1
+PyNaCl==1.3.0
+pytest==3.8.2
+pytest-timeout==1.3.2
+python-apt==1.6.2
+python-dateutil==2.7.3
+pyxdg==0.25
+PyYAML==3.13
+requests==2.19.1
+requests-oauthlib==1.0.0
+retrying==1.3.3
+rsa==4.0
+s3transfer==0.1.13
+scp==0.12.1
+SecretStorage==3.1.0
+six==1.11.0
+sseclient==0.0.14
+teamcity-messages==1.21
+toml==0.10.0
+toolz==0.9.0
+tox==2.5.0
+typed-ast==1.1.0
+unattended-upgrades==0.1
+uritemplate==3.0.0
+urllib3==1.23
+virtualenv==15.2.0
+wrapt==1.10.11

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -14,6 +14,9 @@ toolz==0.9.0
 git+https://github.com/dcos/dcos-test-utils.git@3ebfc18ff9c5a1aa382311474a9192a68c98b0a7
 git+https://github.com/dcos/dcos-launch.git@dc1e116685fba5105f322b007549b7eb104cf441
 
+# AWS CLI for uploading build artifacts
+awscli
+
 # CI:
 teamcity-messages
 

--- a/tools/ci/checks/get_applicable_changes.py
+++ b/tools/ci/checks/get_applicable_changes.py
@@ -9,7 +9,7 @@ from typing import List
 
 
 BUILD_FOLDERS = ["cli/", "clivendor/", "govendor/", "sdk/", "testing/", "tools/"]
-BUILD_FILES = ["conftest.py", "test_requirements.txt", "Dockerfile"]
+BUILD_FILES = ["conftest.py", "test_requirements.txt", "frozen_requirements.txt", "Dockerfile"]
 
 
 def get_changed_files(git_reference: str) -> List[str]:

--- a/tools/diagnostics/create_service_diagnostics_bundle.py
+++ b/tools/diagnostics/create_service_diagnostics_bundle.py
@@ -5,7 +5,7 @@
 
 # Notes:
 # - When run in the dcos-commons Docker image the DC/OS CLI version is specified either in
-# - the image's test_requirements.txt or Dockerfile.
+# - the image's test_requirements.txt, frozen_requirements.txt or Dockerfile.
 
 from typing import Any
 import argparse


### PR DESCRIPTION
I'm aware this is horrible. See the jira ticket for why simpler approaches did not work.