### PR TITLE
[TOOLS] Source required file for setting MESOS_WORK_DIR in clusters created with onprem amis 

### DIFF
--- a/tools/create_testing_volumes.py
+++ b/tools/create_testing_volumes.py
@@ -73,6 +73,7 @@ echo 'Updating disk resources...'
 export MESOS_WORK_DIR MESOS_RESOURCES
 eval $(sed -E "s/^([A-Z_]+)=(.*)$/\\1='\\2'/" /opt/mesosphere/etc/mesos-slave-common)  # Set up `MESOS_WORK_DIR`.
 eval $(sed -E "s/^([A-Z_]+)=(.*)$/\\1='\\2'/" /opt/mesosphere/etc/mesos-slave)         # Set up `MESOS_RESOURCES`.
+source /opt/mesosphere/etc/mesos-slave-common
 /opt/mesosphere/bin/make_disk_resources.py /var/lib/dcos/mesos-resources
 source /var/lib/dcos/mesos-resources
 /opt/mesosphere/bin/python -c "


### PR DESCRIPTION
verified this via https://teamcity.mesosphere.io/viewLog.html?buildId=1715989&buildTypeId=Frameworks_Orchestration_DcosCommons_PrJobs_TestOnpremHelloWorldPr&tab=buildResultsDiv