### PR TITLE
cassandra: Add volume profile support

### DIFF
--- a/frameworks/cassandra/src/main/dist/svc.yml
+++ b/frameworks/cassandra/src/main/dist/svc.yml
@@ -15,6 +15,10 @@ pods:
       path: container-path
       type: {{CASSANDRA_DISK_TYPE}}
       size: {{CASSANDRA_DISK_MB}}
+      {{#CASSANDRA_DISK_PROFILE_ENABLED}}
+      profiles:
+        - {{CASSANDRA_DISK_PROFILE}}
+      {{/CASSANDRA_DISK_PROFILE_ENABLED}}
     uris:
       - {{CASSANDRA_JAVA_URI}}
       - {{CASSANDRA_PYTHON_URI}}

--- a/frameworks/cassandra/universe/config.json
+++ b/frameworks/cassandra/universe/config.json
@@ -193,6 +193,10 @@
           "description": "Disk type to be used for storing Cassandra data. See documentation. [ROOT, MOUNT]",
           "default": "ROOT"
         },
+        "disk_profile": {
+          "type": "string",
+          "description": "Disk profile to be used for storing Cassandra data."
+        },
         "placement_constraint": {
           "type": "string",
           "description": "Placement constraints for nodes (e.g., [[\"hostname\", \"MAX_PER\", \"1\"]]).",

--- a/frameworks/cassandra/universe/marathon.json.mustache
+++ b/frameworks/cassandra/universe/marathon.json.mustache
@@ -68,6 +68,10 @@
     "CASSANDRA_MEMORY_MB": "{{nodes.mem}}",
     "CASSANDRA_DISK_MB": "{{nodes.disk}}",
     "CASSANDRA_DISK_TYPE": "{{nodes.disk_type}}",
+    {{#nodes.disk_profile}}
+    "CASSANDRA_DISK_PROFILE_ENABLED": "true",
+    "CASSANDRA_DISK_PROFILE": "{{nodes.disk_profile}}",
+    {{/nodes.disk_profile}}
     "TASKCFG_ALL_CASSANDRA_HEAP_SIZE_MB": "{{nodes.heap.size}}",
     "TASKCFG_ALL_CASSANDRA_HEAP_NEW_MB": "{{nodes.heap.new}}",
     "CASSANDRA_JAVA_URI": "{{resource.assets.uris.cassandra-jre-tar-gz}}",


### PR DESCRIPTION
This allows users to pick volume profile for the cassandra node.