### PR TITLE
Add envvar to force hello world upgrade

### DIFF
--- a/frameworks/helloworld/universe/marathon.json.mustache
+++ b/frameworks/helloworld/universe/marathon.json.mustache
@@ -105,7 +105,8 @@
     "SCENARIOS": "{{service.scenario}}",
     "ALLOW_REGION_AWARENESS": "{{service.allow_region_awareness}}",
     "HELLO_PORT_ONE": "{{hello.port_one}}",
-    "GLOG_v":"{{service.verbose_mesos_logging}}"
+    "GLOG_v":"{{service.verbose_mesos_logging}}",
+    "TASKCFG_ALL_PACKAGE_VERSION_TO_FORCE_UPDATE": "{{package-version}}"
   },
   "fetch": [
     { "uri": "{{resource.assets.uris.bootstrap-zip}}", "cache": true },


### PR DESCRIPTION
This PR adds an evvar to all tasks to ensure that an upgrade can be tested even when the latest universe version and the version under test have an IDENTICAL task configuration.

If this was not done, ALL upgrade tests would fail as the tasks were not restarted. The scheduler now shows:
```
INFO  2018-11-22 15:18:37,694 [main] DefaultConfigurationUpdater:printConfigDiff(320): Difference between configs:
--- ServiceSpec.old
+++ ServiceSpec.new
@@ -71,4 +71,5 @@
         "value" : "env && echo hello >> hello-container-path/output && sleep $SLEEP_DURATION",
         "environment" : {
+          "PACKAGE_VERSION_TO_FORCE_UPDATE" : "stub-universe",
           "SLEEP_DURATION" : "1000"
         }
@@ -185,4 +186,5 @@
         "value" : "# for graceful shutdown\n#  trap SIGTERM and mock a cleanup timeframe\nterminated () {\n  echo \"$(date) received SIGTERM, zzz for 3 ...\"\n  sleep 3\n  echo \"$(date) ... all clean, peace out\"\n  exit 0\n}\ntrap terminated SIGTERM\necho \"$(date) trapping SIGTERM, watch here for the signal...\"\n\necho 'world1' >>world-container-path1/output &&\necho 'world2' >>world-container-path2/output &&\n# instead of running for a short duration (equal to SLEEP_DURATION), run infinitely\n# to allow for testing of SIGTERM..grace..SIGKILL\nwhile true; do\n  sleep 0.1\ndone\n",
         "environment" : {
+          "PACKAGE_VERSION_TO_FORCE_UPDATE" : "stub-universe",
           "SLEEP_DURATION" : "1000"
         }
```