### PR TITLE
Fix template package.json to include license fields

### DIFF
--- a/frameworks/cassandra/universe/package.json
+++ b/frameworks/cassandra/universe/package.json
@@ -12,5 +12,11 @@
   "tags": ["cassandra"],
   "preInstallNotes": "Default configuration requires 3 agent nodes each with: 0.5 CPU | 4096 MB MEM | 1 10240 MB Disk",
   "postInstallNotes": "The DC/OS Apache Cassandra service is being installed!\n\n\tDocumentation: {{documentation-path}}\n\tIssues: {{issues-path}}",
-  "postUninstallNotes": "The DC/OS Apache Cassandra service is being uninstalled.\n\nFor DC/OS versions from 1.10 no further action is required. For older DC/OS versions follow the instructions at {{documentation-path}}uninstall to remove any persistent state if required."
+  "postUninstallNotes": "The DC/OS Apache Cassandra service is being uninstalled.\n\nFor DC/OS versions from 1.10 no further action is required. For older DC/OS versions follow the instructions at {{documentation-path}}uninstall to remove any persistent state if required.",
+  "licenses": [
+     {
+       "name": "Apache License Version 2.0",
+       "url": "https://raw.githubusercontent.com/apache/cassandra/trunk/LICENSE.txt"
+     }
+  ]
 }

--- a/frameworks/elastic/universe-kibana/package.json
+++ b/frameworks/elastic/universe-kibana/package.json
@@ -12,5 +12,15 @@
   "tags": ["elastic", "elasticsearch", "kibana", "x-pack"],
   "preInstallNotes": "This DC/OS service is currently a beta candidate undergoing testing as part of a formal beta test program. There may be bugs, incomplete features, incorrect documentation, or other discrepancies.\n\nDefault configuration requires 1 agent node with: 0.5 CPU | 2048 MB MEM\n\nContact Mesosphere before deploying this beta candidate service. Product support is available to approved participants in the beta test program.",
   "postInstallNotes": "The DC/OS Kibana service is being installed!\n\n\tDocumentation: {{documentation-path}}\n\tIssues: {{issues-path}}",
-  "postUninstallNotes": "The DC/OS Kibana service is being uninstalled.\n\nFor DC/OS versions from 1.10 no further action is required. For older DC/OS versions follow the instructions at {{documentation-path}}uninstall to remove any persistent state if required."
+  "postUninstallNotes": "The DC/OS Kibana service is being uninstalled.\n\nFor DC/OS versions from 1.10 no further action is required. For older DC/OS versions follow the instructions at {{documentation-path}}uninstall to remove any persistent state if required.",
+  "licenses": [
+    {
+        "name": "Apache License Version 2.0",
+        "url": "https://raw.githubusercontent.com/elastic/kibana/master/LICENSE.txt"
+    },
+    {
+        "name": "Elastic License",
+        "url": "https://raw.githubusercontent.com/elastic/kibana/master/x-pack/README.md"
+    }
+  ]
 }

--- a/frameworks/elastic/universe/package.json
+++ b/frameworks/elastic/universe/package.json
@@ -12,5 +12,15 @@
   "tags": ["elastic", "elasticsearch", "kibana", "x-pack"],
   "preInstallNotes": "Default configuration requires 3 agent nodes each with: CPU: 4.0 | Memory: 9216MB | Disk: 13500MB\n\nMore specifically, each instance type requires:\n\nMaster node: 3 instances | 1.0 CPU | 2048 MB MEM | 1 2000 MB Disk\n\nData node: 2 instances | 1.0 CPU | 4096 MB MEM | 1 10000 MB Disk\n\nCoordinator node: 1 instance | 1.0 CPU | 2048 MB MEM | 1 1000 MB Disk\n\nIngest node: No instances by default | 0.5 CPU | 2048 MB MEM | 1 2000 MB Disk",
   "postInstallNotes": "The DC/OS Elastic service is being installed!\n\n\tDocumentation: {{documentation-path}}\n\tIssues: {{issues-path}}",
