### PR TITLE
[TOOLS] Update .dcos publish tooling to reuse s3_urls_from_env method

### DIFF
--- a/tools/publish_aws.py
+++ b/tools/publish_aws.py
@@ -139,7 +139,7 @@ def s3_urls_from_env(package_name):
             "".join(
                 [
                     random.SystemRandom().choice(string.ascii_letters + string.digits)
-                    for i in range(16)
+                    for _ in range(16)
                 ]
             ),
         )

--- a/tools/publish_dcos_file.py
+++ b/tools/publish_dcos_file.py
@@ -9,18 +9,17 @@
 import json
 import logging
 import os
-import random
 import shutil
 import stat
-import string
 import subprocess
 import sys
 import tempfile
-import time
 import urllib.request
 
 import publish_aws
 import universe
+
+from publish_aws import s3_urls_from_env
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.DEBUG, format="%(message)s")
@@ -44,25 +43,7 @@ class DCOSFilePublisher(object):
         logger.info("Using artifact bucket: {}".format(s3_bucket))
         self._s3_bucket = s3_bucket
 
-        s3_dir_path = os.environ.get("S3_DIR_PATH")
-        if not s3_dir_path:
-            s3_dir_path = os.path.join(
-                "autodelete7d",
-                "{}-{}".format(
-                    time.strftime("%Y%m%d-%H%M%S"),
-                    "".join(
-                        [random.choice(string.ascii_letters + string.digits) for _ in range(16)]
-                    ),
-                ),
-            )
-
-        # Sample S3 file url:
-        # Dev : infinity-artifacts/autodelete7d/20160815-134747-S6vxd0gRQBw43NNy/kafka/stub-universe/kafka-stub-universe.dcos
-        # Release : infinity-artifacts/permanent/kafka/1.2.3/kafka-1.2.3.dcos
-        s3_directory_url = os.environ.get(
-            "S3_URL",
-            "s3://{}/{}/{}/{}".format(s3_bucket, s3_dir_path, package_name, package_version),
-        )
+        s3_directory_url, _ = s3_urls_from_env(package_name)
         self._uploader = universe.S3Uploader(s3_directory_url, self._dry_run)
 
     def upload(self):


### PR DESCRIPTION
Sample output : 
```
---
[S3 URL] DCOS BUNDLE: s3://infinity-artifacts/autodelete7d/hello-world/20181109-125953-EpRDIXWzmU7JuRtv/hello-world-stub-universe.dcos
DCOS BUNDLE: https://infinity-artifacts.s3.amazonaws.com/autodelete7d/hello-world/20181109-125953-EpRDIXWzmU7JuRtv/hello-world-stub-universe.dcos
---
```
For reference (of being consistent) this is a sample stub universe url : 
```
s3://custombucket/autodelete7d/cassandra/20181108-204003-xELpcvU9VZnEzTvw/stub-universe-cassandra.json
```
and this is a sample artifact : 
```
https://infinity-artifacts.s3.amazonaws.com/autodelete7d/cassandra/20181108-204003-xELpcvU9VZnEzTvw/cassandra-scheduler.zip
```

For publishing to a non default bucket/directory : 
```
$ env S3_BUCKET=custombucket S3_DIR_PATH=custom-permanent-path ./frameworks/helloworld/build.sh .dcos
```
would create something like : 
```
s3://custombucket/custom-permanent/hello-world/20181109-125953-EpRDIXWzmU7JuRtv/hello-world-stub-universe.dcos
```
OR 
```
$ env S3_BUCKET=takirala-dev S3_DIR_PATH=custom-permanent S3_DIR_NAME=dir-name ./frameworks/helloworld/build.sh .dcos
```
would create something like :
```
s3://custombucket/custom-permanent/dir-name/hello-world-stub-universe.dcos
```