### PR TITLE
Bump SDK version to 0.56.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ allprojects {
     // 2. In the GitHub UI, add a Release entry against the tag created in step 1. List any changes in release notes.
     // 3. Create a PR which bumps this from '0.10.0-SNAPSHOT' to '0.11.0-SNAPSHOT' in master to start the 0.11.0 track.
     // --
-    version = '0.56.0-SNAPSHOT'
+    version = '0.56.0'
 
     sourceCompatibility = '1.8'
     targetCompatibility = '1.8'


### PR DESCRIPTION
## What changes are proposed in this PR? 

Resolves [DCOS-51580](https://jira.mesosphere.com/browse/DCOS-51580)

This PR bumps the SDK to version `0.56.0` (see [release notes](https://github.com/mesosphere/dcos-commons/releases/tag/0.56.0)). 

## How were these changes tested?
TC CI tests 