### PR TITLE
DCOS-40763 - Enable GLOG_v=1 in hello-world scheduler by default.

### DIFF
--- a/frameworks/helloworld/universe/config.json
+++ b/frameworks/helloworld/universe/config.json
@@ -134,6 +134,7 @@
         "verbose_mesos_logging": {
           "description": "Sets the value of GLOG_v env-var used by Mesos. Enabled by default, set to 0 to disable.",
           "type": "integer",
+          "enum": [0, 1],
           "default": 1
         }
       }

--- a/frameworks/helloworld/universe/config.json
+++ b/frameworks/helloworld/universe/config.json
@@ -130,6 +130,11 @@
           },
           "description": "Placement constraint for the hello-world scheduler",
           "default": []
+        },
+        "verbose_mesos_logging": {
+          "description": "Sets the value of GLOG_v env-var used by Mesos. Enabled by default, set to 0 to disable.",
+          "type": "integer",
+          "default": 1
         }
       }
     },

--- a/frameworks/helloworld/universe/marathon.json.mustache
+++ b/frameworks/helloworld/universe/marathon.json.mustache
@@ -94,7 +94,8 @@
     "TEST_BOOLEAN": "{{service.test_boolean}}",
     "SCENARIOS": "{{service.scenario}}",
     "ALLOW_REGION_AWARENESS": "{{service.allow_region_awareness}}",
-    "HELLO_PORT_ONE": "{{hello.port_one}}"
+    "HELLO_PORT_ONE": "{{hello.port_one}}",
+    "GLOG_v":"{{service.verbose_mesos_logging}}"
   },
   "fetch": [
     { "uri": "{{resource.assets.uris.bootstrap-zip}}", "cache": true },


### PR DESCRIPTION
Config setting service.verbose_mesos_logging = 0 can be used to disable verbose Mesos prints.