### PR TITLE
Dispatch Hello-World MWT Scale Test Jobs in Parallel

### DIFF
--- a/frameworks/helloworld/tests/conftest.py
+++ b/frameworks/helloworld/tests/conftest.py
@@ -16,6 +16,12 @@ def pytest_addoption(parser):
                      help="hello world service yml to use")
     parser.addoption("--service-name", action='store', default='hello-world',
                      help="custom service name to be used instead of default 'hello-world'")
+    parser.addoption('--min', action='store', default=-1,
+                     help='min jenkins index to start from (default: -1).')
+    parser.addoption('--max', action='store', default=-1,
+                     help='max jenkins index to end at (default: -1).')
+    parser.addoption('--batch-size', action='store', default=1,
+                     help='batch size to deploy jenkins masters in (default: 1).')
 
 
 @pytest.fixture
@@ -31,3 +37,18 @@ def scenario(request) -> str:
 @pytest.fixture
 def service_name(request) -> str:
     return str(request.config.getoption('--service-name'))
+
+
+@pytest.fixture
+def min_index(request) -> int:
+    return int(request.config.getoption('--min'))
+
+
+@pytest.fixture
+def max_index(request) -> int:
+    return int(request.config.getoption('--max'))
+
+
+@pytest.fixture
+def batch_size(request) -> int:
+    return int(request.config.getoption('--batch-size'))

--- a/frameworks/helloworld/tests/conftest.py
+++ b/frameworks/helloworld/tests/conftest.py
@@ -17,11 +17,11 @@ def pytest_addoption(parser):
     parser.addoption("--service-name", action='store', default='hello-world',
                      help="custom service name to be used instead of default 'hello-world'")
     parser.addoption('--min', action='store', default=-1,
-                     help='min jenkins index to start from (default: -1).')
+                     help='min hello-world index to start from (default: -1).')
     parser.addoption('--max', action='store', default=-1,
-                     help='max jenkins index to end at (default: -1).')
+                     help='max hello-world index to end at (default: -1).')
     parser.addoption('--batch-size', action='store', default=1,
-                     help='batch size to deploy jenkins masters in (default: 1).')
+                     help='batch size to deploy hello-world masters in (default: 1).')
 
 
 @pytest.fixture

--- a/frameworks/helloworld/tests/scale/test_scale.py
+++ b/frameworks/helloworld/tests/scale/test_scale.py
@@ -3,9 +3,13 @@ import logging
 import sdk_install
 import sdk_security
 import sdk_utils
+
 from tests import config
+from threading_utils import spawn_threads, wait_and_get_failures
 
 log = logging.getLogger(__name__)
+
+JOB_RUN_TIMEOUT = 10 * 60  # 10 mins
 
 
 @pytest.mark.soak