-  "postUninstallNotes": "The DC/OS Elastic service is being uninstalled.\n\nFor DC/OS versions from 1.10 no further action is required. For older DC/OS versions follow the instructions at {{documentation-path}}uninstall to remove any persistent state if required."
+  "postUninstallNotes": "The DC/OS Elastic service is being uninstalled.\n\nFor DC/OS versions from 1.10 no further action is required. For older DC/OS versions follow the instructions at {{documentation-path}}uninstall to remove any persistent state if required.",
+  "licenses": [
+     {
+         "name": "Apache License Version 2.0",
+         "url": "https://raw.githubusercontent.com/elastic/elasticsearch/master/LICENSE.txt"
+     },
+     {
+         "name": "Elastic License",
+         "url": "https://raw.githubusercontent.com/elastic/elasticsearch/master/x-pack/README.md"
+     }
+  ]
 }

--- a/frameworks/hdfs/universe/package.json
+++ b/frameworks/hdfs/universe/package.json
@@ -12,5 +12,11 @@
   "tags": ["hdfs", "hadoop"],
   "preInstallNotes": "Default configuration requires 5 agent nodes each with: CPU: 0.6 | Memory: 4096MB | Disk: 5000MB\n\nMore specifically, each instance type requires:\n\nJournal node: 3 instances | 0.3 CPU | 2048 MB MEM | 1 5000 MB Disk\n\nName node: 2 instances | 0.3 CPU | 2048 MB MEM | 1 5000 MB Disk\n\nZKFC node: 2 instances | 0.3 CPU | 2048 MB MEM\n\nData node: 3 instances | 0.3 CPU | 2048 MB MEM | 1 5000 MB Disk",
   "postInstallNotes": "The DC/OS Apache HDFS service is being installed.\n\n\tDocumentation: {{documentation-path}}\n\tIssues: {{issues-path}}",
-  "postUninstallNotes": "The DC/OS Apache HDFS service is being uninstalled.\n\nFor DC/OS versions from 1.10 no further action is required. For older DC/OS versions follow the instructions at {{documentation-path}}uninstall to remove any persistent state if required."
+  "postUninstallNotes": "The DC/OS Apache HDFS service is being uninstalled.\n\nFor DC/OS versions from 1.10 no further action is required. For older DC/OS versions follow the instructions at {{documentation-path}}uninstall to remove any persistent state if required.",
+  "licenses": [
+     {
+       "name": "Apache License Version 2.0",
+       "url": "https://raw.githubusercontent.com/apache/hadoop/trunk/LICENSE.txt"
+     }
+   ]
 }

--- a/frameworks/helloworld/universe/package.json
+++ b/frameworks/helloworld/universe/package.json
@@ -12,5 +12,11 @@
   "tags": ["example", "reference", "hello-world"],
   "preInstallNotes": "This DC/OS Service is currently in preview.",
   "postInstallNotes": "The DC/OS hello-world service is being installed!\n\n\tDocumentation: {{documentation-path}}\n\tIssues: {{issues-path}}",
-  "postUninstallNotes": "The DC/OS hello-world service is being uninstalled.\n\nFor DC/OS versions from 1.10 no further action is required. For older DC/OS versions follow the instructions at https://docs.mesosphere.com/1.9/deploying-services/uninstall/#framework-cleaner to remove any persistent state if required."
+  "postUninstallNotes": "The DC/OS hello-world service is being uninstalled.\n\nFor DC/OS versions from 1.10 no further action is required. For older DC/OS versions follow the instructions at https://docs.mesosphere.com/1.9/deploying-services/uninstall/#framework-cleaner to remove any persistent state if required.",
+  "licenses": [
+    {
+      "name": "Apache License Version 2.0",
+      "url": "https://raw.githubusercontent.com/mesosphere/dcos-commons/master/LICENSE"
+    }
+  ]
 }


### PR DESCRIPTION
At the request of our legal counsel, all packages in universe need to have the license field set correctly, since we are redistributing the packaged software and correct license attribution is part of our legal obligation. Ravi and I are working through the packages already deployed, but this PR fixes the templates in dcos-commons for future version releases of the frameworks there. 