### PR TITLE
hdfs: Add volume profile support

### DIFF
--- a/frameworks/hdfs/src/main/dist/svc.yml
+++ b/frameworks/hdfs/src/main/dist/svc.yml
@@ -42,6 +42,10 @@ pods:
           path: journal-data
           size: {{JOURNAL_DISK}}
           type: {{JOURNAL_DISK_TYPE}}
+          {{#JOURNAL_DISK_PROFILE_ENABLED}}
+          profiles:
+            - {{JOURNAL_DISK_PROFILE}}
+          {{/JOURNAL_DISK_PROFILE_ENABLED}}
     placement: '{{{JOURNAL_NODE_PLACEMENT}}}'
     tasks:
       bootstrap:
@@ -173,6 +177,10 @@ pods:
           path: name-data
           size: {{NAME_DISK}}
           type: {{NAME_DISK_TYPE}}
+          {{#NAME_DISK_PROFILE_ENABLED}}
+          profiles:
+            - {{NAME_DISK_PROFILE}}
+          {{/NAME_DISK_PROFILE_ENABLED}}
         ports:
           name-rpc:
             port: {{TASKCFG_ALL_NAME_NODE_RPC_PORT}}
@@ -469,6 +477,10 @@ pods:
           path: data-data
           size: {{DATA_DISK}}
           type: {{DATA_DISK_TYPE}}
+          {{#DATA_DISK_PROFILE_ENABLED}}
+          profiles:
+            - {{DATA_DISK_PROFILE}}
+          {{/DATA_DISK_PROFILE_ENABLED}}
         configs:
           {{#SECURITY_KERBEROS_ENABLED}}
           krb5-conf:

--- a/frameworks/hdfs/universe/config.json
+++ b/frameworks/hdfs/universe/config.json
@@ -164,6 +164,10 @@
           "type": "string",
           "default": "ROOT"
         },
+        "disk_profile": {
+          "description": "Journal node disk profile",
+          "type": "string"
+        },
         "enable_readiness_check": {
           "description": "Determines whether to enable readiness checks for Journal Nodes.",
           "type": "boolean",
@@ -266,6 +270,10 @@
           "description": "Name node disk type",
           "type": "string",
           "default": "ROOT"
+        },
+        "disk_profile": {
+          "description": "Name node disk profile",
+          "type": "string"
         },
         "hadoop_namenode_opts": {
           "type": "string",
@@ -752,6 +760,10 @@
           "description": "Data node disk type",
           "type": "string",
           "default": "ROOT"
+        },
+        "disk_profile": {
+          "description": "Data node disk profile",
+          "type": "string"
         },
         "handler_count": {
           "description": "The number of server threads for the datanode.",

--- a/frameworks/hdfs/universe/marathon.json.mustache
+++ b/frameworks/hdfs/universe/marathon.json.mustache
@@ -44,11 +44,19 @@
     "JOURNAL_MEM": "{{journal_node.mem}}",
     "JOURNAL_DISK": "{{journal_node.disk}}",
     "JOURNAL_DISK_TYPE": "{{journal_node.disk_type}}",
+    {{#journal_node.disk_profile}}
+    "JOURNAL_DISK_PROFILE_ENABLED": "true",
+    "JOURNAL_DISK_PROFILE": "{{journal_node.disk_profile}}",
+    {{/journal_node.disk_profile}}
     "JOURNAL_LAGGING_TX_COUNT": "{{journal_node.lagging_tx_count}}",
     "NAME_CPUS": "{{name_node.cpus}}",
     "NAME_MEM": "{{name_node.mem}}",
     "NAME_DISK": "{{name_node.disk}}",
     "NAME_DISK_TYPE": "{{name_node.disk_type}}",
+    {{#name_node.disk_profile}}
+    "NAME_DISK_PROFILE_ENABLED": "true",
+    "NAME_DISK_PROFILE": "{{name_node.disk_profile}}",
+    {{/name_node.disk_profile}}
     "ZKFC_CPUS": "{{zkfc_node.cpus}}",
     "ZKFC_MEM": "{{zkfc_node.mem}}",
     "DATA_COUNT": "{{data_node.count}}",
@@ -56,6 +64,10 @@
     "DATA_MEM": "{{data_node.mem}}",
     "DATA_DISK": "{{data_node.disk}}",
     "DATA_DISK_TYPE": "{{data_node.disk_type}}",
+    {{#data_node.disk_profile}}
+    "DATA_DISK_PROFILE_ENABLED": "true",
+    "DATA_DISK_PROFILE": "{{data_node.disk_profile}}",
+    {{/data_node.disk_profile}}
     "LIBMESOS_URI": "{{resource.assets.uris.libmesos-bundle-tar-gz}}",
     "HDFS_URI": "{{resource.assets.uris.hdfs-tar-gz}}",
     "HDFS_BIN_URI": "{{resource.assets.uris.hdfs-bin-tar-gz}}",


### PR DESCRIPTION
This patch adds volume profile support for HDFS framework. Users are now
allowed to pick a volume profile for journal, name or data node.