### PR TITLE
COPS-4320: Configurable timeouts for readiness checks.

### DIFF
--- a/frameworks/cassandra/src/main/dist/svc.yml
+++ b/frameworks/cassandra/src/main/dist/svc.yml
@@ -77,9 +77,9 @@ pods:
                 export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jdk*/jre/) ;
                 export TASK_IP=$(./bootstrap --get-task-ip) &&
                 ./apache-cassandra-{{CASSANDRA_VERSION}}/bin/nodetool status -p {{TASKCFG_ALL_JMX_PORT}} | grep -q "UN  $TASK_IP"
-          interval: 5
-          delay: 0
-          timeout: 60
+          interval: {{READINESS_CHECK_INTERVAL}}
+          delay: {{READINESS_CHECK_DELAY}}
+          timeout: {{READINESS_CHECK_TIMEOUT}}
         {{#TASKCFG_ALL_SECURITY_TRANSPORT_ENCRYPTION_ENABLED}}
         transport-encryption:
           - name: node

--- a/frameworks/cassandra/universe/config.json
+++ b/frameworks/cassandra/universe/config.json
@@ -108,7 +108,28 @@
               }
             }
           }
-        }
+        },
+        "readiness_check" : {
+          "description" : "Readiness check settings",
+          "type": "object",
+          "properties": {
+            "interval": {
+              "type": "integer",
+              "description": "The period in seconds to wait after the last readiness check has completed to start the next check.",
+              "default": 60
+            },
+            "delay": {
+              "type": "integer",
+              "description": "An amount of time in seconds to wait before starting the readiness check attempts.",
+              "default": 0
+            },
+            "timeout": {
+              "type": "integer",
+              "description": "An amount of time in seconds to wait for a readiness check to succeed.",
+              "default": 20
+            }
+          }
+         }
       },
       "required": [
         "name",

--- a/frameworks/cassandra/universe/config.json
+++ b/frameworks/cassandra/universe/config.json
@@ -110,13 +110,13 @@
           }
         },
         "readiness_check" : {
-          "description" : "Readiness check settings",
+          "description" : "Readiness check settings. Excercise caution when modifying these default values as it can lead to spurious task failures.",
           "type": "object",
           "properties": {
             "interval": {
               "type": "integer",
               "description": "The period in seconds to wait after the last readiness check has completed to start the next check.",
-              "default": 60
+              "default": 5
             },
             "delay": {
               "type": "integer",
@@ -126,7 +126,7 @@
             "timeout": {
               "type": "integer",
               "description": "An amount of time in seconds to wait for a readiness check to succeed.",
-              "default": 20
+              "default": 60
             }
           }
          }

--- a/frameworks/cassandra/universe/config.json
+++ b/frameworks/cassandra/universe/config.json
@@ -116,17 +116,20 @@
             "interval": {
               "type": "integer",
               "description": "The period in seconds to wait after the last readiness check has completed to start the next check.",
-              "default": 5
+              "default": 5,
+              "minimum": 5
             },
             "delay": {
               "type": "integer",
               "description": "An amount of time in seconds to wait before starting the readiness check attempts.",
-              "default": 0
+              "default": 0,
+              "minimum": 0
             },
             "timeout": {
               "type": "integer",
               "description": "An amount of time in seconds to wait for a readiness check to succeed.",
-              "default": 60
+              "default": 60,
+              "minimum": 60
             }
           }
          }

--- a/frameworks/cassandra/universe/marathon.json.mustache
+++ b/frameworks/cassandra/universe/marathon.json.mustache
@@ -169,7 +169,11 @@
     "CASSANDRA_URI": "{{resource.assets.uris.cassandra-tar-gz}}",
     "JAVA_URI": "{{resource.assets.uris.jre-tar-gz}}",
     "LIBMESOS_URI": "{{resource.assets.uris.libmesos-bundle-tar-gz}}",
