### PR TITLE
[DCOS-51307] Propagate options in sdk_upgrade when to_options not specified.

### DIFF
--- a/frameworks/helloworld/tests/test_decommission.py
+++ b/frameworks/helloworld/tests/test_decommission.py
@@ -24,12 +24,14 @@ def configure_package(configure_security):
             from_options={
                 "service": {"name": foldered_name, "scenario": "CUSTOM_DECOMMISSION"}
             },
+            to_options={
+                "service": {"name": foldered_name, "scenario": "CUSTOM_DECOMMISSION"}
+            },
         )
 
         yield  # let the test session execute
     finally:
         sdk_install.uninstall(config.PACKAGE_NAME, foldered_name)
-
 
 @pytest.mark.sanity
 def test_custom_decommission():

--- a/frameworks/helloworld/tests/test_decommission.py
+++ b/frameworks/helloworld/tests/test_decommission.py
@@ -16,22 +16,20 @@ log = logging.getLogger(__name__)
 def configure_package(configure_security):
     try:
         foldered_name = sdk_utils.get_foldered_name(config.SERVICE_NAME)
+        service_options = {"service": {"name": foldered_name, "scenario": "CUSTOM_DECOMMISSION"}}
         sdk_install.uninstall(config.PACKAGE_NAME, foldered_name)
         sdk_upgrade.test_upgrade(
             config.PACKAGE_NAME,
             foldered_name,
             config.DEFAULT_TASK_COUNT,
-            from_options={
-                "service": {"name": foldered_name, "scenario": "CUSTOM_DECOMMISSION"}
-            },
-            to_options={
-                "service": {"name": foldered_name, "scenario": "CUSTOM_DECOMMISSION"}
-            },
+            from_options=service_options,
+            to_options=service_options,
         )
 
         yield  # let the test session execute
     finally:
         sdk_install.uninstall(config.PACKAGE_NAME, foldered_name)
+
 
 @pytest.mark.sanity
 def test_custom_decommission():

--- a/testing/sdk_upgrade.py
+++ b/testing/sdk_upgrade.py
@@ -86,7 +86,7 @@ def test_upgrade(
         package_name,
         service_name,
         to_version,
-        to_options,
+        to_options or from_options,
         expected_running_tasks,
         wait_for_deployment,
         timeout_seconds,


### PR DESCRIPTION
Propagate `from_options` as `to_options` in the upgrade scenario when `to_options` are not explicitly defined to maintain compatibility.
Explicitly propagate hello-world install-options for upgrade scenario in test_decomission tests.