### PR TITLE
[DCOS-52245] Preparatory change for wrapping dcos-launch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,3 +62,5 @@ COPY .pre-commit-config.yaml ${DCOS_COMMONS_DIST_ROOT}/
 
 COPY build.gradle ${DCOS_COMMONS_DIST_ROOT}/build.gradle
 RUN grep -oE "version = '.*?'" ${DCOS_COMMONS_DIST_ROOT}/build.gradle | sed 's/version = //' > ${DCOS_COMMONS_DIST_ROOT}/.version
+
+COPY tools/container/venvs /venvs

--- a/tools/ci/launch_cluster.sh
+++ b/tools/ci/launch_cluster.sh
@@ -9,13 +9,13 @@ RETRY_LAUNCH="True"
 
 while [ x"${LAUNCH_SUCCESS}" == x"False" ]; do
     rm -f ${CLUSTER_INFO_FILE} # dcos-launch complains if the file already exists
-    dcos-launch create --config-path=${LAUNCH_CONFIG_FILE} --info-path=${CLUSTER_INFO_FILE}
+    /venvs/wrap.sh dcos-launch dcos-launch create --config-path=${LAUNCH_CONFIG_FILE} --info-path=${CLUSTER_INFO_FILE}
     if [ x"$RETRY_LAUNCH" == x"True" ]; then
         set +e
     else
         set -e
     fi
-    dcos-launch wait --info-path=${CLUSTER_INFO_FILE} 2>&1 | tee dcos-launch-wait-output.stdout
+    /venvs/wrap.sh dcos-launch dcos-launch wait --info-path=${CLUSTER_INFO_FILE} 2>&1 | tee dcos-launch-wait-output.stdout
 
     # Grep exits with an exit code of 1 if no lines are matched. We thus need to
     # disable exit on errors.
@@ -36,7 +36,7 @@ while [ x"${LAUNCH_SUCCESS}" == x"False" ]; do
         set -e
 
         # We need to wait for the current stack to be deleted
-        dcos-launch delete --info-path=${CLUSTER_INFO_FILE}
+        /venvs/wrap.sh dcos-launch dcos-launch delete --info-path=${CLUSTER_INFO_FILE}
         rm -f ${CLUSTER_INFO_FILE}
         echo "Cluster creation failed. Retrying after 30 seconds"
         sleep 30

--- a/tools/ci/test_runner.sh
+++ b/tools/ci/test_runner.sh
@@ -74,7 +74,7 @@ function get_public_master_url()
     # We retry, since sometimes the cluster is created, but dcos-launch has intermittent problems describing it.
     for attempt in $(seq 1 ${attempts}); do
         # Careful to not use a pipeline!
-        if dcos-launch describe --info-path="${REPO_ROOT_DIR}/cluster_info.json" > "${cluster_description_file}" &&
+        if /venvs/wrap.sh dcos-launch dcos-launch describe --info-path="${REPO_ROOT_DIR}/cluster_info.json" > "${cluster_description_file}" &&
            master_ip=$(jq --raw-output --exit-status '.masters[0].public_ip' < "${cluster_description_file}")
         then
             echo "https://${master_ip}"
@@ -198,7 +198,7 @@ echo "Finished integration tests at "`date`
 
 if [ -n "$CLUSTER_WAS_CREATED" ]; then
     echo "The DC/OS cluster $CLUSTER_URL was created. Please run"
-    echo "\t\$ dcos-launch delete --info-path=${CLUSTER_INFO_FILE}"
+    echo "\t\$ /venvs/wrap.sh dcos-launch dcos-launch delete --info-path=${CLUSTER_INFO_FILE}"
     echo "to remove the cluster."
 fi
 

--- a/tools/container/README.md
+++ b/tools/container/README.md
@@ -1,0 +1,4 @@
+# Tools installed in the docker container
+
+Everything in this directory expects to be installed and run inside the
+`mesosphere/dcos-commons` docker container.

--- a/tools/container/venvs/wrap.sh
+++ b/tools/container/venvs/wrap.sh
@@ -1,6 +1,16 @@
 #!/bin/bash
-# No functionality yet, will be added once TeamCity is updated to use this file.
+# TODO: this is just a pass-through fow now, actual invocation of pipenv will
+# be added after TeamCity configs are updated to use this file.
 set -eu
-venv="$1"
+function usage() {
+	echo "Usage: $0 <PIPENV_PROJECT> <COMMAND> [ ARGS ... ]" >&2
+	echo "Where:" >&2
+	echo "  PIPENV_PROJECT is the name of a directory under /venvs" >&2
+	echo "  COMMAND and ARGS will be run with pipenv using the project" >&2
+}
+pipenv_project="$1"
 shift
+if [[ $# == 0 ]]; then
+	usage
+fi
 exec "$@"

--- a/tools/container/venvs/wrap.sh
+++ b/tools/container/venvs/wrap.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# No functionality yet, will be added once TeamCity is updated to use this file.
+set -eu
+venv="$1"
+shift
+exec "$@"


### PR DESCRIPTION
Introduce a wrapper script around `dcos-launch` as the first stage of encapsulating it and its dependencies. Actual logic will be added once the callers defined in TeamCity configs are converted to use it.
More details about the design in the ticket.