### PR TITLE
DO/CS spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ pods:
     tasks:
       ...
 ```
-* Declared that we need atleast `{{COUNT}}` instances of the `helloworld` pod running at all times, where `COUNT` is the environment variable that is injected into the scheduler process at launch time via Marathon. It defaults to `1` for this example.
+* Declared that we need at least `{{COUNT}}` instances of the `helloworld` pod running at all times, where `COUNT` is the environment variable that is injected into the scheduler process at launch time via Marathon. It defaults to `1` for this example.
 * Defined a task specification for our `server` task using:
 
 ```yaml

--- a/TESTING.md
+++ b/TESTING.md
@@ -52,7 +52,7 @@ This automatically detects the frameworks in the current folder and for each fra
 *Note:* That this assumes that the DC/OS CLI has already been associated with a DC/OS cluster using the `dcos cluster setup` or `dcos cluster attach` commands.
 
 #### Detection of frameworks
-As mentioned above, the `test.sh` script detects all the frameworks in the current folder. This is done with the following precednce:
+As mentioned above, the `test.sh` script detects all the frameworks in the current folder. This is done with the following precedence:
 
 * If a `frameworks` folder exists
 
@@ -103,7 +103,7 @@ Most system integration tests rely on a stub-universe being set up allowing us t
 ```bash
 export STUB_UNIVERSE_URL="https://universe-converter.mesosphere.com/transform?url=https://infinity-artifacts.s3.amazonaws.com/autodelete7d/my-framework/20180806-125351-sdEdQ7mRfHFXQzmT/stub-universe-my-framework.json
 ```
-The stub-universe URL can be optained from an earlier build, or by building the framework (`my-framework` in this case) in the container by running the following command:
+The stub-universe URL can be obtained from an earlier build, or by building the framework (`my-framework` in this case) in the container by running the following command:
 ```bash
 ./frameworks/my-framwork/build.sh aws
 ```

--- a/docs/pages/developer-guide.md
+++ b/docs/pages/developer-guide.md
@@ -1007,7 +1007,7 @@ server-lb.hello-world.l4lb.thisdcos.directory:80
 
 ## Virtual networks
 
-The SDK allows pods to join virtual networks, with the `dcos` virtual network available by defualt. You can specify that a pod should join the virtual network by adding the following to your service spec YAML:
+The SDK allows pods to join virtual networks, with the `dcos` virtual network available by default. You can specify that a pod should join the virtual network by adding the following to your service spec YAML:
 
 ```yaml
 pods:
@@ -1051,11 +1051,11 @@ When a pod is on a virtual network such as the `dcos`:
 Specifying that pods join a virtual network has the following indirect effects:
   * The `ports` resource requirements in the service spec will be ignored as resource requirements, as each pod has their own dedicated IP namespace.
     * This was done so that you do not have to remove all of the port resource requirements just to deploy a service on the virtual network.
-  * A caveat of this is that the SDK does not allow the configuation of a pod to change from the virtual network to the host network or vice-versa.
+  * A caveat of this is that the SDK does not allow the configuration of a pod to change from the virtual network to the host network or vice-versa.
 
 ## Label-Based Discovery
 
-Some external tools such as [Taefik](https://docs.traefik.io) require tasks to be configured with custom labels which are accessed by reading Mesos state. Below is an example of specifying labels for a task in your service spec YAML:
+Some external tools such as [Traefik](https://docs.traefik.io) require tasks to be configured with custom labels which are accessed by reading Mesos state. Below is an example of specifying labels for a task in your service spec YAML:
 
 ```
 name: "hello-world"
@@ -1259,7 +1259,7 @@ SDK-based example service using DC/OS secrets.
 
 The path of a secret defines which service IDs can have access to it. You can think of secret paths as namespaces. _Only_ services that are under the same namespace can read the content of the secret.
 