@@ -18,41 +22,97 @@ def test_soak_load(service_name,
         service_name: name of the service to install as
         scenario: yaml scenario to run helloworld with (normal, crashloop) are added for this case
     """
-    # Note service-names *cannot* have underscores in them.
-    soak_service_name = ("{}-{}-soak".format(service_name, scenario)).replace("_", "-")
-    # service-names can have '/'s in them but service account names cannot, sanitize here.
-    service_account_name = soak_service_name.replace("/", "__")
-    security_info = _create_service_account(service_account_name)
-    _install_service(soak_service_name,
-                     scenario,
-                     security_info)
+    soak_service_name = "{}-{}-soak".format(service_name, scenario)
+    _launch_load(soak_service_name, scenario)
 
 
 @pytest.mark.scale
 def test_scaling_load(service_name,
+                      scenario,
                       service_count,
-                      scenario) -> None:
+                      min_index,
+                      max_index,
+                      batch_size) -> None:
+    """Launch a load test scenario in parallel if needed.
+    This does not verify the results of the test, but does
+    ensure the instances were created.
+
+    Args:
+        service_name: name of the service to install as
+        scenario: yaml scenario to run helloworld with (normal, crashloop) are added for this case
+        service_count: number of helloworld services to install
+        min_index: minimum index to begin suffixes at
+        max_index: maximum index to end suffixes at
+        batch_size: batch size to deploy instances in
+    """
+    scale_service_name = "{}-{}".format(service_name, scenario)
+    deployment_list = []
+    if min_index == -1 or max_index == -1:
+        deployment_list = ["{}-{}".format(scale_service_name, index) for index in range(0, int(service_count))]
+        min_index = 0
+        max_index = service_count
+    else:
+        deployment_list = ["{}-{}".format(scale_service_name, index) for index in range(min_index, max_index)]
+
+    sdk_security.install_enterprise_cli()
+
+    current = 0
+    end = max_index - min_index
+    for current in range(0, end, batch_size):
+        # Get current batch of schedulers to deploy.
+        batched_deployment_list = deployment_list[current:current + batch_size]
+        # Create threads with correct arguments.
+        deployment_threads = spawn_threads(batched_deployment_list,
+                                           _launch_load,
+                                           scenario=scenario)
+        # Launch jobs.
+        wait_and_get_failures(deployment_threads, timeout=JOB_RUN_TIMEOUT)
+
+
+@pytest.mark.scalecleanup
+def test_scaling_cleanup(service_name, scenario, service_count, min_index, max_index) -> None:
+    """ Cleanup of installed hello-world service for specified scenario
+    Args:
+        service_name: name of the service to uninstall
+        scenario: yaml scenario helloworld installed with (normal, crashloop)
+        service_count: number of helloworld services to uninstall
+        min_index: minimum index to begin suffixes at
+        max_index: maximum index to end suffixes at
+    """
+    scale_service_name = "{}-{}".format(service_name, scenario)
+
+    if min_index == -1 or max_index == -1:
+        scale_cleanup_list = ["{}-{}".format(scale_service_name, index) for index in range(0, int(service_count))]
+    else:
+        scale_cleanup_list = ["{}-{}".format(scale_service_name, index) for index in range(min_index, max_index)]
+
+    sdk_security.install_enterprise_cli()
+
+    cleanup_threads = spawn_threads(scale_cleanup_list,
+                                    _uninstall_service)
+    # Launch jobs.
+    wait_and_get_failures(cleanup_threads, timeout=JOB_RUN_TIMEOUT)
+
+
+def _launch_load(service_name, scenario) -> None:
     """Launch a load test scenario. This does not verify the results
     of the test, but does ensure the instances were created.
 
     Args:
         service_name: name of the service to install as
-        service_count: number of helloworld services to install
         scenario: yaml scenario to run helloworld with (normal, crashloop) are added for this case
     """
-    # TODO: parallelize account creation and installation if time is an issue in scale tests
-    for index in range(service_count):
-        # Note service-names *cannot* have underscores in them.
-        scale_service_name = ("{}-{}-{}".format(service_name, scenario, index)).replace("_", "-")
-        # service-names can have '/'s in them but service account names cannot, sanitize here.
-        service_account_name = scale_service_name.replace("/", "__")
-        security_info = _create_service_account(service_account_name)
-        _install_service(scale_service_name,
-                         scenario,
-                         security_info)
+    # Note service-names *cannot* have underscores in them.
+    launch_service_name = service_name.replace("_", "-")
+    # service-names can have '/'s in them but service account names cannot, sanitize here.
+    launch_account_name = launch_service_name.replace("/", "__")
+    security_info = _create_service_account(launch_account_name)
+    _install_service(launch_service_name,
+                     scenario,
+                     security_info)
 
 
-def _install_service(service_name, scenario, security_info):
+def _install_service(service_name, scenario, security_info) -> None:
     # do not wait for deploy plan to complete, all tasks to launch or marathon app deployment
     # supports rapid deployments in scale test scenario
     options = {"service": {"name": service_name, "yaml": scenario}}
@@ -70,7 +130,23 @@ def _install_service(service_name, scenario, security_info):
     )
 
 
-def _create_service_account(service_name):
+def _uninstall_service(service_name) -> None:
+    """Uninstall specified service instance.
+
+    Args:
+        service_name: Service name or Marathon ID
+        role: The role for the service to use (default is no role)
+    """
+    if service_name.startswith('/'):
+        service_name = service_name[1:]
+    # Note service-names *cannot* have underscores in them.
+    service_name = service_name.replace("_", "-")
+    log.info("Uninstalling {}.".format(service_name))
+    sdk_install.uninstall(config.PACKAGE_NAME,
+                          service_name)
+
+
+def _create_service_account(service_name) -> None:
     if sdk_utils.is_strict_mode():
         try:
             log.info("Creating service accounts for '{}'"

--- a/frameworks/helloworld/tests/scale/threading_utils.py
+++ b/frameworks/helloworld/tests/scale/threading_utils.py
@@ -1,5 +1,5 @@
 import time
-import logging 
+import logging
 
 from threading import Thread
 from typing import List, Set
@@ -43,7 +43,7 @@ class ResultThread(Thread):
             self._result = True
         except Exception as e:
             self._result = False
-            log.error("Exception occured in {} with inner exception: {}", self.name, e)
+            log.error("Exception occured in {} with inner exception: {}".format(self.name, str(e)))
         finally:
             end = time.time()
             if self.event:

--- a/frameworks/helloworld/tests/scale/threading_utils.py
+++ b/frameworks/helloworld/tests/scale/threading_utils.py
@@ -1,0 +1,128 @@
+import time
+import logging 
+
+from threading import Thread
+from typing import List, Set
+
+TIMINGS = {}
+DEPLOY_TIMEOUT = 30 * 60  # 30 mins
+
+
+log = logging.getLogger(__name__)
+
+
+class ResultThread(Thread):
+    """A thread that stores the result of the run command."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self._result = None
+        self._event = None
+
+    @property
+    def result(self) -> bool:
+        """Run result
+
+        Returns: True if completed successfully.
+
+        """
+        return bool(self._result)
+
+    @property
+    def event(self):
+        return self._event
+
+    @event.setter
+    def event(self, event):
+        self._event = event
+
+    def run(self) -> None:
+        start = time.time()
+        try:
+            super().run()
+            self._result = True
+        except Exception as e:
+            self._result = False
+            log.error("Exception occured in {} with inner exception: {}", self.name, e)
+        finally:
+            end = time.time()
+            if self.event:
+                TIMINGS[self.event][self.name] = end - start
+
+
+def spawn_threads(names, target, daemon=False, event=None, **kwargs) -> List[ResultThread]:
+    """Create and start threads running target. This will pass
+    the thread name to the target as the first argument.
+
+    Args:
+        names: Thread names
+        target: Function to run in thread
+        **kwargs: Keyword args for target
+
+    Returns:
+        List of threads handling target.
+    """
+    thread_list = list()
+    for service_name in names:
+        # setDaemon allows the main thread to exit even if
+        # these threads are still running.
+        t = ResultThread(target=target,
+                         daemon=daemon,
+                         name=service_name,
+                         args=(service_name,),
+                         kwargs=kwargs)
+        t.event = event
+        thread_list.append(t)
+        t.start()
+    return thread_list
+
+
+def wait_on_threads(thread_list: List[Thread], timeout=DEPLOY_TIMEOUT) -> List[Thread]:
+    """Wait on the threads in `install_threads` until a specified time
+    has elapsed.
+
+    Args:
+        thread_list: List of threads
+        timeout: Timeout is seconds
+
+    Returns:
+        List of threads that are still running.
+
+    """
+    start_time = current_time = time.time()
+    for thread in thread_list:
+        remaining = timeout - (current_time - start_time)
+        if remaining < 1:
+            break
+        thread.join(timeout=remaining)
+        current_time = time.time()
+    active_threads = [x for x in thread_list if x.isAlive()]
+    return active_threads
+
+
+def wait_and_get_failures(thread_list: List[ResultThread], **kwargs) -> Set[Thread]:
+    """Wait on threads to complete or timeout and log errors.
+
+    Args:
+        thread_list: List of threads to wait on
+
+    Returns: A list of service names that failed or timed out.
+
+    """
+    timeout_failures = wait_on_threads(thread_list, **kwargs)
+    timeout_names = [x.name for x in timeout_failures]
+    if timeout_names:
+        log.warning("The following {:d} instance(s) failed to "
+                    "complete in {:d} minutes: {}"
+                    .format(len(timeout_names),
+                            DEPLOY_TIMEOUT // 60,
+                            ', '.join(timeout_names)))
+    # the following did not timeout, but failed
+    run_failures = [x for x in thread_list if not x.result]
+    run_fail_names = [x.name for x in run_failures]
+    if run_fail_names:
+        log.warning("The following {:d} instance(s) "
+                    "encountered an error: {}"
+                    .format(len(run_fail_names),
+                            ', '.join(run_fail_names)))
+    return set(timeout_failures + run_failures)


### PR DESCRIPTION
- Add support for threading to dispatch hello-world runs in parallel. This cuts down the running time of hello-world in MWT from hours to a few mins.
- Add support for batch cleanup of hello-world runs in MWT. This is a nice-to-have but useful.