### PR TITLE
Remove unused raw_data parameter from Package

### DIFF
--- a/tools/universe/package.py
+++ b/tools/universe/package.py
@@ -9,10 +9,9 @@ class Package:
         """Construct a Package object from a json definition"""
         return Package(json["name"], Version(json["releaseVersion"], json["version"]))
 
-    def __init__(self, name, version, raw_data={}):
+    def __init__(self, name, version):
         self._name = name
         self._version = version
-        self._raw_data = raw_data
 
     def __eq__(self, other):
         if self.get_name() != other.get_name():


### PR DESCRIPTION
While adding mypy checks to this repository - https://jira.mesosphere.com/browse/DCOS-48816, we noticed that this parameter / attribute is unused.

That is - nothing is ever supplied to the parameter, and the private attribute is never used.
