### PR TITLE
Update fixes to 'sdk_cmd.{_ssh(), _scp()}'

### DIFF
--- a/testing/sdk_cmd.py
+++ b/testing/sdk_cmd.py
@@ -24,6 +24,7 @@ log = logging.getLogger(__name__)
 
 DEFAULT_TIMEOUT_SECONDS = 30 * 60
 SSH_USERNAME = os.environ.get("DCOS_SSH_USERNAME", "core")
+SSH_KEY_FILE = os.environ.get("DCOS_SSH_KEY_FILE", "")
 
 # Silence this warning. We expect certs to be self-signed:
 # /usr/local/lib/python3.6/dist-packages/urllib3/connectionpool.py:857:
@@ -365,14 +366,28 @@ def _ssh(cmd: str, host: str, timeout_seconds: int, print_output: bool, check: b
         ]
     )
 
+    direct_args = " ".join(
+        [
+            common_args,
+            # -i <identity_file>: The identity file to use for login
+            "-i {}".format(SSH_KEY_FILE) if SSH_KEY_FILE else "",
+        ]
+    )
+
+    nested_args = " ".join(
+        [
+            common_args
+        ]
+    )
+
     if os.environ.get("DCOS_SSH_DIRECT", ""):
         # Direct SSH access to the node:
-        ssh_cmd = 'ssh {} {} -- "{}"'.format(common_args, host, cmd)
+        ssh_cmd = 'ssh {} {} -- "{}"'.format(direct_args, host, cmd)
     else:
         # Nested SSH call via the proxy node. Be careful to nest quotes to match, and escape any
         # command-internal double quotes as well:
         ssh_cmd = 'ssh {} {} -- "ssh {} {} -- \\"{}\\""'.format(
-            common_args, _external_cluster_host(), common_args, host, cmd.replace('"', '\\\\\\"')
+            direct_args, _external_cluster_host(), nested_args, host, cmd.replace('"', '\\\\\\"')
         )
     log.info("SSH command: {}".format(ssh_cmd))
     rc, stdout, stderr = _run_cmd(ssh_cmd, print_output, check, timeout_seconds=timeout_seconds)
@@ -397,6 +412,8 @@ def _scp(
             # -oConnectTimeout=#: Limit the duration for the connection to be created.
             #                     We also configure a timeout for the command itself to run once connected, see below.
             "-oConnectTimeout={}".format(timeout_seconds),
+            # -i <identity_file>: The identity file to use for login
+            "-i {}".format(SSH_KEY_FILE) if SSH_KEY_FILE else "",
         ]
     )
 

--- a/testing/sdk_cmd.py
+++ b/testing/sdk_cmd.py
@@ -409,7 +409,9 @@ def _scp(
         # -q: Don't show banner, if any is configured, and suppress other warning/diagnostic messages.
         #     In particular, avoid messages that may mess up stdout/stderr output.
         # -l <user>: Username to log in as (depends on cluster OS, default to CoreOS)
-        proxy_arg = ' -oProxyCommand="ssh {} -A -q -l {} {}:22 {}"'.format(
+        # -W <host:port>: Requests that standard input and output on the client
+        #                 be forwarded to host on port over the secure channel.
+        proxy_arg = ' -oProxyCommand="ssh {} -A -q -l {} -W {}:22 {}"'.format(
             common_args, SSH_USERNAME, host, _external_cluster_host()
         )
 


### PR DESCRIPTION
This PR updates some of the functionality of the `sdk_cmd._ssh()` and `sdk_cmd._scp()` functions.

First, it adds a missing `-W` parameter to the `sdk_cmd._scp()` function. Without this, the underlying 'scp' with a proxy through SSH would never have worked. I'm guessing this function is no longer used at the moment or else someone would have run into this.

Second, it adds the ability to only send a single key to both `sdk_cmd._ssh()` and `sdk_cmd._scp()`. Previously, there was no way to specifically set the identity file for use by the underlying 'ssh' and 'scp' commands. Now there is.