### PR TITLE
[TOOLS] Do not rebase stale PRs - via renovatebot.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -18,5 +18,6 @@
   "ignorePaths": [
     "frameworks/*/universe*/package.json"
   ],
-  "renovateFork": true
+  "renovateFork": true,
+  "rebaseStalePrs": false
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,7 @@
 {
+  "assignees" : [
+    "takirala"
+  ],  
   "extends": [
     "config:base"
   ],


### PR DESCRIPTION
Renovate bot creates a lot of noise in CI if we let a rebase on stale PRs. This PR changes the configuration to not rebase stale PRs. we can update the branch (which auto reruns the CI) if a PR is considered high risk or else we merge as-is.