### PR TITLE
[DIAGNOSTICS][DCOS-477820] Add initial support for kubernetes diagnostic bundles

### DIFF
--- a/tools/diagnostics/base_tech_bundle/__init__.py
+++ b/tools/diagnostics/base_tech_bundle/__init__.py
@@ -1,12 +1,89 @@
 from service_bundle import ServiceBundle
 
+import json
+import logging
+import config
+import sdk_cmd
 
+log = logging.getLogger(__name__)
 class BaseTechBundle(ServiceBundle):
+
+    def __init__(self, package_name, service_name, scheduler_tasks, service, output_directory):
+        self.package_name = package_name
+        self.service_name = service_name
+        self.scheduler_tasks = scheduler_tasks
+        self.service = service
+        self.framework_id = service.get("id")
+        self.output_directory = output_directory
+        self.install_cli()
+
+    @config.retry
+    def install_cli(self):
+        sdk_cmd.run_cli(
+            "package install {} --cli --yes".format(self.package_name),
+            print_output=False,
+            check=True,
+        )
+
+    @config.retry
+    def create_configuration_file(self):
+        rc, stdout, stderr = sdk_cmd.svc_cli(
+            self.package_name, self.service_name, "describe", print_output=False
+        )
+
+        if rc != 0 or stderr:
+            log.error(
+                "Could not get service configuration\nstdout: '%s'\nstderr: '%s'", stdout, stderr
+            )
+        else:
+            self.write_file("service_configuration.json", stdout)
+
+    @config.retry
+    def create_pod_status_file(self):
+        rc, stdout, stderr = sdk_cmd.svc_cli(
+            self.package_name, self.service_name, "pod status --json", print_output=False
+        )
+
+        if rc != 0 or stderr:
+            log.error("Could not get pod status\nstdout: '%s'\nstderr: '%s'", stdout, stderr)
+        else:
+            self.write_file("service_pod_status.json", stdout)
+
+    @config.retry
+    def create_plan_status_file(self, plan):
+        rc, stdout, stderr = sdk_cmd.svc_cli(
+            self.package_name,
+            self.service_name,
+            "plan status {} --json".format(plan),
+            print_output=False,
+        )
+
+        if rc != 0 or stderr:
+            log.error("Could not get pod status\nstdout: '%s'\nstderr: '%s'", stdout, stderr)
+        else:
+            self.write_file("service_plan_status_{}.json".format(plan), stdout)
+
+    @config.retry
+    def create_plans_status_files(self):
+        rc, stdout, stderr = sdk_cmd.svc_cli(
+            self.package_name, self.service_name, "plan list", print_output=False
+        )
+
+        if rc != 0 or stderr:
+            log.error("Could not get plan list\nstdout: '%s'\nstderr: '%s'", stdout, stderr)
+        else:
+            plans = json.loads(stdout)
+            for plan in plans:
+                self.create_plan_status_file(plan)
+
     def task_exec(self):
         raise NotImplementedError
 
     def create(self):
-        raise NotImplementedError
+        log.info("Creating base-tech bundle")
+        self.create_configuration_file()
+        self.create_pod_status_file()
+        self.create_plans_status_files()
 
 
 from .cassandra_bundle import CassandraBundle  # noqa: E402
@@ -32,12 +109,10 @@ SUPPORTED_PACKAGES = sorted(BASE_TECH_BUNDLE.keys())
 
 
 def get_bundle_class(package_name: str):
