### PR TITLE
COPS-4320: Configurable timeouts for readiness checks.

### DIFF
--- a/frameworks/cassandra/src/main/dist/svc.yml
+++ b/frameworks/cassandra/src/main/dist/svc.yml
@@ -77,9 +77,9 @@ pods:
                 export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jdk*/jre/) ;
                 export TASK_IP=$(./bootstrap --get-task-ip) &&
                 ./apache-cassandra-{{CASSANDRA_VERSION}}/bin/nodetool status -p {{TASKCFG_ALL_JMX_PORT}} | grep -q "UN  $TASK_IP"
-          interval: 5
-          delay: 0
-          timeout: 60
+          interval: {{READINESS_CHECK_INTERVAL}}
+          delay: {{READINESS_CHECK_DELAY}}
+          timeout: {{READINESS_CHECK_TIMEOUT}}
         {{#TASKCFG_ALL_SECURITY_TRANSPORT_ENCRYPTION_ENABLED}}
         transport-encryption:
           - name: node

--- a/frameworks/cassandra/universe/config.json
+++ b/frameworks/cassandra/universe/config.json
@@ -117,6 +117,27 @@
               }
             }
           }
+        },
+        "readiness_check" : {
+          "description" : "Readiness check settings",
+          "type": "object",
+          "properties": {
+            "interval": {
+              "type": "integer",
+              "description": "The period in seconds to wait after the last readiness check has completed to start the next check.",
+              "default": 60
+            },
+            "delay": {
+              "type": "integer",
+              "description": "An amount of time in seconds to wait before starting the readiness check attempts.",
+              "default": 0
+            },
+            "timeout": {
+              "type": "integer",
+              "description": "An amount of time in seconds to wait for a readiness check to succeed.",
+              "default": 20
+            }
+          }
         }
       },
       "required": [

--- a/frameworks/cassandra/universe/marathon.json.mustache
+++ b/frameworks/cassandra/universe/marathon.json.mustache
@@ -162,7 +162,10 @@
     "CASSANDRA_URI": "{{resource.assets.uris.cassandra-tar-gz}}",
     "JAVA_URI": "{{resource.assets.uris.jre-tar-gz}}",
     "LIBMESOS_URI": "{{resource.assets.uris.libmesos-bundle-tar-gz}}",
-    "BACKUP_RESTORE_STRATEGY": "{{service.backup_restore_strategy}}"
+    "BACKUP_RESTORE_STRATEGY": "{{service.backup_restore_strategy}}",
+    "READINESS_CHECK_INTERVAL": "{{service.readiness_check.interval}}",
+    "READINESS_CHECK_DELAY": "{{service.readiness_check.delay}}",
+    "READINESS_CHECK_TIMEOUT": "{{service.readiness_check.timeout}}"
   },
   "uris": [
     "{{resource.assets.uris.bootstrap-zip}}",

--- a/frameworks/elastic/src/main/dist/svc.yml
+++ b/frameworks/elastic/src/main/dist/svc.yml
@@ -74,9 +74,9 @@ pods:
             dest: elasticsearch-{{ELASTIC_VERSION}}/config/elasticsearch.yml
         readiness-check:
           cmd: "curl -k -I -s -f -u {{ELASTICSEARCH_HEALTH_USER}}:{{ELASTICSEARCH_HEALTH_USER_PASSWORD}} {{ELASTICSEARCH_HEALTH_PROTOCOL}}://$TASK_NAME.$FRAMEWORK_HOST:$PORT_HTTP"
-          interval: 5
-          delay: 0
-          timeout: 10
+          interval: {{READINESS_CHECK_INTERVAL}}
+          delay: {{READINESS_CHECK_DELAY}}
+          timeout: {{READINESS_CHECK_TIMEOUT}}
         {{#TASKCFG_ALL_SECURITY_TRANSPORT_ENCRYPTION_ENABLED}}
         transport-encryption:
           - name: node

--- a/frameworks/elastic/universe/config.json
+++ b/frameworks/elastic/universe/config.json
@@ -106,6 +106,27 @@
               }
             }
           }
