### PR TITLE
Add mypy types to the elastic framework

### DIFF
--- a/frameworks/elastic/tests/config.py
+++ b/frameworks/elastic/tests/config.py
@@ -3,6 +3,7 @@ import logging
 import re
 import retrying
 from toolz import get_in
+from typing import Any, Dict, List, Match, Optional, Union
 
 import sdk_cmd
 import sdk_hosts
@@ -76,20 +77,24 @@ DEFAULT_SETTINGS_MAPPINGS = {
     stop_max_delay=KIBANA_DEFAULT_TIMEOUT * 1000,
     retry_on_result=lambda res: not res,
 )
-def check_kibana_adminrouter_integration(path):
+def check_kibana_adminrouter_integration(path: str) -> bool:
     curl_cmd = 'curl -L -I -k -H "Authorization: token={}" -s {}/{}'.format(
         sdk_utils.dcos_token(), sdk_utils.dcos_url().rstrip("/"), path.lstrip("/")
     )
     rc, stdout, _ = sdk_cmd.master_ssh(curl_cmd)
-    return rc == 0 and stdout and "HTTP/1.1 200" in stdout
+    return bool(rc == 0 and stdout and "HTTP/1.1 200" in stdout)
 
 
 @retrying.retry(
     wait_fixed=1000, stop_max_delay=DEFAULT_TIMEOUT * 1000, retry_on_result=lambda res: not res
 )
 def check_elasticsearch_index_health(
-    index_name, color, service_name=SERVICE_NAME, http_user=None, http_password=None
-):
+    index_name: str,
+    color: str,
+    service_name: str = SERVICE_NAME,
+    http_user: Optional[str] = None,
+    http_password: Optional[str] = None,
+) -> bool:
     result = _curl_query(
         service_name,
         "GET",
@@ -97,13 +102,15 @@ def check_elasticsearch_index_health(
         http_user=http_user,
         http_password=http_password,
     )
-    return result and result["status"] == color
+    return bool(result and result["status"] == color)
 
 
 @retrying.retry(wait_fixed=1000, stop_max_delay=5 * 1000, retry_on_result=lambda res: not res)
 def check_custom_elasticsearch_cluster_setting(
-    service_name=SERVICE_NAME, setting_path=None, expected_value=None
-):
+    service_name: str = SERVICE_NAME,
+    setting_path: Optional[str] = None,
+    expected_value: Optional[str] = None,
+) -> bool:
     settings = _curl_query(service_name, "GET", "_cluster/settings?include_defaults=true")["defaults"]
     if not settings:
         return False
@@ -111,26 +118,32 @@ def check_custom_elasticsearch_cluster_setting(
     log.info(
         "Expected '{}' to be '{}', got '{}'".format(setting_path, expected_value, actual_value)
     )
-    return expected_value == actual_value
+    return bool(expected_value == actual_value)
 
 
 @retrying.retry(
     wait_fixed=1000, stop_max_delay=DEFAULT_TIMEOUT * 1000, retry_on_result=lambda res: not res
 )
-def wait_for_expected_nodes_to_exist(service_name=SERVICE_NAME, task_count=DEFAULT_TASK_COUNT):
+def wait_for_expected_nodes_to_exist(
+    service_name: str = SERVICE_NAME,
+    task_count: int = DEFAULT_TASK_COUNT,
+) -> bool:
     result = _curl_query(service_name, "GET", "_cluster/health")
     if not result or "number_of_nodes" not in result:
         log.warning("Missing 'number_of_nodes' key in cluster health response: {}".format(result))
         return False
     node_count = result["number_of_nodes"]
     log.info("Waiting for {} healthy nodes, got {}".format(task_count, node_count))
-    return node_count == task_count
+    return bool(node_count == task_count)
 
 
 @retrying.retry(
     wait_fixed=1000, stop_max_delay=DEFAULT_TIMEOUT * 1000, retry_on_result=lambda res: not res
 )
-def check_kibana_plugin_installed(plugin_name, service_name=SERVICE_NAME):
+def check_kibana_plugin_installed(
+    plugin_name: str,
+    service_name: str = SERVICE_NAME,
+) -> bool:
     task_sandbox = sdk_cmd.get_task_sandbox_path(service_name)
     # Environment variables aren't available on DC/OS 1.9 so we manually inject MESOS_SANDBOX (and
     # can't use ELASTIC_VERSION).
@@ -143,13 +156,15 @@ def check_kibana_plugin_installed(plugin_name, service_name=SERVICE_NAME):
         task_sandbox
     )
     _, stdout, _ = sdk_cmd.marathon_task_exec(service_name, cmd)
-    return plugin_name in stdout
+    return bool(plugin_name in stdout)
 
 
 @retrying.retry(
     wait_fixed=1000, stop_max_delay=DEFAULT_TIMEOUT * 1000, retry_on_result=lambda res: not res
 )
-def check_elasticsearch_plugin_installed(plugin_name, service_name=SERVICE_NAME):
+def check_elasticsearch_plugin_installed(
+    plugin_name: str, service_name: str = SERVICE_NAME,
+) -> bool:
     result = _get_hosts_with_plugin(service_name, plugin_name)
     return result is not None and len(result) == DEFAULT_TASK_COUNT
 
@@ -157,12 +172,15 @@ def check_elasticsearch_plugin_installed(plugin_name, service_name=SERVICE_NAME)
 @retrying.retry(
     wait_fixed=1000, stop_max_delay=DEFAULT_TIMEOUT * 1000, retry_on_result=lambda res: not res
 )
