### PR TITLE
[DCOS-44265] Remove python-apt from frozen_requirements.txt

### DIFF
--- a/frozen_requirements.txt
+++ b/frozen_requirements.txt
@@ -7,7 +7,8 @@
 # 3. docker run -ti IMAGE-ID pip3 freeze > frozen_requirements.txt
 # 4. Manually edit the file to:
 #    - replace the references to dcoscli, dcos, dcos-test-utils and dcos-launch with the four git+http URIs below
-#    - replace urllib 1.24 with 1.23 
+#    - replace urllib 1.24 with 1.23
+#    - remove the line for python-apt (TODO: handle packages that are updated by apt-get)
 #    - add this comment
 # 5. git checkout Dockerfile
 git+https://github.com/dcos/dcos-cli.git@f1fd38c9e72e1d521cf8120fe4948a789fb40cbc#egg=dcoscli&subdirectory=cli
@@ -94,7 +95,6 @@ pylint==2.1.1
 PyNaCl==1.3.0
 pytest==3.8.2
 pytest-timeout==1.3.2
-python-apt==1.6.2
 python-dateutil==2.7.3
 pyxdg==0.25
 PyYAML==3.13


### PR DESCRIPTION
Remove the frozen `python-apt` version as this conflicts with the version installed by apt.