### PR TITLE
[COPS-4469] Shutdown the scheduler when service user changes in a ServiceSpec update

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/config/DefaultConfigurationUpdater.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/config/DefaultConfigurationUpdater.java
@@ -173,6 +173,16 @@ public class DefaultConfigurationUpdater implements ConfigurationUpdater<Service
       logger.warn("New configuration failed validation against current target " +
               "configuration {}, with {} errors across {} validators:\n{}",
           targetConfigId, errors.size(), validators.size(), sj.toString());
+
+      //Process fatal validation errors in-order and halt the scheduler if so.
+      for (ConfigValidationError error : errors) {
+        if (error.isFatal()) {
+          throw new ConfigStoreException(Reason.LOGIC_ERROR, String.format(
+              "FATAL ERROR with Configuration Update, stopping scheduler.%nError:%s",
+              error.toString()));
+        }
+      }
+
       if (!targetConfig.isPresent()) {
         throw new ConfigStoreException(Reason.LOGIC_ERROR, String.format(
             "Configuration failed validation without any prior target configuration" +

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/config/validate/ConfigValidationError.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/config/validate/ConfigValidationError.java
@@ -16,16 +16,20 @@ public final class ConfigValidationError {
 
   private final String message;
 
+  private final boolean isFatal;
+
   private ConfigValidationError(
       String configField,
       String oldConfigValue,
       String newConfigValue,
-      String message)
+      String message,
+      boolean isFatal)
   {
     this.configField = configField;
     this.oldConfigValue = oldConfigValue;
     this.newConfigValue = newConfigValue;
     this.message = message;
+    this.isFatal = isFatal;
   }
 
   /**
@@ -36,7 +40,18 @@ public final class ConfigValidationError {
       String configField, String configValue, String message)
   {
     // Set oldValue to null
-    return new ConfigValidationError(configField, null, configValue, message);
+    return new ConfigValidationError(configField, null, configValue, message, false);
+  }
+
+  /**
+   * Returns a new validation error which indicates that a configuration field has an invalid
+   * value. This is equivalent to a transition error, except with no prior value.
+   */
+  public static ConfigValidationError valueError(
+      String configField, String configValue, String message, boolean isFatal)
+  {
+    // Set oldValue to null
+    return new ConfigValidationError(configField, null, configValue, message, isFatal);
   }
 
   /**
@@ -46,7 +61,18 @@ public final class ConfigValidationError {
   public static ConfigValidationError transitionError(
       String configField, String oldConfigValue, String newConfigValue, String message)
   {
-    return new ConfigValidationError(configField, oldConfigValue, newConfigValue, message);
+    return new ConfigValidationError(configField, oldConfigValue, newConfigValue, message, false);
+  }
+
+  /**
+   * Returns a new validation error which indicates that a configuration field has an invalid
+   * transition from its previous value to the current value.
+   */
+  public static ConfigValidationError transitionError(
+      String configField, String oldConfigValue, String newConfigValue, String message,
+      boolean isFatal)
+  {
+    return new ConfigValidationError(configField, oldConfigValue, newConfigValue, message, isFatal);
   }
 
   /**
@@ -79,16 +105,23 @@ public final class ConfigValidationError {
   }
 
   /**
+   * Returns if this error message is fatal.
+   */
+  public boolean isFatal() {
+    return isFatal;
+  }
+
+  /**
    * Returns a complete user-facing string representation providing the error and its source.
    */
   @Override
   public String toString() {
     if (oldConfigValue != null) {
-      return String.format("Field: '%s'; Transition: '%s' => '%s'; Message: '%s'",
-          configField, oldConfigValue, newConfigValue, message);
+      return String.format("Field: '%s'; Transition: '%s' => '%s'; Message: '%s'; Fatal: %s",
+          configField, oldConfigValue, newConfigValue, message, isFatal);
     } else {
-      return String.format("Field: '%s'; Value: '%s'; Message: '%s'",
-          configField, newConfigValue, message);
+      return String.format("Field: '%s'; Value: '%s'; Message: '%s'; Fatal: %s",
+          configField, newConfigValue, message, isFatal);
     }
   }
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/config/validate/ConfigValidationError.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/config/validate/ConfigValidationError.java
@@ -39,8 +39,7 @@ public final class ConfigValidationError {
   public static ConfigValidationError valueError(
       String configField, String configValue, String message)
   {
-    // Set oldValue to null
-    return new ConfigValidationError(configField, null, configValue, message, false);
+    return valueError(configField, configValue, message, false);
   }
 
   /**
@@ -61,7 +60,7 @@ public final class ConfigValidationError {
   public static ConfigValidationError transitionError(
       String configField, String oldConfigValue, String newConfigValue, String message)
   {
-    return new ConfigValidationError(configField, oldConfigValue, newConfigValue, message, false);
+    return transitionError(configField, oldConfigValue, newConfigValue, message, false);
   }
 
   /**

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/config/validate/UserCannotChange.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/config/validate/UserCannotChange.java
@@ -20,8 +20,22 @@ import java.util.Optional;
  * change as "nobody" will not have access to "root"-owned files in persistent volumes.
  */
 public class UserCannotChange implements ConfigValidator<ServiceSpec> {
-  private static final String USER_CHANGED_ERROR_MESSAGE =
-      "User for old pod type %s must remain the same across deployments.";
+  private static final String POD_USER_CHANGED_ERROR_MESSAGE =
+      "INVALID CONFIGURATION UPDATE. Cannot change existing pod type user from '%s' to '%s'.%n"
+          + "Pod type user must remain the same across deployments. "
+          // SUPPRESS CHECKSTYLE MultipleStringLiterals
+          + "Revert to previous user '%s' to proceed. Current set of configuration updates will NOT"
+          // SUPPRESS CHECKSTYLE MultipleStringLiterals
+          + " be applied.";
+
+  private static final String SERVICE_USER_CHANGED_ERROR_MESSAGE =
+      "INVALID CONFIGURATION UPDATE. Cannot change user of deployed service from '%s' to '%s'.%n"
+          + "Revert to previous user '%s' to proceed. Current set of configuration updates will NOT"
+          + " be applied.";
+
+  private static final String CONFIG_FIELD = "user";
+
+  private static final String UNKNOWN_USER = "null";
 
   @Override
   public Collection<ConfigValidationError> validate(
@@ -36,13 +50,14 @@ public class UserCannotChange implements ConfigValidator<ServiceSpec> {
     if (oldConfig.get().getUser() != null &&
         !oldConfig.get().getUser().equals(newConfig.getUser()))
     {
+      //Add as a fatal error.
       errors.add(ConfigValidationError.transitionError(
-          // SUPPRESS CHECKSTYLE MultipleStringLiterals
-          "user",
+          CONFIG_FIELD,
           oldConfig.get().getUser(),
           newConfig.getUser(),
-          "User for old service must remain the same across deployments."
-      ));
+          String.format(SERVICE_USER_CHANGED_ERROR_MESSAGE,
+              oldConfig.get().getUser(), newConfig.getUser(), oldConfig.get().getUser()),
+          true));
     }
 
     // We can't rely on the order of pods to test new pods against old ones.
@@ -65,12 +80,16 @@ public class UserCannotChange implements ConfigValidator<ServiceSpec> {
       if (oldPods.containsKey(newPod.getType())) {
         oldPod = oldPods.get(newPod.getType());
         if (!oldPod.getUser().equals(newPod.getUser())) {
+          String oldUser = oldPod.getUser().isPresent() ? oldPod.getUser().get() : UNKNOWN_USER;
+          String newUser = newPod.getUser().isPresent() ? newPod.getUser().get() : UNKNOWN_USER;
+
+          //Add as a fatal error.
           errors.add(ConfigValidationError.transitionError(
-              "user",
-              oldPod.getUser().isPresent() ? oldPod.getUser().get() : null,
-              newPod.getUser().isPresent() ? newPod.getUser().get() : null,
-              String.format(USER_CHANGED_ERROR_MESSAGE, oldPod.getType())
-          ));
+              CONFIG_FIELD,
+              oldUser,
+              newUser,
+              String.format(POD_USER_CHANGED_ERROR_MESSAGE, oldUser, newUser, oldUser),
+              true));
         }
       }
     }

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/config/ConfigurationUpdaterTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/config/ConfigurationUpdaterTest.java
@@ -268,7 +268,6 @@ public class ConfigurationUpdaterTest {
         when(mockConfigStore.fetch(TARGET_ID)).thenReturn(serviceSpecWithUser.build());
 
         // Note: the new service spec sets pod users with a non-root user
-        //ConfigurationUpdater.UpdateResult result = null;
         try {
             configurationUpdater.updateConfiguration(ORIGINAL_SERVICE_SPECIFICATION_WITH_USER);
             Assert.fail("Expected ConfigStoreException to be thrown before this line.");
@@ -276,7 +275,6 @@ public class ConfigurationUpdaterTest {
             // since the 2 pods don't set the user their user defaults to "root" which conflicts with the user set as noted above
             Assert.assertTrue(e.getMessage().contains("Cannot change existing pod type user"));
         }
-        //Assert.assertNull(result);
     }
 
 
@@ -338,13 +336,11 @@ public class ConfigurationUpdaterTest {
 
         when(mockConfigStore.fetch(TARGET_ID)).thenReturn(ORIGINAL_SERVICE_SPECIFICATION_WITH_USER);
 
-        //ConfigurationUpdater.UpdateResult result = null;
         try {
             configurationUpdater.updateConfiguration(SERVICE_SPECIFICATION_WITH_NON_DEFAULT_USER);
             Assert.fail("Expected ConfigStoreException to be thrown before this line.");
         } catch (ConfigStoreException e) {
             Assert.assertTrue(e.getMessage().contains("Cannot change user of deployed service"));
         }
-        //Assert.assertNull(result);
     }
 }

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/config/ConfigurationUpdaterTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/config/ConfigurationUpdaterTest.java
@@ -268,19 +268,15 @@ public class ConfigurationUpdaterTest {
         when(mockConfigStore.fetch(TARGET_ID)).thenReturn(serviceSpecWithUser.build());
 
         // Note: the new service spec sets pod users with a non-root user
-        boolean caughtError = false;
-        boolean correctErrorMessage = false;
-        ConfigurationUpdater.UpdateResult result = null;
+        //ConfigurationUpdater.UpdateResult result = null;
         try {
-            result = configurationUpdater.updateConfiguration(ORIGINAL_SERVICE_SPECIFICATION_WITH_USER);
+            configurationUpdater.updateConfiguration(ORIGINAL_SERVICE_SPECIFICATION_WITH_USER);
+            Assert.fail("Expected ConfigStoreException to be thrown before this line.");
         } catch (ConfigStoreException e) {
             // since the 2 pods don't set the user their user defaults to "root" which conflicts with the user set as noted above
-            caughtError = true;
-            correctErrorMessage = e.getMessage().contains("Cannot change existing pod type user");
+            Assert.assertTrue(e.getMessage().contains("Cannot change existing pod type user"));
         }
-        Assert.assertEquals(true, caughtError);
-        Assert.assertEquals(true, correctErrorMessage);
-        Assert.assertNull(result);
+        //Assert.assertNull(result);
     }
 
 
@@ -318,18 +314,13 @@ public class ConfigurationUpdaterTest {
                 .pods(podsWithUsers)
                 .build();
 
-        boolean caughtError = false;
-        boolean correctErrorMessage = false;
-
         ConfigurationUpdater.UpdateResult result = null;
         try {
             result = configurationUpdater.updateConfiguration(SERVICE_SPECIFICATION_WITH_USER);
         } catch (ConfigStoreException e) {
-            caughtError = true;
-            correctErrorMessage = e.getMessage().contains("Cannot change existing pod type user");
+            Assert.fail("Expected ConfigStoreException not be thrown here.");
+            Assert.assertFalse(e.getMessage().contains("Cannot change existing pod type user"));
         }
-        Assert.assertEquals(false, caughtError);
-        Assert.assertEquals(false, correctErrorMessage);
         Assert.assertNotNull(result);
         Assert.assertEquals(TARGET_ID, result.getTargetId());
         Assert.assertEquals(0, result.getErrors().size());
@@ -347,17 +338,13 @@ public class ConfigurationUpdaterTest {
 
         when(mockConfigStore.fetch(TARGET_ID)).thenReturn(ORIGINAL_SERVICE_SPECIFICATION_WITH_USER);
 
-        boolean caughtError = false;
-        boolean correctErrorMessage = false;
-        ConfigurationUpdater.UpdateResult result = null;
+        //ConfigurationUpdater.UpdateResult result = null;
         try {
-            result = configurationUpdater.updateConfiguration(SERVICE_SPECIFICATION_WITH_NON_DEFAULT_USER);
+            configurationUpdater.updateConfiguration(SERVICE_SPECIFICATION_WITH_NON_DEFAULT_USER);
+            Assert.fail("Expected ConfigStoreException to be thrown before this line.");
         } catch (ConfigStoreException e) {
-            caughtError = true;
-            correctErrorMessage = e.getMessage().contains("Cannot change user of deployed service");
+            Assert.assertTrue(e.getMessage().contains("Cannot change user of deployed service"));
         }
-        Assert.assertEquals(true, caughtError);
-        Assert.assertEquals(true, correctErrorMessage);
-        Assert.assertNull(result);
+        //Assert.assertNull(result);
     }
 }


### PR DESCRIPTION
Previously the SDK would detect a change of `user` in the `ServiceSpec`, emit a warning and *not* propagate and store these updates into ZK. The scheduler would however continue to keep running with the updated user and this can cause issues with downstream components such as volumes which may have permissions set for the previous user.

This change explictly disallows changing of users on a previously deployed service. The scheduler issues a *shutdown* with a prescriptive message of how to resolve this issue.

Operators should note the scheduler crash-looping with the following message in the scheduler logs when a service user change is applied:

    'INVALID CONFIGURATION UPDATE. Cannot change user of deployed service from 'userA' to 'userB'.
    Revert to previous user 'userA' to proceed. Current set of configuration updates will NOT be applied.'

The violating updates to the `ServiceSpec` are again *not* propagated to ZK maintaining existing semantics.