### PR TITLE
[DCOS-47843] Improve error-reporting for SDK CI

### DIFF
--- a/frameworks/helloworld/tests/test_resource_refinement.py
+++ b/frameworks/helloworld/tests/test_resource_refinement.py
@@ -1,3 +1,4 @@
+import logging
 import pytest
 import retrying
 
@@ -8,6 +9,7 @@ import sdk_cmd
 
 from tests import config
 
+log = logging.getLogger(__name__)
 
 pytestmark = pytest.mark.skipif(
     sdk_utils.is_strict_mode() and sdk_utils.dcos_version_less_than("1.11"),
@@ -85,6 +87,10 @@ def test_marathon_volume_collision():
                 marathon_app_name, volume_name
             ),
         )
+
+        if rc != 0:
+            log.error(
+                "Could not get slave_public roles. return-code: '%s'\n", rc)
         assert rc == 0
 
         pv_path = pv_path.strip()


### PR DESCRIPTION
Improve error-reporting particularly in spots where we have an `assert` within a `try-catch` clause. The assert gets caught leading to confusing error messages that don't help with diagnosing the root cause.