### PR TITLE
Handle case where service name does *not* omit the first slash.

### DIFF
--- a/tools/diagnostics/create_service_diagnostics_bundle.sh
+++ b/tools/diagnostics/create_service_diagnostics_bundle.sh
@@ -31,7 +31,7 @@ else
   readonly CONTAINER_DCOS_COMMONS_VOLUME_MOUNT=
 fi
 
-readonly VERSION='v0.1.0'
+readonly VERSION='v0.2.0-snapshot'
 
 function version () {
   echo "${VERSION}"

--- a/tools/diagnostics/full_bundle.py
+++ b/tools/diagnostics/full_bundle.py
@@ -30,17 +30,14 @@ def get_dcos_services() -> (bool, str):
         return (True, stdout)
 
 
-def to_dcos_service_name(service_name: str) -> str:
-    """DC/OS service names don't contain the first slash.
-    i.e.: |     SDK service name     |   DC/OS service name    |
+def is_service_named(service_name: str, service: dict) -> bool:
+    """Handles a case where DC/OS service names sometimes don't contain the first slash.
+    e.g.: |     SDK service name     |   DC/OS service name    |
           |--------------------------+-------------------------|
           | /data-services/cassandra | data-services/cassandra |
+          | /production/cassandra    | /production/cassandra   |
     """
-    return service_name.lstrip("/")
-
-
-def is_service_named(service_name: str, service: dict) -> bool:
-    return service.get("name") == to_dcos_service_name(service_name)
+    return service.get("name") in [service_name, service_name.lstrip("/")]
 
 
 def is_service_active(service: dict) -> bool:
@@ -63,9 +60,7 @@ def is_service_scheduler_task(package_name: str, service_name: str, task: dict) 
     dcos_service_name = next(
         iter([l.get("value") for l in labels if l.get("key") == "DCOS_SERVICE_NAME"]), ""
     )
-    return dcos_package_name == package_name and dcos_service_name == to_dcos_service_name(
-        service_name
-    )
+    return dcos_package_name == package_name and dcos_service_name == service_name
 
 
 def directory_date_string() -> str:


### PR DESCRIPTION
Apparently DCOS foldered service names may or may not omit the first slash. This script was looking for the service based on its name with the first slash omitted.

For example: in soak112s a service named `/data-services/cassandra` has `data-services/cassandra` as the service `name` field. On the cluster related to https://jira.mesosphere.com/browse/COPS-4058 a service named `/green/cassandra-green7` has `/green/cassandra-green7` as the service `name` field.