### PR TITLE
[DCOS-49350] Use only deploy plan from raw plans to check if the previous deployment is complete and also use tmp volume only on TaskInfo and not ExecutorInfo

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/curator/CuratorPersister.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/curator/CuratorPersister.java
@@ -312,11 +312,6 @@ public class CuratorPersister implements Persister {
        */
       LOGGER.debug("Deleting children of root {}", path);
       try {
-        client
-            .inTransaction()
-            .check()
-            .forPath(serviceRootPath)
-            .and();
         List<CuratorOp> operations = new ArrayList<>();
         operations.add(client.transactionOp().check().forPath(serviceRootPath));
         Set<String> pendingDeletePaths = new HashSet<>();

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/debug/OfferOutcomeTrackerV2.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/debug/OfferOutcomeTrackerV2.java
@@ -68,7 +68,7 @@ public class OfferOutcomeTrackerV2 implements DebugEndpoint {
       this.acceptedCount = 0;
       this.rejectedCount = 0;
       this.outcomes = EvictingQueue.create(DEFAULT_CAPACITY);
-      this.failureReasons = new HashMap();
+      this.failureReasons = new HashMap<>();
       this.rejectedAgents = new HashedMap();
     }
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluator.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluator.java
@@ -58,8 +58,6 @@ import java.util.stream.Collectors;
 @SuppressWarnings({
     "checkstyle:LineLength",
     "checkstyle:MultipleStringLiterals",
-    "checkstyle:LineLength",
-    "checkstyle:InnerTypeLast",
     "checkstyle:HiddenField",
     "checkstyle:ThrowsCount",
     "checkstyle:FinalClass"
@@ -657,7 +655,6 @@ public class OfferEvaluator {
       // Add resource evaluations for the ResourceSet:
       evaluationStages.addAll(getExistingResourceSetStages(
           podInstanceRequirement,
-          serviceName,
           resourceNamespace,
           allTasksInPod,
           resourceSet,
@@ -681,7 +678,6 @@ public class OfferEvaluator {
    */
   private Collection<OfferEvaluationStage> getExistingResourceSetStages(
       PodInstanceRequirement podInstanceRequirement,
-      String serviceName,
       Optional<String> resourceNamespace,
       Map<String, Protos.TaskInfo> allTasksInPod,
       ResourceSet resourceSet,
@@ -694,8 +690,8 @@ public class OfferEvaluator {
             TaskSpec.getInstanceName(podInstanceRequirement.getPodInstance(), taskSpecName))
         .collect(Collectors.toList());
     Optional<Protos.TaskInfo> taskInfo = taskInfoNames.stream()
-        .map(taskInfoName -> allTasksInPod.get(taskInfoName))
-        .filter(mapTaskInfo -> mapTaskInfo != null)
+        .map(allTasksInPod::get)
+        .filter(Objects::nonNull)
         .findAny();
     if (!taskInfo.isPresent()) {
       // This shouldn't happen, because this codepath is for reevaluating pods that had been launched

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/PodInfoBuilder.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/PodInfoBuilder.java
@@ -571,14 +571,13 @@ public class PodInfoBuilder {
 
     if (isTaskContainer) {
       containerInfo.getLinuxInfoBuilder().setSharePidNamespace(podSpec.getSharePidNamespace());
+      // Isolate the tmp directory of tasks
+      // switch to SANDBOX SELF after dc/os 1.13
+      containerInfo.addVolumes(Protos.Volume.newBuilder()
+          .setContainerPath("/tmp")
+          .setHostPath("tmp")
+          .setMode(Protos.Volume.Mode.RW));
     }
-
-    // Isolate the tmp directory of tasks
-    //switch to SANDBOX SELF after dc/os 1.13
-    containerInfo.addVolumes(Protos.Volume.newBuilder()
-        .setContainerPath("/tmp")
-        .setHostPath("tmp")
-        .setMode(Protos.Volume.Mode.RW));
 
     for (Protos.Volume hostVolume : hostVolumes) {
       containerInfo.addVolumes(hostVolume);

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/Status.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/plan/Status.java
@@ -53,7 +53,7 @@ public enum Status {
 
   /**
    * Execution has performed {@link org.apache.mesos.Protos.Offer.Operation}s and has received feedback, but not all
-   * success requiremens (e.g. readiness checks) have been satisfied.
+   * success requirements (e.g. readiness checks) have been satisfied.
    */
   STARTED,
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/NamedVIPSpec.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/NamedVIPSpec.java
@@ -45,7 +45,7 @@ public final class NamedVIPSpec extends PortSpec {
         portName,
         visibility,
         networkNames,
-        Collections.EMPTY_LIST);
+        Collections.emptyList());
     this.protocol = protocol;
     this.vipName = vipName;
     this.vipPort = vipPort;

--- a/sdk/testing/src/main/java/com/mesosphere/sdk/testing/Expect.java
+++ b/sdk/testing/src/main/java/com/mesosphere/sdk/testing/Expect.java
@@ -34,7 +34,7 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 
 /**
  * A type of {@link SimulationTick} that verifies the scheduler did something.


### PR DESCRIPTION
This PR has two important changes:

1. When upgrading from SDK 40 to 50, the old SDK does not set the `last-completed-update-type` zk node with value `DEPLOY`. Hence, the new SDK, during bootstrap sees that this bit is unset and tries to "guess" the state of previous deploy plan (by doing a task reconciliation). While doing this the current SDK loads all the YAML Plans and validates all the steps in all the plans against the existing ServiceSpec. This behavior may not always be valid especially when the new YAML Plans have steps corresponding to **new** tasks that were non existent before (newly defined tasks). While it is true that we don't need to worry about this problem for SDK 50 -> SDK 60 (or forward) as SDK 0.51.0+ always sets the `last-completed-update-type` zk node with value `DEPLOY`, this needs to be solved for SDK 40 -> SDK 50 upgrades. This was encountered during mesosphere/dse-private#315 Added a note to delete this code-block in SDK 60 series when that happens.
2. In SDK 0.40.x series, we have provision to use a custom executor or default executor. In SDK 50, we always use default executor. While setting container info for "/tmp" volume on SDK 40 series, [we do the following - at least as of 0.42.4 release](https://github.com/mesosphere/dcos-commons/blob/0.42.4/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/PodInfoBuilder.java#L383-L389) :
	```java
	if (!useDefaultExecutor) {
        executorInfoBuilder.setContainer(executorInfoBuilder.getContainerBuilder()
                .addVolumes(Protos.Volume.newBuilder()
                .setContainerPath("/tmp")
                .setHostPath("tmp")
                .setMode(Protos.Volume.Mode.RW)));
    }
	```
    However, in SDK 0.51.x series, there is no use for `useDefaultExecutor` variable as we always use the default executor. That means the above block can be removed as `!useDefaultExecutor` is always `false`. As of SDK release `v0.55.3`, when building the [taskInfo](https://github.com/mesosphere/dcos-commons/blob/v0.55.3/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/PodInfoBuilder.java#L322) and [executorInfo](https://github.com/mesosphere/dcos-commons/blob/v0.55.3/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/PodInfoBuilder.java#L349), we [set the containerInfo](https://github.com/mesosphere/dcos-commons/blob/v0.55.3/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/PodInfoBuilder.java#L576-L581) as :
    ```java
    // Isolate the tmp directory of tasks
    //switch to SANDBOX SELF after dc/os 1.13
    containerInfo.addVolumes(Protos.Volume.newBuilder()
        .setContainerPath("/tmp")
        .setHostPath("tmp")
        .setMode(Protos.Volume.Mode.RW));
    ```
    which becomes invalid when we are trying to reuse an executor from 40 -> 50. This was also found via mesosphere/dse-private#315 which is apparently the first time we tried to test an SDK 40 -> SDK 50 upgrade with the 50 version trying to add new tasks in and existing pod.

The reason (2) above was not seen so far is that we always create a new executor when SDK 40 -> 50 upgrade happens for packages like cassandra, hdfs etc.. For e.g.:

```
# In cassandra upgrade : 
INFO  2019-03-11 20:35:10,575 [pool-6-thread-1] OfferEvaluator:getEvaluationPipeline(268): Generating requirement for existing pod 'node-0' containing tasks: [server]
INFO  2019-03-11 20:35:10,576 [pool-6-thread-1] StateStore:fetchStatus(414): No TaskStatus found for task: node-0-repair
INFO  2019-03-11 20:35:10,649 [pool-6-thread-1] OfferEvaluator:getExecutorInfo(330): Using new executor derived from task node-0-repair: executor_id { value: "" } resources { name: "disk" type: SCALAR scalar { value: 10240.0 } disk { persistence { id: "25f9422c-0a6f-4904-be86-c5feb6e4ce35" principal: "cassandra-principal" } volume { container_path: "container-path" mode: RW } } reservations { principal: "cassandra-principal" labels { labels { key: "resource_id" value: "bbc01602-ab1a-48fd-abcf-8b33ddd35b13" } } role: "cassandra-role" type: DYNAMIC } } resources { name: "cpus" type: SCALAR scalar { value: 0.1 } reservations { principal: "cassandra-principal" labels { labels { key: "resource_id" value: "61c6313c-8299-4923-9b6e-a4b2166a5888" } } role: "cassandra-role" type: DYNAMIC } } resources { name: "mem" type: SCALAR scalar { value: 32.0 } reservations { principal: "cassandra-principal" labels { labels { key: "resource_id" value: "e2eafd40-5593-4fbf-9db7-2c490096ec1a" } } role: "cassandra-role" type: DYNAMIC } } resources { name: "disk" type: SCALAR scalar { value: 256.0 } reservations { principal: "cassandra-principal" labels { labels { key: "resource_id" value: "afe38fe7-b9cb-4d00-80cc-381a1d6d1bd7" } } role: "cassandra-role" type: DYNAMIC } } framework_id { value: "e322bbcc-cedd-41bc-851c-331370cb3d39-0002" } name: "node" container { type: MESOS } labels { labels { key: "DCOS_SPACE" value: "/cassandra" } } type: DEFAULT
INFO  2019-03-11 20:35:10,655 [pool-6-thread-1] ExecutorResourceMapper:getEvaluationStagesInternal(110): Matching executor resources: [com.mesosphere.sdk.offer.evaluate.ResourceLabels@673cfef7[original=name: disk, value: type: SCALAR scalar { value: 10240.0 }, role: cassandra-role, pre-reserved-role: *, principal: cassandra-principal, type: ROOT, container-path: container-path, profiles: [],updated=name: disk, value: type: SCALAR scalar { value: 10240.0 }, role: cassandra-role, pre-reserved-role: *, principal: cassandra-principal, type: ROOT, container-path: container-path, profiles: [],resourceId=bbc01602-ab1a-48fd-abcf-8b33ddd35b13,resourceNamespace=Optional.empty,persistenceId=Optional[25f9422c-0a6f-4904-be86-c5feb6e4ce35],providerId=Optional.empty,diskSource=Optional.empty], com.mesosphere.sdk.offer.evaluate.ResourceLabels@33ba92be[original=name: cpus, value: type: SCALAR scalar { value: 0.1 }, role: cassandra-role, pre-reserved-role: *, principal: cassandra-principal,updated=name: cpus, value: type: SCALAR scalar { value: 0.1 }, role: cassandra-role, pre-reserved-role: *, principal: cassandra-principal,resourceId=61c6313c-8299-4923-9b6e-a4b2166a5888,resourceNamespace=Optional.empty,persistenceId=Optional.empty,providerId=Optional.empty,diskSource=Optional.empty], com.mesosphere.sdk.offer.evaluate.ResourceLabels@60383f2[original=name: mem, value: type: SCALAR scalar { value: 32.0 }, role: cassandra-role, pre-reserved-role: *, principal: cassandra-principal,updated=name: mem, value: type: SCALAR scalar { value: 32.0 }, role: cassandra-role, pre-reserved-role: *, principal: cassandra-principal,resourceId=e2eafd40-5593-4fbf-9db7-2c490096ec1a,resourceNamespace=Optional.empty,persistenceId=Optional.empty,providerId=Optional.empty,diskSource=Optional.empty], com.mesosphere.sdk.offer.evaluate.ResourceLabels@1154ed76[original=name: disk, value: type: SCALAR scalar { value: 256.0 }, role: cassandra-role, pre-reserved-role: *, principal: cassandra-principal,updated=name: disk, value: type: SCALAR scalar { value: 256.0 }, role: cassandra-role, pre-reserved-role: *, principal: cassandra-principal,resourceId=afe38fe7-b9cb-4d00-80cc-381a1d6d1bd7,resourceNamespace=Optional.empty,persistenceId=Optional.empty,providerId=Optional.empty,diskSource=Optional.empty]]
INFO  2019-03-11 20:35:10,663 [pool-6-thread-1] TaskResourceMapper:getEvaluationStagesInternal(122): Matching task/TaskSpec resources: [com.mesosphere.sdk.offer.evaluate.ResourceLabels@803d2aa[original=name: ports, value: type: RANGES ranges { range { begin: 7199 end: 7199 } }, role: cassandra-role, pre-reserved-role: *, principal: cassandra-principal, port-name: jmx, network-names: [], env-key: null, visibility: CLUSTER, ranges [],updated=name: ports, value: type: RANGES ranges { range { begin: 7199 end: 7199 } }, role: cassandra-role, pre-reserved-role: *, principal: cassandra-principal, port-name: jmx, network-names: [], env-key: null, visibility: CLUSTER, ranges [],resourceId=f406fdbd-a826-4ca9-a0d7-2483f5cb1252,resourceNamespace=Optional.empty,persistenceId=Optional.empty,providerId=Optional.empty,diskSource=Optional.empty], com.mesosphere.sdk.offer.evaluate.ResourceLabels@f8b9c53[original=name: ports, value: type: RANGES ranges { range { begin: 7000 end: 7000 } }, role: cassandra-role, pre-reserved-role: *, principal: cassandra-principal, port-name: storage, network-names: [], env-key: null, visibility: CLUSTER, ranges [],updated=name: ports, value: type: RANGES ranges { range { begin: 7000 end: 7000 } }, role: cassandra-role, pre-reserved-role: *, principal: cassandra-principal, port-name: storage, network-names: [], env-key: null, visibility: CLUSTER, ranges [],resourceId=6d3d3e8e-c060-427a-b684-2329c490957c,resourceNamespace=Optional.empty,persistenceId=Optional.empty,providerId=Optional.empty,diskSource=Optional.empty], com.mesosphere.sdk.offer.evaluate.ResourceLabels@20c5d406[original=name: ports, value: type: RANGES ranges { range { begin: 7001 end: 7001 } }, role: cassandra-role, pre-reserved-role: *, principal: cassandra-principal, port-name: ssl, network-names: [], env-key: null, visibility: CLUSTER, ranges [],updated=name: ports, value: type: RANGES ranges { range { begin: 7001 end: 7001 } }, role: cassandra-role, pre-reserved-role: *, principal: cassandra-principal, port-name: ssl, network-names: [], env-key: null, visibility: CLUSTER, ranges [],resourceId=81d3e078-3947-45ab-87e6-dc53248e1111,resourceNamespace=Optional.empty,persistenceId=Optional.empty,providerId=Optional.empty,diskSource=Optional.empty], com.mesosphere.sdk.offer.evaluate.ResourceLabels@7cbad4c2[original=name: ports, value: type: RANGES ranges { range { begin: 9042 end: 9042 } }, role: cassandra-role, pre-reserved-role: *, principal: cassandra-principal, port-name: native-client, network-names: [], env-key: null, visibility: EXTERNAL, ranges [],updated=name: ports, value: type: RANGES ranges { range { begin: 9042 end: 9042 } }, role: cassandra-role, pre-reserved-role: *, principal: cassandra-principal, port-name: native-client, network-names: [], env-key: null, visibility: EXTERNAL, ranges [],resourceId=ffc5770f-6233-4255-a8d7-03d7b1749746,resourceNamespace=Optional.empty,persistenceId=Optional.empty,providerId=Optional.empty,diskSource=Optional.empty], com.mesosphere.sdk.offer.evaluate.ResourceLabels@6a3acf7d[original=name: cpus, value: type: SCALAR scalar { value: 0.5 }, role: cassandra-role, pre-reserved-role: *, principal: cassandra-principal,updated=name: cpus, value: type: SCALAR scalar { value: 0.5 }, role: cassandra-role, pre-reserved-role: *, principal: cassandra-principal,resourceId=77ab1bbd-eaa8-4b60-be65-7dcbc015ec93,resourceNamespace=Optional.empty,persistenceId=Optional.empty,providerId=Optional.empty,diskSource=Optional.empty], com.mesosphere.sdk.offer.evaluate.ResourceLabels@3900af6d[original=name: mem, value: type: SCALAR scalar { value: 4096.0 }, role: cassandra-role, pre-reserved-role: *, principal: cassandra-principal,updated=name: mem, value: type: SCALAR scalar { value: 4096.0 }, role: cassandra-role, pre-reserved-role: *, principal: cassandra-principal,resourceId=2e59f878-7f33-4f9f-95ca-525edd58f7ce,resourceNamespace=Optional.empty,persistenceId=Optional.empty,providerId=Optional.empty,diskSource=Optional.empty]]
INFO  2019-03-11 20:35:11,035 [pool-6-thread-1] OfferEvaluator:evaluate(175): Offer 1, e322bbcc-cedd-41bc-851c-331370cb3d39-O306: failed 10 of 12 evaluation stages for node-0:[server]:
  PASS(ExecutorEvaluationStage): No Executor ID required, generated: 'cassandra__node__ffebac77-b96d-44b3-9e9b-18f2ebd9d434'
  FAIL(VolumeEvaluationStage): Offer lacks previously reserved 'disk' with resourceId: 'bbc01602-ab1a-48fd-abcf-8b33ddd35b13' for resource: 'name: disk, value: type: SCALAR scalar { value: 10240.0 }, role: cassandra-role, pre-reserved-role: *, principal: cassandra-principal, type: ROOT, container-path: container-path, profiles: []'
  FAIL(ResourceEvaluationStage): Offer lacks previously reserved 'cpus' with resourceId: '61c6313c-8299-4923-9b6e-a4b2166a5888' for resource: 'name: cpus, value: type: SCALAR scalar { value: 0.1 }, role: cassandra-role, pre-reserved-role: *, principal: cassandra-principal'
  FAIL(ResourceEvaluationStage): Offer lacks previously reserved 'mem' with resourceId: 'e2eafd40-5593-4fbf-9db7-2c490096ec1a' for resource: 'name: mem, value: type: SCALAR scalar { value: 32.0 }, role: cassandra-role, pre-reserved-role: *, principal: cassandra-principal'
  FAIL(ResourceEvaluationStage): Offer lacks previously reserved 'disk' with resourceId: 'afe38fe7-b9cb-4d00-80cc-381a1d6d1bd7' for resource: 'name: disk, value: type: SCALAR scalar { value: 256.0 }, role: cassandra-role, pre-reserved-role: *, principal: cassandra-principal'
  FAIL(PortEvaluationStage): Offer lacks previously reserved 'ports' with resourceId: 'f406fdbd-a826-4ca9-a0d7-2483f5cb1252' for resource: 'name: ports, value: type: RANGES ranges { range { begin: 7199 end: 7199 } }, role: cassandra-role, pre-reserved-role: *, principal: cassandra-principal, port-name: jmx, network-names: [], env-key: null, visibility: CLUSTER, ranges []'
  FAIL(PortEvaluationStage): Offer lacks previously reserved 'ports' with resourceId: '6d3d3e8e-c060-427a-b684-2329c490957c' for resource: 'name: ports, value: type: RANGES ranges { range { begin: 7000 end: 7000 } }, role: cassandra-role, pre-reserved-role: *, principal: cassandra-principal, port-name: storage, network-names: [], env-key: null, visibility: CLUSTER, ranges []'
  FAIL(PortEvaluationStage): Offer lacks previously reserved 'ports' with resourceId: '81d3e078-3947-45ab-87e6-dc53248e1111' for resource: 'name: ports, value: type: RANGES ranges { range { begin: 7001 end: 7001 } }, role: cassandra-role, pre-reserved-role: *, principal: cassandra-principal, port-name: ssl, network-names: [], env-key: null, visibility: CLUSTER, ranges []'
  FAIL(PortEvaluationStage): Offer lacks previously reserved 'ports' with resourceId: 'ffc5770f-6233-4255-a8d7-03d7b1749746' for resource: 'name: ports, value: type: RANGES ranges { range { begin: 9042 end: 9042 } }, role: cassandra-role, pre-reserved-role: *, principal: cassandra-principal, port-name: native-client, network-names: [], env-key: null, visibility: EXTERNAL, ranges []'
  FAIL(ResourceEvaluationStage): Offer lacks previously reserved 'cpus' with resourceId: '77ab1bbd-eaa8-4b60-be65-7dcbc015ec93' for resource: 'name: cpus, value: type: SCALAR scalar { value: 0.5 }, role: cassandra-role, pre-reserved-role: *, principal: cassandra-principal'
  FAIL(ResourceEvaluationStage): Offer lacks previously reserved 'mem' with resourceId: '2e59f878-7f33-4f9f-95ca-525edd58f7ce' for resource: 'name: mem, value: type: SCALAR scalar { value: 4096.0 }, role: cassandra-role, pre-reserved-role: *, principal: cassandra-principal'
  PASS(LaunchEvaluationStage): Added launch operation for server
WARN  2019-03-11 20:35:11,040 [pool-6-thread-1] PlanScheduler:resourceOffers(108): Unable to find any offers which fulfill requirement provided by step node-0:[server]: node-0:[server](NONE)
```

where as in dse 40 -> 50 upgrade where the 50 version has a new task, we try to reuse the executor : 
```
INFO  2019-03-11 21:20:42,035 [pool-6-thread-1] OfferEvaluator:getEvaluationPipeline(268): Generating requirement for existing pod 'dse-2' containing tasks: [compact-storage]
INFO  2019-03-11 21:20:42,036 [pool-6-thread-1] StateStore:fetchStatus(414): No TaskStatus found for task: dse-2-agent
INFO  2019-03-11 21:20:42,065 [pool-6-thread-1] OfferEvaluator:getExecutorInfo(317): Using existing executor: executor_id { value: "dse__ba71af21-d219-4b2f-96fe-78a804aeed3d" } resources { name: "disk" type: SCALAR scalar { value: 10240.0 } disk { persistence { id: "5af55993-87eb-4e1d-a459-d9f97b2cc32a" principal: "datastax-dse-service-account" } volume { container_path: "dse-data" mode: RW } } reservations { principal: "datastax-dse-service-account" labels { labels { key: "resource_id" value: "3d0aa860-befb-4c2f-af67-fc348b0734d4" } } role: "datastax-dse-role" type: DYNAMIC } } resources { name: "disk" type: SCALAR scalar { value: 1000.0 } disk { persistence { id: "59e1b550-45cb-45df-9b50-d65f5caf8b5d" principal: "datastax-dse-service-account" } volume { container_path: "dse-install" mode: RW } } reservations { principal: "datastax-dse-service-account" labels { labels { key: "resource_id" value: "7f2fdaab-d10d-43fb-9659-e1773d5e020d" } } role: "datastax-dse-role" type: DYNAMIC } } resources { name: "disk" type: SCALAR scalar { value: 1000.0 } disk { persistence { id: "5b121fea-0af7-4b62-9edc-6b92581b77ea" principal: "datastax-dse-service-account" } volume { container_path: "log-data" mode: RW } } reservations { principal: "datastax-dse-service-account" labels { labels { key: "resource_id" value: "56c71801-d0b2-4a79-ab34-0b6a9cd3caa2" } } role: "datastax-dse-role" type: DYNAMIC } } resources { name: "disk" type: SCALAR scalar { value: 10.0 } disk { persistence { id: "14acb37d-7212-4d8d-ad60-46118278375f" principal: "datastax-dse-service-account" } volume { container_path: "dsefs-data" mode: RW } } reservations { principal: "datastax-dse-service-account" labels { labels { key: "resource_id" value: "c12ccba8-00e6-4576-9411-d4390a885764" } } role: "datastax-dse-role" type: DYNAMIC } } resources { name: "disk" type: SCALAR scalar { value: 10240.0 } disk { persistence { id: "b3387a89-ecfb-4e1e-8b2c-bd5fdbba8d45" principal: "datastax-dse-service-account" } volume { container_path: "solr-data" mode: RW } } reservations { principal: "datastax-dse-service-account" labels { labels { key: "resource_id" value: "4f31a12a-49f2-4fe2-a178-09d2021dfd53" } } role: "datastax-dse-role" type: DYNAMIC } } resources { name: "cpus" type: SCALAR scalar { value: 0.1 } reservations { principal: "datastax-dse-service-account" labels { labels { key: "resource_id" value: "7409e09f-6dea-4e8a-b8db-eeb96eeba3ca" } } role: "datastax-dse-role" type: DYNAMIC } } resources { name: "mem" type: SCALAR scalar { value: 32.0 } reservations { principal: "datastax-dse-service-account" labels { labels { key: "resource_id" value: "04758d7f-93fa-471f-8a35-ce070807caff" } } role: "datastax-dse-role" type: DYNAMIC } } resources { name: "disk" type: SCALAR scalar { value: 256.0 } reservations { principal: "datastax-dse-service-account" labels { labels { key: "resource_id" value: "c64bda97-10f2-46ea-93f4-d7954d370805" } } role: "datastax-dse-role" type: DYNAMIC } } framework_id { value: "e322bbcc-cedd-41bc-851c-331370cb3d39-0003" } name: "dse" container { type: MESOS rlimit_info { rlimits { type: RLMT_MEMLOCK hard: 18446744073709551615 soft: 18446744073709551615 } rlimits { type: RLMT_NOFILE hard: 100000 soft: 100000 } rlimits { type: RLMT_NPROC hard: 32768 soft: 32768 } } } labels { labels { key: "DCOS_SPACE" value: "/datastax-dse" } } type: DEFAULT
INFO  2019-03-11 21:20:42,126 [pool-6-thread-1] ExecutorResourceMapper:getEvaluationStagesInternal(110): Matching executor resources: [com.mesosphere.sdk.offer.evaluate.ResourceLabels@1f44f772[original=name: disk, value: type: SCALAR scalar { value: 10240.0 }, role: datastax-dse-role, pre-reserved-role: *, principal: datastax-dse-service-account, type: ROOT, container-path: dse-data, profiles: [],updated=name: disk, value: type: SCALAR scalar { value: 10240.0 }, role: datastax-dse-role, pre-reserved-role: *, principal: datastax-dse-service-account, type: ROOT, container-path: dse-data, profiles: [],resourceId=3d0aa860-befb-4c2f-af67-fc348b0734d4,resourceNamespace=Optional.empty,persistenceId=Optional[5af55993-87eb-4e1d-a459-d9f97b2cc32a],providerId=Optional.empty,diskSource=Optional.empty], com.mesosphere.sdk.offer.evaluate.ResourceLabels@5fa35255[original=name: disk, value: type: SCALAR scalar { value: 1000.0 }, role: datastax-dse-role, pre-reserved-role: *, principal: datastax-dse-service-account, type: ROOT, container-path: dse-install, profiles: [],updated=name: disk, value: type: SCALAR scalar { value: 1000.0 }, role: datastax-dse-role, pre-reserved-role: *, principal: datastax-dse-service-account, type: ROOT, container-path: dse-install, profiles: [],resourceId=7f2fdaab-d10d-43fb-9659-e1773d5e020d,resourceNamespace=Optional.empty,persistenceId=Optional[59e1b550-45cb-45df-9b50-d65f5caf8b5d],providerId=Optional.empty,diskSource=Optional.empty], com.mesosphere.sdk.offer.evaluate.ResourceLabels@739f380f[original=name: disk, value: type: SCALAR scalar { value: 1000.0 }, role: datastax-dse-role, pre-reserved-role: *, principal: datastax-dse-service-account, type: ROOT, container-path: log-data, profiles: [],updated=name: disk, value: type: SCALAR scalar { value: 1000.0 }, role: datastax-dse-role, pre-reserved-role: *, principal: datastax-dse-service-account, type: ROOT, container-path: log-data, profiles: [],resourceId=56c71801-d0b2-4a79-ab34-0b6a9cd3caa2,resourceNamespace=Optional.empty,persistenceId=Optional[5b121fea-0af7-4b62-9edc-6b92581b77ea],providerId=Optional.empty,diskSource=Optional.empty], com.mesosphere.sdk.offer.evaluate.ResourceLabels@e6470d7[original=name: disk, value: type: SCALAR scalar { value: 10.0 }, role: datastax-dse-role, pre-reserved-role: *, principal: datastax-dse-service-account, type: ROOT, container-path: dsefs-data, profiles: [],updated=name: disk, value: type: SCALAR scalar { value: 10.0 }, role: datastax-dse-role, pre-reserved-role: *, principal: datastax-dse-service-account, type: ROOT, container-path: dsefs-data, profiles: [],resourceId=c12ccba8-00e6-4576-9411-d4390a885764,resourceNamespace=Optional.empty,persistenceId=Optional[14acb37d-7212-4d8d-ad60-46118278375f],providerId=Optional.empty,diskSource=Optional.empty], com.mesosphere.sdk.offer.evaluate.ResourceLabels@aaccc0b[original=name: disk, value: type: SCALAR scalar { value: 10240.0 }, role: datastax-dse-role, pre-reserved-role: *, principal: datastax-dse-service-account, type: ROOT, container-path: solr-data, profiles: [],updated=name: disk, value: type: SCALAR scalar { value: 10240.0 }, role: datastax-dse-role, pre-reserved-role: *, principal: datastax-dse-service-account, type: ROOT, container-path: solr-data, profiles: [],resourceId=4f31a12a-49f2-4fe2-a178-09d2021dfd53,resourceNamespace=Optional.empty,persistenceId=Optional[b3387a89-ecfb-4e1e-8b2c-bd5fdbba8d45],providerId=Optional.empty,diskSource=Optional.empty], com.mesosphere.sdk.offer.evaluate.ResourceLabels@69ad9d35[original=name: cpus, value: type: SCALAR scalar { value: 0.1 }, role: datastax-dse-role, pre-reserved-role: *, principal: datastax-dse-service-account,updated=name: cpus, value: type: SCALAR scalar { value: 0.1 }, role: datastax-dse-role, pre-reserved-role: *, principal: datastax-dse-service-account,resourceId=7409e09f-6dea-4e8a-b8db-eeb96eeba3ca,resourceNamespace=Optional.empty,persistenceId=Optional.empty,providerId=Optional.empty,diskSource=Optional.empty], com.mesosphere.sdk.offer.evaluate.ResourceLabels@4ba0b42f[original=name: mem, value: type: SCALAR scalar { value: 32.0 }, role: datastax-dse-role, pre-reserved-role: *, principal: datastax-dse-service-account,updated=name: mem, value: type: SCALAR scalar { value: 32.0 }, role: datastax-dse-role, pre-reserved-role: *, principal: datastax-dse-service-account,resourceId=04758d7f-93fa-471f-8a35-ce070807caff,resourceNamespace=Optional.empty,persistenceId=Optional.empty,providerId=Optional.empty,diskSource=Optional.empty], com.mesosphere.sdk.offer.evaluate.ResourceLabels@1a6ebd72[original=name: disk, value: type: SCALAR scalar { value: 256.0 }, role: datastax-dse-role, pre-reserved-role: *, principal: datastax-dse-service-account,updated=name: disk, value: type: SCALAR scalar { value: 256.0 }, role: datastax-dse-role, pre-reserved-role: *, principal: datastax-dse-service-account,resourceId=c64bda97-10f2-46ea-93f4-d7954d370805,resourceNamespace=Optional.empty,persistenceId=Optional.empty,providerId=Optional.empty,diskSource=Optional.empty]]
ERROR 2019-03-11 21:20:42,136 [pool-6-thread-1] OfferEvaluator:getExistingResourceSetStages(699): Failed to find existing TaskInfo among [dse-2-compact-storage], cannot evaluate existing resource set compact-storage-resource-set
INFO  2019-03-11 21:20:42,522 [pool-6-thread-1] OfferEvaluator:evaluate(210): Offer 1: passed all 10 evaluation stages, returning 2 recommendations for dse-2:[compact-storage]:
  PASS(ExecutorEvaluationStage): Offer contains the matching Executor ID: 'dse__ba71af21-d219-4b2f-96fe-78a804aeed3d'
  PASS(VolumeEvaluationStage): Setting info for already running Executor with existing volume with resourceId: 'Optional[3d0aa860-befb-4c2f-af67-fc348b0734d4]' and persistenceId: 'Optional[5af55993-87eb-4e1d-a459-d9f97b2cc32a]'
  PASS(VolumeEvaluationStage): Setting info for already running Executor with existing volume with resourceId: 'Optional[7f2fdaab-d10d-43fb-9659-e1773d5e020d]' and persistenceId: 'Optional[59e1b550-45cb-45df-9b50-d65f5caf8b5d]'
  PASS(VolumeEvaluationStage): Setting info for already running Executor with existing volume with resourceId: 'Optional[56c71801-d0b2-4a79-ab34-0b6a9cd3caa2]' and persistenceId: 'Optional[5b121fea-0af7-4b62-9edc-6b92581b77ea]'
  PASS(VolumeEvaluationStage): Setting info for already running Executor with existing volume with resourceId: 'Optional[c12ccba8-00e6-4576-9411-d4390a885764]' and persistenceId: 'Optional[14acb37d-7212-4d8d-ad60-46118278375f]'
  PASS(VolumeEvaluationStage): Setting info for already running Executor with existing volume with resourceId: 'Optional[4f31a12a-49f2-4fe2-a178-09d2021dfd53]' and persistenceId: 'Optional[b3387a89-ecfb-4e1e-8b2c-bd5fdbba8d45]'
  PASS(ResourceEvaluationStage): Including running executor's 'cpus' resource with resourceId: '7409e09f-6dea-4e8a-b8db-eeb96eeba3ca': name: cpus, value: type: SCALAR scalar { value: 0.1 }, role: datastax-dse-role, pre-reserved-role: *, principal: datastax-dse-service-account
  PASS(ResourceEvaluationStage): Including running executor's 'mem' resource with resourceId: '04758d7f-93fa-471f-8a35-ce070807caff': name: mem, value: type: SCALAR scalar { value: 32.0 }, role: datastax-dse-role, pre-reserved-role: *, principal: datastax-dse-service-account
  PASS(ResourceEvaluationStage): Including running executor's 'disk' resource with resourceId: 'c64bda97-10f2-46ea-93f4-d7954d370805': name: disk, value: type: SCALAR scalar { value: 256.0 }, role: datastax-dse-role, pre-reserved-role: *, principal: datastax-dse-service-account
  PASS(LaunchEvaluationStage): Added launch operation for compact-storage
```
which would result in the codepath of reusing an existing executor id with new executor info which is invalid as the new executor info would always have the `tmp` volume (while the old one does not). This PR fixes this codepath by making sure the new executorInfo is compatible with old executorInfo.