### PR TITLE
[DCOS-45987] Always publish x86-64 compatible builds for CLI

### DIFF
--- a/tools/build_go_exe.sh
+++ b/tools/build_go_exe.sh
@@ -72,6 +72,7 @@ GOPATH_REPO_ORG_DIR=${GOPATH}/src/${GOPATH_REPO_ORG}
 # ex: /.gopath/src/github.com/mesosphere/dcos-commons/sdk/cli
 GOPATH_EXE_DIR="$GOPATH_REPO_ORG_DIR/$REPO_NAME/$RELATIVE_EXE_DIR"
 GO_LDFLAGS=${GO_LDFLAGS:-""}
+DEFAULT_GO_ARCH=${DEFAULT_GO_ARCH:-"amd64"}
 
 # Add symlink from GOPATH which points into the repository directory, if necessary:
 SYMLINK_LOCATION="$GOPATH_REPO_ORG_DIR/$REPO_NAME"
@@ -146,7 +147,7 @@ else
 
         # available GOOS/GOARCH permutations are listed at:
         # https://golang.org/doc/install/source#environment
-        CGO_ENABLED=0 GOOS=$PLATFORM GOARCH=386 go build -ldflags="-s -w ${GO_LDFLAGS}" -o $PLATFORM_FILENAME
+        CGO_ENABLED=0 GOOS=${PLATFORM} GOARCH=${DEFAULT_GO_ARCH} go build -ldflags="-s -w ${GO_LDFLAGS}" -o ${PLATFORM_FILENAME}
 
         # use upx if:
         # - upx is installed


### PR DESCRIPTION
we added `GOARCH` as `386` when we first added `tools/build_go_exe.sh` in [Jan 2017](https://github.com/mesosphere/dcos-commons/commit/a3a90ccda4d949ab48cf017f67ec390396170159#diff-6f6fe33cd5affd9513259ffffd6cc88bR64). Considering that is relatively recent, i am going to assume no one has faced a problem with using `386` arch builds in 64 bit systems _so far_. Recently, a customer was using a `Ubuntu` in `windows` subsystem and they were not able to execute the binary ([DCOS-45987](https://jira.mesosphere.com/browse/DCOS-45987)). This is the error one gets when tried to execute the `386` binary in a `ubuntu running in 64-bit Windows` : 
```
<filename>: cannot execute binary file: Exec format error.
```
We have two standards that we can comply with:
- Our universe spec says the CLI binaries have to be `x86-64` compatible (See [universe repo spec](https://github.com/mesosphere/universe/blob/850b6d0ec63fb5acd48ea7680ec9d59a58dff09c/repo/meta/schema/vX-repo-definitions.json#L187) and [hw resource.json#L31](https://github.com/mesosphere/universe/blob/version-3.x/repo/packages/H/hello-world/300/resource.json#L31)).
- DC/OS CLI uses `amd64` as the value of `GOARCH` (See [Makefile](https://github.com/dcos/dcos-cli/blob/99ea9368690b953849f1d98e7814e393dfc373c3/Makefile#L17-L20) - It uses the docker image which inherits from `FROM golang:1.11.0` and it has `GOARCH` defaulted to `amd64` ) 
- Without going in the entire argument of 386 vs x86-64, currently there is no supported / documented case of `dcos-commons` CLI being used as a standalone CLI for managing frameworks. So we can just say, whenever core cli works, `dcos-commons` CLI works too.
- If we decide to support other architectures, we need to make changes to `CLI`, `cosmos` etc.. and that requires a bigger discussion.