### PR TITLE
DCOS-17390: Disable EOL tests for 1.9

### DIFF
--- a/frameworks/helloworld/tests/test_multistep_plan.py
+++ b/frameworks/helloworld/tests/test_multistep_plan.py
@@ -30,6 +30,7 @@ def configure_package(configure_security):
 @pytest.mark.sanity
 @pytest.mark.smoke
 @pytest.mark.config_update
+@pytest.mark.dcos_min_version("1.10")
 def test_bump_hello_cpus():
     def close_enough(val0, val1):
         epsilon = 0.00001

--- a/frameworks/helloworld/tests/test_placement.py
+++ b/frameworks/helloworld/tests/test_placement.py
@@ -67,7 +67,7 @@ def fault_domain_vars_are_present(pod_instance):
     return region != 'NO_REGION' and zone != 'NO_ZONE' and len(region) > 0 and len(zone) > 0
 
 
-@pytest.mark.dcos_min_version('1.9')
+@pytest.mark.dcos_min_version('1.10')
 @pytest.mark.smoke
 @pytest.mark.sanity
 @sdk_utils.dcos_ee_only

--- a/frameworks/helloworld/tests/test_sanity.py
+++ b/frameworks/helloworld/tests/test_sanity.py
@@ -35,6 +35,7 @@ def configure_package(configure_security):
 
 
 @pytest.mark.smoke
+@pytest.mark.dcos_min_version("1.10")
 def test_install():
     config.check_running(sdk_utils.get_foldered_name(config.SERVICE_NAME))
 
@@ -52,6 +53,7 @@ def test_mesos_v0_api():
 
 @pytest.mark.sanity
 @pytest.mark.smoke
+@pytest.mark.dcos_min_version('1.10')
 def test_bump_hello_cpus():
     foldered_name = sdk_utils.get_foldered_name(config.SERVICE_NAME)
     config.check_running(foldered_name)
@@ -73,6 +75,7 @@ def test_bump_hello_cpus():
 
 @pytest.mark.sanity
 @pytest.mark.smoke
+@pytest.mark.dcos_min_version("1.10")
 def test_bump_world_cpus():
     foldered_name = sdk_utils.get_foldered_name(config.SERVICE_NAME)
     config.check_running(foldered_name)

--- a/testing/sdk_utils.py
+++ b/testing/sdk_utils.py
@@ -69,7 +69,7 @@ def check_dcos_min_version_mark(item: pytest.Item):
 
     In order for this annotation to take effect, this function must be called by a pytest_runtest_setup() hook.
     '''
-    min_version_mark = item.get_marker('dcos_min_version')
+    min_version_mark = item.get_closest_marker('dcos_min_version')
     if min_version_mark:
         min_version = min_version_mark.args[0]
         message = 'Feature only supported in DC/OS {} and up'.format(min_version)


### PR DESCRIPTION
Set requirement of dcos_min_version("1.10") for the following tests:
test_placement.test_rack_not_found
test_resource_refinement.test_install
test_sanity.test_bump_hello_cpus
test_sanity.test_bump_world_cpus
test_sanity.test_install
test_secrets.test_secrets_basic