### PR TITLE
[DCOS-48462][Cassandra] Honor config JMX_PORT

### DIFF
--- a/frameworks/cassandra/src/main/dist/svc.yml
+++ b/frameworks/cassandra/src/main/dist/svc.yml
@@ -66,6 +66,9 @@ pods:
                     ARGS="$ARGS -R"
                 fi
 
+                # Honor jmx_port config otherwise Cassandra will hardcode to 7199
+                sed -i 's/JMX_PORT=.*/JMX_PORT="{{TASKCFG_ALL_JMX_PORT}}"/' apache-cassandra-{{CASSANDRA_VERSION}}/conf/cassandra-env.sh
+
                 exec ./apache-cassandra-{{CASSANDRA_VERSION}}/bin/cassandra $ARGS
         configs:
           cassandra:

--- a/frameworks/cassandra/tests/test_sanity.py
+++ b/frameworks/cassandra/tests/test_sanity.py
@@ -103,7 +103,7 @@ def test_metrics():
 
 @pytest.mark.sanity
 def test_custom_jmx_port():
-    expected_port = "-Dcassandra.jmx.local.port=7200"
+    expected_open_port = ":7200 (LISTEN)"
 
     new_config = {"cassandra": {"jmx_port": 7200}}
 
@@ -119,5 +119,5 @@ def test_custom_jmx_port():
     tasks = sdk_tasks.get_service_tasks(config.get_foldered_service_name(), "node")
 
     for task in tasks:
-        _, stdout, _ = sdk_cmd.run_cli("task log --lines=1000 {}".format(task.id))
-        assert expected_port in stdout
+        _, stdout, _ = sdk_cmd.run_cli("task exec {} lsof -i :7200".format(task.id))
+        assert expected_open_port in stdout


### PR DESCRIPTION
## What changes were proposed in this PR? 

Resolves [DCOS-48462](https://jira.mesosphere.com/browse/DCOS-48462)

Apache Cassandra 3.11+ adds in new logic and classes for parsing the `JMX_PORT` from `conf/cassandra-env.sh` which is hardcoded to `7199`. This commit replaces the value in the file with the user-specified framework config.

## How were these changes tested?

Added an integration tests for checking logs do output the correct jmx port