-    "BACKUP_RESTORE_STRATEGY": "{{service.backup_restore_strategy}}"
+    "BACKUP_RESTORE_STRATEGY": "{{service.backup_restore_strategy}}",
+
+    "READINESS_CHECK_INTERVAL": "{{service.readiness_check.interval}}",
+    "READINESS_CHECK_DELAY": "{{service.readiness_check.delay}}",
+    "READINESS_CHECK_TIMEOUT": "{{service.readiness_check.timeout}}"
   },
   "fetch": [
     { "uri": "{{resource.assets.uris.bootstrap-zip}}", "cache": true },

--- a/frameworks/elastic/src/main/dist/svc.yml
+++ b/frameworks/elastic/src/main/dist/svc.yml
@@ -85,9 +85,9 @@ pods:
             dest: scripts/setup-java-policy.sh
         readiness-check:
           cmd: "curl -k -I -s -f -u {{ELASTICSEARCH_HEALTH_USER}}:{{ELASTICSEARCH_HEALTH_USER_PASSWORD}} {{ELASTICSEARCH_HEALTH_PROTOCOL}}://$TASK_NAME.$FRAMEWORK_HOST:$PORT_HTTP"
-          interval: 5
-          delay: 0
-          timeout: 10
+          interval: {{MASTER_NODE_READINESS_CHECK_INTERVAL}}
+          delay: {{MASTER_NODE_READINESS_CHECK_DELAY}}
+          timeout: {{MASTER_NODE_READINESS_CHECK_TIMEOUT}}
         {{#TASKCFG_ALL_SECURITY_TRANSPORT_ENCRYPTION_ENABLED}}
         transport-encryption:
           - name: node
@@ -173,9 +173,9 @@ pods:
             dest: scripts/setup-java-policy.sh
         readiness-check:
           cmd: "curl -k -I -s -f -u {{ELASTICSEARCH_HEALTH_USER}}:{{ELASTICSEARCH_HEALTH_USER_PASSWORD}} {{ELASTICSEARCH_HEALTH_PROTOCOL}}://$TASK_NAME.$FRAMEWORK_HOST:$PORT_HTTP"
-          interval: 5
-          delay: 0
-          timeout: 10
+          interval: {{DATA_NODE_READINESS_CHECK_INTERVAL}}
+          delay: {{DATA_NODE_READINESS_CHECK_DELAY}}
+          timeout: {{DATA_NODE_READINESS_CHECK_TIMEOUT}}
         {{#TASKCFG_ALL_SECURITY_TRANSPORT_ENCRYPTION_ENABLED}}
         transport-encryption:
           - name: node
@@ -261,9 +261,9 @@ pods:
             dest: scripts/setup-java-policy.sh
         readiness-check:
           cmd: "curl -k -I -s -f -u {{ELASTICSEARCH_HEALTH_USER}}:{{ELASTICSEARCH_HEALTH_USER_PASSWORD}} {{ELASTICSEARCH_HEALTH_PROTOCOL}}://$TASK_NAME.$FRAMEWORK_HOST:$PORT_HTTP"
-          interval: 5
-          delay: 0
-          timeout: 10
+          interval: {{INGEST_NODE_READINESS_CHECK_INTERVAL}}
+          delay: {{INGEST_NODE_READINESS_CHECK_DELAY}}
+          timeout: {{INGEST_NODE_READINESS_CHECK_TIMEOUT}}
         {{#TASKCFG_ALL_SECURITY_TRANSPORT_ENCRYPTION_ENABLED}}
         transport-encryption:
           - name: node
@@ -349,9 +349,9 @@ pods:
             dest: scripts/setup-java-policy.sh
         readiness-check:
           cmd: "curl -k -I -s -f -u {{ELASTICSEARCH_HEALTH_USER}}:{{ELASTICSEARCH_HEALTH_USER_PASSWORD}} {{ELASTICSEARCH_HEALTH_PROTOCOL}}://$TASK_NAME.$FRAMEWORK_HOST:$PORT_HTTP"
-          interval: 5
-          delay: 0
-          timeout: 10
+          interval: {{COORDINATOR_NODE_READINESS_CHECK_INTERVAL}}
+          delay: {{COORDINATOR_NODE_READINESS_CHECK_DELAY}}
+          timeout: {{COORDINATOR_NODE_READINESS_CHECK_TIMEOUT}}
         {{#TASKCFG_ALL_SECURITY_TRANSPORT_ENCRYPTION_ENABLED}}
         transport-encryption:
           - name: node

--- a/frameworks/elastic/universe/config.json
+++ b/frameworks/elastic/universe/config.json
@@ -166,17 +166,20 @@
             "interval": {
               "type": "integer",
               "description": "The period in seconds to wait after the last readiness check has completed to start the next check.",
-              "default": 5
+              "default": 5,
+              "minimum": 5
             },
             "delay": {
               "type": "integer",
               "description": "An amount of time in seconds to wait before starting the readiness check attempts.",
-              "default": 0
+              "default": 0,
+              "minimum": 0
             },
             "timeout": {
               "type": "integer",
               "description": "An amount of time in seconds to wait for a readiness check to succeed.",
-              "default": 10
+              "default": 10,
+              "minimum": 10
             }
           }
         }
@@ -248,17 +251,20 @@
             "interval": {
               "type": "integer",
               "description": "The period in seconds to wait after the last readiness check has completed to start the next check.",
-              "default": 5
+              "default": 5,
+              "minimum": 5
             },
             "delay": {
               "type": "integer",
               "description": "An amount of time in seconds to wait before starting the readiness check attempts.",
-              "default": 0
+              "default": 0,
+              "minimum": 0
             },
             "timeout": {
               "type": "integer",
               "description": "An amount of time in seconds to wait for a readiness check to succeed.",
-              "default": 10
+              "default": 10,
+              "minimum": 10
             }
           }
         }
@@ -330,17 +336,20 @@
             "interval": {
               "type": "integer",
               "description": "The period in seconds to wait after the last readiness check has completed to start the next check.",
-              "default": 5
+              "default": 5,
+              "minimum": 5
             },
             "delay": {
               "type": "integer",
               "description": "An amount of time in seconds to wait before starting the readiness check attempts.",
-              "default": 0
+              "default": 0,
+              "minimum": 0
             },
             "timeout": {
               "type": "integer",
               "description": "An amount of time in seconds to wait for a readiness check to succeed.",
-              "default": 10
+              "default": 10,
+              "minimum": 10
             }
           }
         }
@@ -412,17 +421,20 @@
             "interval": {
               "type": "integer",
               "description": "The period in seconds to wait after the last readiness check has completed to start the next check.",
-              "default": 5
+              "default": 5,
+              "minimum": 5
             },
             "delay": {
               "type": "integer",
               "description": "An amount of time in seconds to wait before starting the readiness check attempts.",
-              "default": 0
+              "default": 0,
+              "minimum": 0
             },
             "timeout": {
               "type": "integer",
               "description": "An amount of time in seconds to wait for a readiness check to succeed.",
-              "default": 10
+              "default": 10,
+              "minimum": 10
             }
           }
         }

--- a/frameworks/elastic/universe/config.json
+++ b/frameworks/elastic/universe/config.json
@@ -160,13 +160,13 @@
           }
         },
         "readiness_check" : {
-          "description" : "Readiness check settings",
+          "description" : "Readiness check settings. Excercise caution when modifying these default values as it can lead to spurious task failures.",
           "type": "object",
           "properties": {
             "interval": {
               "type": "integer",
               "description": "The period in seconds to wait after the last readiness check has completed to start the next check.",
-              "default": 60
+              "default": 5
             },
             "delay": {
               "type": "integer",
@@ -176,7 +176,7 @@
             "timeout": {
               "type": "integer",
               "description": "An amount of time in seconds to wait for a readiness check to succeed.",
-              "default": 20
+              "default": 10
             }
           }
         }
@@ -242,13 +242,13 @@
           }
         },
         "readiness_check" : {
-          "description" : "Readiness check settings",
+          "description" : "Readiness check settings. Excercise caution when modifying these default values as it can lead to spurious task failures.",
           "type": "object",
           "properties": {
             "interval": {
               "type": "integer",
               "description": "The period in seconds to wait after the last readiness check has completed to start the next check.",
-              "default": 60
+              "default": 5
             },
             "delay": {
               "type": "integer",
@@ -258,7 +258,7 @@
             "timeout": {
               "type": "integer",
               "description": "An amount of time in seconds to wait for a readiness check to succeed.",
-              "default": 20
+              "default": 10
             }
           }
         }
@@ -324,13 +324,13 @@
           }
         },
         "readiness_check" : {
-          "description" : "Readiness check settings",
+          "description" : "Readiness check settings. Excercise caution when modifying these default values as it can lead to spurious task failures.",
           "type": "object",
           "properties": {
             "interval": {
               "type": "integer",
               "description": "The period in seconds to wait after the last readiness check has completed to start the next check.",
-              "default": 60
+              "default": 5
             },
             "delay": {
               "type": "integer",
@@ -340,7 +340,7 @@
             "timeout": {
               "type": "integer",
               "description": "An amount of time in seconds to wait for a readiness check to succeed.",
-              "default": 20
+              "default": 10
             }
           }
         }
@@ -406,13 +406,13 @@
           }
         },
         "readiness_check" : {
-          "description" : "Readiness check settings",
+          "description" : "Readiness check settings. Excercise caution when modifying these default values as it can lead to spurious task failures.",
           "type": "object",
           "properties": {
             "interval": {
               "type": "integer",
               "description": "The period in seconds to wait after the last readiness check has completed to start the next check.",
-              "default": 60
+              "default": 5
             },
             "delay": {
               "type": "integer",
@@ -422,7 +422,7 @@
             "timeout": {
               "type": "integer",
               "description": "An amount of time in seconds to wait for a readiness check to succeed.",
-              "default": 20
+              "default": 10
             }
           }
         }

--- a/frameworks/elastic/universe/config.json
+++ b/frameworks/elastic/universe/config.json
@@ -158,6 +158,27 @@
           "media": {
             "type": "application/x-zone-constraints+json"
           }
+        },
+        "readiness_check" : {
+          "description" : "Readiness check settings",
+          "type": "object",
+          "properties": {
+            "interval": {
+              "type": "integer",
+              "description": "The period in seconds to wait after the last readiness check has completed to start the next check.",
+              "default": 60
+            },
+            "delay": {
+              "type": "integer",
+              "description": "An amount of time in seconds to wait before starting the readiness check attempts.",
+              "default": 0
+            },
+            "timeout": {
+              "type": "integer",
+              "description": "An amount of time in seconds to wait for a readiness check to succeed.",
+              "default": 20
+            }
+          }
         }
       },
       "required": [
@@ -218,6 +239,27 @@
           "default": "[[\"hostname\", \"UNIQUE\"]]",
           "media": {
             "type": "application/x-zone-constraints+json"
+          }
+        },
+        "readiness_check" : {
+          "description" : "Readiness check settings",
+          "type": "object",
+          "properties": {
+            "interval": {
+              "type": "integer",
+              "description": "The period in seconds to wait after the last readiness check has completed to start the next check.",
+              "default": 60
+            },
+            "delay": {
+              "type": "integer",
+              "description": "An amount of time in seconds to wait before starting the readiness check attempts.",
+              "default": 0
+            },
+            "timeout": {
+              "type": "integer",
+              "description": "An amount of time in seconds to wait for a readiness check to succeed.",
+              "default": 20
+            }
           }
         }
       },
