### PR TITLE
[DCOS-51458] Add all necessary dependencies for new pygobject package.

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -32,11 +32,14 @@ RUN apt-get update && \
     curl \
     git \
     jq \
+    libcairo2-dev \
+    libgirepository1.0-dev \
     libssl-dev \
     oracle-java8-installer \
     pkg-config \
     python-pip \
     python3 \
+    python3-cairo-dev \
     python3-dev \
     python3-pip \
     rsync \


### PR DESCRIPTION
This time I tested these should be sufficient.

Required for https://github.com/mesosphere/dcos-commons/pull/2987