### PR TITLE
Increase Elastic xpack_upgrade_matrix test timeout.

### DIFF
--- a/frameworks/elastic/tests/test_upgrade.py
+++ b/frameworks/elastic/tests/test_upgrade.py
@@ -33,7 +33,7 @@ def uninstall_packages(configure_security):
 
 # TODO(mpereira): it is safe to remove this test after the 6.x release.
 @pytest.mark.sanity
-@pytest.mark.timeout(20 * 60)
+@pytest.mark.timeout(30 * 60)
 def test_xpack_update_matrix():
     # Updating from X-Pack 'enabled' to X-Pack security 'enabled' (the default) is more involved
     # than the other cases, so we use `test_upgrade_from_xpack_enabled`.


### PR DESCRIPTION
This test has failed a few times because the timeout for its runtime is exactly 20 minutes and it takes on average 20 minutes to complete (sometimes a bit more, sometimes a bit less).

![screen shot 2019-01-15 at 14 15 57](https://user-images.githubusercontent.com/112426/51183098-8e3ae780-18d0-11e9-85d9-034861062cf9.png)