### PR TITLE
[DIAGNOSTICS] Fix condition where scheduler task can't be found.

### DIFF
--- a/tools/diagnostics/full_bundle.py
+++ b/tools/diagnostics/full_bundle.py
@@ -15,6 +15,9 @@ import config
 log = logging.getLogger(__name__)
 
 
+DCOS_SERVICES_JSON_FILE_NAME = "dcos_services.json"
+
+
 @config.retry
 def get_dcos_services() -> (bool, str):
     rc, stdout, stderr = sdk_cmd.run_cli(
@@ -118,7 +121,7 @@ class FullBundle(Bundle):
 
         all_services = json.loads(all_services_or_error)
 
-        self.write_file("dcos_services.json", all_services, serialize_to_json=True)
+        self.write_file(DCOS_SERVICES_JSON_FILE_NAME, all_services, serialize_to_json=True)
 
         # An SDK service might have multiple DC/OS service entries. We expect that at most one is
         # "active".
@@ -152,8 +155,9 @@ class FullBundle(Bundle):
         ]
         if len(scheduler_tasks) == 0:
             log.warn(
-                "Could not find scheduler tasks for '%s'. Please check the 'dcos_services.json' file.",
+                "Could not find scheduler tasks for '%s' under the Marathon service ('\"name\": \"marathon\"') 'tasks' key in '%s'.",
                 self.service_name,
+                DCOS_SERVICES_JSON_FILE_NAME,
             )
 
         ServiceBundle(

--- a/tools/diagnostics/full_bundle.py
+++ b/tools/diagnostics/full_bundle.py
@@ -30,7 +30,7 @@ def get_dcos_services() -> (bool, str):
         return (True, stdout)
 
 
-def is_service_named(sdk_service_name: str, dcos_service_name: dict) -> bool:
+def is_service_named(sdk_service_name: str, dcos_service_name: str) -> bool:
     """Handles a case where DC/OS service names sometimes don't contain the first slash.
     e.g.: |     SDK service name     |   DC/OS service name    |
           |--------------------------+-------------------------|

--- a/tools/diagnostics/full_bundle.py
+++ b/tools/diagnostics/full_bundle.py
@@ -150,6 +150,11 @@ class FullBundle(Bundle):
             for t in active_marathon_service.get("tasks", [])
             if is_service_scheduler_task(self.package_name, self.service_name, t)
         ]
+        if len(scheduler_tasks) == 0:
+            log.warn(
+                "Could not find scheduler tasks for '%s'. Please check the 'dcos_services.json' file.",
+                self.service_name,
+            )
 
         ServiceBundle(
             self.package_name,

--- a/tools/diagnostics/full_bundle.py
+++ b/tools/diagnostics/full_bundle.py
@@ -49,7 +49,11 @@ def services_with_name(service_name: str, services: List[dict]) -> List[dict]:
 
 
 def active_services_with_name(service_name: str, services: List[dict]) -> List[dict]:
-    return [s for s in services if is_service_named(service_name, s.get("name")) and is_service_active(s)]
+    return [
+        s
+        for s in services
+        if is_service_named(service_name, s.get("name")) and is_service_active(s)
+    ]
 
 
 def is_service_scheduler_task(package_name: str, service_name: str, task: dict) -> bool:

--- a/tools/diagnostics/full_bundle.py
+++ b/tools/diagnostics/full_bundle.py
@@ -33,14 +33,14 @@ def get_dcos_services() -> (bool, str):
         return (True, stdout)
 
 
-def is_service_named(sdk_service_name: str, dcos_service_name: str) -> bool:
+def service_names_match(sdk_service_name: str, dcos_service_name: str) -> bool:
     """Handles a case where DC/OS service names sometimes don't contain the first slash.
     e.g.: |     SDK service name     |   DC/OS service name    |
           |--------------------------+-------------------------|
           | /data-services/cassandra | data-services/cassandra |
           | /production/cassandra    | /production/cassandra   |
     """
-    return dcos_service_name in [sdk_service_name, sdk_service_name.lstrip("/")]
+    return dcos_service_name.lstrip("/") == sdk_service_name.lstrip("/")
 
 
 def is_service_active(service: dict) -> bool:
@@ -48,14 +48,14 @@ def is_service_active(service: dict) -> bool:
 
 
 def services_with_name(service_name: str, services: List[dict]) -> List[dict]:
-    return [s for s in services if is_service_named(service_name, s.get("name"))]
+    return [s for s in services if service_names_match(service_name, s.get("name"))]
 
 
 def active_services_with_name(service_name: str, services: List[dict]) -> List[dict]:
     return [
         s
         for s in services
-        if is_service_named(service_name, s.get("name")) and is_service_active(s)
+        if service_names_match(service_name, s.get("name")) and is_service_active(s)
     ]
 
 
@@ -67,7 +67,7 @@ def is_service_scheduler_task(package_name: str, service_name: str, task: dict) 
     dcos_service_name = next(
         iter([l.get("value") for l in labels if l.get("key") == "DCOS_SERVICE_NAME"]), ""
     )
-    return dcos_package_name == package_name and is_service_named(service_name, dcos_service_name)
+    return dcos_package_name == package_name and service_names_match(service_name, dcos_service_name)
 
 
 def directory_date_string() -> str:
@@ -125,7 +125,7 @@ class FullBundle(Bundle):
 
         # An SDK service might have multiple DC/OS service entries. We expect that at most one is
         # "active".
-        services = [s for s in all_services if is_service_named(self.service_name, s.get("name"))]
+        services = [s for s in all_services if service_names_match(self.service_name, s.get("name"))]
         # TODO: handle inactive services too.
         active_services = [s for s in services if is_service_active(s)]
 
@@ -138,7 +138,7 @@ class FullBundle(Bundle):
 
         active_service = active_services[0]
 
-        marathon_services = [s for s in all_services if is_service_named("marathon", s.get("name"))]
+        marathon_services = [s for s in all_services if service_names_match("marathon", s.get("name"))]
         # TODO: handle the possibility of having no active Marathon services?
         if len(marathon_services) > 1:
             log.warn("More than one marathon services: %s", len(marathon_services))

--- a/tools/diagnostics/full_bundle.py
+++ b/tools/diagnostics/full_bundle.py
@@ -153,7 +153,7 @@ class FullBundle(Bundle):
             for t in active_marathon_service.get("tasks", [])
             if is_service_scheduler_task(self.package_name, self.service_name, t)
         ]
-        if len(scheduler_tasks) == 0:
+        if not scheduler_tasks:
             log.warn(
                 "Could not find scheduler tasks for '%s' under the Marathon service ('\"name\": \"marathon\"') 'tasks' key in '%s'.",
                 self.service_name,


### PR DESCRIPTION
This happens due to a name mismatch. The DCOS_SERVICE_NAME label in SDK services and the service name provided through the CLI (i.e. `dcos $package --name=$service_name ...`) may or may not be prefixed by a slash, so comparing the two as-is sometimes doesn't work.

This change makes sure to get the scheduler task with and without a slash prefix in the name.