### PR TITLE
[DCOS-51458] Update both pygobject and base image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # See Dockerfile.base for instructions on how to update this base image.
-FROM mesosphere/dcos-commons-base:latest@sha256:2aaf8f7398bd6f2fc02c6388e566aafd3a2ad05c0fb8162702aab7aecd263957
+FROM mesosphere/dcos-commons-base:latest@sha256:8c64426a4bfa88b96a88196e23680ae02e1cb99bbbe893a16e759517118713cf
 
 ENV GO_VERSION=1.10.2
 ENV PATH=$PATH:/usr/local/go/bin

--- a/frozen_requirements.txt
+++ b/frozen_requirements.txt
@@ -66,6 +66,9 @@ jsonschema==2.6.0
 keyring==12.0.2
 lazy-object-proxy==1.3.1
 macholib==1.11
+Mako==1.0.7
+Markdown==2.6.9
+MarkupSafe==1.0
 mccabe==0.6.1
 more-itertools==5.0.0
 msrest==0.6.4
@@ -84,11 +87,12 @@ prettytable==0.7.2
 py==1.7.0
 pyasn1==0.4.5
 pyasn1-modules==0.2.3
+pycairo==1.11.1
 pycodestyle==2.5.0
 pycparser==2.19
 pyflakes==2.1.1
 Pygments==2.3.1
-pygobject==3.26.1
+PyGObject==3.30.4
 PyInstaller==3.3
 PyJWT==1.7.1
 pylint==2.3.1


### PR DESCRIPTION
There is a circular dependency between updating pygobject (whose newer
version needs pkg-config) and updating the base image to newer version
whihch contains pkg-config (but whose test job fails beause older
pygobject is no longer installable - pruned from PyPI).

This PR contains both changes.