### PR TITLE
[DCOS-51573][DCOS-51574] authn authz implementation

### DIFF
--- a/frameworks/cassandra/src/main/dist/cassandra.yaml
+++ b/frameworks/cassandra/src/main/dist/cassandra.yaml
@@ -94,8 +94,8 @@ enable_user_defined_functions: false
 enable_scripted_user_defined_functions: false
 windows_timer_interval: 1
 role_manager: CassandraRoleManager
-roles_validity_in_ms: 2000
-permissions_validity_in_ms: 2000
+roles_validity_in_ms: {{ROLES_VALIDITY_IN_MS}}
+permissions_validity_in_ms: {{PERMISSIONS_VALIDITY_IN_MS}}
 disk_failure_policy: {{CASSANDRA_DISK_FAILURE_POLICY}}
 commit_failure_policy: stop
 key_cache_size_in_mb:
@@ -111,8 +111,8 @@ snapshot_before_compaction: false
 auto_snapshot: {{CASSANDRA_AUTO_SNAPSHOT}}
 cross_node_timeout: false
 endpoint_snitch: GossipingPropertyFileSnitch
-roles_update_interval_in_ms: {{CASSANDRA_ROLES_UPDATE_INTERVAL_IN_MS}}
-permissions_update_interval_in_ms: {{CASSANDRA_PERMISSIONS_UPDATE_INTERVAL_IN_MS}}
+roles_update_interval_in_ms: {{ROLES_UPDATE_INTERVAL_IN_MS}}
+permissions_update_interval_in_ms: {{PERMISSIONS_UPDATE_INTERVAL_IN_MS}}
 key_cache_keys_to_save: {{CASSANDRA_KEY_CACHE_KEYS_TO_SAVE}}
 row_cache_keys_to_save: {{CASSANDRA_ROW_CACHE_KEYS_TO_SAVE}}
 counter_cache_keys_to_save: {{CASSANDRA_COUNTER_CACHE_KEYS_TO_SAVE}}
