### PR TITLE
[DCOS-46650] Cassandra base tech upgrade to 3.11.3

### DIFF
--- a/frameworks/cassandra/src/main/dist/svc.yml
+++ b/frameworks/cassandra/src/main/dist/svc.yml
@@ -62,6 +62,10 @@ pods:
                     ARGS="$ARGS -Dcassandra.metricsReporterConfigFile=metrics-reporter-config.yaml"
                 fi
 
+                if [ "$CASSANDRA_USER" = "root" ]; then
+                    ARGS="$ARGS -R"
+                fi
+
                 exec ./apache-cassandra-{{CASSANDRA_VERSION}}/bin/cassandra $ARGS
         configs:
           cassandra:

--- a/frameworks/cassandra/src/main/dist/svc.yml
+++ b/frameworks/cassandra/src/main/dist/svc.yml
@@ -250,9 +250,9 @@ pods:
                 export SSL_CERTFILE=$MESOS_SANDBOX/cqlsh.ca ;
                 {{/TASKCFG_ALL_SECURITY_TRANSPORT_ENCRYPTION_ENABLED}}
                 ./bootstrap --resolve=false &&
-                ./apache-cassandra-{{CASSANDRA_VERSION}}/bin/cqlsh {{{CASSANDRA_CQLSH_SSL_FLAGS}}} --cqlversion=3.4.0 -e "alter keyspace system_traces      WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3};" "node-0-server.${FRAMEWORK_HOST}" {{TASKCFG_ALL_CASSANDRA_NATIVE_TRANSPORT_PORT}} &&
-                ./apache-cassandra-{{CASSANDRA_VERSION}}/bin/cqlsh {{{CASSANDRA_CQLSH_SSL_FLAGS}}} --cqlversion=3.4.0 -e "alter keyspace system_auth        WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3};" "node-0-server.${FRAMEWORK_HOST}" {{TASKCFG_ALL_CASSANDRA_NATIVE_TRANSPORT_PORT}} &&
-                ./apache-cassandra-{{CASSANDRA_VERSION}}/bin/cqlsh {{{CASSANDRA_CQLSH_SSL_FLAGS}}} --cqlversion=3.4.0 -e "alter keyspace system_distributed WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3};" "node-0-server.${FRAMEWORK_HOST}" {{TASKCFG_ALL_CASSANDRA_NATIVE_TRANSPORT_PORT}}
+                ./apache-cassandra-{{CASSANDRA_VERSION}}/bin/cqlsh {{{CASSANDRA_CQLSH_SSL_FLAGS}}} -e "alter keyspace system_traces      WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3};" "node-0-server.${FRAMEWORK_HOST}" {{TASKCFG_ALL_CASSANDRA_NATIVE_TRANSPORT_PORT}} &&
+                ./apache-cassandra-{{CASSANDRA_VERSION}}/bin/cqlsh {{{CASSANDRA_CQLSH_SSL_FLAGS}}} -e "alter keyspace system_auth        WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3};" "node-0-server.${FRAMEWORK_HOST}" {{TASKCFG_ALL_CASSANDRA_NATIVE_TRANSPORT_PORT}} &&
+                ./apache-cassandra-{{CASSANDRA_VERSION}}/bin/cqlsh {{{CASSANDRA_CQLSH_SSL_FLAGS}}} -e "alter keyspace system_distributed WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3};" "node-0-server.${FRAMEWORK_HOST}" {{TASKCFG_ALL_CASSANDRA_NATIVE_TRANSPORT_PORT}}
         resource-set: sidecar-resources
         configs:
           cassandra:

--- a/frameworks/cassandra/tests/config.py
+++ b/frameworks/cassandra/tests/config.py
@@ -14,6 +14,8 @@ log = logging.getLogger(__name__)
 
 PACKAGE_NAME = "cassandra"
 