-def check_elasticsearch_plugin_uninstalled(plugin_name, service_name=SERVICE_NAME):
+def check_elasticsearch_plugin_uninstalled(
+    plugin_name: str,
+    service_name: str = SERVICE_NAME,
+) -> bool:
     result = _get_hosts_with_plugin(service_name, plugin_name)
     return result is not None and result == []
 
 
-def _get_hosts_with_plugin(service_name, plugin_name):
+def _get_hosts_with_plugin(service_name: str, plugin_name: str) -> Optional[List[str]]:
     output = _curl_query(service_name, "GET", "_cat/plugins", return_json=False)
     if output is None:
         return None
@@ -170,17 +188,21 @@ def _get_hosts_with_plugin(service_name, plugin_name):
 
 
 @retrying.retry(wait_fixed=1000, stop_max_delay=120 * 1000, retry_on_result=lambda res: not res)
-def get_elasticsearch_master(service_name=SERVICE_NAME):
+def get_elasticsearch_master(service_name: str = SERVICE_NAME) -> Optional[str]:
     output = _curl_query(service_name, "GET", "_cat/master", return_json=False)
+    assert isinstance(output, str)
     if output is not None and len(output.split()) > 0:
         return output.split()[-1]
-    return False
+    return None
 
 
 @retrying.retry(wait_fixed=1000, stop_max_delay=30 * 1000, retry_on_result=lambda res: not res)
 def verify_graph_explore_endpoint(
-    is_expected_to_be_enabled, service_name=SERVICE_NAME, http_user=None, http_password=None
-):
+    is_expected_to_be_enabled: bool,
+    service_name: str = SERVICE_NAME,
+    http_user: Optional[str] = None,
+    http_password: Optional[str] = None,
+) -> bool:
     index_name = "graph_index"
 
     create_index(
@@ -209,11 +231,14 @@ def verify_graph_explore_endpoint(
 
 
 def verify_commercial_api_status(
-    is_expected_to_be_enabled, service_name=SERVICE_NAME, http_user=None, http_password=None
-):
-    return verify_graph_explore_endpoint(
+    is_expected_to_be_enabled: bool,
+    service_name: str = SERVICE_NAME,
+    http_user: Optional[str] = None,
+    http_password: Optional[str] = None,
+) -> bool:
+    return bool(verify_graph_explore_endpoint(
         is_expected_to_be_enabled, service_name, http_user=http_user, http_password=http_password
-    )
+    ))
 
 
 # On Elastic 6.x, the "Graph Explore API" is available when the Elasticsearch cluster is configured
@@ -246,13 +271,19 @@ def verify_commercial_api_status(
 #     },
 #     "status": 403
 #   }
-def is_graph_explore_endpoint_active(response):
+def is_graph_explore_endpoint_active(response: Dict[str, Any]) -> bool:
     return isinstance(response.get("vertices"), list) and isinstance(
         response.get("connections"), list
     )
 
 
-def verify_document(service_name, document_id, document_fields, http_user=None, http_password=None):
+def verify_document(
+    service_name: str,
+    document_id: int,
+    document_fields: Dict[str, str],
+    http_user: Optional[str] = None,
+    http_password: Optional[str] = None,
+) -> None:
     document = get_document(
         DEFAULT_INDEX_NAME,
         DEFAULT_INDEX_TYPE,
@@ -264,16 +295,25 @@ def verify_document(service_name, document_id, document_fields, http_user=None, 
     assert document["_source"]["name"] == document_fields["name"]
 
 
-def get_xpack_license(service_name=SERVICE_NAME, http_user=None, http_password=None):
-    return _curl_query(
+def get_xpack_license(
+    service_name: str = SERVICE_NAME,
+    http_user: Optional[str] = None,
+    http_password: Optional[str] = None,
+) -> Dict[str, Any]:
+    result = _curl_query(
         service_name, "GET", "_xpack/license", http_user=http_user, http_password=http_password
     )
+    assert isinstance(result, dict)
+    return result
 
 
 @retrying.retry(wait_fixed=1000, stop_max_delay=120 * 1000, retry_on_result=lambda res: not res)
 def verify_xpack_license(
-    license_type, service_name=SERVICE_NAME, http_user=None, http_password=None
-):
+    license_type: str,
+    service_name: str = SERVICE_NAME,
+    http_user: Optional[str] = None,
+    http_password: Optional[str] = None,
+) -> bool:
     response = get_xpack_license(service_name, http_user=http_user, http_password=http_password)
 
     if "license" not in response:
@@ -289,7 +329,10 @@ def verify_xpack_license(
 @retrying.retry(
     wait_fixed=1000, stop_max_delay=5 * 1000, retry_on_result=lambda return_value: not return_value
 )
-def setup_passwords(service_name=SERVICE_NAME, task_name="master-0-node"):
+def setup_passwords(
+    service_name: str = SERVICE_NAME,
+    task_name: str = "master-0-node",
+) -> Union[bool, Dict[str, str]]:
     cmd = "\n".join(
         [
             "set -x",
@@ -301,8 +344,13 @@ def setup_passwords(service_name=SERVICE_NAME, task_name="master-0-node"):
     full_cmd = "bash -c '{}'".format(cmd)
     _, stdout, _ = sdk_cmd.service_task_exec(service_name, task_name, full_cmd)
 
-    elastic_password = re.search("PASSWORD elastic = (.*)", stdout).group(1)
-    kibana_password = re.search("PASSWORD kibana = (.*)", stdout).group(1)
+    elastic_password_search = re.search("PASSWORD elastic = (.*)", stdout)
+    assert isinstance(elastic_password_search, Match)
+    elastic_password = elastic_password_search.group(1)
+
+    kibana_password_search = re.search("PASSWORD kibana = (.*)", stdout)
+    assert isinstance(kibana_password_search, Match)
+    kibana_password = kibana_password_search.group(1)
 
     if not elastic_password or not kibana_password:
         # Retry.
@@ -312,13 +360,13 @@ def setup_passwords(service_name=SERVICE_NAME, task_name="master-0-node"):
 
 
 def explore_graph(
-    service_name=SERVICE_NAME,
-    index_name=DEFAULT_INDEX_NAME,
-    query={},
-    http_user=None,
-    http_password=None,
-):
-    return _curl_query(
+    service_name: str = SERVICE_NAME,
+    index_name: str = DEFAULT_INDEX_NAME,
+    query: Dict[str, Any] = {},
+    http_user: Optional[str] = None,
+    http_password: Optional[str] = None,
+) -> Dict[str, Any]:
+    result = _curl_query(
         service_name,
         "POST",
         "{}/_xpack/_graph/_explore".format(index_name),
@@ -326,20 +374,36 @@ def explore_graph(
         http_user=http_user,
         http_password=http_password,
     )
+    assert isinstance(result, dict)
+    return result
 
 
-def start_trial_license(service_name=SERVICE_NAME):
-    return _curl_query(service_name, "POST", "_xpack/license/start_trial?acknowledge=true")
+def start_trial_license(
+    service_name: str = SERVICE_NAME,
+) -> Dict[str, Any]:
+    result = _curl_query(service_name, "POST", "_xpack/license/start_trial?acknowledge=true")
+    assert isinstance(result, dict)
+    return result
 
 
-def get_elasticsearch_indices_stats(index_name, service_name=SERVICE_NAME):
-    return _curl_query(service_name, "GET", "{}/_stats".format(index_name))
+def get_elasticsearch_indices_stats(
+    index_name: str,
+    service_name: str = SERVICE_NAME,
+) -> Dict[str, Any]:
+    result = _curl_query(service_name, "GET", "{}/_stats".format(index_name))
+    assert isinstance(result, dict)
+    return result
 
 
 def create_index(
-    index_name, params, service_name=SERVICE_NAME, https=False, http_user=None, http_password=None
-):
-    return _curl_query(
+    index_name: str,
+    params: Dict[str, Any],
+    service_name: str = SERVICE_NAME,
+    https: bool = False,
+    http_user: Optional[str] = None,
+    http_password: Optional[str] = None,
+) -> Dict[str, Any]:
+    result = _curl_query(
         service_name,
         "PUT",
         index_name,
@@ -348,12 +412,18 @@ def create_index(
         http_user=http_user,
         http_password=http_password,
     )
+    assert isinstance(result, dict)
+    return result
 
 
 def delete_index(
-    index_name, service_name=SERVICE_NAME, https=False, http_user=None, http_password=None
-):
-    return _curl_query(
+    index_name: str,
+    service_name: str = SERVICE_NAME,
+    https: bool = False,
+    http_user: Optional[str] = None,
+    http_password: Optional[str] = None,
+) -> Dict[str, Any]:
+    result = _curl_query(
         service_name,
         "DELETE",
         index_name,
@@ -361,19 +431,21 @@ def delete_index(
         http_user=http_user,
         http_password=http_password,
     )
+    assert isinstance(result, dict)
+    return result
 
 
 def create_document(
-    index_name,
-    index_type,
-    doc_id,
-    params,
-    service_name=SERVICE_NAME,
-    https=False,
-    http_user=None,
-    http_password=None,
-):
-    return _curl_query(
+    index_name: str,
+    index_type: str,
+    doc_id: int,
+    params: Dict[str, str],
+    service_name: str = SERVICE_NAME,
+    https: bool = False,
+    http_user: Optional[str] = None,
+    http_password: Optional[str] = None,
+) -> Dict[str, Any]:
+    result = _curl_query(
         service_name,
         "PUT",
         "{}/{}/{}?refresh=wait_for".format(index_name, index_type, doc_id),
@@ -382,18 +454,20 @@ def create_document(
         http_user=http_user,
         http_password=http_password,
     )
+    assert isinstance(result, dict)
+    return result
 
 
 def get_document(
-    index_name,
-    index_type,
-    doc_id,
-    service_name=SERVICE_NAME,
-    https=False,
-    http_user=None,
-    http_password=None,
-):
-    return _curl_query(
+    index_name: str,
+    index_type: str,
+    doc_id: int,
+    service_name: str = SERVICE_NAME,
+    https: bool = False,
+    http_user: Optional[str] = None,
+    http_password: Optional[str] = None,
+) -> Dict[str, Any]:
+    result = _curl_query(
         service_name,
         "GET",
         "{}/{}/{}".format(index_name, index_type, doc_id),
@@ -401,10 +475,14 @@ def get_document(
         http_user=http_user,
         http_password=http_password,
     )
+    assert isinstance(result, dict)
+    return result
 
 
-def get_elasticsearch_nodes_info(service_name=SERVICE_NAME):
-    return _curl_query(service_name, "GET", "_nodes")
+def get_elasticsearch_nodes_info(service_name: str = SERVICE_NAME) -> Dict[str, Any]:
+    result = _curl_query(service_name, "GET", "_nodes")
+    assert isinstance(result, dict)
+    return result
 
 
 # Here we only retry if the command itself failed, or if the data couldn't be parsed as JSON when
@@ -412,16 +490,16 @@ def get_elasticsearch_nodes_info(service_name=SERVICE_NAME):
 # the returned data (e.g. expected field is missing).
 @retrying.retry(wait_fixed=1000, stop_max_delay=120 * 1000, retry_on_result=lambda res: res is None)
 def _curl_query(
-    service_name,
-    method,
-    endpoint,
-    json_body=None,
-    task="master-0-node",
-    https=False,
-    return_json=True,
-    http_user=DEFAULT_ELASTICSEARCH_USER,
-    http_password=DEFAULT_ELASTICSEARCH_PASSWORD,
-):
+    service_name: str,
+    method: str,
+    endpoint: str,
+    json_body: Optional[Dict[str, Any]] = None,
+    task: str = "master-0-node",
+    https: bool = False,
+    return_json: bool = True,
+    http_user: Optional[str] = DEFAULT_ELASTICSEARCH_USER,
+    http_password: Optional[str] = DEFAULT_ELASTICSEARCH_PASSWORD,
+) -> Optional[Union[str, Dict[str, Any]]]:
     protocol = "https" if https else "http"
 
     if http_password and not http_user:
@@ -447,7 +525,7 @@ def _curl_query(
     task_name = "master-0-node"
     exit_code, stdout, stderr = sdk_cmd.service_task_exec(service_name, task_name, curl_cmd)
 
-    def build_errmsg(msg):
+    def build_errmsg(msg: str) -> str:
         return "{}\nCommand:\n{}\nstdout:\n{}\nstderr:\n{}".format(msg, curl_cmd, stdout, stderr)
 
     if exit_code:
@@ -460,14 +538,20 @@ def _curl_query(
         return stdout
 
     try:
-        return json.loads(stdout)
+        result = json.loads(stdout)
+        assert isinstance(result, dict)
+        return result
     except Exception:
         log.warning(build_errmsg("Failed to parse stdout as JSON, retrying or giving up."))
         return None
 
 
 # TODO(mpereira): it is safe to remove this test after the 6.x release.
-def test_xpack_enabled_update(service_name, from_xpack_enabled, to_xpack_enabled):
+def test_xpack_enabled_update(
+    service_name: str,
+    from_xpack_enabled: bool,
+    to_xpack_enabled: bool,
+) -> None:
     sdk_upgrade.test_upgrade(
         PACKAGE_NAME,
         service_name,
@@ -485,8 +569,10 @@ def test_xpack_enabled_update(service_name, from_xpack_enabled, to_xpack_enabled
 # TODO(mpereira): change this to xpack_security_enabled to xpack_security_enabled after the 6.x
 # release.
 def test_update_from_xpack_enabled_to_xpack_security_enabled(
-    service_name, xpack_enabled, xpack_security_enabled
-):
+    service_name: str,
+    xpack_enabled: bool,
+    xpack_security_enabled: bool,
+) -> None:
     assert not (
         xpack_enabled is True and xpack_security_enabled is True
     ), "This function does not handle the 'xpack_enabled: True' to 'xpack_security_enabled: True' upgrade scenario"
@@ -506,8 +592,11 @@ def test_update_from_xpack_enabled_to_xpack_security_enabled(
 
 
 def test_upgrade_from_xpack_enabled(
-    package_name: str, service_name: str, options: dict, expected_task_count: int
-):
+    package_name: str,
+    service_name: str,
+    options: Dict[str, Any],
+    expected_task_count: int,
+) -> None:
     # This test needs to run some code in between the Universe version installation and the upgrade
     # to the 'stub-universe' version, so it cannot use `sdk_upgrade.test_upgrade`.
     http_user = DEFAULT_ELASTICSEARCH_USER
@@ -652,7 +741,7 @@ def test_upgrade_from_xpack_enabled(
     )
 
 
-def _master_zero_http_port(service_name):
+def _master_zero_http_port(service_name: str) -> int:
     """Returns a master node hostname+port endpoint that can be queried from within the cluster. We
     cannot cache this value because while the hostnames remain static, the ports are dynamic and may
     change if the master is replaced.
@@ -667,4 +756,4 @@ def _master_zero_http_port(service_name):
 
     port = dns[0].split(":")[-1]
     log.info("Extracted {} as port for {}".format(port, dns[0]))
-    return port
+    return int(port)

--- a/frameworks/elastic/tests/conftest.py
+++ b/frameworks/elastic/tests/conftest.py
@@ -1,8 +1,10 @@
+from typing import Iterable
+
 import pytest
 import sdk_security
 from tests import config
 
 
 @pytest.fixture(scope="session")
-def configure_security(configure_universe):
+def configure_security(configure_universe: None) -> Iterable:
     yield from sdk_security.security_session(config.SERVICE_NAME)

--- a/frameworks/elastic/tests/conftest.py
+++ b/frameworks/elastic/tests/conftest.py
@@ -1,4 +1,4 @@
-from typing import Iterable
+from typing import Iterator
 
 import pytest
 import sdk_security
@@ -6,5 +6,5 @@ from tests import config
 
 
 @pytest.fixture(scope="session")
-def configure_security(configure_universe: None) -> Iterable:
+def configure_security(configure_universe: None) -> Iterator[None]:
     yield from sdk_security.security_session(config.SERVICE_NAME)

--- a/frameworks/elastic/tests/test_overlay.py
+++ b/frameworks/elastic/tests/test_overlay.py
@@ -1,6 +1,6 @@
 import pytest
 import retrying
-from typing import Iterable
+from typing import Iterator
 
 import sdk_install
 import sdk_networks
@@ -9,7 +9,7 @@ from tests import config
 
 
 @pytest.fixture(scope="module", autouse=True)
-def configure_package(configure_security: None) -> Iterable:
+def configure_package(configure_security: None) -> Iterator[None]:
     try:
         sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
         sdk_install.install(

--- a/frameworks/elastic/tests/test_overlay.py
+++ b/frameworks/elastic/tests/test_overlay.py
@@ -1,5 +1,7 @@
 import pytest
 import retrying
+from typing import Iterable
+
 import sdk_install
 import sdk_networks
 import sdk_tasks
@@ -7,7 +9,7 @@ from tests import config
 
 
 @pytest.fixture(scope="module", autouse=True)
-def configure_package(configure_security):
+def configure_package(configure_security: None) -> Iterable:
     try:
         sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
         sdk_install.install(
@@ -23,13 +25,13 @@ def configure_package(configure_security):
 
 
 @pytest.fixture(autouse=True)
-def pre_test_setup():
+def pre_test_setup() -> None:
     sdk_tasks.check_running(config.SERVICE_NAME, config.DEFAULT_TASK_COUNT)
     config.wait_for_expected_nodes_to_exist(task_count=config.DEFAULT_TASK_COUNT)
 
 
 @pytest.fixture
-def default_populated_index():
+def default_populated_index() -> None:
     config.delete_index(config.DEFAULT_INDEX_NAME)
     config.create_index(config.DEFAULT_INDEX_NAME, config.DEFAULT_SETTINGS_MAPPINGS)
     config.create_document(
@@ -48,7 +50,7 @@ def default_populated_index():
     stop_max_delay=config.DEFAULT_TIMEOUT * 1000,
     retry_on_result=lambda res: not res,
 )
-def test_indexing(default_populated_index):
+def test_indexing(default_populated_index: None) -> bool:
     indices_stats = config.get_elasticsearch_indices_stats(config.DEFAULT_INDEX_NAME)
     observed_count = indices_stats["_all"]["primaries"]["docs"]["count"]
     assert observed_count == 1, "Indices has incorrect count: should be 1, got {}".format(
@@ -56,13 +58,13 @@ def test_indexing(default_populated_index):
     )
     doc = config.get_document(config.DEFAULT_INDEX_NAME, config.DEFAULT_INDEX_TYPE, 1)
     observed_name = doc["_source"]["name"]
-    return observed_name == "Loren"
+    return bool(observed_name == "Loren")
 
 
 @pytest.mark.sanity
 @pytest.mark.overlay
 @pytest.mark.dcos_min_version("1.9")
-def test_tasks_on_overlay():
+def test_tasks_on_overlay() -> None:
     tasks = sdk_tasks.check_task_count(config.SERVICE_NAME, config.DEFAULT_TASK_COUNT)
     for task in tasks:
         sdk_networks.check_task_network(task.name)
@@ -71,7 +73,7 @@ def test_tasks_on_overlay():
 @pytest.mark.sanity
 @pytest.mark.overlay
 @pytest.mark.dcos_min_version("1.9")
-def test_endpoints_on_overlay():
+def test_endpoints_on_overlay() -> None:
     endpoints_on_overlay_to_count = {
         "coordinator-http": 1,
         "coordinator-transport": 1,

--- a/frameworks/elastic/tests/test_rack_awareness.py
+++ b/frameworks/elastic/tests/test_rack_awareness.py
@@ -13,7 +13,7 @@ log = logging.getLogger(__name__)
 @pytest.mark.sanity
 @pytest.mark.dcos_min_version("1.11")
 @sdk_utils.dcos_ee_only
-def test_zones_not_referenced_in_placement_constraints():
+def test_zones_not_referenced_in_placement_constraints() -> None:
     sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
     sdk_install.install(config.PACKAGE_NAME, config.SERVICE_NAME, config.DEFAULT_TASK_COUNT)
 
@@ -34,7 +34,7 @@ def test_zones_not_referenced_in_placement_constraints():
 @pytest.mark.sanity
 @pytest.mark.dcos_min_version("1.11")
 @sdk_utils.dcos_ee_only
-def test_zones_referenced_in_placement_constraints():
+def test_zones_referenced_in_placement_constraints() -> None:
     sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
     sdk_install.install(
         config.PACKAGE_NAME,
@@ -62,7 +62,7 @@ def test_zones_referenced_in_placement_constraints():
 @pytest.mark.sanity
 @pytest.mark.dcos_min_version("1.11")
 @sdk_utils.dcos_ee_only
-def test_heterogeneus_zone_constraints():
+def test_heterogeneus_zone_constraints() -> None:
     sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
     sdk_install.install(
         config.PACKAGE_NAME,

--- a/frameworks/elastic/tests/test_sanity.py
+++ b/frameworks/elastic/tests/test_sanity.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Iterable, List
+from typing import Iterator, List
 
 from toolz import get_in
 import pytest
@@ -23,7 +23,7 @@ current_expected_task_count = config.DEFAULT_TASK_COUNT
 
 
 @pytest.fixture(scope="module", autouse=True)
-def configure_package(configure_security: None) -> Iterable:
+def configure_package(configure_security: None) -> Iterator[None]:
     try:
         log.info("Ensure elasticsearch and kibana are uninstalled...")
         sdk_install.uninstall(config.KIBANA_PACKAGE_NAME, config.KIBANA_PACKAGE_NAME)

--- a/frameworks/elastic/tests/test_sanity.py
+++ b/frameworks/elastic/tests/test_sanity.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Iterable, List
 
 from toolz import get_in
 import pytest
@@ -22,7 +23,7 @@ current_expected_task_count = config.DEFAULT_TASK_COUNT
 
 
 @pytest.fixture(scope="module", autouse=True)
-def configure_package(configure_security):
+def configure_package(configure_security: None) -> Iterable:
     try:
         log.info("Ensure elasticsearch and kibana are uninstalled...")
         sdk_install.uninstall(config.KIBANA_PACKAGE_NAME, config.KIBANA_PACKAGE_NAME)
@@ -43,7 +44,7 @@ def configure_package(configure_security):
 
 
 @pytest.fixture(autouse=True)
-def pre_test_setup():
+def pre_test_setup() -> None:
     sdk_tasks.check_running(foldered_name, current_expected_task_count)
     config.wait_for_expected_nodes_to_exist(
         service_name=foldered_name, task_count=current_expected_task_count
@@ -51,7 +52,7 @@ def pre_test_setup():
 
 
 @pytest.fixture
-def default_populated_index():
+def default_populated_index() -> None:
     config.delete_index(config.DEFAULT_INDEX_NAME, service_name=foldered_name)
     config.create_index(
         config.DEFAULT_INDEX_NAME, config.DEFAULT_SETTINGS_MAPPINGS, service_name=foldered_name
@@ -67,7 +68,7 @@ def default_populated_index():
 
 @pytest.mark.recovery
 @pytest.mark.sanity
-def test_pod_replace_then_immediate_config_update():
+def test_pod_replace_then_immediate_config_update() -> None:
     sdk_cmd.svc_cli(config.PACKAGE_NAME, foldered_name, "pod replace data-0")
 
     plugins = "analysis-phonetic"
@@ -86,7 +87,7 @@ def test_pod_replace_then_immediate_config_update():
 
 
 @pytest.mark.sanity
-def test_endpoints():
+def test_endpoints() -> None:
     # Check that we can reach the scheduler via admin router, and that returned endpoints are
     # sanitized.
     for endpoint in config.ENDPOINT_TYPES:
@@ -102,7 +103,7 @@ def test_endpoints():
 
 
 @pytest.mark.sanity
-def test_indexing(default_populated_index):
+def test_indexing(default_populated_index: None) -> None:
     indices_stats = config.get_elasticsearch_indices_stats(
         config.DEFAULT_INDEX_NAME, service_name=foldered_name
     )
@@ -118,14 +119,14 @@ def test_indexing(default_populated_index):
 
 @pytest.mark.sanity
 @pytest.mark.dcos_min_version("1.9")
-def test_metrics():
+def test_metrics() -> None:
     expected_metrics = [
         "node.data-0-node.fs.total.total_in_bytes",
         "node.data-0-node.jvm.mem.pools.old.peak_used_in_bytes",
         "node.data-0-node.jvm.threads.count",
     ]
 
-    def expected_metrics_exist(emitted_metrics):
+    def expected_metrics_exist(emitted_metrics: List[str]) -> bool:
         # Elastic metrics are also dynamic and based on the service name# For eg:
         # elasticsearch.test__integration__elastic.node.data-0-node.thread_pool.listener.completed
         # To prevent this from breaking we drop the service name from the metric name
@@ -147,7 +148,7 @@ def test_metrics():
 
 
 @pytest.mark.sanity
-def test_custom_yaml_base64():
+def test_custom_yaml_base64() -> None:
     # Apply this custom YAML block as a base64-encoded string:
 
     # cluster:
@@ -192,7 +193,7 @@ def test_custom_yaml_base64():
 
 @pytest.mark.sanity
 @pytest.mark.timeout(60 * 60)
-def test_security_toggle_with_kibana(default_populated_index):
+def test_security_toggle_with_kibana(default_populated_index: None) -> None:
     # Verify that commercial APIs are disabled by default in Elasticsearch.
     config.verify_commercial_api_status(False, service_name=foldered_name)
 
@@ -347,7 +348,7 @@ def test_security_toggle_with_kibana(default_populated_index):
 
 @pytest.mark.recovery
 @pytest.mark.sanity
-def test_losing_and_regaining_index_health(default_populated_index):
+def test_losing_and_regaining_index_health(default_populated_index: None) -> None:
     config.check_elasticsearch_index_health(
         config.DEFAULT_INDEX_NAME, "green", service_name=foldered_name
     )
@@ -369,7 +370,7 @@ def test_losing_and_regaining_index_health(default_populated_index):
 
 @pytest.mark.recovery
 @pytest.mark.sanity
-def test_master_reelection():
+def test_master_reelection() -> None:
     initial_master = config.get_elasticsearch_master(service_name=foldered_name)
     sdk_cmd.kill_task_with_pattern(
         "master__.*Elasticsearch",
@@ -388,7 +389,7 @@ def test_master_reelection():
 
 @pytest.mark.recovery
 @pytest.mark.sanity
-def test_master_node_replace():
+def test_master_node_replace() -> None:
     # Ideally, the pod will get placed on a different agent. This test will verify that the
     # remaining two masters find the replaced master at its new IP address. This requires a
     # reasonably low TTL for Java DNS lookups.
@@ -399,7 +400,7 @@ def test_master_node_replace():
 
 @pytest.mark.recovery
 @pytest.mark.sanity
-def test_data_node_replace():
+def test_data_node_replace() -> None:
     sdk_cmd.svc_cli(config.PACKAGE_NAME, foldered_name, "pod replace data-0")
     sdk_plan.wait_for_in_progress_recovery(foldered_name)
     sdk_plan.wait_for_completed_recovery(foldered_name)
@@ -407,7 +408,7 @@ def test_data_node_replace():
 
 @pytest.mark.recovery
 @pytest.mark.sanity
-def test_coordinator_node_replace():
+def test_coordinator_node_replace() -> None:
     sdk_cmd.svc_cli(config.PACKAGE_NAME, foldered_name, "pod replace coordinator-0")
     sdk_plan.wait_for_in_progress_recovery(foldered_name)
     sdk_plan.wait_for_completed_recovery(foldered_name)
@@ -416,7 +417,7 @@ def test_coordinator_node_replace():
 @pytest.mark.recovery
 @pytest.mark.sanity
 @pytest.mark.timeout(15 * 60)
-def test_plugin_install_and_uninstall(default_populated_index):
+def test_plugin_install_and_uninstall(default_populated_index: None) -> None:
     plugins = "analysis-icu"
 
     sdk_service.update_configuration(
@@ -440,7 +441,7 @@ def test_plugin_install_and_uninstall(default_populated_index):
 
 @pytest.mark.recovery
 @pytest.mark.sanity
-def test_add_ingest_and_coordinator_nodes_does_not_restart_master_or_data_nodes():
+def test_add_ingest_and_coordinator_nodes_does_not_restart_master_or_data_nodes() -> None:
     initial_master_task_ids = sdk_tasks.get_task_ids(foldered_name, "master")
     initial_data_task_ids = sdk_tasks.get_task_ids(foldered_name, "data")
 
@@ -479,7 +480,7 @@ def test_add_ingest_and_coordinator_nodes_does_not_restart_master_or_data_nodes(
 
 @pytest.mark.recovery
 @pytest.mark.sanity
-def test_adding_data_node_only_restarts_masters():
+def test_adding_data_node_only_restarts_masters() -> None:
     initial_master_task_ids = sdk_tasks.get_task_ids(foldered_name, "master")
     initial_data_task_ids = sdk_tasks.get_task_ids(foldered_name, "data")
     initial_coordinator_task_ids = sdk_tasks.get_task_ids(foldered_name, "coordinator")

--- a/frameworks/elastic/tests/test_tls.py
+++ b/frameworks/elastic/tests/test_tls.py
@@ -1,6 +1,6 @@
 import json
 import pytest
-from typing import Any, Dict, Iterable
+from typing import Any, Dict, Iterator
 
 import sdk_cmd
 import sdk_install
@@ -21,7 +21,7 @@ pytestmark = [
 
 
 @pytest.fixture(scope="module")
-def service_account(configure_security: None) -> Iterable[Dict[str, Any]]:
+def service_account(configure_security: None) -> Iterator[Dict[str, Any]]:
     """
     Sets up a service account for use with TLS.
     """
@@ -35,7 +35,7 @@ def service_account(configure_security: None) -> Iterable[Dict[str, Any]]:
 
 
 @pytest.fixture(scope="module")
-def elastic_service(service_account: Dict[str, Any]) -> Iterable[Dict[str, Any]]:
+def elastic_service(service_account: Dict[str, Any]) -> Iterator[Dict[str, Any]]:
     service_options = {
         "service": {
             "name": config.SERVICE_NAME,
@@ -62,7 +62,7 @@ def elastic_service(service_account: Dict[str, Any]) -> Iterable[Dict[str, Any]]
 
 
 @pytest.fixture(scope="module")
-def kibana_application(elastic_service: Dict[str, Any]) -> Iterable:
+def kibana_application(elastic_service: Dict[str, Any]) -> Iterator[None]:
     try:
         elasticsearch_url = "https://" + sdk_hosts.vip_host(
             config.SERVICE_NAME, "coordinator", 9200

--- a/frameworks/elastic/tests/test_tls.py
+++ b/frameworks/elastic/tests/test_tls.py
@@ -1,5 +1,6 @@
 import json
 import pytest
+from typing import Any, Dict, Iterable
 
 import sdk_cmd
 import sdk_install
@@ -20,7 +21,7 @@ pytestmark = [
 
 
 @pytest.fixture(scope="module")
-def service_account(configure_security):
+def service_account(configure_security: None) -> Iterable[Dict[str, Any]]:
     """
     Sets up a service account for use with TLS.
     """
@@ -34,7 +35,7 @@ def service_account(configure_security):
 
 
 @pytest.fixture(scope="module")
-def elastic_service(service_account):
+def elastic_service(service_account: Dict[str, Any]) -> Iterable[Dict[str, Any]]:
     service_options = {
         "service": {
             "name": config.SERVICE_NAME,
@@ -61,7 +62,7 @@ def elastic_service(service_account):
 
 
 @pytest.fixture(scope="module")
-def kibana_application(elastic_service):
+def kibana_application(elastic_service: Dict[str, Any]) -> Iterable:
     try:
         elasticsearch_url = "https://" + sdk_hosts.vip_host(
             config.SERVICE_NAME, "coordinator", 9200
@@ -90,7 +91,7 @@ def kibana_application(elastic_service):
 
 @pytest.mark.tls
 @pytest.mark.sanity
-def test_crud_over_tls(elastic_service):
+def test_crud_over_tls(elastic_service: Dict[str, Any]) -> None:
     config.create_index(
         config.DEFAULT_INDEX_NAME,
         config.DEFAULT_SETTINGS_MAPPINGS,
@@ -118,7 +119,7 @@ def test_crud_over_tls(elastic_service):
 @pytest.mark.skip(
     message="Kibana 6.3 with TLS enabled is not working due Admin Router request header. Details in https://jira.mesosphere.com/browse/DCOS-43386"
 )
-def test_kibana_tls(kibana_application):
+def test_kibana_tls(kibana_application: Dict[str, Any]) -> None:
     config.check_kibana_adminrouter_integration(
         "service/{}/login".format(config.KIBANA_SERVICE_NAME)
     )
@@ -127,7 +128,10 @@ def test_kibana_tls(kibana_application):
 @pytest.mark.tls
 @pytest.mark.sanity
 @pytest.mark.recovery
-def test_tls_recovery(elastic_service, service_account):
+def test_tls_recovery(
+    elastic_service: Dict[str, Any],
+    service_account: Dict[str, Any],
+) -> None:
     rc, stdout, _ = sdk_cmd.svc_cli(
         elastic_service["package_name"], elastic_service["service"]["name"], "pod list"
     )

--- a/frameworks/elastic/tests/test_upgrade.py
+++ b/frameworks/elastic/tests/test_upgrade.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Iterable
+from typing import Iterator
 
 import pytest
 
@@ -14,12 +14,12 @@ expected_task_count = config.DEFAULT_TASK_COUNT
 
 
 @pytest.fixture(scope="module", autouse=True)
-def set_up_security(configure_security: None) -> Iterable:
+def set_up_security(configure_security: None) -> Iterator[None]:
     yield
 
 
 @pytest.fixture(autouse=True)
-def uninstall_packages(configure_security: None) -> Iterable:
+def uninstall_packages(configure_security: None) -> Iterator[None]:
     try:
         log.info("Ensuring Elastic and Kibana are uninstalled before running test")
         sdk_install.uninstall(config.KIBANA_PACKAGE_NAME, config.KIBANA_PACKAGE_NAME)

--- a/frameworks/elastic/tests/test_upgrade.py
+++ b/frameworks/elastic/tests/test_upgrade.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Iterable
 
 import pytest
 
@@ -13,12 +14,12 @@ expected_task_count = config.DEFAULT_TASK_COUNT
 
 
 @pytest.fixture(scope="module", autouse=True)
-def set_up_security(configure_security):
+def set_up_security(configure_security: None) -> Iterable:
     yield
 
 
 @pytest.fixture(autouse=True)
-def uninstall_packages(configure_security):
+def uninstall_packages(configure_security: None) -> Iterable:
     try:
         log.info("Ensuring Elastic and Kibana are uninstalled before running test")
         sdk_install.uninstall(config.KIBANA_PACKAGE_NAME, config.KIBANA_PACKAGE_NAME)
@@ -34,7 +35,7 @@ def uninstall_packages(configure_security):
 # TODO(mpereira): it is safe to remove this test after the 6.x release.
 @pytest.mark.sanity
 @pytest.mark.timeout(30 * 60)
-def test_xpack_update_matrix():
+def test_xpack_update_matrix() -> None:
     # Updating from X-Pack 'enabled' to X-Pack security 'enabled' (the default) is more involved
     # than the other cases, so we use `test_upgrade_from_xpack_enabled`.
     log.info("Updating X-Pack from 'enabled' to 'enabled'")
@@ -59,7 +60,7 @@ def test_xpack_update_matrix():
 # release.
 @pytest.mark.sanity
 @pytest.mark.timeout(30 * 60)
-def test_xpack_security_enabled_update_matrix():
+def test_xpack_security_enabled_update_matrix() -> None:
     # Updating from X-Pack 'enabled' to X-Pack security 'enabled' is more involved than the other
     # cases, so we use `test_upgrade_from_xpack_enabled`.
     log.info("Updating from X-Pack 'enabled' to X-Pack security 'enabled'")

--- a/testing/sdk_security.py
+++ b/testing/sdk_security.py
@@ -10,7 +10,7 @@ import retrying
 
 from subprocess import check_output
 
-from typing import Any, Dict, Generator, List, Set
+from typing import Any, Dict, Iterator, List, Set
 
 import sdk_cmd
 import sdk_utils
@@ -331,7 +331,7 @@ def security_session(
     linux_user: str = DEFAULT_LINUX_USER,
     service_account: str = "service-acct",
     service_account_secret: str = "secret",
-) -> Generator:
+) -> Iterator[None]:
     """Create a service account and configure permissions for strict-mode tests.
 
     This should generally be used as a fixture in a framework's conftest.py:


### PR DESCRIPTION
This is a subset of #2979.

@wavesoft already looked at the changes there.
However, as that PR was huge, I was fairly asked to split it up.

A key question from @wavesoft was why we wrap a few things in `bool()`.
The answer is that sometimes `mypy` is not sure that something will evaluate to a boolean.

For example, if we take the following pseudocode:

```
@retry.retry(...)
def my_function() -> bool:
    return True

my_var = my_function()
```

We can fairly interpret as humans that `my_var` is likely a boolean.
However, the `retry` function has no type hints and could in theory change the return value of the function.