@@ -280,6 +322,27 @@
           "media": {
             "type": "application/x-zone-constraints+json"
           }
+        },
+        "readiness_check" : {
+          "description" : "Readiness check settings",
+          "type": "object",
+          "properties": {
+            "interval": {
+              "type": "integer",
+              "description": "The period in seconds to wait after the last readiness check has completed to start the next check.",
+              "default": 60
+            },
+            "delay": {
+              "type": "integer",
+              "description": "An amount of time in seconds to wait before starting the readiness check attempts.",
+              "default": 0
+            },
+            "timeout": {
+              "type": "integer",
+              "description": "An amount of time in seconds to wait for a readiness check to succeed.",
+              "default": 20
+            }
+          }
         }
       },
       "required": [
@@ -340,6 +403,27 @@
           "default": "[[\"hostname\", \"UNIQUE\"]]",
           "media": {
             "type": "application/x-zone-constraints+json"
+          }
+        },
+        "readiness_check" : {
+          "description" : "Readiness check settings",
+          "type": "object",
+          "properties": {
+            "interval": {
+              "type": "integer",
+              "description": "The period in seconds to wait after the last readiness check has completed to start the next check.",
+              "default": 60
+            },
+            "delay": {
+              "type": "integer",
+              "description": "An amount of time in seconds to wait before starting the readiness check attempts.",
+              "default": 0
+            },
+            "timeout": {
+              "type": "integer",
+              "description": "An amount of time in seconds to wait for a readiness check to succeed.",
+              "default": 20
+            }
           }
         }
       },

