### PR TITLE
[DCOS-29208] switch to mesosphere client images

### DIFF
--- a/frameworks/hdfs/tests/config.py
+++ b/frameworks/hdfs/tests/config.py
@@ -24,8 +24,7 @@ HDFS_POD_TYPES = {"journal", "name", "data"}
 KEYTAB = "hdfs.keytab"
 HADOOP_VERSION = "hadoop-2.6.0-cdh5.9.1"
 
-# TODO: This should be replaced once the tests pass.
-DOCKER_IMAGE_NAME = "elezar/hdfs-testing-client:dev"
+DOCKER_IMAGE_NAME = "mesosphere/hdfs-testing-client:6972ea3833c9449111aceaa998e3e093a9c8dcee"
 CLIENT_APP_NAME = "hdfs-client"
 
 

--- a/frameworks/hdfs/tests/config.py
+++ b/frameworks/hdfs/tests/config.py
@@ -24,7 +24,8 @@ HDFS_POD_TYPES = {"journal", "name", "data"}
 KEYTAB = "hdfs.keytab"
 HADOOP_VERSION = "hadoop-2.6.0-cdh5.9.1"
 
-DOCKER_IMAGE_NAME = "mesosphere/hdfs-testing-client:30ff636fdf1795a7c3f443cfa77898720a3e6fd3"
+# TODO: This should be replaced once the tests pass.
+DOCKER_IMAGE_NAME = "elezar/hdfs-testing-client:dev"
 CLIENT_APP_NAME = "hdfs-client"
 
 

--- a/frameworks/hdfs/tests/config.py
+++ b/frameworks/hdfs/tests/config.py
@@ -24,7 +24,7 @@ HDFS_POD_TYPES = {"journal", "name", "data"}
 KEYTAB = "hdfs.keytab"
 HADOOP_VERSION = "hadoop-2.6.0-cdh5.9.1"
 
-DOCKER_IMAGE_NAME = "elezar/hdfs-client:dev"
+DOCKER_IMAGE_NAME = "mesosphere/hdfs-testing-client:30ff636fdf1795a7c3f443cfa77898720a3e6fd3"
 CLIENT_APP_NAME = "hdfs-client"
 
 

--- a/frameworks/hdfs/tests/test_kerberos_auth.py
+++ b/frameworks/hdfs/tests/test_kerberos_auth.py
@@ -129,9 +129,17 @@ def test_users_have_appropriate_permissions(hdfs_client, kerberos):
 
     alice_dir = "/users/alice"
     success = True
-    success = success and config.run_client_command(" ".join(["mkdir", "-p", alice_dir]))
-    success = success and config.run_client_command(" ".join(["chown", "alice:users", alice_dir]))
-    success = success and config.run_client_command(" ".join(["chmod", "700", alice_dir]))
+    cmd_lists = [
+        ["mkdir", "-p", alice_dir],
+        ["chown", "alice:users", alice_dir],
+        ["chmod", "700", alice_dir],
+    ]
+    for cmd_list in cmd_lists:
+        cmd = config.hdfs_command(" ".join(cmd_list))
+        cmd_success = config.run_client_command(cmd)
+        if not cmd_success:
+            log.error("Error executing: %s", cmd)
+        success = success and cmd_success
 
     if not success:
         log.error("Error creating %s", alice_dir)

--- a/frameworks/kafka/tests/client.py
+++ b/frameworks/kafka/tests/client.py
@@ -146,7 +146,7 @@ class KafkaClient:
             "mem": 512,
             "container": {
                 "type": "MESOS",
-                "docker": {"image": "elezar/kafka-client:deca3d0", "forcePullImage": True},
+                "docker": {"image": "mesosphere/kafka-testing-client:30ff636fdf1795a7c3f443cfa77898720a3e6fd3", "forcePullImage": True},
             },
             "networks": [{"mode": "host"}],
             "env": {

--- a/frameworks/kafka/tests/test_active_directory_auth.py
+++ b/frameworks/kafka/tests/test_active_directory_auth.py
@@ -83,7 +83,7 @@ def kafka_client(kerberos, kafka_server):
             "mem": 512,
             "container": {
                 "type": "MESOS",
-                "docker": {"image": "elezar/kafka-client:4b9c060", "forcePullImage": True},
+                "docker": {"image": "mesosphere/kafka-testing-client:30ff636fdf1795a7c3f443cfa77898720a3e6fd3", "forcePullImage": True},
                 "volumes": [
                     {
                         "containerPath": "/tmp/kafkaconfig/kafka-client.keytab",

--- a/frameworks/kafka/tests/test_active_directory_zookeeper_auth.py
+++ b/frameworks/kafka/tests/test_active_directory_zookeeper_auth.py
@@ -121,7 +121,7 @@ def kafka_client(kerberos, kafka_server):
             "mem": 512,
             "container": {
                 "type": "MESOS",
-                "docker": {"image": "elezar/kafka-client:4b9c060", "forcePullImage": True},
+                "docker": {"image": "mesosphere/kafka-testing-client:30ff636fdf1795a7c3f443cfa77898720a3e6fd3", "forcePullImage": True},
                 "volumes": [
                     {
                         "containerPath": "/tmp/kafkaconfig/kafka-client.keytab",


### PR DESCRIPTION
This PR switches the testing client Docker images to ones in the mesosphere docker org.

These are hosted at: https://github.com/mesosphere/dcos-commons-ci/tree/master/docker/testing-client