@@ -140,3 +140,5 @@ buffer_pool_use_heap_if_exhausted: {{CASSANDRA_BUFFER_POOL_USE_HEAP_IF_EXHAUSTED
 disk_optimization_strategy: {{CASSANDRA_DISK_OPTIMIZATION_STRATEGY}}
 max_value_size_in_mb: {{CASSANDRA_MAX_VALUE_SIZE_IN_MB}}
 otc_coalescing_strategy: {{CASSANDRA_OTC_COALESCING_STRATEGY}}
+credentials_validity_in_ms: {{CREDENTIALS_VALIDITY_IN_MS}}
+credentials_update_interval_in_ms: {{CREDENTIALS_UPDATE_INTERVAL_IN_MS}}

--- a/frameworks/cassandra/src/main/dist/svc.yml
+++ b/frameworks/cassandra/src/main/dist/svc.yml
@@ -320,7 +320,7 @@ plans:
         pod: node
         steps:
           - 0: [[init_system_keyspaces]]
-          - default: [[]]
+          - default: []
   replace:
     strategy: serial
     phases:
@@ -427,3 +427,4 @@ plans:
         pod: node
         steps:
           - default: [[restore-snapshot]]
+

--- a/frameworks/cassandra/src/main/dist/svc.yml
+++ b/frameworks/cassandra/src/main/dist/svc.yml
@@ -269,6 +269,7 @@ pods:
         goal: ONCE
         cmd: >
                 export PATH=$MESOS_SANDBOX/python-dist/bin:$PATH ;
+                export PATH=$MESOS_SANDBOX/apache-cassandra-{{CASSANDRA_VERSION}}/bin:$PATH ;
                 export LD_LIBRARY_PATH=$MESOS_SANDBOX/openssl-dist:$LD_LIBRARY_PATH ;
                 export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jdk*/jre/) ;
                 echo Using $(python --version 2>&1) in $(which python) ;
@@ -281,17 +282,17 @@ pods:
                 {{/SECURITY_AUTHENTICATION_ENABLED}}                
                 ./bootstrap --resolve=false &&
                 {{#SECURITY_AUTHENTICATION_ENABLED}}
-                ./apache-cassandra-{{CASSANDRA_VERSION}}/bin/cqlsh -u cassandra -p cassandra {{{CASSANDRA_CQLSH_SSL_FLAGS}}} -e "alter keyspace system_traces      WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3};" "node-0-server.${FRAMEWORK_HOST}" {{TASKCFG_ALL_CASSANDRA_NATIVE_TRANSPORT_PORT}} &&
-                ./apache-cassandra-{{CASSANDRA_VERSION}}/bin/cqlsh -u cassandra -p cassandra {{{CASSANDRA_CQLSH_SSL_FLAGS}}} -e "alter keyspace system_auth        WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3};" "node-0-server.${FRAMEWORK_HOST}" {{TASKCFG_ALL_CASSANDRA_NATIVE_TRANSPORT_PORT}} &&
-                ./apache-cassandra-{{CASSANDRA_VERSION}}/bin/cqlsh -u cassandra -p cassandra {{{CASSANDRA_CQLSH_SSL_FLAGS}}} -e "alter keyspace system_distributed WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3};" "node-0-server.${FRAMEWORK_HOST}" {{TASKCFG_ALL_CASSANDRA_NATIVE_TRANSPORT_PORT}} &&
-                ./apache-cassandra-{{CASSANDRA_VERSION}}/bin/nodetool repair system_auth &&
-                ./apache-cassandra-{{CASSANDRA_VERSION}}/bin/cqlsh -u cassandra -p cassandra {{{CASSANDRA_CQLSH_SSL_FLAGS}}} -e "CREATE ROLE {{TASKCFG_ALL_NEW_SUPERUSER}} WITH PASSWORD = '${NEW_USER_PASSWORD}' AND SUPERUSER = true AND LOGIN = true;" "node-0-server.${FRAMEWORK_HOST}" {{TASKCFG_ALL_CASSANDRA_NATIVE_TRANSPORT_PORT}} &&
-                ./apache-cassandra-{{CASSANDRA_VERSION}}/bin/cqlsh -u {{TASKCFG_ALL_NEW_SUPERUSER}} -p ${NEW_USER_PASSWORD} {{{CASSANDRA_CQLSH_SSL_FLAGS}}} -e "ALTER ROLE cassandra WITH PASSWORD='${NEW_RANDOM_PASSWORD}' AND SUPERUSER=false;" "node-0-server.${FRAMEWORK_HOST}" {{TASKCFG_ALL_CASSANDRA_NATIVE_TRANSPORT_PORT}}
+                cqlsh -u cassandra -p cassandra {{{CASSANDRA_CQLSH_SSL_FLAGS}}} -e "alter keyspace system_traces      WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3};" "node-0-server.${FRAMEWORK_HOST}" {{TASKCFG_ALL_CASSANDRA_NATIVE_TRANSPORT_PORT}} &&
+                cqlsh -u cassandra -p cassandra {{{CASSANDRA_CQLSH_SSL_FLAGS}}} -e "alter keyspace system_auth        WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3};" "node-0-server.${FRAMEWORK_HOST}" {{TASKCFG_ALL_CASSANDRA_NATIVE_TRANSPORT_PORT}} &&
+                cqlsh -u cassandra -p cassandra {{{CASSANDRA_CQLSH_SSL_FLAGS}}} -e "alter keyspace system_distributed WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3};" "node-0-server.${FRAMEWORK_HOST}" {{TASKCFG_ALL_CASSANDRA_NATIVE_TRANSPORT_PORT}} &&
+                nodetool repair system_auth &&
+                cqlsh -u cassandra -p cassandra {{{CASSANDRA_CQLSH_SSL_FLAGS}}} -e "CREATE ROLE {{TASKCFG_ALL_NEW_SUPERUSER}} WITH PASSWORD = '${NEW_USER_PASSWORD}' AND SUPERUSER = true AND LOGIN = true;" "node-0-server.${FRAMEWORK_HOST}" {{TASKCFG_ALL_CASSANDRA_NATIVE_TRANSPORT_PORT}} &&
+                cqlsh -u {{TASKCFG_ALL_NEW_SUPERUSER}} -p ${NEW_USER_PASSWORD} {{{CASSANDRA_CQLSH_SSL_FLAGS}}} -e "ALTER ROLE cassandra WITH PASSWORD='${NEW_RANDOM_PASSWORD}' AND SUPERUSER=false;" "node-0-server.${FRAMEWORK_HOST}" {{TASKCFG_ALL_CASSANDRA_NATIVE_TRANSPORT_PORT}}
                 {{/SECURITY_AUTHENTICATION_ENABLED}}
                 {{^SECURITY_AUTHENTICATION_ENABLED}}                
-                ./apache-cassandra-{{CASSANDRA_VERSION}}/bin/cqlsh {{{CASSANDRA_CQLSH_SSL_FLAGS}}} -e "alter keyspace system_traces      WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3};" "node-0-server.${FRAMEWORK_HOST}" {{TASKCFG_ALL_CASSANDRA_NATIVE_TRANSPORT_PORT}} &&
-                ./apache-cassandra-{{CASSANDRA_VERSION}}/bin/cqlsh {{{CASSANDRA_CQLSH_SSL_FLAGS}}} -e "alter keyspace system_auth        WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3};" "node-0-server.${FRAMEWORK_HOST}" {{TASKCFG_ALL_CASSANDRA_NATIVE_TRANSPORT_PORT}} &&
-                ./apache-cassandra-{{CASSANDRA_VERSION}}/bin/cqlsh {{{CASSANDRA_CQLSH_SSL_FLAGS}}} -e "alter keyspace system_distributed WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3};" "node-0-server.${FRAMEWORK_HOST}" {{TASKCFG_ALL_CASSANDRA_NATIVE_TRANSPORT_PORT}}
+                cqlsh {{{CASSANDRA_CQLSH_SSL_FLAGS}}} -e "alter keyspace system_traces      WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3};" "node-0-server.${FRAMEWORK_HOST}" {{TASKCFG_ALL_CASSANDRA_NATIVE_TRANSPORT_PORT}} &&
+                cqlsh {{{CASSANDRA_CQLSH_SSL_FLAGS}}} -e "alter keyspace system_auth        WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3};" "node-0-server.${FRAMEWORK_HOST}" {{TASKCFG_ALL_CASSANDRA_NATIVE_TRANSPORT_PORT}} &&
+                cqlsh {{{CASSANDRA_CQLSH_SSL_FLAGS}}} -e "alter keyspace system_distributed WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3};" "node-0-server.${FRAMEWORK_HOST}" {{TASKCFG_ALL_CASSANDRA_NATIVE_TRANSPORT_PORT}}
                 {{/SECURITY_AUTHENTICATION_ENABLED}}
         resource-set: sidecar-resources
         configs:

--- a/frameworks/cassandra/src/main/dist/svc.yml
+++ b/frameworks/cassandra/src/main/dist/svc.yml
@@ -11,6 +11,12 @@ pods:
       {{VIRTUAL_NETWORK_NAME}}:
         labels: {{VIRTUAL_NETWORK_PLUGIN_LABELS}}
     {{/ENABLE_VIRTUAL_NETWORK}}
+    {{#SECURITY_AUTHENTICATION_ENABLED}}
+    secrets:
+      publicapikey:
+        secret: {{TASKCFG_ALL_PASSWORD_SECRET_PATH}}
+        file: new_user_password
+    {{/SECURITY_AUTHENTICATION_ENABLED}}
     volume:
       path: container-path
       type: {{CASSANDRA_DISK_TYPE}}
@@ -115,7 +121,13 @@ pods:
                 export SSL_CERTFILE=$MESOS_SANDBOX/cqlsh.ca ;
         {{/TASKCFG_ALL_SECURITY_TRANSPORT_ENCRYPTION_ENABLED}}
                 mkdir container-path/snapshot ;
+                {{#SECURITY_AUTHENTICATION_ENABLED}}
+                export NEW_USER_PASSWORD=`cat $MESOS_SANDBOX/new_user_password`;
+                ./apache-cassandra-{{CASSANDRA_VERSION}}/bin/cqlsh -u {{TASKCFG_ALL_NEW_SUPERUSER}} -p ${NEW_USER_PASSWORD} {{{CASSANDRA_CQLSH_SSL_FLAGS}}} -e "DESC SCHEMA" "node-${POD_INSTANCE_INDEX}-server.${FRAMEWORK_HOST}" ${CASSANDRA_NATIVE_TRANSPORT_PORT} > container-path/snapshot/schema.cql
+                {{/SECURITY_AUTHENTICATION_ENABLED}}
+                {{^SECURITY_AUTHENTICATION_ENABLED}}
                 ./apache-cassandra-{{CASSANDRA_VERSION}}/bin/cqlsh {{{CASSANDRA_CQLSH_SSL_FLAGS}}} -e "DESC SCHEMA" "node-${POD_INSTANCE_INDEX}-server.${FRAMEWORK_HOST}" ${CASSANDRA_NATIVE_TRANSPORT_PORT} > container-path/snapshot/schema.cql
+                {{/SECURITY_AUTHENTICATION_ENABLED}}
         resource-set: sidecar-resources
         {{#TASKCFG_ALL_SECURITY_TRANSPORT_ENCRYPTION_ENABLED}}
         configs:
@@ -197,7 +209,13 @@ pods:
 
                 export SSL_CERTFILE=$MESOS_SANDBOX/cqlsh.ca ;
         {{/TASKCFG_ALL_SECURITY_TRANSPORT_ENCRYPTION_ENABLED}}
+                {{#SECURITY_AUTHENTICATION_ENABLED}}
+                export NEW_USER_PASSWORD=`cat $MESOS_SANDBOX/new_user_password`;
+                ./apache-cassandra-{{CASSANDRA_VERSION}}/bin/cqlsh -u {{TASKCFG_ALL_NEW_SUPERUSER}} -p ${NEW_USER_PASSWORD} {{{CASSANDRA_CQLSH_SSL_FLAGS}}} -e "source 'container-path/snapshot/schema.cql'" node-${POD_INSTANCE_INDEX}-server.${FRAMEWORK_HOST} ${CASSANDRA_NATIVE_TRANSPORT_PORT}
+                {{/SECURITY_AUTHENTICATION_ENABLED}}
+                {{^SECURITY_AUTHENTICATION_ENABLED}}
                 ./apache-cassandra-{{CASSANDRA_VERSION}}/bin/cqlsh {{{CASSANDRA_CQLSH_SSL_FLAGS}}} -e "source 'container-path/snapshot/schema.cql'" node-${POD_INSTANCE_INDEX}-server.${FRAMEWORK_HOST} ${CASSANDRA_NATIVE_TRANSPORT_PORT}
+                {{/SECURITY_AUTHENTICATION_ENABLED}}
         resource-set: sidecar-resources
         {{#TASKCFG_ALL_SECURITY_TRANSPORT_ENCRYPTION_ENABLED}}
         configs:
@@ -252,14 +270,29 @@ pods:
         cmd: >
                 export PATH=$MESOS_SANDBOX/python-dist/bin:$PATH ;
                 export LD_LIBRARY_PATH=$MESOS_SANDBOX/openssl-dist:$LD_LIBRARY_PATH ;
+                export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jdk*/jre/) ;
                 echo Using $(python --version 2>&1) in $(which python) ;
                 {{#TASKCFG_ALL_SECURITY_TRANSPORT_ENCRYPTION_ENABLED}}
                 export SSL_CERTFILE=$MESOS_SANDBOX/cqlsh.ca ;
                 {{/TASKCFG_ALL_SECURITY_TRANSPORT_ENCRYPTION_ENABLED}}
+                {{#SECURITY_AUTHENTICATION_ENABLED}}
+                export NEW_USER_PASSWORD=`cat $MESOS_SANDBOX/new_user_password`;                
+                export NEW_RANDOM_PASSWORD=`cat /dev/urandom | tr -cd 'a-f0-9' | head -c 32`;
+                {{/SECURITY_AUTHENTICATION_ENABLED}}                
                 ./bootstrap --resolve=false &&
+                {{#SECURITY_AUTHENTICATION_ENABLED}}
+                ./apache-cassandra-{{CASSANDRA_VERSION}}/bin/cqlsh -u cassandra -p cassandra {{{CASSANDRA_CQLSH_SSL_FLAGS}}} -e "alter keyspace system_traces      WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3};" "node-0-server.${FRAMEWORK_HOST}" {{TASKCFG_ALL_CASSANDRA_NATIVE_TRANSPORT_PORT}} &&
+                ./apache-cassandra-{{CASSANDRA_VERSION}}/bin/cqlsh -u cassandra -p cassandra {{{CASSANDRA_CQLSH_SSL_FLAGS}}} -e "alter keyspace system_auth        WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3};" "node-0-server.${FRAMEWORK_HOST}" {{TASKCFG_ALL_CASSANDRA_NATIVE_TRANSPORT_PORT}} &&
+                ./apache-cassandra-{{CASSANDRA_VERSION}}/bin/cqlsh -u cassandra -p cassandra {{{CASSANDRA_CQLSH_SSL_FLAGS}}} -e "alter keyspace system_distributed WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3};" "node-0-server.${FRAMEWORK_HOST}" {{TASKCFG_ALL_CASSANDRA_NATIVE_TRANSPORT_PORT}} &&
+                ./apache-cassandra-{{CASSANDRA_VERSION}}/bin/nodetool repair system_auth &&
+                ./apache-cassandra-{{CASSANDRA_VERSION}}/bin/cqlsh -u cassandra -p cassandra {{{CASSANDRA_CQLSH_SSL_FLAGS}}} -e "CREATE ROLE {{TASKCFG_ALL_NEW_SUPERUSER}} WITH PASSWORD = '${NEW_USER_PASSWORD}' AND SUPERUSER = true AND LOGIN = true;" "node-0-server.${FRAMEWORK_HOST}" {{TASKCFG_ALL_CASSANDRA_NATIVE_TRANSPORT_PORT}} &&
+                ./apache-cassandra-{{CASSANDRA_VERSION}}/bin/cqlsh -u {{TASKCFG_ALL_NEW_SUPERUSER}} -p ${NEW_USER_PASSWORD} {{{CASSANDRA_CQLSH_SSL_FLAGS}}} -e "ALTER ROLE cassandra WITH PASSWORD='${NEW_RANDOM_PASSWORD}' AND SUPERUSER=false;" "node-0-server.${FRAMEWORK_HOST}" {{TASKCFG_ALL_CASSANDRA_NATIVE_TRANSPORT_PORT}}
+                {{/SECURITY_AUTHENTICATION_ENABLED}}
+                {{^SECURITY_AUTHENTICATION_ENABLED}}                
                 ./apache-cassandra-{{CASSANDRA_VERSION}}/bin/cqlsh {{{CASSANDRA_CQLSH_SSL_FLAGS}}} -e "alter keyspace system_traces      WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3};" "node-0-server.${FRAMEWORK_HOST}" {{TASKCFG_ALL_CASSANDRA_NATIVE_TRANSPORT_PORT}} &&
                 ./apache-cassandra-{{CASSANDRA_VERSION}}/bin/cqlsh {{{CASSANDRA_CQLSH_SSL_FLAGS}}} -e "alter keyspace system_auth        WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3};" "node-0-server.${FRAMEWORK_HOST}" {{TASKCFG_ALL_CASSANDRA_NATIVE_TRANSPORT_PORT}} &&
                 ./apache-cassandra-{{CASSANDRA_VERSION}}/bin/cqlsh {{{CASSANDRA_CQLSH_SSL_FLAGS}}} -e "alter keyspace system_distributed WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3};" "node-0-server.${FRAMEWORK_HOST}" {{TASKCFG_ALL_CASSANDRA_NATIVE_TRANSPORT_PORT}}
+                {{/SECURITY_AUTHENTICATION_ENABLED}}
         resource-set: sidecar-resources
         configs:
           cassandra:
@@ -281,8 +314,13 @@ plans:
         strategy: serial
         pod: node
         steps:
-          - 0: [[server], [init_system_keyspaces]]
           - default: [[server]]
+      keyspace-deploy:
+        strategy: serial
+        pod: node
+        steps:
+          - 0: [[init_system_keyspaces]]
+          - default: [[]]
   replace:
     strategy: serial
     phases:

--- a/frameworks/cassandra/tests/config.py
+++ b/frameworks/cassandra/tests/config.py
@@ -21,7 +21,7 @@ SERVICE_NAME = os.environ.get("SOAK_SERVICE_NAME") or "cassandra"
 
 DEFAULT_TASK_COUNT = 3
 DEFAULT_CASSANDRA_TIMEOUT = 600
-SECRET_VALUE= "password"
+SECRET_VALUE = "password"
 # Soak artifact scripts may override the service name to test
 
 DEFAULT_NODE_ADDRESS = os.getenv(
@@ -113,11 +113,11 @@ def _get_test_job(
     return job
 
 
-def _cqlsh(query: str, node_address: str, node_port: str, auth: bool ) -> str:
+def _cqlsh(query: str, node_address: str, node_port: str, auth: bool) -> str:
     if auth:
-       return 'cqlsh -u dcossuperuser -p password -e "{}" {} {}'.format(query, node_address, node_port)
+        return 'cqlsh -u dcossuperuser -p password -e "{}" {} {}'.format(query, node_address, node_port)
     else:
-       return 'cqlsh -e "{}" {} {}'.format(query, node_address, node_port)        
+        return 'cqlsh -e "{}" {} {}'.format(query, node_address, node_port)
 
 
 def get_delete_data_job(

--- a/frameworks/cassandra/tests/config.py
+++ b/frameworks/cassandra/tests/config.py
@@ -173,14 +173,16 @@ def get_verify_deletion_job(
             _cqlsh(
                 "SELECT * FROM system_schema.tables WHERE keyspace_name='testspace1';",
                 node_address,
-                node_port, auth,
+                node_port,
+                auth,
             )
         ),
         '{} | grep "0 rows"'.format(
             _cqlsh(
                 "SELECT * FROM system_schema.tables WHERE keyspace_name='testspace2';",
                 node_address,
-                node_port, auth,
+                node_port,
+                auth,
             )
         ),
     ]

--- a/frameworks/cassandra/tests/config.py
+++ b/frameworks/cassandra/tests/config.py
@@ -21,6 +21,7 @@ SERVICE_NAME = os.environ.get("SOAK_SERVICE_NAME") or "cassandra"
 
 DEFAULT_TASK_COUNT = 3
 DEFAULT_CASSANDRA_TIMEOUT = 600
+SECRET_VALUE= "password"
 # Soak artifact scripts may override the service name to test
 
 DEFAULT_NODE_ADDRESS = os.getenv(
@@ -112,14 +113,18 @@ def _get_test_job(
     return job
 
 
-def _cqlsh(query: str, node_address: str, node_port: str) -> str:
-    return 'cqlsh -e "{}" {} {}'.format(query, node_address, node_port)
+def _cqlsh(query: str, node_address: str, node_port: str, auth: bool ) -> str:
+    if auth:
+       return 'cqlsh -u dcossuperuser -p password -e "{}" {} {}'.format(query, node_address, node_port)
+    else:
+       return 'cqlsh -e "{}" {} {}'.format(query, node_address, node_port)        
 
 
 def get_delete_data_job(
     node_address: str = DEFAULT_NODE_ADDRESS,
     node_port: str = DEFAULT_NODE_PORT,
     dcos_ca_bundle: Optional[str] = None,
+    auth: bool = False,
 ) -> Dict[str, Any]:
     cql = " ".join(
         [
@@ -131,7 +136,7 @@ def get_delete_data_job(
     )
     return _get_test_job(
         "delete-data-retry",
-        [_cqlsh(cql, node_address, node_port)],
+        [_cqlsh(cql, node_address, node_port, auth)],
         node_address,
         node_port,
         dcos_ca_bundle=dcos_ca_bundle,
@@ -142,13 +147,14 @@ def get_verify_data_job(
     node_address: str = DEFAULT_NODE_ADDRESS,
     node_port: str = DEFAULT_NODE_PORT,
     dcos_ca_bundle: Optional[str] = None,
+    auth: bool = False,
 ) -> Dict[str, Any]:
     cmds = [
         "{} | grep testkey1".format(
-            _cqlsh("SELECT * FROM testspace1.testtable1;", node_address, node_port)
+            _cqlsh("SELECT * FROM testspace1.testtable1;", node_address, node_port, auth)
         ),
         "{} | grep testkey2".format(
-            _cqlsh("SELECT * FROM testspace2.testtable2;", node_address, node_port)
+            _cqlsh("SELECT * FROM testspace2.testtable2;", node_address, node_port, auth)
         ),
     ]
     return _get_test_job(
@@ -160,20 +166,21 @@ def get_verify_deletion_job(
     node_address: str = DEFAULT_NODE_ADDRESS,
     node_port: str = DEFAULT_NODE_PORT,
     dcos_ca_bundle: Optional[str] = None,
+    auth: bool = False,
 ) -> Dict[str, Any]:
     cmds = [
         '{} | grep "0 rows"'.format(
             _cqlsh(
                 "SELECT * FROM system_schema.tables WHERE keyspace_name='testspace1';",
                 node_address,
-                node_port,
+                node_port, auth,
             )
         ),
         '{} | grep "0 rows"'.format(
             _cqlsh(
                 "SELECT * FROM system_schema.tables WHERE keyspace_name='testspace2';",
                 node_address,
-                node_port,
+                node_port, auth,
             )
         ),
     ]
@@ -186,6 +193,7 @@ def get_write_data_job(
     node_address: str = DEFAULT_NODE_ADDRESS,
     node_port: str = DEFAULT_NODE_PORT,
     dcos_ca_bundle: Optional[str] = None,
+    auth: bool = False,
 ) -> Dict[str, Any]:
     cql = " ".join(
         [
@@ -201,7 +209,7 @@ def get_write_data_job(
     )
     return _get_test_job(
         "write-data",
-        [_cqlsh(cql, node_address, node_port)],
+        [_cqlsh(cql, node_address, node_port, auth)],
         node_address,
         node_port,
         dcos_ca_bundle=dcos_ca_bundle,
@@ -211,12 +219,13 @@ def get_write_data_job(
 def get_all_jobs(
     node_address: str = DEFAULT_NODE_ADDRESS,
     node_port: str = DEFAULT_NODE_PORT,
+    auth: bool = False,
 ) -> List[Dict[str, Any]]:
     return [
-        get_write_data_job(node_address),
-        get_verify_data_job(node_address),
-        get_delete_data_job(node_address),
-        get_verify_deletion_job(node_address),
+        get_write_data_job(node_address, auth=auth),
+        get_verify_data_job(node_address, auth=auth),
+        get_delete_data_job(node_address, auth=auth),
+        get_verify_deletion_job(node_address, auth=auth),
     ]
 
 
@@ -264,5 +273,28 @@ def run_backup_and_restore(
     sdk_jobs.run_job(verify_data_job)
 
     # Delete data in preparation for any other backup tests
+    sdk_jobs.run_job(delete_data_job)
+    sdk_jobs.run_job(verify_deletion_job)
+
+
+def verify_client_can_write_read_and_delete_with_auth(
+    job_node_address: str = DEFAULT_NODE_ADDRESS,
+) -> None:
+    write_data_job = get_write_data_job(node_address=job_node_address, auth=True)
+    verify_data_job = get_verify_data_job(node_address=job_node_address, auth=True)
+    delete_data_job = get_delete_data_job(node_address=job_node_address, auth=True)
+    verify_deletion_job = get_verify_deletion_job(node_address=job_node_address, auth=True)
+
+    # Ensure the keyspaces we will use aren't present. In practice this should run once and fail
+    # because the data isn't present. When the job is flagged as failed (due to restart=NEVER),
+    # the run_job() call will throw.
+    try:
+        sdk_jobs.run_job(delete_data_job)
+    except Exception:
+        log.info("Error during delete (normal if no stale data)")
+        log.info(traceback.format_exc())
+
+    sdk_jobs.run_job(write_data_job)
+    sdk_jobs.run_job(verify_data_job)
     sdk_jobs.run_job(delete_data_job)
     sdk_jobs.run_job(verify_deletion_job)

--- a/frameworks/cassandra/tests/test_auth.py
+++ b/frameworks/cassandra/tests/test_auth.py
@@ -1,10 +1,14 @@
 import retrying
 from typing import Any, Dict, Iterator, List
+import logging
 import pytest
 import sdk_jobs
 import sdk_cmd
 import sdk_install
+import sdk_tasks
 from tests import config
+
+log = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -38,7 +42,7 @@ def configure_package(configure_security: None) -> Iterator[None]:
         yield  # let the test session execute
     finally:
         sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
-
+        delete_secret(secret=config.PACKAGE_NAME + '/' + config.SECRET_VALUE)
         # remove job definitions from metronome
         for job in test_jobs:
             sdk_jobs.remove_job(job)
@@ -49,6 +53,9 @@ def test_auth() -> None:
     config.verify_client_can_write_read_and_delete_with_auth(
         config.get_foldered_node_address(),
     )
+    tasks = sdk_tasks.get_service_tasks(config.SERVICE_NAME, "node-0")[0]
+    _, stdout, stderr = sdk_cmd.run_cli("task exec {} bash -c 'export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jdk*/jre/) ;  export PATH=$MESOS_SANDBOX/python-dist/bin:$PATH ; export PATH=$(ls -d $MESOS_SANDBOX/apache-cassandra-*/bin):$PATH ; cqlsh -u dcossuperuser -p wrongpassword -e \"SHOW VERSION\" node-0-server.$FRAMEWORK_HOST $CASSANDRA_NATIVE_TRANSPORT_PORT' ".format(tasks.id))
+    assert "Provided username dcossuperuser and/or password are incorrect" in stderr
 
 
 def create_secret(secret_value: str, secret_path: str) -> None:
@@ -61,8 +68,6 @@ def create_secret(secret_value: str, secret_path: str) -> None:
         )
     )
 
-    # delete_secret(secret=secret_path)
-
 
 def delete_secret(secret: str) -> None:
 
@@ -74,9 +79,8 @@ def install_enterprise_cli(force=False):
 
     if not force:
         _, stdout, _ = sdk_cmd.run_cli("security --version", print_output=False)
-        # if stdout:
-        #     log.info("DC/OS enterprise version %s CLI already installed", stdout.strip())
-        #     return
+        if stdout:
+            log.info("DC/OS enterprise version %s CLI already installed", stdout.strip())
 
     @retrying.retry(
         stop_max_attempt_number=3,

--- a/frameworks/cassandra/tests/test_auth.py
+++ b/frameworks/cassandra/tests/test_auth.py
@@ -1,0 +1,86 @@
+import pytest
+import logging
+import retrying
+from typing import Any, Dict, Iterator, List
+
+import sdk_jobs
+import sdk_cmd
+import sdk_install
+import sdk_service
+import sdk_tasks
+from tests import config
+
+def test_auth() -> None:
+    test_jobs: List[Dict[str, Any]] = []
+    try:
+        test_jobs = config.get_all_jobs(auth=True)
+        # destroy/reinstall any prior leftover jobs, so that they don't touch the newly installed service:
+        for job in test_jobs:
+            sdk_jobs.install_job(job)
+        
+
+        create_service_account(
+            secret_value=config.SECRET_VALUE, secret_path=config.PACKAGE_NAME + '/' + config.SECRET_VALUE
+         )
+        service_options = {
+            "service": {
+                "name": config.SERVICE_NAME,
+         	    "security": {"authentication": {"enabled": True}, "authorization": {"enabled": True}},
+            }
+         }
+            
+        sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
+            
+        sdk_install.install(
+            config.PACKAGE_NAME,
+            service_name=config.SERVICE_NAME,
+            expected_running_tasks=config.DEFAULT_TASK_COUNT,
+            additional_options=service_options,
+        )
+            
+        config.verify_client_can_write_read_and_delete_with_auth(
+             config.get_foldered_node_address(),
+        )
+        
+    finally:
+        sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
+        for job in test_jobs:
+            sdk_jobs.remove_job(job)
+
+    
+
+def create_service_account(secret_value: str, secret_path: str) -> None:
+    
+    install_enterprise_cli()
+    delete_secret(secret=secret_path)
+    sdk_cmd.run_cli(
+        'security secrets create --value="{account}" "{secret}"'.format(
+            account=secret_value, secret=secret_path
+        )
+    )
+
+    # delete_secret(secret=secret_path)
+
+
+def delete_secret(secret: str) -> None:
+  
+    sdk_cmd.run_cli("security secrets delete {}".format(secret))
+
+def install_enterprise_cli(force=False):
+    """ Install the enterprise CLI if required """
+
+    if not force:
+        _, stdout, _ = sdk_cmd.run_cli("security --version", print_output=False)
+        # if stdout:
+        #     log.info("DC/OS enterprise version %s CLI already installed", stdout.strip())
+        #     return
+
+    @retrying.retry(
+        stop_max_attempt_number=3,
+        wait_fixed=2000,
+        retry_on_exception=lambda e: isinstance(e, Exception),
+    )
+    def _install_impl():
+        sdk_cmd.run_cli("package install --yes --cli dcos-enterprise-cli", check=True)
+
+    _install_impl()

--- a/frameworks/cassandra/tests/test_auth.py
+++ b/frameworks/cassandra/tests/test_auth.py
@@ -53,6 +53,10 @@ def test_auth() -> None:
     config.verify_client_can_write_read_and_delete_with_auth(
         config.get_foldered_node_address(),
     )
+
+
+@pytest.mark.sanity
+def test_unauthorized_users() -> None:
     tasks = sdk_tasks.get_service_tasks(config.SERVICE_NAME, "node-0")[0]
     _, stdout, stderr = sdk_cmd.run_cli("task exec {} bash -c 'export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jdk*/jre/) ;  export PATH=$MESOS_SANDBOX/python-dist/bin:$PATH ; export PATH=$(ls -d $MESOS_SANDBOX/apache-cassandra-*/bin):$PATH ; cqlsh -u dcossuperuser -p wrongpassword -e \"SHOW VERSION\" node-0-server.$FRAMEWORK_HOST $CASSANDRA_NATIVE_TRANSPORT_PORT' ".format(tasks.id))
     assert "Provided username dcossuperuser and/or password are incorrect" in stderr

--- a/frameworks/cassandra/tests/test_auth.py
+++ b/frameworks/cassandra/tests/test_auth.py
@@ -1,14 +1,11 @@
-import pytest
-import logging
 import retrying
-from typing import Any, Dict, Iterator, List
+from typing import Any, Dict, List
 
 import sdk_jobs
 import sdk_cmd
 import sdk_install
-import sdk_service
-import sdk_tasks
 from tests import config
+
 
 def test_auth() -> None:
     test_jobs: List[Dict[str, Any]] = []
@@ -17,40 +14,38 @@ def test_auth() -> None:
         # destroy/reinstall any prior leftover jobs, so that they don't touch the newly installed service:
         for job in test_jobs:
             sdk_jobs.install_job(job)
-        
 
         create_service_account(
             secret_value=config.SECRET_VALUE, secret_path=config.PACKAGE_NAME + '/' + config.SECRET_VALUE
-         )
+        )
         service_options = {
             "service": {
                 "name": config.SERVICE_NAME,
-         	    "security": {"authentication": {"enabled": True}, "authorization": {"enabled": True}},
+                "security": {"authentication": {"enabled": True}, "authorization": {"enabled": True}},
             }
-         }
-            
+        }
+
         sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
-            
+
         sdk_install.install(
             config.PACKAGE_NAME,
             service_name=config.SERVICE_NAME,
             expected_running_tasks=config.DEFAULT_TASK_COUNT,
             additional_options=service_options,
         )
-            
+
         config.verify_client_can_write_read_and_delete_with_auth(
-             config.get_foldered_node_address(),
+            config.get_foldered_node_address(),
         )
-        
+
     finally:
         sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
         for job in test_jobs:
             sdk_jobs.remove_job(job)
 
-    
 
 def create_service_account(secret_value: str, secret_path: str) -> None:
-    
+
     install_enterprise_cli()
     delete_secret(secret=secret_path)
     sdk_cmd.run_cli(
@@ -63,8 +58,9 @@ def create_service_account(secret_value: str, secret_path: str) -> None:
 
 
 def delete_secret(secret: str) -> None:
-  
+
     sdk_cmd.run_cli("security secrets delete {}".format(secret))
+
 
 def install_enterprise_cli(force=False):
     """ Install the enterprise CLI if required """

--- a/frameworks/cassandra/universe/config.json
+++ b/frameworks/cassandra/universe/config.json
@@ -130,7 +130,7 @@
                                 "type": "string",
                                 "description": "The path in the DC/OS Secret Store to retrieve the superuser password from" ,
                                 "default": "cassandra/password"
-			                      }
+			    }
                         }
                     }
                 }

--- a/frameworks/cassandra/universe/config.json
+++ b/frameworks/cassandra/universe/config.json
@@ -107,8 +107,78 @@
                   "default": false
                 }
               }
+            },
+	   "authentication": {
+            "type": "object",
+            "description": "DC/OS Apache Cassandra authentication settings",
+            "properties": {
+                "enabled": {
+                    "description": "Enable Apache Cassandra's native password authentication",
+                    "type": "boolean",
+                    "default": false
+                },
+                "superuser": {
+                    "type": "object",
+                    "description": "Superuser configuration",
+                    "properties": {
+                            "name": {
+                                "type": "string",
+                                "description": "The name of the superuser",
+                                "default": "dcossuperuser"
+                            },
+                            "password_secret_path": {
+                                "type": "string",
+                                "description": "The path in the DC/OS Secret Store to retrieve the superuser password from" ,
+                                "default": "cassandra/password"
+			                      }
+                        }
+                    }
+                }
+            
+        },
+        "authorization": {
+            "type": "object",
+            "description": "DC/OS Apache Cassandra authorization settings",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Apache Cassandra's native authorization",
+                    "default": false
+                },
+                "roles_validity_in_ms": {
+                    "type": "integer",
+                    "description": "Validity period for roles cache; set to 0 to disable",
+                    "default": 2000
+                },
+                "roles_update_interval_in_ms": {
+                    "type": "integer",
+                    "description": "After this interval, cache entries become eligible for refresh. Upon next access, Cassandra schedules an async reload, and returns the old value until the reload completes. If roles_validity_in_ms is non-zero, then this must be also.",
+                    "default": 2000
+                },
+                "credentials_validity_in_ms": {
+                    "type": "integer",
+                    "description": " This cache is tightly coupled to the provided PasswordAuthenticator implementation of IAuthenticator. If another IAuthenticator implementation is configured, Cassandra does not use this cache, and these settings have no effect. Set to 0 to disable.",
+                    "default": 2000
+                },
+                "credentials_update_interval_in_ms": {
+                    "type": "integer",
+                    "description": "After this interval, cache entries become eligible for refresh. The next time the cache is accessed, the system schedules an asynchronous reload of the cache. Until this cache reload is complete, the cache returns the old values. If credentials_validity_in_ms is nonzero, this property must also be nonzero.",
+                    "default": 2000
+                },
+                "permissions_validity_in_ms": {
+                    "type": "integer",
+                    "description": "How many milliseconds permissions in cache remain valid. Fetching permissions can be resource intensive. To disable the cache, set this to 0.",
+                    "default": 2000
+                },
+                "permissions_update_interval_in_ms": {
+                    "type": "integer",
+                    "description": "If enabled, sets refresh interval for the permissions cache. After this interval, cache entries become eligible for refresh. On next access, Cassandra schedules an async reload and returns the old value until the reload completes. If permissions_validity_in_ms is nonzero, permissions_update_interval_in_ms must also be non-zero.",
+                    "default": 2000
+                }
+
             }
-          }
+        }
+                }
         },
         "readiness_check" : {
           "description" : "Readiness check settings. Excercise caution when modifying these default values as it can lead to spurious task failures.",
@@ -251,16 +321,6 @@
           "type": "string",
           "description": "The name of the cluster managed by the Service",
           "default": "cassandra"
-        },
-        "authenticator": {
-          "type": "string",
-          "description": "The authentication backend. It implements IAuthenticator, which is used to identify users.",
-          "default": "AllowAllAuthenticator"
-        },
-        "authorizer": {
-          "type": "string",
-          "description": "The authorization backend. It implements IAuthenticator, which limits access and provides permissions.",
-          "default": "AllowAllAuthorizer"
         },
         "jmx_port": {
           "type": "integer",
@@ -507,16 +567,6 @@
           "description": "Take a snapshot of the data before truncating a keyspace or dropping a table",
           "default": true
         },
-        "roles_update_interval_in_ms": {
-          "type": "integer",
-          "description": "The refresh interval for the roles cache",
-          "default": 1000
-        },
-        "permissions_update_interval_in_ms": {
-          "type": "integer",
-          "description": "The refresh interval for the permissions cache",
-          "default": 1000
-        },
         "key_cache_keys_to_save": {
           "type": "integer",
           "description": "The number of keys from the key cache to save",
@@ -716,8 +766,6 @@
         "concurrent_materialized_view_writes",
         "commitlog_total_space_in_mb",
         "auto_snapshot",
-        "roles_update_interval_in_ms",
-        "permissions_update_interval_in_ms",
         "key_cache_keys_to_save",
         "row_cache_keys_to_save",
         "counter_cache_keys_to_save",

--- a/frameworks/cassandra/universe/marathon.json.mustache
+++ b/frameworks/cassandra/universe/marathon.json.mustache
@@ -60,9 +60,34 @@
     "CASSANDRA_CQLSH_SSL_FLAGS": "",
     {{/service.security.transport_encryption.enabled}}
 
+    "SECURITY_AUTHENTICATION_ENABLED": "{{service.security.authentication.enabled}}",
+    "SECURITY_AUTHORIZATION_ENABLED": "{{service.security.authorization.enabled}}",
+    
+    {{#service.security.authentication.enabled}}
+    "TASKCFG_ALL_CASSANDRA_AUTHENTICATOR": "PasswordAuthenticator",
+    {{/service.security.authentication.enabled}}
+    {{^service.security.authentication.enabled}}
+    "TASKCFG_ALL_CASSANDRA_AUTHENTICATOR": "AllowAllAuthenticator",
+    {{/service.security.authentication.enabled}}
+    
+    {{#service.security.authorization.enabled}}
+    "TASKCFG_ALL_CASSANDRA_AUTHORIZER": "CassandraAuthorizer",
+    {{/service.security.authorization.enabled}}
+    {{^service.security.authorization.enabled}}
+    "TASKCFG_ALL_CASSANDRA_AUTHORIZER": "AllowAllAuthorizer",
+    {{/service.security.authorization.enabled}}
+
+    "TASKCFG_ALL_NEW_SUPERUSER": "{{service.security.authentication.superuser.name}}",
+    "TASKCFG_ALL_PASSWORD_SECRET_PATH": "{{service.security.authentication.superuser.password_secret_path}}",    
+    "TASKCFG_ALL_ROLES_UPDATE_INTERVAL_IN_MS": "{{service.security.authorization.roles_update_interval_in_ms}}",    
+    "TASKCFG_ALL_ROLES_VALIDITY_IN_MS": "{{service.security.authorization.roles_validity_in_ms}}",
+    "TASKCFG_ALL_CREDENTIALS_VALIDITY_IN_MS": "{{service.security.authorization.credentials_validity_in_ms}}",
+    "TASKCFG_ALL_CREDENTIALS_UPDATE_INTERVAL_IN_MS": "{{service.security.authorization.credentials_update_interval_in_ms}}",
+    "TASKCFG_ALL_PERMISSIONS_VALIDITY_IN_MS": "{{service.security.authorization.permissions_validity_in_ms}}",
+    "TASKCFG_ALL_PERMISSIONS_UPDATE_INTERVAL_IN_MS": "{{service.security.authorization.permissions_update_interval_in_ms}}",
+
     "TASKCFG_ALL_CASSANDRA_CLUSTER_NAME": "{{cassandra.cluster_name}}",
-    "TASKCFG_ALL_CASSANDRA_AUTHENTICATOR": "{{cassandra.authenticator}}",
-    "TASKCFG_ALL_CASSANDRA_AUTHORIZER": "{{cassandra.authorizer}}",
+
     "NODES": "{{nodes.count}}",
     "CASSANDRA_CPUS": "{{nodes.cpus}}",
     "CASSANDRA_MEMORY_MB": "{{nodes.mem}}",
@@ -133,8 +158,6 @@
     "TASKCFG_ALL_CASSANDRA_MATERIALIZED_VIEW_WRITES": "{{cassandra.concurrent_materialized_view_writes}}",
     "TASKCFG_ALL_CASSANDRA_COMMITLOG_TOTAL_SPACE_IN_MB": "{{cassandra.commitlog_total_space_in_mb}}",
     "TASKCFG_ALL_CASSANDRA_AUTO_SNAPSHOT": "{{cassandra.auto_snapshot}}",
-    "TASKCFG_ALL_CASSANDRA_ROLES_UPDATE_INTERVAL_IN_MS": "{{cassandra.roles_update_interval_in_ms}}",
-    "TASKCFG_ALL_CASSANDRA_PERMISSIONS_UPDATE_INTERVAL_IN_MS": "{{cassandra.permissions_update_interval_in_ms}}",
     "TASKCFG_ALL_CASSANDRA_KEY_CACHE_KEYS_TO_SAVE": "{{cassandra.key_cache_keys_to_save}}",
     "TASKCFG_ALL_CASSANDRA_ROW_CACHE_KEYS_TO_SAVE": "{{cassandra.row_cache_keys_to_save}}",
     "TASKCFG_ALL_CASSANDRA_COUNTER_CACHE_KEYS_TO_SAVE": "{{cassandra.counter_cache_keys_to_save}}",


### PR DESCRIPTION
[DCOS-51573][DCOS-51574] authn authz implementation
## Release Notes 

With this Release internal authentication and internal authorization will be added to this framework.
 
Cassandra uses rolenames and passwords for internal authentication. Role-based authentication encompasses both users and roles to bring a number of useful features to authorization. Roles can represent either actual individual users or roles that those users have in administering and accessing the Cassandra cluster.

Design Document :- 
https://docs.google.com/document/d/1L2MR7czxXYcfHxlKLMQGNGVq5cj4L0wXQblIKD6cny8/edit?usp=sharing