### PR TITLE
DCOS-46811: Configureable RLIMITs for RLIMIT_NOFILE

### DIFF
--- a/frameworks/cassandra/src/main/dist/svc.yml
+++ b/frameworks/cassandra/src/main/dist/svc.yml
@@ -21,6 +21,10 @@ pods:
       - {{CASSANDRA_OPENSSL_URI}}
       - {{CASSANDRA_URI}}
       - {{BOOTSTRAP_URI}}
+    rlimits:
+      RLIMIT_NOFILE:
+        soft: {{RLIMITS_NOFILE_SOFT}}
+        hard: {{RLIMITS_NOFILE_HARD}}
     resource-sets:
       server-resources:
         cpus: {{CASSANDRA_CPUS}}

--- a/frameworks/cassandra/src/main/dist/svc.yml
+++ b/frameworks/cassandra/src/main/dist/svc.yml
@@ -23,8 +23,8 @@ pods:
       - {{BOOTSTRAP_URI}}
     rlimits:
       RLIMIT_NOFILE:
-        soft: {{RLIMITS_NOFILE_SOFT}}
-        hard: {{RLIMITS_NOFILE_HARD}}
+        soft: {{RLIMIT_NOFILE_SOFT}}
+        hard: {{RLIMIT_NOFILE_HARD}}
     resource-sets:
       server-resources:
         cpus: {{CASSANDRA_CPUS}}

--- a/frameworks/cassandra/universe/config.json
+++ b/frameworks/cassandra/universe/config.json
@@ -132,7 +132,31 @@
               "minimum": 60
             }
           }
