### PR TITLE
elastic: Add volume profile support

### DIFF
--- a/frameworks/elastic/src/main/dist/svc.yml
+++ b/frameworks/elastic/src/main/dist/svc.yml
@@ -45,6 +45,10 @@ pods:
           path: "container-path"
           type: {{MASTER_NODE_DISK_TYPE}}
           size: {{MASTER_NODE_DISK}}
+          {{#MASTER_NODE_DISK_PROFILE_ENABLED}}
+          profiles:
+            - {{MASTER_NODE_DISK_PROFILE}}
+          {{/MASTER_NODE_DISK_PROFILE_ENABLED}}
         cmd: |
           set -ex
 
@@ -135,6 +139,10 @@ pods:
           path: "container-path"
           type: {{DATA_NODE_DISK_TYPE}}
           size: {{DATA_NODE_DISK}}
+          {{#DATA_NODE_DISK_PROFILE_ENABLED}}
+          profiles:
+            - {{DATA_NODE_DISK_PROFILE}}
+          {{/DATA_NODE_DISK_PROFILE_ENABLED}}
         cmd: |
           set -ex
 
@@ -223,6 +231,10 @@ pods:
           path: "container-path"
           type: {{INGEST_NODE_DISK_TYPE}}
           size: {{INGEST_NODE_DISK}}
+          {{#INGEST_NODE_DISK_PROFILE_ENABLED}}
+          profiles:
+            - {{INGEST_NODE_DISK_PROFILE}}
+          {{/INGEST_NODE_DISK_PROFILE_ENABLED}}
         cmd: |
           set -ex
 
@@ -311,6 +323,10 @@ pods:
           path: "container-path"
           type: {{COORDINATOR_NODE_DISK_TYPE}}
           size: {{COORDINATOR_NODE_DISK}}
+          {{#COORDINATOR_NODE_DISK_PROFILE_ENABLED}}
+          profiles:
+            - {{COORDINATOR_NODE_DISK_PROFILE}}
+          {{/COORDINATOR_NODE_DISK_PROFILE_ENABLED}}
         cmd: |
           set -ex
 

--- a/frameworks/elastic/universe/config.json
+++ b/frameworks/elastic/universe/config.json
@@ -146,6 +146,10 @@
           "description": "Disk type to be used for storing data. [ROOT, MOUNT]",
           "default": "ROOT"
         },
+        "disk_profile": {
+          "description": "Master node disk profile",
+          "type": "string"
+        },
         "transport_port": {
           "description": "Transport port for master nodes to listen on.",
           "type": "integer",
@@ -260,6 +264,10 @@
           "description": "Disk type to be used for storing data. [ROOT, MOUNT]",
           "default": "ROOT"
         },
+        "disk_profile": {
+          "description": "Data node disk profile",
+          "type": "string"
+        },
         "placement": {
           "description": "Placement constraints for data nodes (e.g., [[\"hostname\", \"UNIQUE\"]]).",
           "type": "string",
@@ -369,6 +377,10 @@
           "description": "Disk type to be used for storing data. [ROOT, MOUNT]",
           "default": "ROOT"
         },
+        "disk_profile": {
+          "description": "Ingest node disk profile",
+          "type": "string"
+        },
         "placement": {
           "description": "Placement constraints for ingest nodes (e.g., [[\"hostname\", \"UNIQUE\"]]).",
           "type": "string",
@@ -477,6 +489,10 @@
           "type": "string",
           "description": "Disk type to be used for storing data. [ROOT, MOUNT]",
           "default": "ROOT"
+        },
+        "disk_profile": {
+          "description": "Coordinator node disk profile",
+          "type": "string"
         },
         "placement": {
           "description": "Placement constraints for coordinator nodes (e.g., [[\"hostname\", \"UNIQUE\"]]).",

--- a/frameworks/elastic/universe/marathon.json.mustache
+++ b/frameworks/elastic/universe/marathon.json.mustache
@@ -79,6 +79,10 @@
     "MASTER_NODE_DISK": "{{master_nodes.disk}}",
     "MASTER_NODE_DISK_TYPE": "{{master_nodes.disk_type}}",
     "MASTER_NODE_TRANSPORT_PORT": "{{master_nodes.transport_port}}",
+    {{#master_nodes.disk_profile}}
+    "MASTER_NODE_DISK_PROFILE_ENABLED": "true",
+    "MASTER_NODE_DISK_PROFILE": "{{master_nodes.disk_profile}}",
+    {{/master_nodes.disk_profile}}
     "DATA_NODE_COUNT": "{{data_nodes.count}}",
     "DATA_NODE_CPUS": "{{data_nodes.cpus}}",
     "DATA_NODE_MEM": "{{data_nodes.mem}}",
@@ -86,6 +90,10 @@
     "DATA_NODE_HEAP_MB": "{{data_nodes.heap.size}}",
     "DATA_NODE_DISK": "{{data_nodes.disk}}",
     "DATA_NODE_DISK_TYPE": "{{data_nodes.disk_type}}",
+    {{#data_nodes.disk_profile}}
+    "DATA_NODE_DISK_PROFILE_ENABLED": "true",
+    "DATA_NODE_DISK_PROFILE": "{{data_nodes.disk_profile}}",
+    {{/data_nodes.disk_profile}}
     "INGEST_NODE_COUNT": "{{ingest_nodes.count}}",
     "INGEST_NODE_CPUS": "{{ingest_nodes.cpus}}",
     "INGEST_NODE_MEM": "{{ingest_nodes.mem}}",
@@ -93,6 +101,10 @@
     "INGEST_NODE_HEAP_MB": "{{ingest_nodes.heap.size}}",
     "INGEST_NODE_DISK": "{{ingest_nodes.disk}}",
     "INGEST_NODE_DISK_TYPE": "{{ingest_nodes.disk_type}}",
+    {{#ingest_nodes.disk_profile}}
+    "INGEST_NODE_DISK_PROFILE_ENABLED": "true",
+    "INGEST_NODE_DISK_PROFILE": "{{ingest_nodes.disk_profile}}",
+    {{/ingest_nodes.disk_profile}}
     "COORDINATOR_NODE_COUNT": "{{coordinator_nodes.count}}",
     "COORDINATOR_NODE_CPUS": "{{coordinator_nodes.cpus}}",
     "COORDINATOR_NODE_MEM": "{{coordinator_nodes.mem}}",
@@ -100,6 +112,10 @@
     "COORDINATOR_NODE_HEAP_MB": "{{coordinator_nodes.heap.size}}",
     "COORDINATOR_NODE_DISK": "{{coordinator_nodes.disk}}",
     "COORDINATOR_NODE_DISK_TYPE": "{{coordinator_nodes.disk_type}}",
+    {{#coordinator_nodes.disk_profile}}
+    "COORDINATOR_NODE_DISK_PROFILE_ENABLED": "true",
+    "COORDINATOR_NODE_DISK_PROFILE": "{{coordinator_nodes.disk_profile}}",
+    {{/coordinator_nodes.disk_profile}}
     {{#service.region}}
     "SERVICE_REGION": "{{service.region}}",
     {{/service.region}}


### PR DESCRIPTION
This patch adds volume profile support for Elastic framework. Users are
now allowed to pick a volume profile for master, data, ingest or
coordinator node.