### PR TITLE
[DCOS-46514] Adding a regex validator

### DIFF
--- a/frameworks/hdfs/tests/config.py
+++ b/frameworks/hdfs/tests/config.py
@@ -22,7 +22,7 @@ TEST_CONTENT_SMALL = "This is some test data"
 DEFAULT_HDFS_TIMEOUT = 5 * 60
 HDFS_POD_TYPES = {"journal", "name", "data"}
 KEYTAB = "hdfs.keytab"
-HADOOP_VERSION = "hadoop-2.6.0-cdh5.16.1"
+HADOOP_VERSION = "hadoop-2.6.0-cdh5.9.1"
 
 DOCKER_IMAGE_NAME = "mesosphere/hdfs-testing-client:6972ea3833c9449111aceaa998e3e093a9c8dcee"
 CLIENT_APP_NAME = "hdfs-client"

--- a/frameworks/hdfs/tests/config.py
+++ b/frameworks/hdfs/tests/config.py
@@ -22,7 +22,7 @@ TEST_CONTENT_SMALL = "This is some test data"
 DEFAULT_HDFS_TIMEOUT = 5 * 60
 HDFS_POD_TYPES = {"journal", "name", "data"}
 KEYTAB = "hdfs.keytab"
-HADOOP_VERSION = "hadoop-2.6.0-cdh5.9.1"
+HADOOP_VERSION = "hadoop-2.6.0-cdh5.16.1"
 
 DOCKER_IMAGE_NAME = "mesosphere/hdfs-testing-client:6972ea3833c9449111aceaa998e3e093a9c8dcee"
 CLIENT_APP_NAME = "hdfs-client"

--- a/frameworks/hdfs/universe/config.json
+++ b/frameworks/hdfs/universe/config.json
@@ -6,7 +6,7 @@
       "description": "DC/OS service configuration properties",
       "properties": {
         "name": {
-          "description": "The name of the service instance",
+          "description": "Unique name for the service instance consisting of a series of words separated by slashes. Each word must be at least 1 alphanumeric character and may only contain digits (`0-9`), dashes (`-`), dots (`.`), and lowercase letters (`a-z`). The word may not begin or end with a dash",
           "type": "string",
           "pattern": "^(\\/?((\\.\\.)|(([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9]))?($|\\/))+$",
           "default": "hdfs"

--- a/frameworks/hdfs/universe/config.json
+++ b/frameworks/hdfs/universe/config.json
@@ -8,6 +8,7 @@
         "name": {
           "description": "The name of the service instance",
           "type": "string",
+          "pattern": "^(\\/?((\\.\\.)|(([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9]))?($|\\/))+$",
           "default": "hdfs"
         },
         "user": {


### PR DESCRIPTION
# What changes were proposed in this pull request?
Added a regex validator to check stub universe name for the service instance consisted of a series of words separated by slashes. Each word must be at least 1 alphanumeric character and may only contain digits (`0-9`), dashes (`-`), dots (`.`), and lowercase letters (`a-z`). The word may not begin or end with a dash",
# How were the changes tested?
Manually by creating a HDFS package on a CCM cluster.