### PR TITLE
[DCOS-47377] Configure `node.attr.zone` as long as `ZONE` is available.

### DIFF
--- a/frameworks/elastic/src/main/dist/elasticsearch.yml
+++ b/frameworks/elastic/src/main/dist/elasticsearch.yml
@@ -19,12 +19,12 @@ bootstrap.memory_lock: false
 metrics.statsd.host: {{STATSD_UDP_HOST}}
 metrics.statsd.port: {{STATSD_UDP_PORT}}
 
-{{#PLACEMENT_REFERENCED_ZONE}}
 {{#ZONE}}
 node.attr.zone: {{ZONE}}
+{{#PLACEMENT_REFERENCED_ZONE}}
 cluster.routing.allocation.awareness.attributes: zone
-{{/ZONE}}
 {{/PLACEMENT_REFERENCED_ZONE}}
+{{/ZONE}}
 
 {{#MASTER_ENABLED}}
 gateway.expected_master_nodes: 3

--- a/frameworks/elastic/tests/test_rack_awareness.py
+++ b/frameworks/elastic/tests/test_rack_awareness.py
@@ -57,3 +57,32 @@ def test_zones_referenced_in_placement_constraints():
         assert sdk_fault_domain.is_valid_zone(get_in(["attributes", "zone"], node))
 
     sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
+
+
+@pytest.mark.sanity
+@pytest.mark.dcos_min_version("1.11")
+@sdk_utils.dcos_ee_only
+def test_heterogeneus_zone_constraints():
+    sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
+    sdk_install.install(
+        config.PACKAGE_NAME,
+        config.SERVICE_NAME,
+        config.DEFAULT_TASK_COUNT,
+        additional_options={
+            "master_nodes": {"placement": '[["@zone", "GROUP_BY"]]'},
+            "data_nodes": {"placement": '[["hostname", "UNIQUE"]]'},
+        },
+    )
+
+    document_id = 99
+    document_fields = {"name": "X-Pack", "role": "commercial plugin"}
+    config.create_document(
+        config.DEFAULT_INDEX_NAME,
+        config.DEFAULT_INDEX_TYPE,
+        document_id,
+        document_fields,
+        service_name=config.SERVICE_NAME,
+    )
+    config.verify_document(config.SERVICE_NAME, document_id, document_fields)
+
+    sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)

--- a/frameworks/elastic/tests/test_rack_awareness.py
+++ b/frameworks/elastic/tests/test_rack_awareness.py
@@ -26,7 +26,7 @@ def test_zones_not_referenced_in_placement_constraints():
             )
             is None
         )
-        assert get_in(["attributes", "zone"], node) is None
+        assert sdk_fault_domain.is_valid_zone(get_in(["attributes", "zone"], node))
 
     sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
 


### PR DESCRIPTION
This prevents shards from being unable to be allocated due to heterogeneity in @zone constraints for pods.

I first added the test, made sure it failed without the config file change, then added the config file change and verified that the test passed.