-         }
+        },
+        "rlimits": {
+          "description" : "POSIX resource limits applied to the pod. Excercise caution when modifying these default values as it can lead to spurious task failures.",
+          "type": "object",
+          "properties": {
+            "rlimit_nofile": {
+              "description": "Specifies RLIMIT_NOFILE, a value one greater than the maximum file descriptor number that can be opened by this process.",
+              "type": "object",
+              "properties": {
+                "soft" : {
+                  "type": "integer",
+                  "description": "The  soft  limit  is  the  value that the kernel enforces for the corresponding resource.",
+                  "default": 128000,
+                  "minimum": 128000
+                },
+                "hard" : {
+                  "type": "integer",
+                  "description": "The  hard  limit  acts as a ceiling for the soft limit.",
+                  "default": 128000,
+                  "minimum": 128000
+                }
+              }
+            }
+          }
+        }
       },
       "required": [
         "name",

--- a/frameworks/cassandra/universe/marathon.json.mustache
+++ b/frameworks/cassandra/universe/marathon.json.mustache
@@ -173,7 +173,10 @@
 
     "READINESS_CHECK_INTERVAL": "{{service.readiness_check.interval}}",
     "READINESS_CHECK_DELAY": "{{service.readiness_check.delay}}",
-    "READINESS_CHECK_TIMEOUT": "{{service.readiness_check.timeout}}"
+    "READINESS_CHECK_TIMEOUT": "{{service.readiness_check.timeout}}",
+
+    "RLIMITS_NOFILE_SOFT": "{{service.rlimits.rlimit_nofile.soft}}",
+    "RLIMITS_NOFILE_HARD": "{{service.rlimits.rlimit_nofile.hard}}"
   },
   "fetch": [
     { "uri": "{{resource.assets.uris.bootstrap-zip}}", "cache": true },

--- a/frameworks/cassandra/universe/marathon.json.mustache
+++ b/frameworks/cassandra/universe/marathon.json.mustache
@@ -175,8 +175,8 @@
     "READINESS_CHECK_DELAY": "{{service.readiness_check.delay}}",
     "READINESS_CHECK_TIMEOUT": "{{service.readiness_check.timeout}}",
 
-    "RLIMITS_NOFILE_SOFT": "{{service.rlimits.rlimit_nofile.soft}}",
-    "RLIMITS_NOFILE_HARD": "{{service.rlimits.rlimit_nofile.hard}}"
+    "RLIMIT_NOFILE_SOFT": "{{service.rlimits.rlimit_nofile.soft}}",
+    "RLIMIT_NOFILE_HARD": "{{service.rlimits.rlimit_nofile.hard}}"
   },
   "fetch": [
     { "uri": "{{resource.assets.uris.bootstrap-zip}}", "cache": true },

--- a/frameworks/elastic/src/main/dist/svc.yml
+++ b/frameworks/elastic/src/main/dist/svc.yml
@@ -18,8 +18,8 @@ pods:
       - {{STATSD_URI}}
     rlimits:
       RLIMIT_NOFILE:
-        soft: {{MASTER_NODE_RLIMITS_NOFILE_SOFT}}
-        hard: {{MASTER_NODE_RLIMITS_NOFILE_HARD}}
+        soft: {{MASTER_NODE_RLIMIT_NOFILE_SOFT}}
+        hard: {{MASTER_NODE_RLIMIT_NOFILE_HARD}}
     placement: '{{{MASTER_NODE_PLACEMENT}}}'
     tasks:
       node:
@@ -108,8 +108,8 @@ pods:
       - {{STATSD_URI}}
     rlimits:
       RLIMIT_NOFILE:
-        soft: {{DATA_NODE_RLIMITS_NOFILE_SOFT}}
-        hard: {{DATA_NODE_RLIMITS_NOFILE_HARD}}
+        soft: {{DATA_NODE_RLIMIT_NOFILE_SOFT}}
+        hard: {{DATA_NODE_RLIMIT_NOFILE_HARD}}
     placement: '{{{DATA_NODE_PLACEMENT}}}'
     tasks:
       node:
@@ -196,8 +196,8 @@ pods:
       - {{STATSD_URI}}
     rlimits:
       RLIMIT_NOFILE:
-        soft: {{INGEST_NODE_RLIMITS_NOFILE_SOFT}}
-        hard: {{INGEST_NODE_RLIMITS_NOFILE_HARD}}
+        soft: {{INGEST_NODE_RLIMIT_NOFILE_SOFT}}
+        hard: {{INGEST_NODE_RLIMIT_NOFILE_HARD}}
     placement: '{{{INGEST_NODE_PLACEMENT}}}'
     tasks:
       node:
@@ -284,8 +284,8 @@ pods:
       - {{STATSD_URI}}
     rlimits:
       RLIMIT_NOFILE:
-        soft: {{COORDINATOR_NODE_RLIMITS_NOFILE_SOFT}}
-        hard: {{COORDINATOR_NODE_RLIMITS_NOFILE_HARD}}
+        soft: {{COORDINATOR_NODE_RLIMIT_NOFILE_SOFT}}
+        hard: {{COORDINATOR_NODE_RLIMIT_NOFILE_HARD}}
     placement: '{{{COORDINATOR_NODE_PLACEMENT}}}'
     tasks:
       node:

--- a/frameworks/elastic/src/main/dist/svc.yml
+++ b/frameworks/elastic/src/main/dist/svc.yml
@@ -18,8 +18,8 @@ pods:
       - {{STATSD_URI}}
     rlimits:
       RLIMIT_NOFILE:
-        soft: 128000
-        hard: 128000
+        soft: {{MASTER_NODE_RLIMITS_NOFILE_SOFT}}
+        hard: {{MASTER_NODE_RLIMITS_NOFILE_HARD}}
     placement: '{{{MASTER_NODE_PLACEMENT}}}'
     tasks:
       node:
@@ -108,8 +108,8 @@ pods:
       - {{STATSD_URI}}
     rlimits:
       RLIMIT_NOFILE:
-        soft: 128000
-        hard: 128000
+        soft: {{DATA_NODE_RLIMITS_NOFILE_SOFT}}
+        hard: {{DATA_NODE_RLIMITS_NOFILE_HARD}}
     placement: '{{{DATA_NODE_PLACEMENT}}}'
     tasks:
       node:
@@ -196,8 +196,8 @@ pods:
       - {{STATSD_URI}}
     rlimits:
       RLIMIT_NOFILE:
-        soft: 128000
-        hard: 128000
+        soft: {{INGEST_NODE_RLIMITS_NOFILE_SOFT}}
+        hard: {{INGEST_NODE_RLIMITS_NOFILE_HARD}}
     placement: '{{{INGEST_NODE_PLACEMENT}}}'
     tasks:
       node:
@@ -284,8 +284,8 @@ pods:
       - {{STATSD_URI}}
     rlimits:
       RLIMIT_NOFILE:
-        soft: 128000
-        hard: 128000
+        soft: {{COORDINATOR_NODE_RLIMITS_NOFILE_SOFT}}
+        hard: {{COORDINATOR_NODE_RLIMITS_NOFILE_HARD}}
     placement: '{{{COORDINATOR_NODE_PLACEMENT}}}'
     tasks:
       node:

--- a/frameworks/elastic/universe/config.json
+++ b/frameworks/elastic/universe/config.json
@@ -182,6 +182,30 @@
               "minimum": 10
             }
           }