-    return BASE_TECH_BUNDLE.get(package_name)
-
-
-def is_package_supported(package_name: str):
-    return package_name in SUPPORTED_PACKAGES
-
+    if package_name in SUPPORTED_PACKAGES:
+        return BASE_TECH_BUNDLE.get(package_name)
+    else:
+        return BaseTechBundle
 
 __all__ = [
     "BASE_TECH_BUNDLE",

--- a/tools/diagnostics/base_tech_bundle/__init__.py
+++ b/tools/diagnostics/base_tech_bundle/__init__.py
@@ -6,6 +6,8 @@ import config
 import sdk_cmd
 
 log = logging.getLogger(__name__)
+
+
 class BaseTechBundle(ServiceBundle):
 
     def __init__(self, package_name, service_name, scheduler_tasks, service, output_directory):
@@ -85,6 +87,7 @@ class BaseTechBundle(ServiceBundle):
         self.create_pod_status_file()
         self.create_plans_status_files()
 
+
 from .cassandra_bundle import CassandraBundle  # noqa: E402
 from .elastic_bundle import ElasticBundle  # noqa: E402
 from .hdfs_bundle import HdfsBundle  # noqa: E402
@@ -114,6 +117,7 @@ def get_bundle_class(package_name: str):
         return BASE_TECH_BUNDLE.get(package_name)
     else:
         return BaseTechBundle
+
 
 __all__ = [
     "BASE_TECH_BUNDLE",

--- a/tools/diagnostics/base_tech_bundle/__init__.py
+++ b/tools/diagnostics/base_tech_bundle/__init__.py
@@ -90,6 +90,7 @@ from .cassandra_bundle import CassandraBundle  # noqa: E402
 from .elastic_bundle import ElasticBundle  # noqa: E402
 from .hdfs_bundle import HdfsBundle  # noqa: E402
 from .kafka_bundle import KafkaBundle  # noqa: E402
+from .kubernetes_bundle import KubernetesBundle   # noqa: E402
 
 
 BASE_TECH_BUNDLE = {
@@ -102,6 +103,7 @@ BASE_TECH_BUNDLE = {
     "elastic": ElasticBundle,
     "hdfs": HdfsBundle,
     "kafka": KafkaBundle,
+    "kubernetes": KubernetesBundle,
 }
 
 

--- a/tools/diagnostics/base_tech_bundle/__init__.py
+++ b/tools/diagnostics/base_tech_bundle/__init__.py
@@ -85,7 +85,6 @@ class BaseTechBundle(ServiceBundle):
         self.create_pod_status_file()
         self.create_plans_status_files()
 
-
 from .cassandra_bundle import CassandraBundle  # noqa: E402
 from .elastic_bundle import ElasticBundle  # noqa: E402
 from .hdfs_bundle import HdfsBundle  # noqa: E402

--- a/tools/diagnostics/base_tech_bundle/cassandra_bundle.py
+++ b/tools/diagnostics/base_tech_bundle/cassandra_bundle.py
@@ -33,23 +33,27 @@ class CassandraBundle(BaseTechBundle):
     def create_nodetool_status_file(self, task_id):
         rc, stdout, stderr = self.task_exec(task_id, "${CASSANDRA_DIRECTORY}/bin/nodetool status")
 
-        if rc != 0 or stderr:
+        if rc != 0:
             logger.error(
-                "Could not get Cassandra nodetool stats\nstdout: '%s'\nstderr: '%s'", stdout, stderr
+                "Could not get Cassandra nodetool stats. return-code: '%s'\n"
+                "stdout: '%s'\nstderr: '%s'", rc, stdout, stderr
             )
         else:
+            if stderr:
+                logger.warning("Non-fatal nodetool stats message\nstderr: '%s'", stderr)
             self.write_file("cassandra_nodetool_status_{}.txt".format(task_id), stdout)
 
     def create_nodetool_tpstats_file(self, task_id):
         rc, stdout, stderr = self.task_exec(task_id, "${CASSANDRA_DIRECTORY}/bin/nodetool tpstats")
 
-        if rc != 0 or stderr:
+        if rc != 0:
             logger.error(
-                "Could not get Cassandra nodetool tpstats\nstdout: '%s'\nstderr: '%s'",
-                stdout,
-                stderr,
+                "Could not get Cassandra nodetool tpstats. return-code: '%s'\n"
+                "stdout: '%s'\nstderr: '%s'", rc, stdout, stderr
             )
         else:
+            if stderr:
+                logger.warning("Non-fatal nodetool tpstats message\nstderr: '%s'", stderr)
             self.write_file("cassandra_nodetool_tpstats_{}.txt".format(task_id), stdout)
 
     def create_tasks_nodetool_status_files(self):

--- a/tools/diagnostics/base_tech_bundle/cassandra_bundle.py
+++ b/tools/diagnostics/base_tech_bundle/cassandra_bundle.py
@@ -9,6 +9,15 @@ logger = logging.getLogger(__name__)
 
 
 class CassandraBundle(BaseTechBundle):
+
+    def __init__(self, package_name, service_name, scheduler_tasks, service, output_directory):
+        super().__init__(self,
+                         package_name,
+                         service_name,
+                         scheduler_tasks,
+                         service,
+                         output_directory)
+
     @config.retry
     def task_exec(self, task_id, cmd):
         full_cmd = " ".join(

--- a/tools/diagnostics/base_tech_bundle/cassandra_bundle.py
+++ b/tools/diagnostics/base_tech_bundle/cassandra_bundle.py
@@ -11,8 +11,7 @@ logger = logging.getLogger(__name__)
 class CassandraBundle(BaseTechBundle):
 
     def __init__(self, package_name, service_name, scheduler_tasks, service, output_directory):
-        super().__init__(self,
-                         package_name,
+        super().__init__(package_name,
                          service_name,
                          scheduler_tasks,
                          service,

--- a/tools/diagnostics/base_tech_bundle/cassandra_bundle.py
+++ b/tools/diagnostics/base_tech_bundle/cassandra_bundle.py
@@ -61,5 +61,8 @@ class CassandraBundle(BaseTechBundle):
 
     def create(self):
         logger.info("Creating Cassandra bundle")
+        self.create_configuration_file()
+        self.create_pod_status_file()
+        self.create_plans_status_files()
         self.create_tasks_nodetool_status_files()
         self.create_tasks_nodetool_tpstats_files()

--- a/tools/diagnostics/base_tech_bundle/elastic_bundle.py
+++ b/tools/diagnostics/base_tech_bundle/elastic_bundle.py
@@ -11,8 +11,7 @@ logger = logging.getLogger(__name__)
 class ElasticBundle(BaseTechBundle):
 
     def __init__(self, package_name, service_name, scheduler_tasks, service, output_directory):
-        super().__init__(self,
-                         package_name,
+        super().__init__(package_name,
                          service_name,
                          scheduler_tasks,
                          service,

--- a/tools/diagnostics/base_tech_bundle/elastic_bundle.py
+++ b/tools/diagnostics/base_tech_bundle/elastic_bundle.py
@@ -46,4 +46,7 @@ class ElasticBundle(BaseTechBundle):
 
     def create(self):
         logger.info("Creating Elastic bundle")
+        self.create_configuration_file()
+        self.create_pod_status_file()
+        self.create_plans_status_files()
         self.create_tasks_stats_files()

--- a/tools/diagnostics/base_tech_bundle/elastic_bundle.py
+++ b/tools/diagnostics/base_tech_bundle/elastic_bundle.py
@@ -9,6 +9,15 @@ logger = logging.getLogger(__name__)
 
 
 class ElasticBundle(BaseTechBundle):
+
+    def __init__(self, package_name, service_name, scheduler_tasks, service, output_directory):
+        super().__init__(self,
+                         package_name,
+                         service_name,
+                         scheduler_tasks,
+                         service,
+                         output_directory)
+
     @config.retry
     def task_exec(self, task_id, cmd):
         full_cmd = " ".join(

--- a/tools/diagnostics/base_tech_bundle/elastic_bundle.py
+++ b/tools/diagnostics/base_tech_bundle/elastic_bundle.py
@@ -33,11 +33,15 @@ class ElasticBundle(BaseTechBundle):
     def create_stats_file(self, task_id):
         command = "curl -s ${MESOS_CONTAINER_IP}:${PORT_HTTP}/_stats"
         rc, stdout, stderr = self.task_exec(task_id, command)
-        if rc != 0 or stderr:
+
+        if rc != 0:
             logger.error(
-                "Could not get Elasticsearch /_stats\nstdout: '%s'\nstderr: '%s'", stdout, stderr
+                "Could not get Elasticsearch /_stats. return-code: '%s'\n"
+                "stdout: '%s'\nstderr: '%s'", rc, stdout, stderr
             )
         else:
+            if stderr:
+                logger.warning("Non-fatal Elasticsearch /_stats message\nstderr: '%s'", stderr)
             self.write_file("elasticsearch_stats_{}.json".format(task_id), stdout)
 
     def create_tasks_stats_files(self):

--- a/tools/diagnostics/base_tech_bundle/hdfs_bundle.py
+++ b/tools/diagnostics/base_tech_bundle/hdfs_bundle.py
@@ -7,9 +7,8 @@ logger = logging.getLogger(__name__)
 
 class HdfsBundle(BaseTechBundle):
 
-     def __init__(self, package_name, service_name, scheduler_tasks, service, output_directory):
-        super().__init__(self,
-                         package_name,
+    def __init__(self, package_name, service_name, scheduler_tasks, service, output_directory):
+        super().__init__(package_name,
                          service_name,
                          scheduler_tasks,
                          service,

--- a/tools/diagnostics/base_tech_bundle/hdfs_bundle.py
+++ b/tools/diagnostics/base_tech_bundle/hdfs_bundle.py
@@ -6,5 +6,14 @@ logger = logging.getLogger(__name__)
 
 
 class HdfsBundle(BaseTechBundle):
+
+     def __init__(self, package_name, service_name, scheduler_tasks, service, output_directory):
+        super().__init__(self,
+                         package_name,
+                         service_name,
+                         scheduler_tasks,
+                         service,
+                         output_directory)
+
     def create(self):
         logger.info("Creating HDFS bundle (noop)")

--- a/tools/diagnostics/base_tech_bundle/hdfs_bundle.py
+++ b/tools/diagnostics/base_tech_bundle/hdfs_bundle.py
@@ -16,4 +16,7 @@ class HdfsBundle(BaseTechBundle):
                          output_directory)
 
     def create(self):
+        self.create_configuration_file()
+        self.create_pod_status_file()
+        self.create_plans_status_files()
         logger.info("Creating HDFS bundle (noop)")

--- a/tools/diagnostics/base_tech_bundle/kafka_bundle.py
+++ b/tools/diagnostics/base_tech_bundle/kafka_bundle.py
@@ -11,9 +11,8 @@ logger = logging.getLogger(__name__)
 
 class KafkaBundle(BaseTechBundle):
 
-     def __init__(self, package_name, service_name, scheduler_tasks, service, output_directory):
-        super().__init__(self,
-                         package_name,
+    def __init__(self, package_name, service_name, scheduler_tasks, service, output_directory):
+        super().__init__(package_name,
                          service_name,
                          scheduler_tasks,
                          service,

--- a/tools/diagnostics/base_tech_bundle/kafka_bundle.py
+++ b/tools/diagnostics/base_tech_bundle/kafka_bundle.py
@@ -21,6 +21,9 @@ class KafkaBundle(BaseTechBundle):
 
     def create(self):
         logger.info("Creating Kafka bundle")
+        self.create_configuration_file()
+        self.create_pod_status_file()
+        self.create_plans_status_files()
         brokers = self.create_broker_list_file()
         if brokers:
             for broker_id in brokers:

--- a/tools/diagnostics/base_tech_bundle/kafka_bundle.py
+++ b/tools/diagnostics/base_tech_bundle/kafka_bundle.py
@@ -10,6 +10,15 @@ logger = logging.getLogger(__name__)
 
 
 class KafkaBundle(BaseTechBundle):
+
+     def __init__(self, package_name, service_name, scheduler_tasks, service, output_directory):
+        super().__init__(self,
+                         package_name,
+                         service_name,
+                         scheduler_tasks,
+                         service,
+                         output_directory)
+
     def create(self):
         logger.info("Creating Kafka bundle")
         brokers = self.create_broker_list_file()

--- a/tools/diagnostics/base_tech_bundle/kubernetes_bundle.py
+++ b/tools/diagnostics/base_tech_bundle/kubernetes_bundle.py
@@ -24,7 +24,7 @@ class KubernetesBundle(BaseTechBundle):
         )
 
         if rc != 0 or stderr:
-            log.error(
+            logging.error(
                 "Could not get service configuration\nstdout: '%s'\nstderr: '%s'", stdout, stderr
             )
         else:
@@ -124,4 +124,3 @@ class KubernetesBundle(BaseTechBundle):
         self.create_cluster_list()
         self.create_cluster_debug_state_properties()
         self.create_cluster_pod_status()
-

--- a/tools/diagnostics/base_tech_bundle/kubernetes_bundle.py
+++ b/tools/diagnostics/base_tech_bundle/kubernetes_bundle.py
@@ -23,11 +23,14 @@ class KubernetesBundle(BaseTechBundle):
             self.package_name, self.service_name, "manager describe", print_output=False
         )
 
-        if rc != 0 or stderr:
+        if rc != 0:
             logging.error(
-                "Could not get service configuration\nstdout: '%s'\nstderr: '%s'", stdout, stderr
+                "Could not get service configuration. return-code: '%s'\n"
+                "stdout: '%s'\nstderr: '%s'", rc, stdout, stderr
             )
         else:
+            if stderr:
+                logging.warning("Non-fatal service configuration message\nstderr: '%s'", stderr)
             self.write_file("manager_service_configuration.json", stdout)
 
     @config.retry
@@ -36,9 +39,14 @@ class KubernetesBundle(BaseTechBundle):
             self.package_name, self.service_name, "manager pod status --json", print_output=False
         )
 
-        if rc != 0 or stderr:
-            logging.error("Could not get pod status\nstdout: '%s'\nstderr: '%s'", stdout, stderr)
+        if rc != 0:
+            logging.error(
+                "Could not get pod status. return-code: '%s'\n"
+                "stdout: '%s'\nstderr: '%s'", rc, stdout, stderr
+            )
         else:
+            if stderr:
+                logging.warning("Non-fatal pod status message\nstderr: '%s'", stderr)
             self.write_file("manager_service_pod_status.json", stdout)
 
     @config.retry
@@ -50,9 +58,14 @@ class KubernetesBundle(BaseTechBundle):
             print_output=False,
         )
 
-        if rc != 0 or stderr:
-            logging.error("Could not get pod status\nstdout: '%s'\nstderr: '%s'", stdout, stderr)
+        if rc != 0:
+            logging.error(
+                "Could not get pod status. return-code: '%s'\n"
+                "stdout: '%s'\nstderr: '%s'", rc, stdout, stderr
+            )
         else:
+            if stderr:
+                logging.warning("Non-fatal pod status message\nstderr: '%s'", stderr)
             self.write_file("manager_service_plan_status_{}.json".format(plan), stdout)
 
     @config.retry
@@ -61,12 +74,24 @@ class KubernetesBundle(BaseTechBundle):
             self.package_name, self.service_name, "manager plan list", print_output=False
         )
 
-        if rc != 0 or stderr:
-            logging.error("Could not get plan list\nstdout: '%s'\nstderr: '%s'", stdout, stderr)
+        if rc != 0:
+            logging.error(
+                "Could not get plan list. return-code: '%s'\n"
+                "stdout: '%s'\nstderr: '%s'", rc, stdout, stderr
+            )
         else:
-            plans = json.loads(stdout)
-            for plan in plans:
-                self.create_plan_status_file(plan)
+            if stderr:
+                logging.warning("Non-fatal plan list message\nstderr: '%s'", stderr)
+
+            try:
+                plans = json.loads(stdout)
+                for plan in plans:
+                    self.create_plan_status_file(plan)
+            except Exception:
+                logging.error(
+                    "Could not parse plan list json.\nstdout: '%s'\nstderr: '%s'",
+                    stdout, stderr
+                )
 
     @config.retry
     def create_cluster_list(self):
@@ -74,9 +99,14 @@ class KubernetesBundle(BaseTechBundle):
             self.package_name, self.service_name, "cluster list", print_output=False
         )
 
-        if rc != 0 or stderr:
-            logging.error("Could not get cluster list\nstdout: '%s'\nstderr: '%s'", stdout, stderr)
+        if rc != 0:
+            logging.error(
+                "Could not get cluster list. return-code: '%s'\n"
+                "stdout: '%s'\nstderr: '%s'", rc, stdout, stderr
+            )
         else:
+            if stderr:
+                logging.warning("Non-fatal cluster list message\nstderr: '%s'", stderr)
             self.write_file("cluster_list.json", stdout)
 
     @config.retry
@@ -85,9 +115,14 @@ class KubernetesBundle(BaseTechBundle):
             self.package_name, self.service_name, "cluster debug state properties", print_output=False
         )
 
-        if rc != 0 or stderr:
-            logging.error("Could not get cluster state properties\nstdout: '%s'\nstderr: '%s'", stdout, stderr)
+        if rc != 0:
+            logging.error(
+                "Could not get cluster state properties. return-code: '%s'\n"
+                "stdout: '%s'\nstderr: '%s'", rc, stdout, stderr
+            )
         else:
+            if stderr:
+                logging.warning("Non-fatal cluster state properties message\nstderr: '%s'", stderr)
             self.write_file("cluster_debug_state_properties.json", stdout)
 
     @config.retry
@@ -96,9 +131,14 @@ class KubernetesBundle(BaseTechBundle):
             self.package_name, self.service_name, "cluster debug endpoints", print_output=False
         )
 
-        if rc != 0 or stderr:
-            logging.error("Could not get cluster debug endpoints\nstdout: '%s'\nstderr: '%s'", stdout, stderr)
+        if rc != 0:
+            logging.error(
+                "Could not get cluster debug endpoints. return-code: '%s'\n"
+                "stdout: '%s'\nstderr: '%s'", rc, stdout, stderr
+            )
         else:
+            if stderr:
+                logging.warning("Non-fatal cluster debug endpoints message\nstderr: '%s'", stderr)
             self.write_file("cluster_debug_endpoints.json", stdout)
 
     @config.retry
@@ -107,9 +147,14 @@ class KubernetesBundle(BaseTechBundle):
             self.package_name, self.service_name, "cluster debug pod status --json", print_output=False
         )
 
-        if rc != 0 or stderr:
-            logging.error("Could not get cluster pod status\nstdout: '%s'\nstderr: '%s'", stdout, stderr)
+        if rc != 0:
+            logging.error(
+                "Could not get cluster pod status. return-code: '%s'\n"
+                "stdout: '%s'\nstderr: '%s'", rc, stdout, stderr
+            )
         else:
+            if stderr:
+                logging.warning("Non-fatal cluster pod status message\nstderr: '%s'", stderr)
             self.write_file("cluster_debug_pod_status.json", stdout)
 
     @config.retry

--- a/tools/diagnostics/base_tech_bundle/kubernetes_bundle.py
+++ b/tools/diagnostics/base_tech_bundle/kubernetes_bundle.py
@@ -1,0 +1,126 @@
+import logging
+
+import sdk_cmd
+
+from base_tech_bundle import BaseTechBundle
+import config
+
+logging = logging.getLogger(__name__)
+
+class KubernetesBundle(BaseTechBundle):
+
+    def __init__(self, package_name, service_name, scheduler_tasks, service, output_directory):
+        super().__init__(self,
+                         package_name,
+                         service_name,
+                         scheduler_tasks,
+                         service,
+                         output_directory)
+
+    @config.retry
+    def create_configuration_file(self):
+        rc, stdout, stderr = sdk_cmd.svc_cli(
+            self.package_name, self.service_name, "manager describe", print_output=False
+        )
+
+        if rc != 0 or stderr:
+            log.error(
+                "Could not get service configuration\nstdout: '%s'\nstderr: '%s'", stdout, stderr
+            )
+        else:
+            self.write_file("manager_service_configuration.json", stdout)
+
+    @config.retry
+    def create_pod_status_file(self):
+        rc, stdout, stderr = sdk_cmd.svc_cli(
+            self.package_name, self.service_name, "manager pod status --json", print_output=False
+        )
+
+        if rc != 0 or stderr:
+            logging.error("Could not get pod status\nstdout: '%s'\nstderr: '%s'", stdout, stderr)
+        else:
+            self.write_file("manager_service_pod_status.json", stdout)
+
+    @config.retry
+    def create_plan_status_file(self, plan):
+        rc, stdout, stderr = sdk_cmd.svc_cli(
+            self.package_name,
+            self.service_name,
+            "manager plan status {} --json".format(plan),
+            print_output=False,
+        )
+
+        if rc != 0 or stderr:
+            logging.error("Could not get pod status\nstdout: '%s'\nstderr: '%s'", stdout, stderr)
+        else:
+            self.write_file("manager_service_plan_status_{}.json".format(plan), stdout)
+
+    @config.retry
+    def create_plans_status_files(self):
+        rc, stdout, stderr = sdk_cmd.svc_cli(
+            self.package_name, self.service_name, "manager plan list", print_output=False
+        )
+
+        if rc != 0 or stderr:
+            logging.error("Could not get plan list\nstdout: '%s'\nstderr: '%s'", stdout, stderr)
+        else:
+            plans = json.loads(stdout)
+            for plan in plans:
+                self.create_plan_status_file(plan)
+
+    @config.retry
+    def create_cluster_list(self):
+        rc, stdout, stderr = sdk_cmd.svc_cli(
+            self.package_name, self.service_name, "cluster list", print_output=False
+        )
+
+        if rc != 0 or stderr:
+            logging.error("Could not get cluster list\nstdout: '%s'\nstderr: '%s'", stdout, stderr)
+        else:
+            self.write_file("cluster_list.json", stdout)
+
+    @config.retry
+    def create_cluster_debug_state_properties(self):
+        rc, stdout, stderr = sdk_cmd.svc_cli(
+            self.package_name, self.service_name, "cluster debug state properties", print_output=False
+        )
+
+        if rc != 0 or stderr:
+            logging.error("Could not get cluster list\nstdout: '%s'\nstderr: '%s'", stdout, stderr)
+        else:
+            self.write_file("cluster_debug_state_properties.json", stdout)
+
+    @config.retry
+    def create_cluster_debug_endpoints(self):
+        rc, stdout, stderr = sdk_cmd.svc_cli(
+            self.package_name, self.service_name, "cluster debug endpoints", print_output=False
+        )
+
+        if rc != 0 or stderr:
+            logging.error("Could not get cluster list\nstdout: '%s'\nstderr: '%s'", stdout, stderr)
+        else:
+            self.write_file("cluster_debug_endpoints.json", stdout)
+
+    @config.retry
+    def task_exec(self, task_id, cmd):
+        pass
+
+    def create(self):
+        logging.info("Creating Kubernetes Bundle")
+        self.create_configuration_file()
+        self.create_plans_status_files()
+        self.create_pod_status_file()
+        self.create_cluster_list()
+        self.create_cluster_debug_state_properties()
+
+
+# class KubernetesClusterBundle(KubernetesBundle):
+#     def __init__(self, package_name, service_name, scheduler_tasks, service, output_directory,
+#                  cluster_name):
+#         super().__init__(self,
+#                          package_name,
+#                          service_name,
+#                          scheduler_tasks,
+#                          service,
+#                          output_directory)
+

--- a/tools/diagnostics/base_tech_bundle/kubernetes_bundle.py
+++ b/tools/diagnostics/base_tech_bundle/kubernetes_bundle.py
@@ -157,10 +157,6 @@ class KubernetesBundle(BaseTechBundle):
                 logging.warning("Non-fatal cluster pod status message\nstderr: '%s'", stderr)
             self.write_file("cluster_debug_pod_status.json", stdout)
 
-    @config.retry
-    def task_exec(self, task_id, cmd):
-        pass
-
     def create(self):
         logging.info("Creating Kubernetes Bundle")
         self.create_configuration_file()

--- a/tools/diagnostics/full_bundle.py
+++ b/tools/diagnostics/full_bundle.py
@@ -168,26 +168,19 @@ class FullBundle(Bundle):
             self.output_directory,
         ).create()
 
-        if base_tech.is_package_supported(self.package_name):
-            BaseTechBundle = base_tech.get_bundle_class(self.package_name)
+        log.info("Completed creating DC/OS and service-level diagnostics.")
 
-            BaseTechBundle(
-                self.package_name,
-                self.service_name,
-                scheduler_tasks,
-                active_service,
-                self.output_directory,
-            ).create()
-        else:
-            log.info(
-                "Don't know how to get base tech diagnostics for package '%s'", self.package_name
-            )
-            log.info(
-                "Supported packages:\n%s",
-                "\n".join(["- {}".format(k) for k in base_tech.SUPPORTED_PACKAGES]),
-            )
-            log.info("This is ok, we were still able to get DC/OS and service-level diagnostics")
+        # Find and dispatch to the appropriate BaseTechBundle.
+        # If nothing is found run the BaseTechBundle
+        BaseTechBundle = base_tech.get_bundle_class(self.package_name)
+        BaseTechBundle(
+            self.package_name,
+            self.service_name,
+            scheduler_tasks,
+            active_service,
+            self.output_directory,
+        ).create()
 
-        log.info("\nCreated %s", os.path.abspath(self.output_directory))
+        log.info("\nCreated base-tech bundle at %s", os.path.abspath(self.output_directory))
 
         return 0, self

--- a/tools/diagnostics/full_bundle.py
+++ b/tools/diagnostics/full_bundle.py
@@ -168,7 +168,7 @@ class FullBundle(Bundle):
             self.output_directory,
         ).create()
 
-        log.info("Completed creating DC/OS and service-level diagnostics.")
+        log.info("Completed creating service-level diagnostics.")
 
         # Find and dispatch to the appropriate BaseTechBundle.
         # If nothing is found run the BaseTechBundle


### PR DESCRIPTION
In this PR we refactor the code to allow the introduction of a kubernetes_bundle

Diagnostics for the following commands have been added in this patch:
- `manager describe`
- `manager pod status --json`
- `manager plan list` and associated `manager plan status` for each plans from the list.
- `cluster list`
- `cluster debug state properties`
- `cluster debug endpoints`
- `cluster debug pod status --json`

Commands which deal with iterating through properties of the cluster such as
`dcos kubernetes cluster debug config list` aren't supported right now as not all commands in the `dcos kubernetes` cli sub-command group support a full JSON output as of this moment (particularly ones such as `cluster list`).

Lacking a JSON output makes it error-prone to parse the output. Work will be required on the kubernetes cli to emit full json versions before we can add diagnostic support for them here in a future release. 
