### PR TITLE
[DCOS-44265] Create a base image dockerfile.

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,0 +1,38 @@
+# This is the base image for mesosphere/dcos-commons, to be built and pushed manually in order to overcome issues
+# such as DCOS-44265 which come about because neither the 18.04 tag is immutable, nor the apt-get install command
+# is repeatable.
+#
+# Build with:
+# $ TAG=$(date +%Y%m%da)  # change the letter a, if building more than one image in a day
+# $ docker build -f Dockerfile.base -t mesosphere/dcos-commons-base:$TAG .
+# $ docker push mesosphere/dcos-commons-base:$TAG
+# and adjust the FROM line in the Dockerfile.
+# TODO(DCOS-42576): set up periodic build/push of this base image, and then a periodic job to update the FROM line
+# in Dockerfile, so that we pick up updates regularly but in a controlled manner.
+#
+FROM ubuntu:18.04
+
+# Install JDK via PPA: https://github.com/franzwong/til/blob/master/java/silent-install-oracle-jdk8-ubuntu.md
+RUN apt-get update && \
+    apt-get install -y python3-software-properties software-properties-common && \
+    add-apt-repository -y ppa:webupd8team/java && \
+    apt-get update && \
+    echo "oracle-java8-installer shared/accepted-oracle-license-v1-1 select true" | debconf-set-selections && \
+    apt-get install -y \
+    curl \
+    git \
+    jq \
+    libssl-dev \
+    oracle-java8-installer \
+    python-pip \
+    python3 \
+    python3-dev \
+    python3-pip \
+    rsync \
+    tox \
+    software-properties-common \
+    upx-ucl \
+    wget \
+    zip && \
+    rm -rf /var/lib/apt/lists/* && \
+    java -version


### PR DESCRIPTION
This needs to be merged first, and the job to build+push the base image created.
After the image is available on github, the second part can be merged, which
changes the main image to be based upon this base image.