### PR TITLE
Add multiple custom plans to plan.yml

### DIFF
--- a/frameworks/helloworld/src/main/dist/plan.yml
+++ b/frameworks/helloworld/src/main/dist/plan.yml
@@ -45,6 +45,30 @@ pods:
           delay: 0
           timeout: 10
           max-consecutive-failures: 3
+  custom-pod-A:
+    count: 1
+    tasks:
+      simple-task:
+        cpus: 0.1
+        memory: 32
+        goal: RUNNING
+        cmd: "echo custom-pod-A-simple-task && sleep 10000"
+  custom-pod-B:
+    count: 1
+    tasks:
+      simple-task:
+        cpus: 0.1
+        memory: 32
+        goal: RUNNING
+        cmd: "echo custom-pod-B-simple-task && sleep 10000"
+  custom-pod-C:
+    count: 1
+    tasks:
+      simple-task:
+        cpus: 0.1
+        memory: 32
+        goal: RUNNING
+        cmd: "echo custom-pod-C-simple-task && sleep 10000"
 plans:
   deploy:
     strategy: serial
@@ -55,4 +79,15 @@ plans:
       world-deploy:
         strategy: parallel
         pod: world
-
+  manual-plan-0:
+    phases:
+      manual-plan-0-phase:
+        pod: custom-pod-A
+  manual-plan-1:
+    phases:
+      manual-plan-1-phase:
+        pod: custom-pod-B
+  manual-plan-2:
+    phases:
+      manual-plan-2-phase:
+        pod: custom-pod-C

--- a/frameworks/helloworld/tests/test_parallel_plans.py
+++ b/frameworks/helloworld/tests/test_parallel_plans.py
@@ -26,7 +26,7 @@ def configure_package(configure_security):
 
 @pytest.mark.sanity
 def test_all_tasks_are_launched():
-    service_options = {"service": {"yaml": "sidecar"}, "hello": {"count": 1}}
+    service_options = {"service": {"yaml": "plan"}}
     sdk_install.install(
         config.PACKAGE_NAME,
         foldered_name,
@@ -36,21 +36,24 @@ def test_all_tasks_are_launched():
         wait_for_all_conditions=True
     )
     # after above method returns, start all plans right away.
-    sdk_plan.start_plan(foldered_name, "sidecar")
-    sdk_plan.start_plan(foldered_name, "sidecar-parameterized", {"PLAN_PARAMETER": "parameterized"})
-    sdk_plan.wait_for_completed_plan(foldered_name, "sidecar")
-    sdk_plan.wait_for_completed_plan(foldered_name, "sidecar-parameterized")
-    # /pod/<pod-id>/info fetches data from SDK's persistence layer
-    pod_hello_0_info = sdk_cmd.service_request(
-        "GET", foldered_name, "/v1/pod/hello-0/info"
-    ).json()
-    for taskInfoAndStatus in pod_hello_0_info:
-        info = taskInfoAndStatus["info"]
-        status = taskInfoAndStatus["status"]
-        # While `info` object is always present, `status` may or may not be present based on whether the
-        # task was launched and we received an update from mesos (or not).
-        if status:
-            assert info["taskId"]["value"] == status["taskId"]["value"]
-            assert len(info["taskId"]["value"]) > 0
-        else:
-            assert len(info["taskId"]["value"]) == 0
+    plans = ["manual-plan-0", "manual-plan-1", "manual-plan-2"]
+    for plan in plans:
+        sdk_plan.start_plan(foldered_name, plan)
+    for plan in plans:
+        sdk_plan.wait_for_completed_plan(foldered_name, plan)
+    pods = ["custom-pod-A-0", "custom-pod-B-0", "custom-pod-C-0"]
+    for pod in pods:
+        # /pod/<pod-id>/info fetches data from SDK's persistence layer
+        pod_hello_0_info = sdk_cmd.service_request(
+            "GET", foldered_name, "/v1/pod/{}/info".format(pod)
+        ).json()
+        for taskInfoAndStatus in pod_hello_0_info:
+            info = taskInfoAndStatus["info"]
+            status = taskInfoAndStatus["status"]
+            # While `info` object is always present, `status` may or may not be present based
+            # on whether the task was launched and we received an update from mesos (or not).
+            if status:
+                assert info["taskId"]["value"] == status["taskId"]["value"]
+                assert len(info["taskId"]["value"]) > 0
+            else:
+                assert len(info["taskId"]["value"]) == 0


### PR DESCRIPTION
In `test_parallel_plans.py` we use plans from sidecar.yml which has multiple pods with all tasks sharing a single resource-set, this sometimes leads to inconsistencies (offer starvation) when all the tasks are run in parallel and the test times out before all the offers are received back to make progress. This PR adds new plans to `plan.yml` that can be used more reliably to make sure that all the plans progress simultaneously without waiting for each other.