### PR TITLE
[DCOS-52239] Replace the spec section with a quickstart one

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,58 +13,15 @@
 __DC/OS SDK__ is a collection of tools, libraries, and documentation for easy integration of technologies such as Kafka, Cassandra, HDFS, Spark, and TensorFlow with DC/OS.
 
 ---
-### Understanding the Hello World Service Specification
+### Quick Start
 
-The service specification declaratively defines the `helloworld` service:
+To create a new service based on the SDK:
+1. read the [developer guide](https://mesosphere.github.io/dcos-commons/developer-guide/) and the [FAQ](https://mesosphere.github.io/dcos-commons/faq/)
+1. either install and use the [dcosdev tool](https://github.com/mesosphere/dcosdev) or follow the example of [hello-world framework](frameworks/helloworld)
 
-```yaml
-name: "helloworld"
-pods:
-  helloworld:
-    count: {{COUNT}}
-    tasks:
-      server:
-        goal: RUNNING
-        cmd: "echo 'Hello World!' >> helloworld-container-volume/output && sleep 10"
-        cpus: {{SERVER_CPU}}
-        memory: 32
-        volume:
-          path: "helloworld-container-volume"
-          type: ROOT
-          size: 64
-```
-
-In the above YAML file, we have:
-* Defined a service with the name `helloworld`
-* Defined a pod specification for our `helloworld` pod using:
-
-```yaml
-pods:
-  helloworld:
-    count: {{COUNT}}
-    tasks:
-      ...
-```
-* Declared that we need at least `{{COUNT}}` instances of the `helloworld` pod running at all times, where `COUNT` is the environment variable that is injected into the scheduler process at launch time via Marathon. It defaults to `1` for this example.
-* Defined a task specification for our `server` task using:
-
-```yaml
-tasks:
-  server:
-    goal: RUNNING
-    cmd: "echo 'Hello World!' >> helloworld-container-volume/output && sleep 10"
-    cpus: {{SERVER_CPU}}
-    memory: 32
-```
-We have configured it to use `{{SERVER_CPU}}` CPUs (which defaults to `0.5` for this example) and `32 MB` of memory.
-* And finally, configured a `64 MB` persistent volume for our server task where the task data can be persisted using:
-
-```yaml
-volume:
-  path: "helloworld-container-volume"
-  type: ROOT
-  size: 64
-```
+To update an existing framework to use the latest version of the SDK:
+1. review the [SDK changelog](changelog.md), and
+1. refer to the current [update instructions](tools/distribution/UPDATING.md)
 
 ---
 ### References

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 ## Changes to v0.56.0
 
 - [DCOS-49197](https://jira.mesosphere.com/browse/DCOS-49197) Introduce new service status codes.
+- [DCOS-48777](https://jira.mesosphere.com/browse/DCOS-48777) The `init` developer helper script in docker image was renamed to `copy-files`
 
 ## Changes to v0.55.5
 


### PR DESCRIPTION
Remove the short section on the service spec - there is a very similar but
better one in the developer guide already, and it's not really appropriate
to attack a complete newcomer with such details.

Instead, re-add the quick-start section that should be more useful to
someone who wants to start using the SDK. In there, point them at the
dcosdev tool and the helloworld example for the lack of a better HOWTO
guide.