### PR TITLE
[DCOS-44001] Fix GitHub Security Warnings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # not be updating this dependency.  See
 # https://mesosphere.slack.com/archives/C4E91G0CX/p1541505296001800 for more
 # background.
-FROM mesosphere/dcos-commons-base:af8469627a8cc4c823fac826a5e02f0acaf07869
+FROM mesosphere/dcos-commons-base@sha256:076d1fdf4033ccd25fcedc3402a23cf017285672181d94e2f6fb11ace48c310e
 
 ENV GO_VERSION=1.10.2
 ENV PATH=$PATH:/usr/local/go/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # not be updating this dependency.  See
 # https://mesosphere.slack.com/archives/C4E91G0CX/p1541505296001800 for more
 # background.
-FROM mesosphere/dcos-commons-base@sha256:e9f67d72aa1431f4a15544981285f028decc7507538f8e5aa8b0888a94d820c0
+FROM mesosphere/dcos-commons-base@sha256:af8469627a8cc4c823fac826a5e02f0acaf07869
 
 ENV GO_VERSION=1.10.2
 ENV PATH=$PATH:/usr/local/go/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # not be updating this dependency.  See
 # https://mesosphere.slack.com/archives/C4E91G0CX/p1541505296001800 for more
 # background.
-FROM mesosphere/dcos-commons-base@sha256:af8469627a8cc4c823fac826a5e02f0acaf07869
+FROM mesosphere/dcos-commons-base:af8469627a8cc4c823fac826a5e02f0acaf07869
 
 ENV GO_VERSION=1.10.2
 ENV PATH=$PATH:/usr/local/go/bin

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -46,3 +46,6 @@ RUN apt-get update && \
     zip && \
     rm -rf /var/lib/apt/lists/* && \
     java -version
+
+#Remove pycrypto-2.6.1 due to https://nvd.nist.gov/vuln/detail/CVE-2018-6594 
+RUN apt-get remove -y python3-crypto

--- a/frozen_requirements.txt
+++ b/frozen_requirements.txt
@@ -44,7 +44,7 @@ cfgv==1.1.0
 chardet==3.0.4
 Click==7.0
 colorama==0.3.9
-cryptography==2.0.2
+cryptography==2.3.1
 dcos-shakedown==1.4.12
 docopt==0.6.2
 docutils==0.14
@@ -98,7 +98,7 @@ pytest-timeout==1.3.2
 python-dateutil==2.7.3
 pyxdg==0.25
 PyYAML==3.13
-requests==2.19.1
+requests==2.20.0
 requests-oauthlib==1.0.0
 retrying==1.3.3
 rsa==4.0

--- a/frozen_requirements.txt
+++ b/frozen_requirements.txt
@@ -85,7 +85,7 @@ pyasn1==0.4.4
 pyasn1-modules==0.2.2
 pycodestyle==2.3.1
 pycparser==2.19
-pycrypto==2.6.1
+pycryptodome==3.7.0
 pyflakes==1.6.0
 Pygments==2.2.0
 pygobject==3.26.1


### PR DESCRIPTION
Update the following packages:
- cryptography to 2.3.1
- requests to 2.20.0

Remove pycrypto-2.6.1 by removing python3-crypto
Replace pycrypto-2.6.1 with pycryptodome-3.7.0
