### PR TITLE
Adding 'sudo' to janitor docker run command

### DIFF
--- a/testing/sdk_install.py
+++ b/testing/sdk_install.py
@@ -164,6 +164,7 @@ def install(
 )
 def _retried_run_janitor(service_name):
     cmd_list = [
+        "sudo",
         "docker",
         "run",
         "mesosphere/janitor",


### PR DESCRIPTION
Running janitor on CentOS fails silently due to the lack of `sudo` which is needed to run Docker containers in this OS. This PR adds `sudo` to janitor command.