--- a/frameworks/elastic/universe/marathon.json.mustache
+++ b/frameworks/elastic/universe/marathon.json.mustache
@@ -328,7 +328,23 @@
     {{#elasticsearch.indices_requests_cache_size}}
     "TASKCFG_ALL_INDICES_REQUESTS_CACHE_SIZE": "{{elasticsearch.indices_requests_cache_size}}",
     {{/elasticsearch.indices_requests_cache_size}}
-    "CUSTOM_YAML_BLOCK_BASE64": "{{elasticsearch.custom_elasticsearch_yml}}"
+    "CUSTOM_YAML_BLOCK_BASE64": "{{elasticsearch.custom_elasticsearch_yml}}",
+
+    "MASTER_NODE_READINESS_CHECK_INTERVAL": "{{master_nodes.readiness_check.interval}}",
+    "MASTER_NODE_READINESS_CHECK_DELAY": "{{master_nodes.readiness_check.delay}}",
+    "MASTER_NODE_READINESS_CHECK_TIMEOUT": "{{master_nodes.readiness_check.timeout}}",
+
+    "DATA_NODE_READINESS_CHECK_INTERVAL": "{{data_nodes.readiness_check.interval}}",
+    "DATA_NODE_READINESS_CHECK_DELAY": "{{data_nodes.readiness_check.delay}}",
+    "DATA_NODE_READINESS_CHECK_TIMEOUT": "{{data_nodes.readiness_check.timeout}}",
+
+    "INGEST_NODE_READINESS_CHECK_INTERVAL": "{{ingest_nodes.readiness_check.interval}}",
+    "INGEST_NODE_READINESS_CHECK_DELAY": "{{ingest_nodes.readiness_check.delay}}",
+    "INGEST_NODE_READINESS_CHECK_TIMEOUT": "{{ingest_nodes.readiness_check.timeout}}",
+
+    "COORDINATOR_NODE_READINESS_CHECK_INTERVAL": "{{coordinator_nodes.readiness_check.interval}}",
+    "COORDINATOR_NODE_READINESS_CHECK_DELAY": "{{coordinator_nodes.readiness_check.delay}}",
+    "COORDINATOR_NODE_READINESS_CHECK_TIMEOUT": "{{coordinator_nodes.readiness_check.timeout}}"
   },
   "fetch": [
     { "uri": "{{resource.assets.uris.bootstrap-zip}}", "cache": true },

--- a/frameworks/hdfs/src/main/dist/svc.yml
+++ b/frameworks/hdfs/src/main/dist/svc.yml
@@ -129,9 +129,9 @@ pods:
               # give it a chance to roll completely and start a new edits segment
               sleep 30
             fi
-          delay: 30
-          interval: 30
-          timeout: 60
+          delay: {{JOURNAL_NODE_READINESS_CHECK_DELAY}}
+          interval: {{JOURNAL_NODE_READINESS_CHECK_INTERVAL}}
+          timeout: {{JOURNAL_NODE_READINESS_CHECK_TIMEOUT}}
         {{/JOURNAL_READINESS_CHECK_ENABLED}}
         {{#SECURITY_TRANSPORT_ENCRYPTION_ENABLED}}
         transport-encryption:
@@ -219,9 +219,9 @@ pods:
             KRB5_CONFIG=$MESOS_SANDBOX/{{TASKCFG_ALL_HDFS_VERSION}}/etc/hadoop/krb5.conf kinit -k -t $MESOS_SANDBOX/hdfs.keytab $SECURITY_KERBEROS_PRIMARY/$TASK_NAME.$FRAMEWORK_HOST@$SECURITY_KERBEROS_REALM
             {{/SECURITY_KERBEROS_ENABLED}}
             ./{{TASKCFG_ALL_HDFS_VERSION}}/bin/hdfs haadmin -getServiceState $TASK_NAME
-          interval: 5
-          delay: 0
-          timeout: 180
+          interval: {{NAME_NODE_READINESS_CHECK_INTERVAL}}
+          delay: {{NAME_NODE_READINESS_CHECK_DELAY}}
+          timeout: {{NAME_NODE_READINESS_CHECK_TIMEOUT}}
         configs:
           {{#SECURITY_KERBEROS_ENABLED}}
           krb5-conf:
@@ -494,9 +494,9 @@ pods:
             export TASK_IP=$(./bootstrap --get-task-ip)
             MATCH="$(./{{TASKCFG_ALL_HDFS_VERSION}}/bin/hdfs dfsadmin -report | grep $TASK_IP | wc -l)"
             [[ $MATCH -ge 1 ]]
-          interval: 10
-          delay: 120
-          timeout: 60
+          interval: {{DATA_NODE_READINESS_CHECK_INTERVAL}}
+          delay: {{DATA_NODE_READINESS_CHECK_DELAY}}
+          timeout: {{DATA_NODE_READINESS_CHECK_TIMEOUT}}
         {{#SECURITY_TRANSPORT_ENCRYPTION_ENABLED}}
         transport-encryption:
           - name: node

--- a/frameworks/hdfs/universe/config.json
+++ b/frameworks/hdfs/universe/config.json
@@ -169,6 +169,27 @@
           "type": "boolean",
           "default": true
         },
+        "readiness_check" : {
+          "description" : "Readiness check settings",
+          "type": "object",
+          "properties": {
+            "interval": {
+              "type": "integer",
+              "description": "The period in seconds to wait after the last readiness check has completed to start the next check.",
+              "default": 30
+            },
+            "delay": {
+              "type": "integer",
+              "description": "An amount of time in seconds to wait before starting the readiness check attempts.",
+              "default": 30
+            },
+            "timeout": {
+              "type": "integer",
+              "description": "An amount of time in seconds to wait for a readiness check to succeed.",
+              "default": 60
+            }
+          }
+        },
         "lagging_tx_count": {
           "description": "The number of transactions that this JournalNode is lagging",
           "type": "string",
@@ -541,6 +562,27 @@
           "media": {
             "type": "application/x-zone-constraints+json"
           }
+        },
+        "readiness_check" : {
+          "description" : "Readiness check settings",
+          "type": "object",
+          "properties": {
+            "interval": {
+              "type": "integer",
+              "description": "The period in seconds to wait after the last readiness check has completed to start the next check.",
+              "default": 5
+            },
+            "delay": {
+              "type": "integer",
+              "description": "An amount of time in seconds to wait before starting the readiness check attempts.",
+              "default": 0
+            },
+            "timeout": {
+              "type": "integer",
+              "description": "An amount of time in seconds to wait for a readiness check to succeed.",
+              "default": 180
+            }
+          }
         }
       },
       "required": [
@@ -789,6 +831,27 @@
           "type": "string",
           "description": "JVM options to specify when running the data node. This overrides HADOOP_HEAPSIZE Xmx value for the data nodes.",
           "default": ""
+        },
+        "readiness_check" : {
+          "description" : "Readiness check settings",
+          "type": "object",
+          "properties": {
+            "interval": {
+              "type": "integer",
+              "description": "The period in seconds to wait after the last readiness check has completed to start the next check.",
+              "default": 10
+            },
+            "delay": {
+              "type": "integer",
+              "description": "An amount of time in seconds to wait before starting the readiness check attempts.",
+              "default": 120
+            },
+            "timeout": {
+              "type": "integer",
+              "description": "An amount of time in seconds to wait for a readiness check to succeed.",
+              "default": 60
+            }
+          }
         }
       },
       "required": [

--- a/frameworks/hdfs/universe/config.json
+++ b/frameworks/hdfs/universe/config.json
@@ -170,7 +170,7 @@
           "default": true
         },
         "readiness_check" : {
-          "description" : "Readiness check settings",
+          "description" : "Readiness check settings. Excercise caution when modifying these default values as it can lead to spurious task failures.",
           "type": "object",
           "properties": {
             "interval": {
@@ -564,7 +564,7 @@
           }
         },
         "readiness_check" : {
-          "description" : "Readiness check settings",
+          "description" : "Readiness check settings. Excercise caution when modifying these default values as it can lead to spurious task failures.",
           "type": "object",
           "properties": {
             "interval": {
@@ -833,7 +833,7 @@
           "default": ""
         },
         "readiness_check" : {
-          "description" : "Readiness check settings",
+          "description" : "Readiness check settings. Excercise caution when modifying these default values as it can lead to spurious task failures.",
           "type": "object",
           "properties": {
             "interval": {

--- a/frameworks/hdfs/universe/config.json
+++ b/frameworks/hdfs/universe/config.json
@@ -176,17 +176,20 @@
             "interval": {
               "type": "integer",
               "description": "The period in seconds to wait after the last readiness check has completed to start the next check.",
-              "default": 30
+              "default": 30,
+              "minimum": 30
             },
             "delay": {
               "type": "integer",
               "description": "An amount of time in seconds to wait before starting the readiness check attempts.",
-              "default": 30
+              "default": 30,
+              "minimum": 30
             },
             "timeout": {
               "type": "integer",
               "description": "An amount of time in seconds to wait for a readiness check to succeed.",
-              "default": 60
+              "default": 60,
+              "minimum": 60
             }
           }
         },
@@ -570,17 +573,20 @@
             "interval": {
               "type": "integer",
               "description": "The period in seconds to wait after the last readiness check has completed to start the next check.",
-              "default": 5
+              "default": 5,
+              "minimum": 5
             },
             "delay": {
               "type": "integer",
               "description": "An amount of time in seconds to wait before starting the readiness check attempts.",
-              "default": 0
+              "default": 0,
+              "minimum": 0
             },
             "timeout": {
               "type": "integer",
               "description": "An amount of time in seconds to wait for a readiness check to succeed.",
-              "default": 180
+              "default": 180,
+              "minimum": 180
             }
           }
         }
@@ -839,17 +845,20 @@
             "interval": {
               "type": "integer",
               "description": "The period in seconds to wait after the last readiness check has completed to start the next check.",
-              "default": 10
+              "default": 10,
+              "minimum": 10
             },
             "delay": {
               "type": "integer",
               "description": "An amount of time in seconds to wait before starting the readiness check attempts.",
-              "default": 120
+              "default": 120,
+              "minimum": 120
             },
             "timeout": {
               "type": "integer",
               "description": "An amount of time in seconds to wait for a readiness check to succeed.",
-              "default": 60
+              "default": 60,
+              "minimum": 60
             }
           }
         }

--- a/frameworks/hdfs/universe/marathon.json.mustache
+++ b/frameworks/hdfs/universe/marathon.json.mustache
@@ -92,11 +92,22 @@
     {{#journal_node.enable_readiness_check}}
     "JOURNAL_READINESS_CHECK_ENABLED": "{{journal_node.enable_readiness_check}}",
     "TASKCFG_ALL_JOURNAL_READINESS_CHECK_ENABLED": "{{journal_node.enable_readiness_check}}",
+    "JOURNAL_NODE_READINESS_CHECK_DELAY": "{{journal_node.readiness_check.delay}}",
+    "JOURNAL_NODE_READINESS_CHECK_INTERVAL": "{{journal_node.readiness_check.interval}}",
+    "JOURNAL_NODE_READINESS_CHECK_TIMEOUT": "{{journal_node.readiness_check.timeout}}",
     {{/journal_node.enable_readiness_check}}
 
     "JOURNAL_NODE_PLACEMENT": "{{{journal_node.placement}}}",
     "NAME_NODE_PLACEMENT": "{{{name_node.placement}}}",
     "DATA_NODE_PLACEMENT": "{{{data_node.placement}}}",
+
+    "NAME_NODE_READINESS_CHECK_DELAY": "{{name_node.readiness_check.delay}}",
+    "NAME_NODE_READINESS_CHECK_INTERVAL": "{{name_node.readiness_check.interval}}",
+    "NAME_NODE_READINESS_CHECK_TIMEOUT": "{{name_node.readiness_check.timeout}}",
+
+    "DATA_NODE_READINESS_CHECK_DELAY": "{{data_node.readiness_check.delay}}",
+    "DATA_NODE_READINESS_CHECK_INTERVAL": "{{data_node.readiness_check.interval}}",
+    "DATA_NODE_READINESS_CHECK_TIMEOUT": "{{data_node.readiness_check.timeout}}",
 
     {{#service.security.kerberos.enabled}}
     "SECURITY_KERBEROS_KEYTAB_SECRET": "{{service.security.kerberos.keytab_secret}}",

--- a/frameworks/helloworld/src/main/dist/svc.yml
+++ b/frameworks/helloworld/src/main/dist/svc.yml
@@ -70,7 +70,7 @@ pods:
           # so send the error to /dev/null, BUT also zero-left-pad the variable BYTES to ensure that it is zero
           # on empty for comparison sake.
           cmd: BYTES="$(wc -c world-container-path2/output 2>/dev/null| awk '{print $1;}')" && [ 0$BYTES -gt 0 ]
-          interval: 5
-          delay: 0
-          timeout: 10
+          interval: {{WORLD_READINESS_CHECK_INTERVAL}}
+          delay: {{WORLD_READINESS_CHECK_DELAY}}
+          timeout: {{WORLD_READINESS_CHECK_TIMEOUT}}
         kill-grace-period: {{WORLD_KILL_GRACE_PERIOD}}

--- a/frameworks/helloworld/universe/config.json
+++ b/frameworks/helloworld/universe/config.json
@@ -295,13 +295,13 @@
           "default": 0
         },
         "readiness_check" : {
-          "description" : "Readiness check settings",
+          "description" : "Readiness check settings. Excercise caution when modifying these default values as it can lead to spurious task failures.",
           "type": "object",
           "properties": {
             "interval": {
               "type": "integer",
               "description": "The period in seconds to wait after the last readiness check has completed to start the next check.",
-              "default": 60
+              "default": 5
             },
             "delay": {
               "type": "integer",
@@ -311,7 +311,7 @@
             "timeout": {
               "type": "integer",
               "description": "An amount of time in seconds to wait for a readiness check to succeed.",
-              "default": 20
+              "default": 10
             }
           }
         }

--- a/frameworks/helloworld/universe/config.json
+++ b/frameworks/helloworld/universe/config.json
@@ -301,17 +301,20 @@
             "interval": {
               "type": "integer",
               "description": "The period in seconds to wait after the last readiness check has completed to start the next check.",
-              "default": 5
+              "default": 5,
+              "minimum": 5
             },
             "delay": {
               "type": "integer",
               "description": "An amount of time in seconds to wait before starting the readiness check attempts.",
-              "default": 0
+              "default": 0,
+              "minimum": 0
             },
             "timeout": {
               "type": "integer",
               "description": "An amount of time in seconds to wait for a readiness check to succeed.",
-              "default": 10
+              "default": 10,
+              "minimum": 10
             }
           }
         }

--- a/frameworks/helloworld/universe/config.json
+++ b/frameworks/helloworld/universe/config.json
@@ -293,6 +293,27 @@
           "description": "The number of seconds of grace to await a clean shutdown following SIGTERM before sending SIGKILL, default: `0`",
           "type": "integer",
           "default": 0
+        },
+        "readiness_check" : {
+          "description" : "Readiness check settings",
+          "type": "object",
+          "properties": {
+            "interval": {
+              "type": "integer",
+              "description": "The period in seconds to wait after the last readiness check has completed to start the next check.",
+              "default": 60
+            },
+            "delay": {
+              "type": "integer",
+              "description": "An amount of time in seconds to wait before starting the readiness check attempts.",
+              "default": 0
+            },
+            "timeout": {
+              "type": "integer",
+              "description": "An amount of time in seconds to wait for a readiness check to succeed.",
+              "default": 20
+            }
+          }
         }
       },
       "required": [

--- a/frameworks/helloworld/universe/marathon.json.mustache
+++ b/frameworks/helloworld/universe/marathon.json.mustache
@@ -107,7 +107,11 @@
     "ALLOW_REGION_AWARENESS": "{{service.allow_region_awareness}}",
     "HELLO_PORT_ONE": "{{hello.port_one}}",
     "GLOG_v":"{{service.verbose_mesos_logging}}",
-    "TASKCFG_ALL_PACKAGE_VERSION_TO_FORCE_UPDATE": "{{package-version}}"
+    "TASKCFG_ALL_PACKAGE_VERSION_TO_FORCE_UPDATE": "{{package-version}}",
+
+    "WORLD_READINESS_CHECK_INTERVAL": "{{world.readiness_check.interval}}",
+    "WORLD_READINESS_CHECK_DELAY": "{{world.readiness_check.delay}}",
+    "WORLD_READINESS_CHECK_TIMEOUT": "{{world.readiness_check.timeout}}"
   },
   "fetch": [
     { "uri": "{{resource.assets.uris.bootstrap-zip}}", "cache": true },


### PR DESCRIPTION
Make readiness-check interval, timeout and delay configurable for the following:
- Cassandra
- HDFS (current defaults maintained for journal-node, name-node and data-node)
- Elasticsearch
- Hello-World

Default readiness interval is set to 60 and timeout to 20 to match Marathon default values. Values still need to be fine-tuned via discussion through this PR.