-For the example given above, the secret with path `secret-svc/Secret_Path1` can only be accessed by a services with ID `/secret-svc` or any service with  ID under `/secret-svc/`. Servicess with IDs `/secret-svc/dev1` and `/secret-svc/instance2/dev2` all have access to this secret, because they are under `/secret-svc/`.
+For the example given above, the secret with path `secret-svc/Secret_Path1` can only be accessed by a services with ID `/secret-svc` or any service with  ID under `/secret-svc/`. Services with IDs `/secret-svc/dev1` and `/secret-svc/instance2/dev2` all have access to this secret, because they are under `/secret-svc/`.
 
 On the other hand, the secret with path `secret-svc/instance1/Secret_Path2` cannot be accessed by a service with ID `/secret-svc` because it is not _under_ this secret's namespace, which is `/secret-svc/instance1`. `secret-svc/instance1/Secret_Path2` can be accessed by a service with ID `/secret-svc/instance1` or any service with ID under `/secret-svc/instance1/`, for example `/secret-svc/instance1/dev3` and `/secret-svc/instance1/someDir/dev4`.
 
@@ -1368,7 +1368,7 @@ pods:
 
 Every item under `transport-encryption` must have a unique `name`. The `type` field defines the serialization format with which the private key and certificate will be delivered into the task sandbox. Currently, there are two supported formats - `TLS` and `KEYSTORE`. Each item will result in a unique private key and the corresponding certificate.
 
-The TLS artifacts within a single task will be unique for a task instance and won't be shared across all instances of the pod task. Different tasks can request TLS artficats with the same name, but each task will get unique private key and certificate, and they won't get shared across different tasks.
+The TLS artifacts within a single task will be unique for a task instance and won't be shared across all instances of the pod task. Different tasks can request TLS artifacts with the same name, but each task will get unique private key and certificate, and they won't get shared across different tasks.
 
 In the above example, the `$MESOS_SANDBOX` directory would contain following files:
 
@@ -1387,7 +1387,7 @@ Here, the file `server.crt` contains an end-entity certificate in the OpenSSL PE
 
 TLS artifacts are provisioned by the **scheduler** based on the service configuration. Generated artifacts are stored as secrets in the `default` secrets store. The scheduler stores each artifact (private key, certificate, CA bundle, keystore, and truststore) as a separate secret under the task's `DCOS_SPACE` path. This approach ensures that tasks launched by the scheduler [will get access](../operations-guide/#authorization-for-secrets) to all necessary secrets. If the secret exists for a single artifact, then it is **not** overwritten and the existing value is used. Currently there is no exposed automated way of regenerating TLS artifacts. The operator can delete secrets from DC/OS secret store which will trigger generating new TLS artifacts.
 
-The scheduler will generate and store TLS artfiacts for both possible formats (`TLS`, `KEYSTORE`). Changing the format will not create a new private key.
+The scheduler will generate and store TLS artifacts for both possible formats (`TLS`, `KEYSTORE`). Changing the format will not create a new private key.
 
 Generated artifacts are stored as secrets with the following naming scheme:
 
@@ -1423,7 +1423,7 @@ The scheduler provisions the *private key* and `X.509` *certificate* and exposes
 
 ### Private key
 
