### PR TITLE
Regex validator to check service name for Cassandra

### DIFF
--- a/frameworks/cassandra/universe/config.json
+++ b/frameworks/cassandra/universe/config.json
@@ -6,8 +6,9 @@
       "description": "DC/OS Apache Cassandra service configuration properties",
       "properties": {
         "name": {
-          "description": "The name of the Cassandra service instance.",
+          "description": "Unique name for the Cassandra service instance consisting of a series of words separated by slashes. Each word must be at least 1 alphanumeric character and may only contain digits (`0-9`), dashes (`-`), dots (`.`), and lowercase letters (`a-z`). The word may not begin or end with a dash",
           "type": "string",
+          "pattern": "^(\\/?((\\.\\.)|(([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9]))?($|\\/))+$",
           "default": "cassandra"
         },
         "user": {


### PR DESCRIPTION
## What does this PR aim to do?
- Adds a regex validator to check that the Cassandra service instance name adheres to the following:
   - Has a name consisting of a series of words separated by slashes.
   - Each word must be at least 1 alphanumeric character and may only contain digits (`0-9`), dashes (`-`), dots (`.`), and lowercase letters (`a-z`) 
   - The word may not begin or end with a dash
## How was this PR tested?
  - Running a CCM cluster and checking the validator works