### PR TITLE
Use the `Version` type when creating a Package

### DIFF
--- a/tools/publish_aws.py
+++ b/tools/publish_aws.py
@@ -18,6 +18,7 @@ import sys
 import time
 
 import universe
+from universe.package import Version
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.DEBUG, format="%(message)s")
@@ -72,7 +73,8 @@ class AWSPublisher(object):
 
     def upload(self):
         """generates a unique directory, then uploads artifacts and a new stub universe to that directory"""
-        package_info = universe.Package(self._pkg_name, self._pkg_version)
+        version = Version(release_version=0, package_version=self._pkg_version)
+        package_info = universe.Package(name=self._pkg_name, version=version)
         package_manager = universe.PackageManager(dry_run=self._dry_run)
         builder = universe.UniversePackageBuilder(
             package_info,

--- a/tools/publish_dcos_file.py
+++ b/tools/publish_dcos_file.py
@@ -18,6 +18,7 @@ import urllib.request
 
 import publish_aws
 import universe
+from universe.package import Version
 
 from publish_aws import s3_urls_from_env
 
@@ -47,9 +48,11 @@ class DCOSFilePublisher(object):
         self._uploader = universe.S3Uploader(s3_directory_url, self._dry_run)
 
     def upload(self):
+        version = Version(release_version=0, package_version=self._pkg_version)
+        package = universe.Package(name=self._pkg_name, version=version)
         with tempfile.TemporaryDirectory() as scratch:
             builder = universe.UniversePackageBuilder(
-                universe.Package(self._pkg_name, self._pkg_version),
+                package,
                 universe.PackageManager(dry_run=self._dry_run),
                 self._input_dir_path,
                 self._directory_url,

--- a/tools/publish_http.py
+++ b/tools/publish_http.py
@@ -122,7 +122,8 @@ class HTTPPublisher(object):
 
         http_url_root = "http://{}:{}".format(self._http_host, port)
 
-        package_info = universe.Package(self._pkg_name, self._pkg_version)
+        version = Version(release_version=0, package_version=self._pkg_version)
+        package_info = universe.Package(name=self._pkg_name, version=version)
         package_manager = universe.PackageManager()
         self._package_builder = universe.UniversePackageBuilder(
             package_info, package_manager, self._input_dir_path, http_url_root, self._artifact_paths

--- a/tools/publish_http.py
+++ b/tools/publish_http.py
@@ -18,6 +18,7 @@ import subprocess
 import sys
 
 import universe
+from universe.package import Version
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.DEBUG, format="%(message)s")

--- a/tools/universe/package_builder.py
+++ b/tools/universe/package_builder.py
@@ -168,7 +168,7 @@ class UniversePackageBuilder(object):
         now = time.time()
         template_mapping = {
             "package-name": self._package.get_name(),
-            "package-version": self._package.get_version(),
+            "package-version": str(self._package.get_version()),
             "package-build-time-epoch-ms": str(int(round(now * 1000))),
             "package-build-time-str": time.strftime("%a %b %d %Y %H:%M:%S +0000", time.gmtime(now)),
             "upgrades-from": self._get_upgrades_from(),


### PR DESCRIPTION
While adding mypy checks to this repository ([DCOS-48816](https://jira.mesosphere.com/browse/DCOS-48816)), we found that there was a type error.

In particular, `universe.Package`'s "version" parameter is expected in the class to be a `Version`.

However, multiple callers of the class were giving `version` as a `str`.

A `Version` includes a `release_version` (`int`) and a `package_version` (`str`).
In this PR, we choose for all existing callers which ignored `release_version` to set that to 0.
I am happy to take other suggestions!
From what I can tell, it just so happens that none of these callers ever call use any functionality of `Package` which rely on the `version` being set correctly.

Tests for `tools` are not touched because they are removed in https://github.com/mesosphere/dcos-commons/pull/2952.