### PR TITLE
[DCOS-44511] Insert `:latest` tag into FROM line

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,5 @@
 # See Dockerfile.base for instructions on how to update this base image.
-# TODO: change to mesosphere/dcos-commons-base:latest@sha256:somechecksum once
-# the docker on TeamCity is recent enough. Until it happens, renovatebot will
-# not be updating this dependency.  See
-# https://mesosphere.slack.com/archives/C4E91G0CX/p1541505296001800 for more
-# background.
-FROM mesosphere/dcos-commons-base@sha256:2aaf8f7398bd6f2fc02c6388e566aafd3a2ad05c0fb8162702aab7aecd263957
+FROM mesosphere/dcos-commons-base:latest@sha256:2aaf8f7398bd6f2fc02c6388e566aafd3a2ad05c0fb8162702aab7aecd263957
 
 ENV GO_VERSION=1.10.2
 ENV PATH=$PATH:/usr/local/go/bin


### PR DESCRIPTION
This tells renovatebot what tag to take updates from.
It is effectively a revert of #2745.
We can do this now that a recent-enough docker is installed on TeamCity
(DCOS-44509).