### PR TITLE
[DIAGNOSTICS][DCOS-47783]: Initial support for Edge-LB Diagnostic Bundle

### DIFF
--- a/tools/diagnostics/base_tech_bundle/__init__.py
+++ b/tools/diagnostics/base_tech_bundle/__init__.py
@@ -118,6 +118,7 @@ from .elastic_bundle import ElasticBundle  # noqa: E402
 from .hdfs_bundle import HdfsBundle  # noqa: E402
 from .kafka_bundle import KafkaBundle  # noqa: E402
 from .kubernetes_bundle import KubernetesBundle   # noqa: E402
+from .edgelb_bundle import EdgeLBBundle   # noqa: E402
 
 
 BASE_TECH_BUNDLE = {
@@ -131,6 +132,7 @@ BASE_TECH_BUNDLE = {
     "hdfs": HdfsBundle,
     "kafka": KafkaBundle,
     "kubernetes": KubernetesBundle,
+    "edgelb-pool": EdgeLBBundle,
 }
 
 
@@ -151,4 +153,6 @@ __all__ = [
     "ElasticBundle",
     "HdfsBundle",
     "KafkaBundle",
+    "KubernetesBundle",
+    "EdgeLBBundle",
 ]

--- a/tools/diagnostics/base_tech_bundle/edgelb_bundle.py
+++ b/tools/diagnostics/base_tech_bundle/edgelb_bundle.py
@@ -12,11 +12,11 @@ logging = logging.getLogger(__name__)
 class EdgeLBBundle(BaseTechBundle):
     def __init__(self, package_name, service_name, scheduler_tasks, service, output_directory):
         # Override package name as 'edgelb' rather than 'edgelb-pool'
-        if package_name is not 'edgelb':
+        if package_name != 'edgelb':
             package_name = 'edgelb'
 
         # Override service name as 'edgelb' rather than 'dcos-edgelb/pools/<pool-name>'
-        if service_name is not 'edgelb':
+        if service_name != 'edgelb':
             service_name = 'edgelb'
 
         super().__init__(package_name,

--- a/tools/diagnostics/base_tech_bundle/edgelb_bundle.py
+++ b/tools/diagnostics/base_tech_bundle/edgelb_bundle.py
@@ -1,0 +1,171 @@
+import logging
+
+import sdk_cmd
+
+from base_tech_bundle import BaseTechBundle
+import config
+import json
+
+logging = logging.getLogger(__name__)
+
+
+class EdgeLBBundle(BaseTechBundle):
+    def __init__(self, package_name, service_name, scheduler_tasks, service, output_directory):
+        # Override package name as 'edgelb' rather than 'edgelb-pool'
+        if package_name is not 'edgelb':
+            package_name = 'edgelb'
+
+        # Override service name as 'edgelb' rather than 'dcos-edgelb/pools/<pool-name>'
+        if service_name is not 'edgelb':
+            service_name = 'edgelb'
+
+        super().__init__(package_name,
+                         service_name,
+                         scheduler_tasks,
+                         service,
+                         output_directory)
+
+    @config.retry
+    def create_version_file(self):
+        rc, stdout, stderr = sdk_cmd.svc_cli(
+            self.package_name, self.service_name, "version", print_output=False
+        )
+
+        if rc != 0:
+            logging.error(
+                "Could not get service version. return-code: '%s'\n"
+                "stdout: '%s'\nstderr: '%s'", rc, stdout, stderr
+            )
+        else:
+            if stderr:
+                logging.warning("Non-fatal service version message\nstderr: '%s'", stderr)
+            self.write_file("edgelb_version", stdout)
+
+    @config.retry
+    def create_ping_file(self):
+        rc, stdout, stderr = sdk_cmd.svc_cli(
+            self.package_name, self.service_name, "ping", print_output=False
+        )
+
+        if rc != 0:
+            logging.error(
+                "Could not ping service. return-code: '%s'\n"
+                "stdout: '%s'\nstderr: '%s'", rc, stdout, stderr
+            )
+        else:
+            if stderr:
+                logging.warning("Non-fatal service ping message\nstderr: '%s'", stderr)
+            self.write_file("edgelb_ping", stdout)
+
+    @config.retry
+    def create_pool_status_file(self, pool):
+        pool_name = pool['name']
+        rc, stdout, stderr = sdk_cmd.svc_cli(
+            self.package_name, self.service_name, "status {} --json".format(pool_name),
+            print_output=False
+        )
+
+        if rc != 0:
+            logging.error(
+                "Could not generate status for pool {}. return-code: '%s'\n"
+                "stdout: '%s'\nstderr: '%s'".format(pool_name), rc, stdout, stderr
+            )
+        else:
+            if stderr:
+                logging.warning("Non-fatal status {} message\nstderr: '%s'".format(pool_name),
+                                stderr)
+            self.write_file("edgelb_status_{}.json".format(pool_name), stdout)
+
+    @config.retry
+    def create_pool_endpoints_file(self, pool):
+        pool_name = pool['name']
+        rc, stdout, stderr = sdk_cmd.svc_cli(
+            self.package_name, self.service_name, "endpoints {} --json".format(pool_name),
+            print_output=False
+        )
+
+        if rc != 0:
+            logging.error(
+                "Could not generate endpoints for pool {}. return-code: '%s'\n"
+                "stdout: '%s'\nstderr: '%s'".format(pool_name), rc, stdout, stderr
+            )
+        else:
+            if stderr:
+                logging.warning("Non-fatal endpoints {} message\nstderr: '%s'".format(pool_name),
+                                stderr)
+            self.write_file("edgelb_endpoints_{}.json".format(pool_name), stdout)
+
+    @config.retry
+    def create_pool_lb_config_file(self, pool):
+        pool_name = pool['name']
+        rc, stdout, stderr = sdk_cmd.svc_cli(
+            self.package_name, self.service_name, "lb-config {}".format(pool_name),
+            print_output=False
+        )
+
+        if rc != 0:
+            logging.error(
+                "Could not generate lb-config for pool {}. return-code: '%s'\n"
+                "stdout: '%s'\nstderr: '%s'".format(pool_name), rc, stdout, stderr
+            )
+        else:
+            if stderr:
+                logging.warning("Non-fatal lb-config {} message\nstderr: '%s'".format(pool_name),
+                                stderr)
+            self.write_file("edgelb_lb-config_{}".format(pool_name), stdout)
+
+    @config.retry
+    def create_pool_lb_template_file(self, pool):
+        pool_name = pool['name']
+        rc, stdout, stderr = sdk_cmd.svc_cli(
+            self.package_name, self.service_name, "template show {}".format(pool_name),
+            print_output=False
+        )
+
+        if rc != 0:
+            logging.error(
+                "Could not generate template show for pool {}. return-code: '%s'\n"
+                "stdout: '%s'\nstderr: '%s'".format(pool_name), rc, stdout, stderr
+            )
+        else:
+            if stderr:
+                logging.warning("Non-fatal template show {} message\nstderr: '%s'".format(pool_name),
+                                stderr)
+            self.write_file("edgelb_template_show_{}".format(pool_name), stdout)
+
+    @config.retry
+    def create_pool_files(self):
+        rc, stdout, stderr = sdk_cmd.svc_cli(
+            self.package_name, self.service_name, "list --json", print_output=False
+        )
+
+        if rc != 0:
+            logging.error(
+                "Could not generate pool list. return-code: '%s'\n"
+                "stdout: '%s'\nstderr: '%s'", rc, stdout, stderr
+            )
+        else:
+            if stderr:
+                logging.warning("Non-fatal pool list message\nstderr: '%s'", stderr)
+
+            try:
+                pools = json.loads(stdout)
+                # Write out full pools list.
+                self.write_file("edgelb_pools_list.json", stdout)
+                # Issue pool specific command.
+                for pool in pools:
+                    self.create_pool_status_file(pool)
+                    self.create_pool_endpoints_file(pool)
+                    self.create_pool_lb_config_file(pool)
+                    self.create_pool_lb_template_file(pool)
+            except Exception:
+                logging.error(
+                    "Could not parse pool list json.\nstdout: '%s'\nstderr: '%s'",
+                    stdout, stderr
+                )
+
+    def create(self):
+        logging.info("Creating EdgeLB Bundle")
+        self.create_version_file()
+        self.create_ping_file()
+        self.create_pool_files()


### PR DESCRIPTION
In this PR we add initial support for Edge-LB Pools with the following edgelb related commands:
- `dcos edgelb version`
- `dcos edgelb ping`
- `dcos edgelb list --json`

Additionally for each pool in the list above, the following edgelb commands are issued:
- `dcos edgelb status <pool-name> --json`
- `dcos edgelb endpoints <pool-name> --json`
- `dcos edgelb lb-config <pool-name>`
- `dcos edgelb template show <pool-name>`

Executor logs for *only the specified edge-lb pool* are collected ie:
`./tools/diagnostics/create_service_diagnostics_bundle.sh --package-name=edgelb-pool --service-name=dcos-edgelb/pools/test-http-pool --yes`
will collect the executor logs only for `dcos-edgelb/pools/test-http-pool`. Other pools executor logs will not be present in this collection.

Executor logs for other pools are collected via additional invocations with the pool supplied via `--service-name`.