### PR TITLE
[DCOS-46514] Adding regex validation to stub universe names

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ allprojects {
     // 2. In the GitHub UI, add a Release entry against the tag created in step 1. List any changes in release notes.
     // 3. Create a PR which bumps this from '0.10.0-SNAPSHOT' to '0.11.0-SNAPSHOT' in master to start the 0.11.0 track.
     // --
-    version = '0.55.0-SNAPSHOT'
+    version = '0.54.3'
 
     sourceCompatibility = '1.8'
     targetCompatibility = '1.8'

--- a/frameworks/hdfs/src/main/dist/core-site.xml
+++ b/frameworks/hdfs/src/main/dist/core-site.xml
@@ -275,6 +275,10 @@
         <value>{{IPC_CLIENT_CONNECT_MAX_RETRIES}}</value>
     </property>
     <property>
+        <name>ipc.maximum.data.length</name>
+        <value>{{IPC_MAXIMUM_DATA_LENGTH}}</value>
+    </property>
+    <property>
         <name>ipc.client.connect.retry.interval</name>
         <value>{{IPC_CLIENT_CONNECT_RETRY_INTERVAL}}</value>
     </property>

--- a/frameworks/hdfs/src/main/dist/svc.yml
+++ b/frameworks/hdfs/src/main/dist/svc.yml
@@ -45,7 +45,7 @@ pods:
         cmd: |
           set -e
           echo "Creating version directory in the journal-data persistent volume"
-          mkdir -p journal-data/hdfs/current
+          mkdir -p journal-data/hdfs/current/paxos
           echo "Fetching VERSION file"
           curl ${SCHEDULER_API_HOSTNAME}:${SCHEDULER_API_PORT}/v1/state/files/VERSION > journal-data/hdfs/current/VERSION
           echo "VERSION has the following content:"

--- a/frameworks/hdfs/universe/config.json
+++ b/frameworks/hdfs/universe/config.json
@@ -8,7 +8,7 @@
         "name": {
           "description": "Unique name for the service instance consisting of a series of words separated by slashes. Each word must be at least 1 alphanumeric character and may only contain digits (`0-9`), dashes (`-`), dots (`.`), and lowercase letters (`a-z`). The word may not begin or end with a dash",
           "type": "string",
-          "pattern": "^(\/?((\.\.)|(([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])\.)*([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9]))?($|\/))+$",
+          "pattern":"\"^(\\/?((\\.\\.)|(([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9]))?($|\\/))+$\"",
           "default": "hdfs"
         },
         "user": {

--- a/frameworks/hdfs/universe/config.json
+++ b/frameworks/hdfs/universe/config.json
@@ -1663,6 +1663,11 @@
           "description": "The default implementation of Hash. Currently this can take one of the two values: 'murmur' to select MurmurHash and 'jenkins' to select JenkinsHash.",
           "default": "murmur"
         },
+        "ipc_maximum_data_length": {
+          "type": "string",
+          "description": "Defines the maximum length or rpc calls for data node reports to the name node.",
+          "default": "67108864"
+        },
         "ipc_client_idlethreshold": {
           "type": "string",
           "description": "Defines the threshold number of connections after which connections will be inspected for idleness.",

--- a/frameworks/hdfs/universe/config.json
+++ b/frameworks/hdfs/universe/config.json
@@ -6,8 +6,9 @@
       "description": "DC/OS service configuration properties",
       "properties": {
         "name": {
-          "description": "The name of the service instance",
+          "description": "Unique name for the service instance consisting of a series of words separated by slashes. Each word must be at least 1 alphanumeric character and may only contain digits (`0-9`), dashes (`-`), dots (`.`), and lowercase letters (`a-z`). The word may not begin or end with a dash",
           "type": "string",
+          "pattern": "^(\/?((\.\.)|(([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])\.)*([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9]))?($|\/))+$",
           "default": "hdfs"
         },
         "user": {

--- a/frameworks/hdfs/universe/config.json
+++ b/frameworks/hdfs/universe/config.json
@@ -8,7 +8,7 @@
         "name": {
           "description": "Unique name for the service instance consisting of a series of words separated by slashes. Each word must be at least 1 alphanumeric character and may only contain digits (`0-9`), dashes (`-`), dots (`.`), and lowercase letters (`a-z`). The word may not begin or end with a dash",
           "type": "string",
-          "pattern":"\"^(\\/?((\\.\\.)|(([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9]))?($|\\/))+$\"",
+          "pattern":"^(\\/?((\\.\\.)|(([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9]))?($|\\/))+$",
           "default": "hdfs"
         },
         "user": {

--- a/frameworks/hdfs/universe/marathon.json.mustache
+++ b/frameworks/hdfs/universe/marathon.json.mustache
@@ -37,7 +37,7 @@
     "PACKAGE_BUILD_TIME_STR": "{{package-build-time-str}}",
     "FRAMEWORK_NAME": "{{service.name}}",
     "FRAMEWORK_LOG_LEVEL": "{{service.log_level}}",
-    "TASKCFG_ALL_HDFS_VERSION": "hadoop-2.6.0-cdh5.11.0",
+    "TASKCFG_ALL_HDFS_VERSION": "hadoop-2.6.0-cdh5.16.1",
     "DEPLOY_STRATEGY": "{{service.deploy_strategy}}",
     "SERVICE_PRINCIPAL": "{{service.service_account}}",
     "JOURNAL_CPUS": "{{journal_node.cpus}}",

--- a/frameworks/hdfs/universe/marathon.json.mustache
+++ b/frameworks/hdfs/universe/marathon.json.mustache
@@ -367,6 +367,7 @@
     "TASKCFG_ALL_IO_SEQFILE_BLOOM_SIZE": "{{hdfs.io_seqfile_bloom_size}}",
     "TASKCFG_ALL_IO_SEQFILE_BLOOM_ERROR_RATE": "{{hdfs.io_seqfile_bloom_error_rate}}",
     "TASKCFG_ALL_HADOOP_UTIL_HASH_TYPE": "{{hdfs.hadoop_util_hash_type}}",
+    "TASKCFG_ALL_IPC_MAXIMUM_DATA_LENGTH": "{{hdfs.ipc_maximum_data_length}}",
     "TASKCFG_ALL_IPC_CLIENT_IDLETHRESHOLD": "{{hdfs.ipc_client_idlethreshold}}",
     "TASKCFG_ALL_IPC_CLIENT_KILL_MAX": "{{hdfs.ipc_client_kill_max}}",
     "TASKCFG_ALL_IPC_CLIENT_CONNECTION_MAXIDLETIME": "{{hdfs.ipc_client_connection_maxidletime}}",

--- a/frameworks/hdfs/universe/resource.json
+++ b/frameworks/hdfs/universe/resource.json
@@ -3,7 +3,7 @@
     "uris": {
       "jre-tar-gz": "{{jre-url}}",
       "libmesos-bundle-tar-gz": "{{libmesos-bundle-url}}",
-      "hdfs-tar-gz": "https://downloads.mesosphere.com/hdfs/assets/hadoop-2.6.0-cdh5.11.0.tar.gz",
+      "hdfs-tar-gz": "https://downloads.mesosphere.io/hdfs/assets/hadoop-2.6.0-cdh5.16.1.tar.gz",
       "hdfs-bin-tar-gz": "https://downloads.mesosphere.com/hdfs/assets/hdfs-bin.tar.gz",
       "hdfs-jre-tar-gz": "{{jre-url}}",
       "bootstrap-zip": "{{artifact-dir}}/bootstrap.zip",

--- a/tools/universe/package_builder.py
+++ b/tools/universe/package_builder.py
@@ -18,7 +18,7 @@ logging.basicConfig(level=logging.DEBUG, format="%(message)s")
 
 _jre_url = "https://downloads.mesosphere.com/java/server-jre-8u192-linux-x64.tar.gz"
 _libmesos_bundle_url = (
-    "https://downloads.mesosphere.com/libmesos-bundle/libmesos-bundle-1.11.0.tar.gz"
+    "https://downloads.mesosphere.com/libmesos-bundle/libmesos-bundle-1.12.0.tar.gz"
 )
 _dcos_sdk_version = "0.41.0-SNAPSHOT"
 

--- a/tools/universe/package_builder.py
+++ b/tools/universe/package_builder.py
@@ -174,7 +174,7 @@ class UniversePackageBuilder(object):
             "package-build-time-epoch-ms": str(int(round(now * 1000))),
             "package-build-time-str": time.strftime("%a %b %d %Y %H:%M:%S +0000", time.gmtime(now)),
             "upgrades-from": self._get_upgrades_from(),
-            "downgrades-to": self._get_downgrades_to(),
+            "Fdowngrades-to": self._get_downgrades_to(),
             "artifact-dir": self._upload_dir_uri,
             "documentation-path": self._get_documentation_path(),
             "issues-path": self._get_issues_path(),

--- a/tools/universe/package_builder.py
+++ b/tools/universe/package_builder.py
@@ -174,7 +174,7 @@ class UniversePackageBuilder(object):
             "package-build-time-epoch-ms": str(int(round(now * 1000))),
             "package-build-time-str": time.strftime("%a %b %d %Y %H:%M:%S +0000", time.gmtime(now)),
             "upgrades-from": self._get_upgrades_from(),
-            "Fdowngrades-to": self._get_downgrades_to(),
+            "downgrades-to": self._get_downgrades_to(),
             "artifact-dir": self._upload_dir_uri,
             "documentation-path": self._get_documentation_path(),
             "issues-path": self._get_issues_path(),


### PR DESCRIPTION
# What changes were proposed in this pull request?
A regex validator was added to check that stub universe name for the hdfs service instance consisted of a series of words separated by slashes and each word was at least 1 alphanumeric character and contained only digits (`0-9`), dashes (`-`), dots (`.`), and lowercase letters (`a-z`). The word did not begin or end with a dash.
# How were these changes tested?
The changes were tested manually by creating a hdfs service on a ccm cluster.