### PR TITLE
[TOOLS] Update swagger spec for v1/plans/<plan>

### DIFF
--- a/docs/reference/swagger-api/swagger-spec.yaml
+++ b/docs/reference/swagger-api/swagger-spec.yaml
@@ -97,6 +97,8 @@ paths:
           description: "List of the plan's contents."
         404:
           description: "Plan not found."
+        417:
+          description: "Plan is in an error state."
   /plans/{name}/start:
     post:
       tags:


### PR DESCRIPTION
We added a 417 error code via https://github.com/mesosphere/dcos-commons/pull/1365/files#diff-9a32c2bd67042145f1dc9d3f533b2c9bR76 but swagger spec doesn't seem to reflect the same. This PR addresses that to avoid any confusion.