### PR TITLE
[DCOS-47352][COPS-4389] Don't escape characters for Elastic custom YAML.

### DIFF
--- a/frameworks/elastic/src/main/dist/elasticsearch.yml
+++ b/frameworks/elastic/src/main/dist/elasticsearch.yml
@@ -283,4 +283,4 @@ cluster.routing.allocation.balance.threshold: {{CLUSTER_ROUTING_ALLOCATION_BALAN
 indices.requests.cache.size: {{INDICES_REQUESTS_CACHE_SIZE}}
 {{/INDICES_REQUESTS_CACHE_SIZE}}
 
-{{CUSTOM_YAML_BLOCK}}
+{{{CUSTOM_YAML_BLOCK}}}

--- a/frameworks/elastic/tests/config.py
+++ b/frameworks/elastic/tests/config.py
@@ -568,9 +568,7 @@ def test_upgrade_from_xpack_enabled(
         test_version,
         {
             "service": {"update_strategy": "parallel"},
-            "elasticsearch": {
-                "xpack_security_enabled": False,
-            },
+            "elasticsearch": {"xpack_security_enabled": False},
         },
         expected_task_count,
     )


### PR DESCRIPTION
As per the manual/spec[1] on which the Java library we use bases its
implementation, one needs to use triple braces for variables that
should not have escaped characters when expanded. Without this, for
example, if one has quotes in the YAML content, they will get expanded
to their HTML entity: `&#34;`.

[1]: http://mustache.github.io/mustache.5.html