+        },
+        "rlimits": {
+          "description" : "POSIX resource limits applied to the pod. Excercise caution when modifying these default values as it can lead to spurious task failures.",
+          "type": "object",
+          "properties": {
+            "rlimit_nofile": {
+              "description": "Specifies RLIMIT_NOFILE, a value one greater than the maximum file descriptor number that can be opened by this process.",
+              "type": "object",
+              "properties": {
+                "soft" : {
+                  "type": "integer",
+                  "description": "The  soft  limit  is  the  value that the kernel enforces for the corresponding resource.",
+                  "default": 128000,
+                  "minimum": 128000
+                },
+                "hard" : {
+                  "type": "integer",
+                  "description": "The  hard  limit  acts as a ceiling for the soft limit.",
+                  "default": 128000,
+                  "minimum": 128000
+                }
+              }
+            }
+          }
         }
       },
       "required": [
@@ -265,6 +289,30 @@
               "description": "An amount of time in seconds to wait for a readiness check to succeed.",
               "default": 10,
               "minimum": 10
+            }
+          }
+        },
+        "rlimits": {
+          "description" : "POSIX resource limits applied to the pod. Excercise caution when modifying these default values as it can lead to spurious task failures.",
+          "type": "object",
+          "properties": {
+            "rlimit_nofile": {
+              "description": "Specifies RLIMIT_NOFILE, a value one greater than the maximum file descriptor number that can be opened by this process.",
+              "type": "object",
+              "properties": {
+                "soft" : {
+                  "type": "integer",
+                  "description": "The  soft  limit  is  the  value that the kernel enforces for the corresponding resource.",
+                  "default": 128000,
+                  "minimum": 128000
+                },
+                "hard" : {
+                  "type": "integer",
+                  "description": "The  hard  limit  acts as a ceiling for the soft limit.",
+                  "default": 128000,
+                  "minimum": 128000
+                }
+              }
             }
           }
         }
@@ -352,6 +400,30 @@
               "minimum": 10
             }
           }
+        },
+        "rlimits": {
+          "description" : "POSIX resource limits applied to the pod. Excercise caution when modifying these default values as it can lead to spurious task failures.",
+          "type": "object",
+          "properties": {
+            "rlimit_nofile": {
+              "description": "Specifies RLIMIT_NOFILE, a value one greater than the maximum file descriptor number that can be opened by this process.",
+              "type": "object",
+              "properties": {
+                "soft" : {
+                  "type": "integer",
+                  "description": "The  soft  limit  is  the  value that the kernel enforces for the corresponding resource.",
+                  "default": 128000,
+                  "minimum": 128000
+                },
+                "hard" : {
+                  "type": "integer",
+                  "description": "The  hard  limit  acts as a ceiling for the soft limit.",
+                  "default": 128000,
+                  "minimum": 128000
+                }
+              }
+            }
+          }
         }
       },
       "required": [
@@ -437,7 +509,31 @@
               "minimum": 10
             }
           }
