### PR TITLE
[DCOS-43947] Update JRE to 8u192 to address CVEs (#2728)

### DIFF
--- a/tools/universe/package_builder.py
+++ b/tools/universe/package_builder.py
@@ -16,9 +16,9 @@ import urllib.request
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.DEBUG, format="%(message)s")
 
-_jre_url = 'https://downloads.mesosphere.com/java/server-jre-8u162-linux-x64.tar.gz'
+_jre_url = 'https://downloads.mesosphere.com/java/server-jre-8u192-linux-x64.tar.gz'
 _libmesos_bundle_url = 'https://downloads.mesosphere.com/libmesos-bundle/libmesos-bundle-1.11.0.tar.gz'
-_dcos_sdk_version = '0.40.0-SNAPSHOT'
+_dcos_sdk_version = '0.42.4-SNAPSHOT'
 
 _docs_root = "https://docs.mesosphere.com"
 


### PR DESCRIPTION
This PR is a backport of #2728 :

* Updates the JRE version to `8u192`
* Updates the SDK version string in `package_builder.py` to match that in `build.gradle` (Cosmetic change)