### PR TITLE
Fix broken links

### DIFF
--- a/frameworks/helloworld/README.md
+++ b/frameworks/helloworld/README.md
@@ -10,9 +10,9 @@ The default example [svc.yml](src/main/dist/svc.yml) has two pods, with volumes 
 
 [Multiple example configuration files](src/main/dist/examples/) are also provided (change the name of the default YAML file at ["universe/config.json"](universe/config.json)). In particular:
 
- - [simple.yml](src/main/dist/examples/simple.yml): Bare minimum example. Just one pod, with no extra features.
- - [plan.yml](src/main/dist/examples/plan.yml): Two pods, with healthcheck, volumes, ports, and with a plan structure.
- - [uri.yml](src/main/dist/examples/uri.yml): Sample pod and task-specific URIs that are downloaded before task launch.
+ - [simple.yml](src/main/dist/simple.yml): Bare minimum example. Just one pod, with no extra features.
+ - [plan.yml](src/main/dist/plan.yml): Two pods, with healthcheck, volumes, ports, and with a plan structure.
+ - [uri.yml](src/main/dist/uri.yml): Sample pod and task-specific URIs that are downloaded before task launch.
 
 
 See [marathon.json.mustache](universe/marathon.json.mustache) for more information:


### PR DESCRIPTION
Fix broken links. The location of yamls has changed from `src/main/dist/examples` to `src/main/dist`