-        }
+        },
+        "rlimits": {
+          "description" : "POSIX resource limits applied to the pod. Excercise caution when modifying these default values as it can lead to spurious task failures.",
+          "type": "object",
+          "properties": {
+            "rlimit_nofile": {
+              "description": "Specifies RLIMIT_NOFILE, a value one greater than the maximum file descriptor number that can be opened by this process.",
+              "type": "object",
+              "properties": {
+                "soft" : {
+                  "type": "integer",
+                  "description": "The  soft  limit  is  the  value that the kernel enforces for the corresponding resource.",
+                  "default": 128000,
+                  "minimum": 128000
+                },
+                "hard" : {
+                  "type": "integer",
+                  "description": "The  hard  limit  acts as a ceiling for the soft limit.",
+                  "default": 128000,
+                  "minimum": 128000
+                }
+              }
+            }
+          }
+        }     
       },
       "required": [
         "cpus",

--- a/frameworks/elastic/universe/marathon.json.mustache
+++ b/frameworks/elastic/universe/marathon.json.mustache
@@ -334,17 +334,29 @@
     "MASTER_NODE_READINESS_CHECK_DELAY": "{{master_nodes.readiness_check.delay}}",
     "MASTER_NODE_READINESS_CHECK_TIMEOUT": "{{master_nodes.readiness_check.timeout}}",
 
+    "MASTER_NODE_RLIMITS_NOFILE_SOFT": "{{master_nodes.rlimits.rlimit_nofile.soft}}",
+    "MASTER_NODE_RLIMITS_NOFILE_HARD": "{{master_nodes.rlimits.rlimit_nofile.hard}}",
+
     "DATA_NODE_READINESS_CHECK_INTERVAL": "{{data_nodes.readiness_check.interval}}",
     "DATA_NODE_READINESS_CHECK_DELAY": "{{data_nodes.readiness_check.delay}}",
     "DATA_NODE_READINESS_CHECK_TIMEOUT": "{{data_nodes.readiness_check.timeout}}",
+
+    "DATA_NODE_RLIMITS_NOFILE_SOFT": "{{data_nodes.rlimits.rlimit_nofile.soft}}",
+    "DATA_NODE_RLIMITS_NOFILE_HARD": "{{data_nodes.rlimits.rlimit_nofile.hard}}",
 
     "INGEST_NODE_READINESS_CHECK_INTERVAL": "{{ingest_nodes.readiness_check.interval}}",
     "INGEST_NODE_READINESS_CHECK_DELAY": "{{ingest_nodes.readiness_check.delay}}",
     "INGEST_NODE_READINESS_CHECK_TIMEOUT": "{{ingest_nodes.readiness_check.timeout}}",
 
+    "INGEST_NODE_RLIMITS_NOFILE_SOFT": "{{ingest_nodes.rlimits.rlimit_nofile.soft}}",
+    "INGEST_NODE_RLIMITS_NOFILE_HARD": "{{ingest_nodes.rlimits.rlimit_nofile.hard}}",
+
     "COORDINATOR_NODE_READINESS_CHECK_INTERVAL": "{{coordinator_nodes.readiness_check.interval}}",
     "COORDINATOR_NODE_READINESS_CHECK_DELAY": "{{coordinator_nodes.readiness_check.delay}}",
-    "COORDINATOR_NODE_READINESS_CHECK_TIMEOUT": "{{coordinator_nodes.readiness_check.timeout}}"
+    "COORDINATOR_NODE_READINESS_CHECK_TIMEOUT": "{{coordinator_nodes.readiness_check.timeout}}",
+
+    "COORDINATOR_NODE_RLIMITS_NOFILE_SOFT": "{{coordinator_nodes.rlimits.rlimit_nofile.soft}}",
+    "COORDINATOR_NODE_RLIMITS_NOFILE_HARD": "{{coordinator_nodes.rlimits.rlimit_nofile.hard}}"
   },
   "fetch": [
     { "uri": "{{resource.assets.uris.bootstrap-zip}}", "cache": true },

--- a/frameworks/elastic/universe/marathon.json.mustache
+++ b/frameworks/elastic/universe/marathon.json.mustache
@@ -334,29 +334,29 @@
     "MASTER_NODE_READINESS_CHECK_DELAY": "{{master_nodes.readiness_check.delay}}",
     "MASTER_NODE_READINESS_CHECK_TIMEOUT": "{{master_nodes.readiness_check.timeout}}",
 
-    "MASTER_NODE_RLIMITS_NOFILE_SOFT": "{{master_nodes.rlimits.rlimit_nofile.soft}}",
-    "MASTER_NODE_RLIMITS_NOFILE_HARD": "{{master_nodes.rlimits.rlimit_nofile.hard}}",
+    "MASTER_NODE_RLIMIT_NOFILE_SOFT": "{{master_nodes.rlimits.rlimit_nofile.soft}}",
+    "MASTER_NODE_RLIMIT_NOFILE_HARD": "{{master_nodes.rlimits.rlimit_nofile.hard}}",
 
     "DATA_NODE_READINESS_CHECK_INTERVAL": "{{data_nodes.readiness_check.interval}}",
     "DATA_NODE_READINESS_CHECK_DELAY": "{{data_nodes.readiness_check.delay}}",
     "DATA_NODE_READINESS_CHECK_TIMEOUT": "{{data_nodes.readiness_check.timeout}}",
 
-    "DATA_NODE_RLIMITS_NOFILE_SOFT": "{{data_nodes.rlimits.rlimit_nofile.soft}}",
-    "DATA_NODE_RLIMITS_NOFILE_HARD": "{{data_nodes.rlimits.rlimit_nofile.hard}}",
+    "DATA_NODE_RLIMIT_NOFILE_SOFT": "{{data_nodes.rlimits.rlimit_nofile.soft}}",
+    "DATA_NODE_RLIMIT_NOFILE_HARD": "{{data_nodes.rlimits.rlimit_nofile.hard}}",
 
     "INGEST_NODE_READINESS_CHECK_INTERVAL": "{{ingest_nodes.readiness_check.interval}}",
     "INGEST_NODE_READINESS_CHECK_DELAY": "{{ingest_nodes.readiness_check.delay}}",
     "INGEST_NODE_READINESS_CHECK_TIMEOUT": "{{ingest_nodes.readiness_check.timeout}}",
 
-    "INGEST_NODE_RLIMITS_NOFILE_SOFT": "{{ingest_nodes.rlimits.rlimit_nofile.soft}}",
-    "INGEST_NODE_RLIMITS_NOFILE_HARD": "{{ingest_nodes.rlimits.rlimit_nofile.hard}}",
+    "INGEST_NODE_RLIMIT_NOFILE_SOFT": "{{ingest_nodes.rlimits.rlimit_nofile.soft}}",
+    "INGEST_NODE_RLIMIT_NOFILE_HARD": "{{ingest_nodes.rlimits.rlimit_nofile.hard}}",
 
     "COORDINATOR_NODE_READINESS_CHECK_INTERVAL": "{{coordinator_nodes.readiness_check.interval}}",
     "COORDINATOR_NODE_READINESS_CHECK_DELAY": "{{coordinator_nodes.readiness_check.delay}}",
     "COORDINATOR_NODE_READINESS_CHECK_TIMEOUT": "{{coordinator_nodes.readiness_check.timeout}}",
 
-    "COORDINATOR_NODE_RLIMITS_NOFILE_SOFT": "{{coordinator_nodes.rlimits.rlimit_nofile.soft}}",
-    "COORDINATOR_NODE_RLIMITS_NOFILE_HARD": "{{coordinator_nodes.rlimits.rlimit_nofile.hard}}"
+    "COORDINATOR_NODE_RLIMIT_NOFILE_SOFT": "{{coordinator_nodes.rlimits.rlimit_nofile.soft}}",
+    "COORDINATOR_NODE_RLIMIT_NOFILE_HARD": "{{coordinator_nodes.rlimits.rlimit_nofile.hard}}"
   },
   "fetch": [
     { "uri": "{{resource.assets.uris.bootstrap-zip}}", "cache": true },

--- a/frameworks/hdfs/src/main/dist/svc.yml
+++ b/frameworks/hdfs/src/main/dist/svc.yml
@@ -12,8 +12,8 @@ pods:
       - {{BOOTSTRAP_URI}}
     rlimits:
       RLIMIT_NOFILE:
-        soft: {{JOURNAL_NODE_RLIMITS_NOFILE_SOFT}}
-        hard: {{JOURNAL_NODE_RLIMITS_NOFILE_HARD}}
+        soft: {{JOURNAL_NODE_RLIMIT_NOFILE_SOFT}}
+        hard: {{JOURNAL_NODE_RLIMIT_NOFILE_HARD}}
     {{#SECURITY_KERBEROS_ENABLED}}
     secrets:
       keytab:
@@ -152,8 +152,8 @@ pods:
       - {{ZONE_RESOLVER}}
     rlimits:
       RLIMIT_NOFILE:
-        soft: {{NAME_NODE_RLIMITS_NOFILE_SOFT}}
-        hard: {{NAME_NODE_RLIMITS_NOFILE_HARD}}
+        soft: {{NAME_NODE_RLIMIT_NOFILE_SOFT}}
+        hard: {{NAME_NODE_RLIMIT_NOFILE_HARD}}
     {{#SECURITY_KERBEROS_ENABLED}}
     secrets:
       keytab:
@@ -423,8 +423,8 @@ pods:
       - {{BOOTSTRAP_URI}}
     rlimits:
       RLIMIT_NOFILE:
-        soft: {{DATA_NODE_RLIMITS_NOFILE_SOFT}}
-        hard: {{DATA_NODE_RLIMITS_NOFILE_HARD}}
+        soft: {{DATA_NODE_RLIMIT_NOFILE_SOFT}}
+        hard: {{DATA_NODE_RLIMIT_NOFILE_HARD}}
     {{#SECURITY_KERBEROS_ENABLED}}
     secrets:
       keytab:

--- a/frameworks/hdfs/src/main/dist/svc.yml
+++ b/frameworks/hdfs/src/main/dist/svc.yml
@@ -10,6 +10,10 @@ pods:
       - {{HDFS_BIN_URI}}
       - {{HDFS_JAVA_URI}}
       - {{BOOTSTRAP_URI}}
+    rlimits:
+      RLIMIT_NOFILE:
+        soft: {{JOURNAL_NODE_RLIMITS_NOFILE_SOFT}}
+        hard: {{JOURNAL_NODE_RLIMITS_NOFILE_HARD}}
     {{#SECURITY_KERBEROS_ENABLED}}
     secrets:
       keytab:
@@ -146,6 +150,10 @@ pods:
       - {{HDFS_JAVA_URI}}
       - {{BOOTSTRAP_URI}}
       - {{ZONE_RESOLVER}}
+    rlimits:
+      RLIMIT_NOFILE:
+        soft: {{NAME_NODE_RLIMITS_NOFILE_SOFT}}
+        hard: {{NAME_NODE_RLIMITS_NOFILE_HARD}}
     {{#SECURITY_KERBEROS_ENABLED}}
     secrets:
       keytab:
@@ -413,6 +421,10 @@ pods:
       - {{HDFS_BIN_URI}}
       - {{HDFS_JAVA_URI}}
       - {{BOOTSTRAP_URI}}
+    rlimits:
+      RLIMIT_NOFILE:
+        soft: {{DATA_NODE_RLIMITS_NOFILE_SOFT}}
+        hard: {{DATA_NODE_RLIMITS_NOFILE_HARD}}
     {{#SECURITY_KERBEROS_ENABLED}}
     secrets:
       keytab:

--- a/frameworks/hdfs/universe/config.json
+++ b/frameworks/hdfs/universe/config.json
@@ -210,6 +210,30 @@
           "type": "string",
           "description": "JVM options to specify when running the journal node. This overrides HADOOP_HEAPSIZE Xmx value for the journal nodes.",
           "default": ""
+        },
+        "rlimits": {
+          "description" : "POSIX resource limits applied to the pod. Excercise caution when modifying these default values as it can lead to spurious task failures.",
+          "type": "object",
+          "properties": {
+            "rlimit_nofile": {
+              "description": "Specifies RLIMIT_NOFILE, a value one greater than the maximum file descriptor number that can be opened by this process.",
+              "type": "object",
+              "properties": {
+                "soft" : {
+                  "type": "integer",
+                  "description": "The  soft  limit  is  the  value that the kernel enforces for the corresponding resource.",
+                  "default": 128000,
+                  "minimum": 128000
+                },
+                "hard" : {
+                  "type": "integer",
+                  "description": "The  hard  limit  acts as a ceiling for the soft limit.",
+                  "default": 128000,
+                  "minimum": 128000
+                }
+              }
+            }
+          }
         }
       },
       "required": [
@@ -589,6 +613,30 @@
               "minimum": 180
             }
           }
+        },
+        "rlimits": {
+          "description" : "POSIX resource limits applied to the pod. Excercise caution when modifying these default values as it can lead to spurious task failures.",
+          "type": "object",
+          "properties": {
+            "rlimit_nofile": {
+              "description": "Specifies RLIMIT_NOFILE, a value one greater than the maximum file descriptor number that can be opened by this process.",
+              "type": "object",
+              "properties": {
+                "soft" : {
+                  "type": "integer",
+                  "description": "The  soft  limit  is  the  value that the kernel enforces for the corresponding resource.",
+                  "default": 128000,
+                  "minimum": 128000
+                },
+                "hard" : {
+                  "type": "integer",
+                  "description": "The  hard  limit  acts as a ceiling for the soft limit.",
+                  "default": 128000,
+                  "minimum": 128000
+                }
+              }
+            }
+          }
         }
       },
       "required": [
@@ -859,6 +907,30 @@
               "description": "An amount of time in seconds to wait for a readiness check to succeed.",
               "default": 60,
               "minimum": 60
+            }
+          }
+        },
+        "rlimits": {
+          "description" : "POSIX resource limits applied to the pod. Excercise caution when modifying these default values as it can lead to spurious task failures.",
+          "type": "object",
+          "properties": {
+            "rlimit_nofile": {
+              "description": "Specifies RLIMIT_NOFILE, a value one greater than the maximum file descriptor number that can be opened by this process.",
+              "type": "object",
+              "properties": {
+                "soft" : {
+                  "type": "integer",
+                  "description": "The  soft  limit  is  the  value that the kernel enforces for the corresponding resource.",
+                  "default": 128000,
+                  "minimum": 128000
+                },
+                "hard" : {
+                  "type": "integer",
+                  "description": "The  hard  limit  acts as a ceiling for the soft limit.",
+                  "default": 128000,
+                  "minimum": 128000
+                }
+              }
             }
           }
         }

--- a/frameworks/hdfs/universe/marathon.json.mustache
+++ b/frameworks/hdfs/universe/marathon.json.mustache
@@ -109,14 +109,14 @@
     "DATA_NODE_READINESS_CHECK_INTERVAL": "{{data_node.readiness_check.interval}}",
     "DATA_NODE_READINESS_CHECK_TIMEOUT": "{{data_node.readiness_check.timeout}}",
 
-    "JOURNAL_NODE_RLIMITS_NOFILE_SOFT" : "{{journal_node.rlimits.rlimit_nofile.soft}}",
-    "JOURNAL_NODE_RLIMITS_NOFILE_HARD" : "{{journal_node.rlimits.rlimit_nofile.hard}}",
+    "JOURNAL_NODE_RLIMIT_NOFILE_SOFT" : "{{journal_node.rlimits.rlimit_nofile.soft}}",
+    "JOURNAL_NODE_RLIMIT_NOFILE_HARD" : "{{journal_node.rlimits.rlimit_nofile.hard}}",
 
-    "NAME_NODE_RLIMITS_NOFILE_SOFT" : "{{name_node.rlimits.rlimit_nofile.soft}}",
-    "NAME_NODE_RLIMITS_NOFILE_HARD" : "{{name_node.rlimits.rlimit_nofile.hard}}",
+    "NAME_NODE_RLIMIT_NOFILE_SOFT" : "{{name_node.rlimits.rlimit_nofile.soft}}",
+    "NAME_NODE_RLIMIT_NOFILE_HARD" : "{{name_node.rlimits.rlimit_nofile.hard}}",
 
-    "DATA_NODE_RLIMITS_NOFILE_SOFT" : "{{data_node.rlimits.rlimit_nofile.soft}}",
-    "DATA_NODE_RLIMITS_NOFILE_HARD" : "{{data_node.rlimits.rlimit_nofile.hard}}",
+    "DATA_NODE_RLIMIT_NOFILE_SOFT" : "{{data_node.rlimits.rlimit_nofile.soft}}",
+    "DATA_NODE_RLIMIT_NOFILE_HARD" : "{{data_node.rlimits.rlimit_nofile.hard}}",
 
     {{#service.security.kerberos.enabled}}
     "SECURITY_KERBEROS_KEYTAB_SECRET": "{{service.security.kerberos.keytab_secret}}",

--- a/frameworks/hdfs/universe/marathon.json.mustache
+++ b/frameworks/hdfs/universe/marathon.json.mustache
@@ -109,6 +109,15 @@
     "DATA_NODE_READINESS_CHECK_INTERVAL": "{{data_node.readiness_check.interval}}",
     "DATA_NODE_READINESS_CHECK_TIMEOUT": "{{data_node.readiness_check.timeout}}",
 
+    "JOURNAL_NODE_RLIMITS_NOFILE_SOFT" : "{{journal_node.rlimits.rlimit_nofile.soft}}",
+    "JOURNAL_NODE_RLIMITS_NOFILE_HARD" : "{{journal_node.rlimits.rlimit_nofile.hard}}",
+
+    "NAME_NODE_RLIMITS_NOFILE_SOFT" : "{{name_node.rlimits.rlimit_nofile.soft}}",
+    "NAME_NODE_RLIMITS_NOFILE_HARD" : "{{name_node.rlimits.rlimit_nofile.hard}}",
+
+    "DATA_NODE_RLIMITS_NOFILE_SOFT" : "{{data_node.rlimits.rlimit_nofile.soft}}",
+    "DATA_NODE_RLIMITS_NOFILE_HARD" : "{{data_node.rlimits.rlimit_nofile.hard}}",
+
     {{#service.security.kerberos.enabled}}
     "SECURITY_KERBEROS_KEYTAB_SECRET": "{{service.security.kerberos.keytab_secret}}",
     "SECURITY_KERBEROS_ENABLED": "{{service.security.kerberos.enabled}}",

--- a/frameworks/helloworld/src/main/dist/svc.yml
+++ b/frameworks/helloworld/src/main/dist/svc.yml
@@ -8,8 +8,8 @@ pods:
     placement: '{{{HELLO_PLACEMENT}}}'
     rlimits:
       RLIMIT_NOFILE:
-        soft: {{HELLO_RLIMITS_NOFILE_SOFT}}
-        hard: {{HELLO_RLIMITS_NOFILE_HARD}}
+        soft: {{HELLO_RLIMIT_NOFILE_SOFT}}
+        hard: {{HELLO_RLIMIT_NOFILE_HARD}}
     tasks:
       server:
         goal: RUNNING
@@ -36,8 +36,8 @@ pods:
     placement: '{{{WORLD_PLACEMENT}}}'
     rlimits:
       RLIMIT_NOFILE:
-        soft: {{WORLD_RLIMITS_NOFILE_SOFT}}
-        hard: {{WORLD_RLIMITS_NOFILE_HARD}}
+        soft: {{WORLD_RLIMIT_NOFILE_SOFT}}
+        hard: {{WORLD_RLIMIT_NOFILE_HARD}}
     tasks:
       server:
         goal: RUNNING

--- a/frameworks/helloworld/src/main/dist/svc.yml
+++ b/frameworks/helloworld/src/main/dist/svc.yml
@@ -6,6 +6,10 @@ pods:
   hello:
     count: {{HELLO_COUNT}}
     placement: '{{{HELLO_PLACEMENT}}}'
+    rlimits:
+      RLIMIT_NOFILE:
+        soft: {{HELLO_RLIMITS_NOFILE_SOFT}}
+        hard: {{HELLO_RLIMITS_NOFILE_HARD}}
     tasks:
       server:
         goal: RUNNING
@@ -30,6 +34,10 @@ pods:
     count: {{WORLD_COUNT}}
     allow-decommission: true
     placement: '{{{WORLD_PLACEMENT}}}'
+    rlimits:
+      RLIMIT_NOFILE:
+        soft: {{WORLD_RLIMITS_NOFILE_SOFT}}
+        hard: {{WORLD_RLIMITS_NOFILE_HARD}}
     tasks:
       server:
         goal: RUNNING

--- a/frameworks/helloworld/universe/config.json
+++ b/frameworks/helloworld/universe/config.json
@@ -229,6 +229,30 @@
           "description": "labels",
           "type": "string",
           "default": ""
+        },
+        "rlimits": {
+          "description" : "POSIX resource limits applied to the pod. Excercise caution when modifying these default values as it can lead to spurious task failures.",
+          "type": "object",
+          "properties": {
+            "rlimit_nofile": {
+              "description": "Specifies RLIMIT_NOFILE, a value one greater than the maximum file descriptor number that can be opened by this process.",
+              "type": "object",
+              "properties": {
+                "soft" : {
+                  "type": "integer",
+                  "description": "The  soft  limit  is  the  value that the kernel enforces for the corresponding resource.",
+                  "default": 128000,
+                  "minimum": 128000
+                },
+                "hard" : {
+                  "type": "integer",
+                  "description": "The  hard  limit  acts as a ceiling for the soft limit.",
+                  "default": 128000,
+                  "minimum": 128000
+                }
+              }
+            }
+          }
         }
       },
       "required": [
@@ -312,6 +336,30 @@
               "description": "An amount of time in seconds to wait for a readiness check to succeed.",
               "default": 10,
               "minimum": 10
+            }
+          }
+        },
+        "rlimits": {
+          "description" : "POSIX resource limits applied to the pod. Excercise caution when modifying these default values as it can lead to spurious task failures.",
+          "type": "object",
+          "properties": {
+            "rlimit_nofile": {
+              "description": "Specifies RLIMIT_NOFILE, a value one greater than the maximum file descriptor number that can be opened by this process.",
+              "type": "object",
+              "properties": {
+                "soft" : {
+                  "type": "integer",
+                  "description": "The  soft  limit  is  the  value that the kernel enforces for the corresponding resource.",
+                  "default": 128000,
+                  "minimum": 128000
+                },
+                "hard" : {
+                  "type": "integer",
+                  "description": "The  hard  limit  acts as a ceiling for the soft limit.",
+                  "default": 128000,
+                  "minimum": 128000
+                }
+              }
             }
           }
         }

--- a/frameworks/helloworld/universe/marathon.json.mustache
+++ b/frameworks/helloworld/universe/marathon.json.mustache
@@ -113,11 +113,11 @@
     "WORLD_READINESS_CHECK_DELAY": "{{world.readiness_check.delay}}",
     "WORLD_READINESS_CHECK_TIMEOUT": "{{world.readiness_check.timeout}}",
 
-    "HELLO_RLIMITS_NOFILE_SOFT": "{{hello.rlimits.rlimit_nofile.soft}}",
-    "HELLO_RLIMITS_NOFILE_HARD": "{{hello.rlimits.rlimit_nofile.hard}}",
+    "HELLO_RLIMIT_NOFILE_SOFT": "{{hello.rlimits.rlimit_nofile.soft}}",
+    "HELLO_RLIMIT_NOFILE_HARD": "{{hello.rlimits.rlimit_nofile.hard}}",
 
-    "WORLD_RLIMITS_NOFILE_SOFT": "{{world.rlimits.rlimit_nofile.soft}}",
-    "WORLD_RLIMITS_NOFILE_HARD": "{{world.rlimits.rlimit_nofile.hard}}"
+    "WORLD_RLIMIT_NOFILE_SOFT": "{{world.rlimits.rlimit_nofile.soft}}",
+    "WORLD_RLIMIT_NOFILE_HARD": "{{world.rlimits.rlimit_nofile.hard}}"
   },
   "fetch": [
     { "uri": "{{resource.assets.uris.bootstrap-zip}}", "cache": true },

--- a/frameworks/helloworld/universe/marathon.json.mustache
+++ b/frameworks/helloworld/universe/marathon.json.mustache
@@ -111,7 +111,13 @@
 
     "WORLD_READINESS_CHECK_INTERVAL": "{{world.readiness_check.interval}}",
     "WORLD_READINESS_CHECK_DELAY": "{{world.readiness_check.delay}}",
-    "WORLD_READINESS_CHECK_TIMEOUT": "{{world.readiness_check.timeout}}"
+    "WORLD_READINESS_CHECK_TIMEOUT": "{{world.readiness_check.timeout}}",
+
+    "HELLO_RLIMITS_NOFILE_SOFT": "{{hello.rlimits.rlimit_nofile.soft}}",
+    "HELLO_RLIMITS_NOFILE_HARD": "{{hello.rlimits.rlimit_nofile.hard}}",
+
+    "WORLD_RLIMITS_NOFILE_SOFT": "{{world.rlimits.rlimit_nofile.soft}}",
+    "WORLD_RLIMITS_NOFILE_HARD": "{{world.rlimits.rlimit_nofile.hard}}"
   },
   "fetch": [
     { "uri": "{{resource.assets.uris.bootstrap-zip}}", "cache": true },


### PR DESCRIPTION
Extract and templatize elastic's RLIMIT_NOFILE settings.

Apply elastic's defaults (128000) from above to the following:
- Cassandra.
- HDFS
- Hello-World