-The private key is generated by using Java [`KeyPairGenerator`](https://docs.oracle.com/javase/7/docs/api/java/security/KeyPairGenerator.html) initialized with `RSA` algorithm. The `RSA` key is generated with `2048` bit size based on [NIST recommnedations](https://www.keylength.com/en/4/).
+The private key is generated by using Java [`KeyPairGenerator`](https://docs.oracle.com/javase/7/docs/api/java/security/KeyPairGenerator.html) initialized with `RSA` algorithm. The `RSA` key is generated with `2048` bit size based on [NIST recommendations](https://www.keylength.com/en/4/).
 
 ### X.509 certificate
 
@@ -1439,7 +1439,7 @@ ST=CA
 C=US
 ```
 
-Additional X.509 `Subject Alternative Names`, based on the pod `discovery` and `vip` confiagurations, are encoded into the certificate. If no `discovery` or port exposed over VIP is configured, the single the certificate comes with a single SAN.
+Additional X.509 `Subject Alternative Names`, based on the pod `discovery` and `vip` configurations, are encoded into the certificate. If no `discovery` or port exposed over VIP is configured, the single the certificate comes with a single SAN.
 
 ```
 DNSName([pod-index-task].[service-name].autoip.dcos.thisdcos.directory)
@@ -1482,7 +1482,7 @@ The [Java Keystore (JKS)](https://en.wikipedia.org/wiki/Keystore) is a repositor
 
 A **.keystore** is a JKS file that contains a private key with an end-entity certificate and a complete certificate chain, including the root CA certificate. The certificate is stored under the alias name **`default`**. The keystore and key are protected by the password **`notsecure`**.
 
-A **.truststore** is a JKS file that contains the DC/OS root CA certificate stored as a trust certificate. The certificte is stored under alias **`dcos-root`**. The keystore is protected by **`notsecure`** password.
+A **.truststore** is a JKS file that contains the DC/OS root CA certificate stored as a trust certificate. The certificate is stored under alias **`dcos-root`**. The keystore is protected by **`notsecure`** password.
 
 The password **`notsecure`** that protects both JKS files (containing an end-entity certificate with private key and root CA certificate) has been selected because most Java tools and libraries require a password. It is not to meant to provide any additional protection. Security of both files is achieved by using DC/OS secrets store with file-based in-memory secrets. No other schedulers or tasks can access TLS artifacts provisioned by a scheduler.
 
@@ -1675,7 +1675,7 @@ pods:
 For a full list of which rlimits are supported, refer to [the Mesos documentation on rlimits](https://github.com/apache/mesos/blob/master/docs/isolators/posix-rlimits.md).
 
 **Virtual networks**
-The SDK supports having pods join virtual neworks (including the `dcos` overlay network). For an in-depth explanation of how virtual networks work on DC/OS see the [documentation](https://docs.mesosphere.com/latest/networking/virtual-networks/#virtual-network-service-dns). When a pod joins a virtual network it gets its own IP address and has access to its own array of ports. Therefore when a pod specifies that it is joining `dcos` we ignore the `ports` resource requirements, because the pod will not consume the ports on the host machine. The DNS for pods on this virtual network is `<task_name>.<framework_name>.autoip.dcos.thisdcos.directory`. Note that this DNS will also work for pods on the host network. **Because the `ports` resources are not used when a pod is on the virtual network, we do not allow a pod to be moved from a virtual network to the host network or vice-versa**. This is to prevent potential starvation of the task when the host with the reserved resources for the task does not have the available ports required to launch the task.
+The SDK supports having pods join virtual networks (including the `dcos` overlay network). For an in-depth explanation of how virtual networks work on DC/OS see the [documentation](https://docs.mesosphere.com/latest/networking/virtual-networks/#virtual-network-service-dns). When a pod joins a virtual network it gets its own IP address and has access to its own array of ports. Therefore when a pod specifies that it is joining `dcos` we ignore the `ports` resource requirements, because the pod will not consume the ports on the host machine. The DNS for pods on this virtual network is `<task_name>.<framework_name>.autoip.dcos.thisdcos.directory`. Note that this DNS will also work for pods on the host network. **Because the `ports` resources are not used when a pod is on the virtual network, we do not allow a pod to be moved from a virtual network to the host network or vice-versa**. This is to prevent potential starvation of the task when the host with the reserved resources for the task does not have the available ports required to launch the task.
 
 ### Placement Rules
 
@@ -1982,7 +1982,7 @@ When the `bootstrap` helper is run, it would automatically create a populated ve
   <port>1984</port>
   <game>mysvc</game>
   <!-- ... -->
-<config>
+</config>
 ```
 
 To be clear, the config templating provided by the `bootstrap` tool may be applied to _any text format_, not just XML as in this example. This makes it a powerful tool for handling any config files your service may need. Read more about setting this up in the [Bootstrap Tool](#bootstrap) section.

--- a/docs/pages/glossary.md
+++ b/docs/pages/glossary.md
@@ -7,7 +7,7 @@ redirect_from: /glossary.html
 ## D
 
 ### Deploy Plan
-A Deploy Plan explicity defines the order in which work needs to be performed in order to successfully deploy a given service.
+A Deploy Plan explicitly defines the order in which work needs to be performed in order to successfully deploy a given service.
 
 ## H
 

--- a/docs/pages/plans.md
+++ b/docs/pages/plans.md
@@ -174,7 +174,7 @@ deploy (serial strategy) (IN_PROGRESS)
    └─ world-1:[server, sidecar] (PENDING)
 ```
 
-Once the service has found a Mesos offer which matches the Step's `PodInstanceRequirement`, the service would tell Mesos to reserve the required resources and to launch the `hello-0-server` task. The service would then notify the `hello-0` Step that the launch had occured. The Step will set its internal state to `STARTING` to reflect that it's waiting for the task to actually launch:
+Once the service has found a Mesos offer which matches the Step's `PodInstanceRequirement`, the service would tell Mesos to reserve the required resources and to launch the `hello-0-server` task. The service would then notify the `hello-0` Step that the launch had occurred. The Step will set its internal state to `STARTING` to reflect that it's waiting for the task to actually launch:
 ```
 deploy (serial strategy) (STARTING)
 ├─ hello (serial strategy) (STARTING)
@@ -257,7 +257,7 @@ The `world-0` pod will be updated to have 1.5 CPUs from its prior allocation of 
 
 ### Recovery: Pod Restart/Replace
 
-As hinted at elsewhere, the `recovery` Plan is special because starts in an empty state and is later automatically populated with any detected tasks that need to be recovered. At the moment, completed operations can remain as `COMPLETE` phases in the `recovery` plan indefinitely until the scheduler process is restarted. To show an example of how the `recovery` plan typically opeprates we can also look at what happens when an operator requests a `pod restart` or `pod replace` operation. These operations rely on the `recovery` Plan to relaunch the task. As such, the recovery of restarted/replaced pods can likewise be customized by the developer.
+As hinted at elsewhere, the `recovery` Plan is special because starts in an empty state and is later automatically populated with any detected tasks that need to be recovered. At the moment, completed operations can remain as `COMPLETE` phases in the `recovery` plan indefinitely until the scheduler process is restarted. To show an example of how the `recovery` plan typically operates we can also look at what happens when an operator requests a `pod restart` or `pod replace` operation. These operations rely on the `recovery` Plan to relaunch the task. As such, the recovery of restarted/replaced pods can likewise be customized by the developer.
 
 For `pod restart` (kill and relaunch pod at current location), the sequence works as follows:
 1. Mesos is told to kill task

--- a/docs/pages/tutorials/secrets-tutorial.md
+++ b/docs/pages/tutorials/secrets-tutorial.md
@@ -7,7 +7,7 @@ type: tutorial
 
 The SDK enables you to integrate DC/OS secrets using both a declarative YAML API and flexible JAVA API. In YAML, secrets are declared within the `secret:` section in a pod specification. Similarly, in JAVA API, a `SecretSpec` is added to the `PodSpec` object.
 
-Refer to the [Developer Guide](../../developer-guide/) for more information about the JAVA API. Refer to the [Operations Guide](../../operations-guide/) for a detailed explaination of how to use DC/OS secrets in your SDK-based service.
+Refer to the [Developer Guide](../../developer-guide/) for more information about the JAVA API. Refer to the [Operations Guide](../../operations-guide/) for a detailed explanation of how to use DC/OS secrets in your SDK-based service.
 
 In this tutorial, we will use the existing `hello-world` service to experiment with secrets. First, create a DC/OS Enterprise 1.10 cluster (at least 3 nodes is recommended).
 
@@ -117,7 +117,7 @@ pods:
 
 The `hello` pod has two secrets. The first secret, with path `hello-world/secret1`, is exposed both as an environment variable and as a file. The second one is exposed only as a file. The value of the second secret with path `hello-world/secret2`, which is the private key, will be copied to the `HELLO_SECRET2_FILE` file located in the sandbox.
 
-The `world` pod has three secrets. The first one is exposed only as an environment variable. The second and third secrets are exposed only as files. All `server` tasks in the `world` pod will have access to the values of these three secrets, either as a file and/or as an evironment variable.
+The `world` pod has three secrets. The first one is exposed only as an environment variable. The second and third secrets are exposed only as files. All `server` tasks in the `world` pod will have access to the values of these three secrets, either as a file and/or as an environment variable.
 
 *Note*: The secret path is the default file path if no `file` keyword is given. Therefore, the file path for the third secret is same as the secret path.
 

--- a/docs/pages/yaml-reference.md
+++ b/docs/pages/yaml-reference.md
@@ -380,7 +380,7 @@ This documentation effectively reflects the Java object tree under [RawServiceSp
 
     * `health-check`
 
-      Health checks are additional validation that your task is healthy, in addition to just the fact that its process is still running. This is an extra convenience for citations where a service can enter a zombie state from which it can never return. For example, it might query an HTTP endpoint to validate that an HTTP service is still responding.
+      Health checks are additional validation that your task is healthy, in addition to just the fact that its process is still running. This is an extra convenience for situations where a service can enter a zombie state from which it can never return. For example, it might query an HTTP endpoint to validate that an HTTP service is still responding.
 
       * `cmd`
 

--- a/docs/pages/yaml-reference.md
+++ b/docs/pages/yaml-reference.md
@@ -380,7 +380,7 @@ This documentation effectively reflects the Java object tree under [RawServiceSp
 
     * `health-check`
 
-      Health checks are additional validation that your task is healthy, in addition to just the fact that its process is still running. This is an extra convenience for sitations where a service can enter a zombie state from which it can never return. For example, it might query an HTTP endpoint to validate that an HTTP service is still responding.
+      Health checks are additional validation that your task is healthy, in addition to just the fact that its process is still running. This is an extra convenience for citations where a service can enter a zombie state from which it can never return. For example, it might query an HTTP endpoint to validate that an HTTP service is still responding.
 
       * `cmd`
 

--- a/frameworks/helloworld/tests/tls/keystore/README.md
+++ b/frameworks/helloworld/tests/tls/keystore/README.md
@@ -20,7 +20,7 @@ directory:
 
 - `integration-test.yml`: can be used in SDK launched container task that
   requests for TLS certificate with name `dropwizard` that are exposed as a
-  keystore and trustore files.
+  keystore and truststore files.
   
 Local version requires `config/local.keystore` and `config/local.truststore` files.
 The both JKS files must be protected with `notsecure` password. To see the details
@@ -71,7 +71,7 @@ that can be used to run SDK TLS integration tests run:
 ./gradlew :keystore-app:integrationTestZip
 ```
 
-The task builds a ZIP file contianing `shadowJar` package and the
+The task builds a ZIP file containing `shadowJar` package and the
 `integration-test.yml` in `distributions` directory. The artifact can be
 downloaded by `mesos-fetcher` to a container with `java` runtime.
 

--- a/govendor/README.md
+++ b/govendor/README.md
@@ -6,4 +6,4 @@ This is a workaround for the Go tooling being confused by e.g. `github.com/mesos
 
 Frameworks in `dcos-commons/frameworks/` should create a `vendor` symlink which points to here. In other words, a symlink at `frameworks/yoursvc/cli/dcos-yoursvc/vendor` should point to `govendor/`.
 
-This workaround only applies to frameworks which are colocated in the `dcos-commons` repository. External projects shouldn't have to do this, and can instead have a regular `vendor` directory structure with a copy of `github.com/mesosphere/dcos-commons/cli`.
+This workaround only applies to frameworks which are collocated in the `dcos-commons` repository. External projects shouldn't have to do this, and can instead have a regular `vendor` directory structure with a copy of `github.com/mesosphere/dcos-commons/cli`.

--- a/govendor/github.com/dcos/dcos-cni/cmd/l4lb/README.md
+++ b/govendor/github.com/dcos/dcos-cni/cmd/l4lb/README.md
@@ -29,13 +29,13 @@ The CNI plugin is designed to work with any 3rd party network plugin. Below we g
         }
 }
 ```
-In the above example the `delegate` clause informs the `dcos-l4lb` plugin to invoke the `bridge` plugin with its respective parameters. During CNI ADD the `dcos-l4lb` plugin will first invoke the `bridge` plugin, with the config specified in `delegate`. On successful execution of the bridge plugin it will attach the container network namespace to the spartan network, and will also register the container's network namespace with minuteman. Attaching the container to the spartan network will allow the container to route all DNS queries to spartan, and registering network namespace with minuteman will allow minuteman to insert IPVS enteries into the container's network namespace for load-balancing.
+In the above example the `delegate` clause informs the `dcos-l4lb` plugin to invoke the `bridge` plugin with its respective parameters. During CNI ADD the `dcos-l4lb` plugin will first invoke the `bridge` plugin, with the config specified in `delegate`. On successful execution of the bridge plugin it will attach the container network namespace to the spartan network, and will also register the container's network namespace with minuteman. Attaching the container to the spartan network will allow the container to route all DNS queries to spartan, and registering network namespace with minuteman will allow minuteman to insert IPVS entries into the container's network namespace for load-balancing.
 
 During CNI DEL the `dcos-l4lb` will first detach the container network namespace from the spartan network. It will then `de-register` the network namespace from minuteman. Finally it will invoke DEL on the bridge plugin.
 
 While invoking CNI ADD or DEL on the bridge plugin the `dcos-l4lb` plugin will copy the `cniVersion`, `name` and `args` parameters specified in its own CNI configuration to the CNI configuration of the `bridge` plugin specified in the `delegate` field.
 
-**NOTE:** While this example specifically deals with the CNI bridge plugin, we could potentially use any other CNI plugin instead of the bridge pluging to provide IP connectivity to the container. Just replace the CNI configuration of bridge plugin with the configuration of the desired plugin in the `delegate` field. 
+**NOTE:** While this example specifically deals with the CNI bridge plugin, we could potentially use any other CNI plugin instead of the bridge plugging to provide IP connectivity to the container. Just replace the CNI configuration of bridge plugin with the configuration of the desired plugin in the `delegate` field. 
 
 # Parameters
 By default `Spartan` and `Minuteman` features are enabled in the `dcos-l4lb` plugin. However we give the user the flexibility of turning of `Spartan` or `Minuteman` (but not both) features of the plugin. These are the extra parameters that can be specified in the CNI configuration for the plugin

--- a/tools/distribution/UPDATING.md
+++ b/tools/distribution/UPDATING.md
@@ -37,7 +37,7 @@ Older versions of `build.gradle` contained the following dependencies and no ent
 * `compile "mesosphere:scheduler:<CURRENT_SDK_VERSION>"`
 * `testCompile "mesosphere:testing:<CURRENT_SDK_VERSION>"`
 
-Although this is supported in the current upgrade path, it is recommended that hese are changed to match the dependencies at the start of this section as this will result in a single line diff in the `build.gradle` file on update.
+Although this is supported in the current upgrade path, it is recommended that these are changed to match the dependencies at the start of this section as this will result in a single line diff in the `build.gradle` file on update.
 
 ### Check the `universe/resource.json` file
 
@@ -143,10 +143,10 @@ Note that the update procedure could also *delete* unneeded files.
 
 Check the differences in `build.gradle` and `tools/release_builder.py` to ensure that the `<NEW_SDK_VERSION>` is present in both files.
 
-Now add the changes to version control using the required git commants (`git add`, `git rm`).
+Now add the changes to version control using the required git commands (`git add`, `git rm`).
 
 ## Further steps
 
 * See the SDK release notes for any changes required when consuming the SKD.
 * If the build process is heavily customized, it may be that additional changes will be required to the `build.sh` file in the repo.
-* The API of the testing tools in `testing` could have changed, and any integration tests may need to be updted. Run `git diff testing` to check for any relevant changes.
+* The API of the testing tools in `testing` could have changed, and any integration tests may need to be updated. Run `git diff testing` to check for any relevant changes.

--- a/tools/kdc/README.md
+++ b/tools/kdc/README.md
@@ -3,7 +3,7 @@ Kerberos Domain Controller (KDC) server.
 
 The `kdc.json` config is used by the `sdk_auth` testing module to configure a KDC in the integration test environment.
 
-The Dockerfile is used to maintain/build a docker image which serves the KDC. The `run.sh` and `kdc.conf` files faciliate the bootstrap for
+The Dockerfile is used to maintain/build a docker image which serves the KDC. The `run.sh` and `kdc.conf` files facilitate the bootstrap for
 said server as they're copied into the image via the Dockerfile recipe.
 
 The `kdc.py` script is an ad-hoc tool to deploy/teardown a KDC instance outside of the testing environment. Its usage


### PR DESCRIPTION
The PR suggests to fix a bunch of misprints which I faced going through docs
atleast       =>  at least 
precednce => precedence
optained => obtained 
defualt => default
configuation => configuration 
[Taefik](https://docs.traefik.io) => [Traefik](https://docs.traefik.io)
Servicess  => Services
artficats => artifacts 
recommnedations => recommendations
confiagurations => configurations
certificte => certificate 
neworks => networks 
explicity => explicitly 
occured => occurred
opeprates => operates
explaination => explanation 
evironment => environment 
sitations => citations 
trustore => truststore 
contianing => containing 
colocated  => collocated 
enteries => entries
pluging => plugging 
hese  => these
commants  => commands 
updted => updated
faciliate  => facilitate 
```
<config>
  <port>1984</port>
  <game>mysvc</game>
  <!-- ... -->
<config>
``` 
=>
 ```
<config>
  <port>1984</port>
  <game>mysvc</game>
  <!-- ... -->
</config>
```