### PR TITLE
[DCOS-51458] Update pygobject depdendency

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -34,6 +34,7 @@ RUN apt-get update && \
     jq \
     libssl-dev \
     oracle-java8-installer \
+    pkg-config \
     python-pip \
     python3 \
     python3-dev \

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -34,7 +34,6 @@ RUN apt-get update && \
     jq \
     libssl-dev \
     oracle-java8-installer \
-    pkg-config \
     python-pip \
     python3 \
     python3-dev \

--- a/frozen_requirements.txt
+++ b/frozen_requirements.txt
@@ -88,7 +88,7 @@ pycodestyle==2.5.0
 pycparser==2.19
 pyflakes==2.1.1
 Pygments==2.3.1
-pygobject==3.26.1
+PyGObject==3.30.4
 PyInstaller==3.3
 PyJWT==1.7.1
 pylint==2.3.1

--- a/frozen_requirements.txt
+++ b/frozen_requirements.txt
@@ -84,6 +84,7 @@ prettytable==0.7.2
 py==1.7.0
 pyasn1==0.4.5
 pyasn1-modules==0.2.3
+pycairo==1.11.1
 pycodestyle==2.5.0
 pycparser==2.19
 pyflakes==2.1.1


### PR DESCRIPTION
Change the letter case to match the official name on PyPI to see whether this helps renovatebot realize that there *are* newer releases available.
For the same reason, use the one but latest release, to see whether renotatebot picks it up.