### PR TITLE
[DCOS-41496] Use Elastic and Kibana resources from downloads.mesosphere.com.

### DIFF
--- a/frameworks/elastic/universe-kibana/resource.json
+++ b/frameworks/elastic/universe-kibana/resource.json
@@ -1,13 +1,13 @@
 {
   "assets": {
     "uris": {
-      "kibana-tar-gz": "https://artifacts.elastic.co/downloads/kibana/kibana-{{elastic-version}}-linux-x86_64.tar.gz",
-      "xpack-zip": "https://artifacts.elastic.co/downloads/packs/x-pack/x-pack-{{elastic-version}}.zip"
+      "kibana-tar-gz": "https://downloads.mesosphere.com/elastic/assets/kibana-{{elastic-version}}-linux-x86_64.tar.gz",
+      "xpack-zip": "https://downloads.mesosphere.com/elastic/assets/x-pack-{{elastic-version}}.zip"
     }
   },
   "images": {
-    "icon-small": "https://static-www.elastic.co/assets/blt282ae2420e32fc38/icon-kibana-bb.svg",
-    "icon-medium": "https://static-www.elastic.co/assets/blt282ae2420e32fc38/icon-kibana-bb.svg",
-    "icon-large": "https://static-www.elastic.co/assets/blt282ae2420e32fc38/icon-kibana-bb.svg"
+    "icon-small": "https://downloads.mesosphere.com/elastic/assets/icon-kibana-bb.svg",
+    "icon-medium": "https://downloads.mesosphere.com/elastic/assets/icon-kibana-bb.svg",
+    "icon-large": "https://downloads.mesosphere.com/elastic/assets/icon-kibana-bb.svg"
   }
 }

--- a/frameworks/elastic/universe/resource.json
+++ b/frameworks/elastic/universe/resource.json
@@ -5,11 +5,11 @@
       "libmesos-bundle-tar-gz": "{{libmesos-bundle-url}}",
       "bootstrap-zip": "{{artifact-dir}}/bootstrap.zip",
       "scheduler-zip": "{{artifact-dir}}/elastic-scheduler.zip",
-      "statsd-plugin-zip": "https://github.com/mesosphere/elasticsearch-statsd-plugin/releases/download/{{elastic-statsd-version}}/elasticsearch-statsd-{{elastic-statsd-version}}.zip",
+      "statsd-plugin-zip": "https://downloads.mesosphere.com/elastic/assets/elasticsearch-statsd-{{elastic-statsd-version}}.zip",
       "elasticsearch-jre-tar-gz": "{{jre-url}}",
-      "elasticsearch-tar-gz": "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-{{elastic-version}}.tar.gz",
-      "xpack-zip": "https://artifacts.elastic.co/downloads/packs/x-pack/x-pack-{{elastic-version}}.zip",
-      "diagnostics-zip": "https://github.com/elastic/elasticsearch-support-diagnostics/releases/download/{{support-diagnostics-version}}/support-diagnostics-{{support-diagnostics-version}}-dist.zip"
+      "elasticsearch-tar-gz": "https://downloads.mesosphere.com/elastic/assets/elasticsearch-{{elastic-version}}.tar.gz",
+      "xpack-zip": "https://downloads.mesosphere.com/elastic/assets/x-pack-{{elastic-version}}.zip",
+      "diagnostics-zip": "https://downloads.mesosphere.com/elastic/assets/support-diagnostics-{{support-diagnostics-version}}-dist.zip"
     }
   },
   "images": {


### PR DESCRIPTION
I uploaded the resources using the [Jenkins job](https://jenkins.mesosphere.com/service/jenkins/view/Infinity/job/infinity-tools/job/production-asset-tools/job/upload-production-asset/) and tested on a local cluster. Apparently the `svg` Kibana icon images lose the `image/svg` content type when uploaded, so they don't show up in the DC/OS UI. I still need to look into that.