### PR TITLE
[DCOS-46788] Improve confluent-kafka support in diag bundle script

### DIFF
--- a/tools/diagnostics/base_tech_bundle/__init__.py
+++ b/tools/diagnostics/base_tech_bundle/__init__.py
@@ -21,6 +21,7 @@ BASE_TECH_BUNDLE = {
     "beta-hdfs": HdfsBundle,
     "beta-kafka": KafkaBundle,
     "cassandra": CassandraBundle,
+    "confluent-kafka": KafkaBundle,
     "elastic": ElasticBundle,
     "hdfs": HdfsBundle,
     "kafka": KafkaBundle,

--- a/tools/diagnostics/base_tech_bundle/kafka_bundle.py
+++ b/tools/diagnostics/base_tech_bundle/kafka_bundle.py
@@ -1,5 +1,8 @@
 import logging
 
+import sdk_cmd
+
+import config
 from base_tech_bundle import BaseTechBundle
 
 logger = logging.getLogger(__name__)
@@ -7,4 +10,18 @@ logger = logging.getLogger(__name__)
 
 class KafkaBundle(BaseTechBundle):
     def create(self):
-        logger.info("Creating Kafka bundle (noop)")
+        logger.info("Creating Kafka bundle")
+        self.create_broker_list_file()
+
+    @config.retry
+    def create_broker_list_file(self):
+        rc, stdout, stderr = sdk_cmd.svc_cli(
+            self.package_name, self.service_name, "broker list", print_output=False
+        )
+
+        if rc != 0 or stderr:
+            logger.error(
+                "Could not get broker list\nstdout: '%s'\nstderr: '%s'", stdout, stderr
+            )
+        else:
+            self.write_file("broker-list.json", stdout)

--- a/tools/diagnostics/bundle.py
+++ b/tools/diagnostics/bundle.py
@@ -7,6 +7,17 @@ log = logging.getLogger(__name__)
 
 class Bundle:
     def write_file(self, file_name, content, serialize_to_json=False):
+        """"
+        Writes content to a file.
+
+        Please follow the following convention for file names and use underscores rather than dashes:
+        * dcos_ prefix for dcos-related outputs
+          (e.g. dcos services --json -> dcos_services.json)
+        * service_ prefix for service-related outputs
+          (e.g. dcos kafka broker list -> service_broker_list.json)
+        * $base_tech_ prefix for base-tech-related outputs
+          (e.g. dcos task exec $node_0 nodetool status-> cassandra_nodetool_status_0.txt)
+        """
         file_path = os.path.join(self.output_directory, file_name)
 
         with open(file_path, "w") as f:


### PR DESCRIPTION
- Save `broker list` and `broker get`s in KafkaBundle.
- Use KafkaBundle for confluent-kafka as well.
- Document file naming convention.