### PR TITLE
[DCOS-47829] Use dcos node decommission only in DC/OS 1.11 and above

### DIFF
--- a/frameworks/helloworld/tests/test_zzzrecovery.py
+++ b/frameworks/helloworld/tests/test_zzzrecovery.py
@@ -347,6 +347,7 @@ def test_config_update_while_partitioned():
 # WARNING: KEEP THIS TEST AT THE END
 # @@@@@@@
 @pytest.mark.sanity
+@pytest.mark.dcos_min_version("1.11")
 def test_auto_replace_on_decommission():
     candidate_tasks = sdk_tasks.get_tasks_avoiding_scheduler(
         config.SERVICE_NAME, re.compile("^(hello|world)-[0-9]+-server$")

--- a/testing/sdk_agents.py
+++ b/testing/sdk_agents.py
@@ -11,6 +11,7 @@ import retrying
 import traceback
 
 import sdk_cmd
+import sdk_utils
 
 log = logging.getLogger(__name__)
 
@@ -124,6 +125,8 @@ def reconnect_agent(agent_host: str):
 
 
 def decommission_agent(agent_id: str):
+    assert sdk_utils.dcos_version_at_least("1.11"),\
+        "node decommission is supported in DC/OS 1.11 and above only"
     rc, _, _ = sdk_cmd.run_cli(
         "node decommission {}".format(agent_id)
     )


### PR DESCRIPTION
According to [DCOS-18981](https://jira.mesosphere.com/browse/DCOS-18981) and [1.11 Release Notes](https://docs.mesosphere.com/1.11/release-notes/1.11.0-rc1/#platform) decommission is relatively new and thus we should run tests 1.11 and above only.