+        },
+        "readiness_check" : {
+          "description" : "Readiness check settings",
+          "type": "object",
+          "properties": {
+            "interval": {
+              "type": "integer",
+              "description": "The period in seconds to wait after the last readiness check has completed to start the next check.",
+              "default": 60
+            },
+            "delay": {
+              "type": "integer",
+              "description": "An amount of time in seconds to wait before starting the readiness check attempts.",
+              "default": 0
+            },
+            "timeout": {
+              "type": "integer",
+              "description": "An amount of time in seconds to wait for a readiness check to succeed.",
+              "default": 20
+            }
+          }
         }
       },
       "required": [

--- a/frameworks/elastic/universe/marathon.json.mustache
+++ b/frameworks/elastic/universe/marathon.json.mustache
@@ -324,7 +324,10 @@
     {{#elasticsearch.indices_requests_cache_size}}
     "TASKCFG_ALL_INDICES_REQUESTS_CACHE_SIZE": "{{elasticsearch.indices_requests_cache_size}}",
     {{/elasticsearch.indices_requests_cache_size}}
-    "CUSTOM_YAML_BLOCK_BASE64": "{{elasticsearch.custom_elasticsearch_yml}}"
+    "CUSTOM_YAML_BLOCK_BASE64": "{{elasticsearch.custom_elasticsearch_yml}}",
+    "READINESS_CHECK_INTERVAL": "{{service.readiness_check.interval}}",
+    "READINESS_CHECK_DELAY": "{{service.readiness_check.delay}}",
+    "READINESS_CHECK_TIMEOUT": "{{service.readiness_check.timeout}}"
   },
   "uris": [
     "{{resource.assets.uris.bootstrap-zip}}",

--- a/frameworks/hdfs/src/main/dist/svc.yml
+++ b/frameworks/hdfs/src/main/dist/svc.yml
@@ -129,9 +129,9 @@ pods:
               # give it a chance to roll completely and start a new edits segment
               sleep 30
             fi
-          delay: 30
-          interval: 30
-          timeout: 60
+          delay: {{JOURNAL_NODE_READINESS_CHECK_DELAY}}
+          interval: {{JOURNAL_NODE_READINESS_CHECK_INTERVAL}}
+          timeout: {{JOURNAL_NODE_READINESS_CHECK_TIMEOUT}}
         {{/JOURNAL_READINESS_CHECK_ENABLED}}
         {{#SECURITY_TRANSPORT_ENCRYPTION_ENABLED}}
         transport-encryption:
@@ -219,9 +219,9 @@ pods:
             KRB5_CONFIG=$MESOS_SANDBOX/{{TASKCFG_ALL_HDFS_VERSION}}/etc/hadoop/krb5.conf kinit -k -t $MESOS_SANDBOX/hdfs.keytab $SECURITY_KERBEROS_PRIMARY/$TASK_NAME.$FRAMEWORK_HOST@$SECURITY_KERBEROS_REALM
             {{/SECURITY_KERBEROS_ENABLED}}
             ./{{TASKCFG_ALL_HDFS_VERSION}}/bin/hdfs haadmin -getServiceState $TASK_NAME
-          interval: 5
-          delay: 0
-          timeout: 180
+          interval: {{NAME_NODE_READINESS_CHECK_INTERVAL}}
+          delay: {{NAME_NODE_READINESS_CHECK_DELAY}}
+          timeout: {{NAME_NODE_READINESS_CHECK_TIMEOUT}}
         configs:
           {{#SECURITY_KERBEROS_ENABLED}}
           krb5-conf:
@@ -494,9 +494,9 @@ pods:
             export TASK_IP=$(./bootstrap --get-task-ip)
             MATCH="$(./{{TASKCFG_ALL_HDFS_VERSION}}/bin/hdfs dfsadmin -report | grep $TASK_IP | wc -l)"
             [[ $MATCH -ge 1 ]]
-          interval: 10
-          delay: 120
-          timeout: 60
+          interval: {{DATA_NODE_READINESS_CHECK_INTERVAL}}
+          delay: {{DATA_NODE_READINESS_CHECK_INTERVAL}}
+          timeout: {{DATA_NODE_READINESS_CHECK_INTERVAL}}
         {{#SECURITY_TRANSPORT_ENCRYPTION_ENABLED}}
         transport-encryption:
           - name: node

--- a/frameworks/hdfs/universe/config.json
+++ b/frameworks/hdfs/universe/config.json
@@ -177,6 +177,27 @@
           "type": "boolean",
           "default": true
         },
+        "readiness_check" : {
+          "description" : "Readiness check settings",
+          "type": "object",
+          "properties": {
+            "interval": {
+              "type": "integer",
+              "description": "The period in seconds to wait after the last readiness check has completed to start the next check.",
+              "default": 30
+            },
+            "delay": {
+              "type": "integer",
+              "description": "An amount of time in seconds to wait before starting the readiness check attempts.",
+              "default": 30
+            },
+            "timeout": {
+              "type": "integer",
+              "description": "An amount of time in seconds to wait for a readiness check to succeed.",
+              "default": 60
+            }
+          }
+        },
         "lagging_tx_count": {
           "description": "The number of transactions that this JournalNode is lagging",
           "type": "string",
@@ -549,6 +570,27 @@
           "media": {
             "type": "application/x-zone-constraints+json"
           }
+        },
+        "readiness_check" : {
+          "description" : "Readiness check settings",
+          "type": "object",
+          "properties": {
+            "interval": {
+              "type": "integer",
+              "description": "The period in seconds to wait after the last readiness check has completed to start the next check.",
+              "default": 5
+            },
+            "delay": {
+              "type": "integer",
+              "description": "An amount of time in seconds to wait before starting the readiness check attempts.",
+              "default": 0
+            },
+            "timeout": {
+              "type": "integer",
+              "description": "An amount of time in seconds to wait for a readiness check to succeed.",
+              "default": 180
+            }
+          }
         }
       },
       "required": [
@@ -797,6 +839,27 @@
           "type": "string",
           "description": "JVM options to specify when running the data node. This overrides HADOOP_HEAPSIZE Xmx value for the data nodes.",
           "default": ""
+        },
+        "readiness_check" : {
+          "description" : "Readiness check settings",
+          "type": "object",
+          "properties": {
+            "interval": {
+              "type": "integer",
+              "description": "The period in seconds to wait after the last readiness check has completed to start the next check.",
+              "default": 10
+            },
+            "delay": {
+              "type": "integer",
+              "description": "An amount of time in seconds to wait before starting the readiness check attempts.",
+              "default": 120
+            },
+            "timeout": {
+              "type": "integer",
+              "description": "An amount of time in seconds to wait for a readiness check to succeed.",
+              "default": 60
+            }
+          }
         }
       },
       "required": [

--- a/frameworks/hdfs/universe/marathon.json.mustache
+++ b/frameworks/hdfs/universe/marathon.json.mustache
@@ -85,11 +85,22 @@
     {{#journal_node.enable_readiness_check}}
     "JOURNAL_READINESS_CHECK_ENABLED": "{{journal_node.enable_readiness_check}}",
     "TASKCFG_ALL_JOURNAL_READINESS_CHECK_ENABLED": "{{journal_node.enable_readiness_check}}",
+    "JOURNAL_NODE_READINESS_CHECK_DELAY": "{{journal_node.readiness_check.delay}}",
+    "JOURNAL_NODE_READINESS_CHECK_INTERVAL": "{{journal_node.readiness_check.interval}}",
+    "JOURNAL_NODE_READINESS_CHECK_TIMEOUT": "{{journal_node.readiness_check.timeout}}",
     {{/journal_node.enable_readiness_check}}
 
     "JOURNAL_NODE_PLACEMENT": "{{{journal_node.placement}}}",
     "NAME_NODE_PLACEMENT": "{{{name_node.placement}}}",
     "DATA_NODE_PLACEMENT": "{{{data_node.placement}}}",
+
+    "NAME_NODE_READINESS_CHECK_DELAY": "{{name_node.readiness_check.delay}}",
+    "NAME_NODE_READINESS_CHECK_INTERVAL": "{{name_node.readiness_check.interval}}",
+    "NAME_NODE_READINESS_CHECK_TIMEOUT": "{{name_node.readiness_check.timeout}}",
+
+    "DATA_NODE_READINESS_CHECK_DELAY": "{{data_node.readiness_check.delay}}",
+    "DATA_NODE_READINESS_CHECK_INTERVAL": "{{data_node.readiness_check.interval}}",
+    "DATA_NODE_READINESS_CHECK_TIMEOUT": "{{name_node.readiness_check.timeout}}",
 
     {{#service.security.kerberos.enabled}}
     "SECURITY_KERBEROS_KEYTAB_SECRET": "{{service.security.kerberos.keytab_secret}}",

--- a/frameworks/helloworld/src/main/dist/svc.yml
+++ b/frameworks/helloworld/src/main/dist/svc.yml
@@ -69,7 +69,7 @@ pods:
           # so send the error to /dev/null, BUT also zero-left-pad the variable BYTES to ensure that it is zero
           # on empty for comparison sake.
           cmd: BYTES="$(wc -c world-container-path2/output 2>/dev/null| awk '{print $1;}')" && [ 0$BYTES -gt 0 ]
-          interval: 5
-          delay: 0
-          timeout: 10
+          interval: {{WORLD_READINESS_CHECK_INTERVAL}}
+          delay: {{WORLD_READINESS_CHECK_DELAY}}
+          timeout: {{WORLD_READINESS_CHECK_TIMEOUT}}
         kill-grace-period: {{WORLD_KILL_GRACE_PERIOD}}

--- a/frameworks/helloworld/universe/config.json
+++ b/frameworks/helloworld/universe/config.json
@@ -237,6 +237,27 @@
           "description": "The number of seconds of grace to await a clean shutdown following SIGTERM before sending SIGKILL, default: `0`",
           "type": "integer",
           "default": 0
+        },
+        "readiness_check" : {
+          "description" : "Readiness check settings",
+          "type": "object",
+          "properties": {
+            "interval": {
+              "type": "integer",
+              "description": "The period in seconds to wait after the last readiness check has completed to start the next check.",
+              "default": 60
+            },
+            "delay": {
+              "type": "integer",
+              "description": "An amount of time in seconds to wait before starting the readiness check attempts.",
+              "default": 0
+            },
+            "timeout": {
+              "type": "integer",
+              "description": "An amount of time in seconds to wait for a readiness check to succeed.",
+              "default": 20
+            }
+          }
         }
       },
       "required": [

--- a/frameworks/helloworld/universe/marathon.json.mustache
+++ b/frameworks/helloworld/universe/marathon.json.mustache
@@ -91,7 +91,11 @@
     "NGINX_CONTAINER_VERSION": "{{tls.nginx_container_version}}",
     "TEST_BOOLEAN": "{{service.test_boolean}}",
     "SCENARIO": "{{service.scenario}}",
-    "ALLOW_REGION_AWARENESS": "{{service.allow_region_awareness}}"
+    "ALLOW_REGION_AWARENESS": "{{service.allow_region_awareness}}",
+
+    "WORLD_READINESS_CHECK_INTERVAL": "{{world.readiness_check.interval}}",
+    "WORLD_READINESS_CHECK_DELAY": "{{world.readiness_check.delay}}",
+    "WORLD_READINESS_CHECK_TIMEOUT": "{{world.readiness_check.timeout}}"
   },
   "uris": [
     "{{resource.assets.uris.bootstrap-zip}}",

--- a/frameworks/kafka/src/main/dist/svc.yml
+++ b/frameworks/kafka/src/main/dist/svc.yml
@@ -140,9 +140,9 @@ pods:
             fi
             echo "Required log line found. Broker is ready."
             exit 0
-          interval: 5
-          delay: 0
-          timeout: 10
+          interval: {{READINESS_CHECK_INTERVAL}}
+          delay: {{READINESS_CHECK_DELAY}}
+          timeout: {{READINESS_CHECK_TIMEOUT}}
         {{#TASKCFG_ALL_SECURITY_TRANSPORT_ENCRYPTION_ENABLED}}
         transport-encryption:
           - name: broker

--- a/frameworks/kafka/universe/config.json
+++ b/frameworks/kafka/universe/config.json
@@ -227,6 +227,27 @@
               "description": "A custom domain to be used in place of autoip.dcos.thisdcos.directory. This can be used to expose the service securely outside of the cluster, but requires setting up external DNS. See the service documentation for details."
             }
           }
+        },
+        "readiness_check" : {
+          "description" : "Readiness check settings",
+          "type": "object",
+          "properties": {
+            "interval": {
+              "type": "integer",
+              "description": "The period in seconds to wait after the last readiness check has completed to start the next check.",
+              "default": 60
+            },
+            "delay": {
+              "type": "integer",
+              "description": "An amount of time in seconds to wait before starting the readiness check attempts.",
+              "default": 0
+            },
+            "timeout": {
+              "type": "integer",
+              "description": "An amount of time in seconds to wait for a readiness check to succeed.",
+              "default": 20
+            }
+          }
         }
       },
       "required": [

--- a/frameworks/kafka/universe/marathon.json.mustache
+++ b/frameworks/kafka/universe/marathon.json.mustache
@@ -248,7 +248,11 @@
     "TASKCFG_ALL_KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR": "{{kafka.transaction_state_log_replication_factor}}",
     "TASKCFG_ALL_KAFKA_TRANSACTION_STATE_LOG_MIN_ISR": "{{kafka.transaction_state_log_min_isr}}",
     "TASKCFG_ALL_KAFKA_REPLICATION_QUOTA_WINDOW_NUM": "{{kafka.replication_quota_window_num}}",
-    "TASKCFG_ALL_KAFKA_REPLICATION_QUOTA_WINDOW_SIZE_SECONDS": "{{kafka.replication_quota_window_size_seconds}}"
+    "TASKCFG_ALL_KAFKA_REPLICATION_QUOTA_WINDOW_SIZE_SECONDS": "{{kafka.replication_quota_window_size_seconds}}",
+
+    "READINESS_CHECK_INTERVAL": "{{service.readiness_check.interval}}",
+    "READINESS_CHECK_DELAY": "{{service.readiness_check.delay}}",
+    "READINESS_CHECK_TIMEOUT": "{{service.readiness_check.timeout}}"
   },
   "uris": [
     "{{resource.assets.uris.bootstrap-zip}}",


### PR DESCRIPTION
Make readiness-check interval, timeout and delay configurable for the following:
- Cassandra
- Kafka
- HDFS (current defaults maintained for journal-node, name-node and data-node)
- Elasticsearch
- Hello-World

Default readiness interval is set to 60 and timeout to 20 to match Marathon default values.
