### PR TITLE
[DCOS-46650] Added a regex name validator for Cassandra to check that stub universe names follow a pattern.

### DIFF
--- a/frameworks/cassandra/universe/config.json
+++ b/frameworks/cassandra/universe/config.json
@@ -6,8 +6,9 @@
       "description": "DC/OS Apache Cassandra service configuration properties",
       "properties": {
         "name": {
-          "description": "The name of the Cassandra service instance.",
+          "description": "Unique name for the service instance consisting of a series of words separated by slashes. Each word must be at least 1 alphanumeric character and may only contain digits (`0-9`), dashes (`-`), dots (`.`), and lowercase letters (`a-z`). The word may not begin or end with a dash",
           "type": "string",
+          "pattern": "^(\\/?((\\.\\.)|(([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9]))?($|\\/))+$",
           "default": "cassandra"
         },
         "user": {

--- a/tools/universe/test_package.py
+++ b/tools/universe/test_package.py
@@ -1,6 +1,6 @@
 from .package import Package
 from .package import Version
-
+import re
 
 def test_version_comparison():
     assert Version(0, "1.2.4") < Version(10, "1.2.4")
@@ -61,3 +61,10 @@ def test_elastic_ordering():
 
     assert p0 < p1
     assert p7 > p0
+
+def test_package_name_follows_stub_universe_convention():
+    pattern = re.compile("^(\\/?((\\.\\.)|(([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9]))?($|\\/))+$")
+    assert pattern.match("-cassandra") == False
+    assert pattern.match("cassandra-") == False
+    assert pattern.match("$cassandra") == False
+    assert pattern.match("cassandra") == True

--- a/tools/universe/test_package.py
+++ b/tools/universe/test_package.py
@@ -64,7 +64,7 @@ def test_elastic_ordering():
 
 def test_package_name_follows_stub_universe_convention():
     pattern = re.compile("^(\\/?((\\.\\.)|(([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9]))?($|\\/))+$")
-    assert pattern.match("-cassandra") == False
-    assert pattern.match("cassandra-") == False
-    assert pattern.match("$cassandra") == False
-    assert pattern.match("cassandra") == True
+    assert pattern.match("-cassandra") is False
+    assert pattern.match("cassandra-") is False
+    assert pattern.match("$cassandra") is False
+    assert pattern.match("cassandra") is True


### PR DESCRIPTION
## What this PR aims to do?
1. Part of  Release Cassandra-2.5.0-3.11.3.
2. Adds a regex name validator to Cassandra to check that it follows a specific pattern.
## How were the features tested?
The regex name validator was tested manually by creating a CCM cluster and trying an incorrect name.