### PR TITLE
Address GitHub CVE Warnings.

### DIFF
--- a/frozen_requirements.txt
+++ b/frozen_requirements.txt
@@ -44,7 +44,7 @@ cfgv==1.1.0
 chardet==3.0.4
 Click==7.0
 colorama==0.3.9
-cryptography==2.0.2
+cryptography==2.3.1
 dcos-shakedown==1.4.12
 docopt==0.6.2
 docutils==0.14
@@ -98,7 +98,7 @@ pytest-timeout==1.3.2
 python-dateutil==2.7.3
 pyxdg==0.25
 PyYAML==3.13
-requests==2.19.1
+requests==2.20.0
 requests-oauthlib==1.0.0
 retrying==1.3.3
 rsa==4.0

--- a/frozen_requirements.txt
+++ b/frozen_requirements.txt
@@ -85,7 +85,7 @@ pyasn1==0.4.4
 pyasn1-modules==0.2.2
 pycodestyle==2.3.1
 pycparser==2.19
-pycrypto==2.6.1
+pycryptodome==3.7.0
 pyflakes==1.6.0
 Pygments==2.2.0
 pygobject==3.26.1


### PR DESCRIPTION
Update frozen_requirements.txt to resolve CVE warnings.
- update cryptography to 2.3.1
- update requests to 2.20.0
- replace pycrypto with pycryptodome as pycrypto is no longer maintained.