+CASSANDRA_DOCKER_IMAGE = "cassandra:3.11.3"
+
 SERVICE_NAME = os.environ.get("SOAK_SERVICE_NAME") or "cassandra"
 
 DEFAULT_TASK_COUNT = 3
@@ -80,7 +82,7 @@ def _get_test_job(
         "id": "test.cassandra." + name,
         "run": {
             "cmd": " && ".join(commands),
-            "docker": {"image": "cassandra:3.11.3"},
+            "docker": {"image": CASSANDRA_DOCKER_IMAGE},
             "cpus": 1,
             "mem": 512,
             "disk": 100,

--- a/frameworks/cassandra/tests/config.py
+++ b/frameworks/cassandra/tests/config.py
@@ -84,7 +84,7 @@ def _get_test_job(
         "id": "test.cassandra." + name,
         "run": {
             "cmd": " && ".join(commands),
-            "docker": {"image": "cassandra:3.0.13"},
+            "docker": {"image": "cassandra:3.11.3"},
             "cpus": 1,
             "mem": 512,
             "disk": 100,

--- a/frameworks/cassandra/tests/config.py
+++ b/frameworks/cassandra/tests/config.py
@@ -42,10 +42,6 @@ def _get_cqlsh_tls_rc_config(node_address, node_port, certfile="/mnt/mesos/sandb
     """
     return textwrap.dedent(
         """
-        [cql]
-        ; Substitute for the version of Cassandra you are connecting to.
-        version = 3.11.3
-
         [connection]
         hostname = {hostname}
         port = {port}

--- a/frameworks/cassandra/tests/config.py
+++ b/frameworks/cassandra/tests/config.py
@@ -44,7 +44,7 @@ def _get_cqlsh_tls_rc_config(node_address, node_port, certfile="/mnt/mesos/sandb
         """
         [cql]
         ; Substitute for the version of Cassandra you are connecting to.
-        version = 3.4.0
+        version = 3.11.3
 
         [connection]
         hostname = {hostname}

--- a/frameworks/cassandra/universe/marathon.json.mustache
+++ b/frameworks/cassandra/universe/marathon.json.mustache
@@ -50,7 +50,7 @@
     {{/service.service_account_secret}}
     {{#service.security.transport_encryption.enabled}}
     "TASKCFG_ALL_SECURITY_TRANSPORT_ENCRYPTION_ENABLED": "{{service.security.transport_encryption.enabled}}",
-    "CASSANDRA_CQLSH_SSL_FLAGS": "--ssl --cqlshrc=./apache-cassandra-{{CASSANDRA_VERSION}}/conf/cqlshrc",
+    "CASSANDRA_CQLSH_SSL_FLAGS": "--ssl --cqlshrc=./apache-cassandra-${CASSANDRA_VERSION}/conf/cqlshrc",
     {{#service.security.transport_encryption.allow_plaintext}}
     "TASKCFG_ALL_SECURITY_TRANSPORT_ENCRYPTION_ALLOW_PLAINTEXT": "{{service.security.transport_encryption.allow_plaintext}}",
     {{/service.security.transport_encryption.allow_plaintext}}

--- a/frameworks/cassandra/universe/marathon.json.mustache
+++ b/frameworks/cassandra/universe/marathon.json.mustache
@@ -83,6 +83,7 @@
     {{#service.region}}
     "SERVICE_REGION": "{{service.region}}",
     {{/service.region}}
+    "TASKCFG_ALL_CASSANDRA_USER": "{{service.user}}",
     "TASKCFG_ALL_JMX_PORT": "{{cassandra.jmx_port}}",
     "TASKCFG_ALL_CASSANDRA_NUM_TOKENS": "{{cassandra.num_tokens}}",
     "TASKCFG_ALL_CASSANDRA_HINTED_HANDOFF_ENABLED": "{{cassandra.hinted_handoff_enabled}}",

--- a/frameworks/cassandra/universe/marathon.json.mustache
+++ b/frameworks/cassandra/universe/marathon.json.mustache
@@ -50,7 +50,7 @@
     {{/service.service_account_secret}}
     {{#service.security.transport_encryption.enabled}}
     "TASKCFG_ALL_SECURITY_TRANSPORT_ENCRYPTION_ENABLED": "{{service.security.transport_encryption.enabled}}",
-    "CASSANDRA_CQLSH_SSL_FLAGS": "--ssl --cqlshrc=./apache-cassandra-3.11.3/conf/cqlshrc",
+    "CASSANDRA_CQLSH_SSL_FLAGS": "--ssl --cqlshrc=./apache-cassandra-{{CASSANDRA_VERSION}}/conf/cqlshrc",
     {{#service.security.transport_encryption.allow_plaintext}}
     "TASKCFG_ALL_SECURITY_TRANSPORT_ENCRYPTION_ALLOW_PLAINTEXT": "{{service.security.transport_encryption.allow_plaintext}}",
     {{/service.security.transport_encryption.allow_plaintext}}

--- a/frameworks/cassandra/universe/marathon.json.mustache
+++ b/frameworks/cassandra/universe/marathon.json.mustache
@@ -50,7 +50,7 @@
     {{/service.service_account_secret}}
     {{#service.security.transport_encryption.enabled}}
     "TASKCFG_ALL_SECURITY_TRANSPORT_ENCRYPTION_ENABLED": "{{service.security.transport_encryption.enabled}}",
-    "CASSANDRA_CQLSH_SSL_FLAGS": "--ssl --cqlshrc=./apache-cassandra-3.0.16/conf/cqlshrc",
+    "CASSANDRA_CQLSH_SSL_FLAGS": "--ssl --cqlshrc=./apache-cassandra-3.11.3/conf/cqlshrc",
     {{#service.security.transport_encryption.allow_plaintext}}
     "TASKCFG_ALL_SECURITY_TRANSPORT_ENCRYPTION_ALLOW_PLAINTEXT": "{{service.security.transport_encryption.allow_plaintext}}",
     {{/service.security.transport_encryption.allow_plaintext}}

--- a/frameworks/cassandra/universe/marathon.json.mustache
+++ b/frameworks/cassandra/universe/marathon.json.mustache
@@ -39,7 +39,7 @@
     "SERVICE_USER": "{{service.user}}",
     "SERVICE_PRINCIPAL": "{{service.service_account}}",
     "FRAMEWORK_LOG_LEVEL": "{{service.log_level}}",
-    "CASSANDRA_VERSION": "3.0.16",
+    "CASSANDRA_VERSION": "3.11.3",
     "S3CLI_VERSION": "s3cli-0.0.55-linux-amd64",
 
     {{#service.service_account_secret}}

--- a/frameworks/cassandra/universe/resource.json
+++ b/frameworks/cassandra/universe/resource.json
@@ -7,7 +7,7 @@
       "cassandra-openssl-tar-gz": "https://downloads.mesosphere.com/cassandra/assets/openssl-1.0.2n-libs.tar.gz",
       "libmesos-bundle-tar-gz": "{{libmesos-bundle-url}}",
       "scheduler-zip": "{{artifact-dir}}/cassandra-scheduler.zip",
-      "cassandra-tar-gz": "https://downloads.mesosphere.com/cassandra/assets/apache-cassandra-3.11.3-bin.tar.gz",
+      "cassandra-tar-gz": "https://downloads.mesosphere.io/cassandra/assets/apache-cassandra-3.11.3-bin-dcos.tar.gz",
       "bootstrap-zip": "{{artifact-dir}}/bootstrap.zip"
     }
   },

--- a/frameworks/cassandra/universe/resource.json
+++ b/frameworks/cassandra/universe/resource.json
@@ -7,7 +7,7 @@
       "cassandra-openssl-tar-gz": "https://downloads.mesosphere.com/cassandra/assets/openssl-1.0.2n-libs.tar.gz",
       "libmesos-bundle-tar-gz": "{{libmesos-bundle-url}}",
       "scheduler-zip": "{{artifact-dir}}/cassandra-scheduler.zip",
-      "cassandra-tar-gz": "https://downloads.mesosphere.com/cassandra/assets/apache-cassandra-3.0.16-bin-dcos.tar.gz",
+      "cassandra-tar-gz": "https://downloads.mesosphere.com/cassandra/assets/apache-cassandra-3.11.3-bin.tar.gz",
       "bootstrap-zip": "{{artifact-dir}}/bootstrap.zip"
     }
   },

--- a/frameworks/cassandra/universe/resource.json
+++ b/frameworks/cassandra/universe/resource.json
@@ -7,7 +7,7 @@
       "cassandra-openssl-tar-gz": "https://downloads.mesosphere.com/cassandra/assets/openssl-1.0.2n-libs.tar.gz",
       "libmesos-bundle-tar-gz": "{{libmesos-bundle-url}}",
       "scheduler-zip": "{{artifact-dir}}/cassandra-scheduler.zip",
-      "cassandra-tar-gz": "https://s3-us-west-2.amazonaws.com/akirillov-dev/apache-cassandra-3.11.3-bin.tar.gz",
+      "cassandra-tar-gz": "https://downloads.mesosphere.com/cassandra/assets/apache-cassandra-3.11.3-bin.tar.gz",
       "bootstrap-zip": "{{artifact-dir}}/bootstrap.zip"
     }
   },

--- a/frameworks/cassandra/universe/resource.json
+++ b/frameworks/cassandra/universe/resource.json
@@ -7,7 +7,7 @@
       "cassandra-openssl-tar-gz": "https://downloads.mesosphere.com/cassandra/assets/openssl-1.0.2n-libs.tar.gz",
       "libmesos-bundle-tar-gz": "{{libmesos-bundle-url}}",
       "scheduler-zip": "{{artifact-dir}}/cassandra-scheduler.zip",
-      "cassandra-tar-gz": "https://downloads.mesosphere.io/cassandra/assets/apache-cassandra-3.11.3-bin-dcos.tar.gz",
+      "cassandra-tar-gz": "https://downloads.mesosphere.com/cassandra/assets/apache-cassandra-3.11.3-bin-dcos.tar.gz",
       "bootstrap-zip": "{{artifact-dir}}/bootstrap.zip"
     }
   },

--- a/frameworks/cassandra/universe/resource.json
+++ b/frameworks/cassandra/universe/resource.json
@@ -7,7 +7,7 @@
       "cassandra-openssl-tar-gz": "https://downloads.mesosphere.com/cassandra/assets/openssl-1.0.2n-libs.tar.gz",
       "libmesos-bundle-tar-gz": "{{libmesos-bundle-url}}",
       "scheduler-zip": "{{artifact-dir}}/cassandra-scheduler.zip",
-      "cassandra-tar-gz": "https://downloads.mesosphere.com/cassandra/assets/apache-cassandra-3.11.3-bin.tar.gz",
+      "cassandra-tar-gz": "https://s3-us-west-2.amazonaws.com/akirillov-dev/apache-cassandra-3.11.3-bin.tar.gz",
       "bootstrap-zip": "{{artifact-dir}}/bootstrap.zip"
     }
   },

--- a/tools/universe/test_package.py
+++ b/tools/universe/test_package.py
@@ -61,3 +61,4 @@ def test_elastic_ordering():
 
     assert p0 < p1
     assert p7 > p0
+

--- a/tools/universe/test_package.py
+++ b/tools/universe/test_package.py
@@ -61,4 +61,3 @@ def test_elastic_ordering():
 
     assert p0 < p1
     assert p7 > p0
-


### PR DESCRIPTION
## What does this PR aim to do?
- Upgrade Cassandra base tech version for cassandra package release.
- Defaults to the package CQL sh version which is 5.0.1

## How were the changes tested?
- By running a CI build.