### PR TITLE
[Dcos-53277] generalize auth n+z configs

### DIFF
--- a/frameworks/cassandra/src/main/dist/cassandra.yaml
+++ b/frameworks/cassandra/src/main/dist/cassandra.yaml
@@ -93,7 +93,7 @@ gc_warn_threshold_in_ms: 1000
 enable_user_defined_functions: {{CASSANDRA_ENABLE_USER_DEFINED_FUNCTIONS}}
 enable_scripted_user_defined_functions: {{CASSANDRA_ENABLE_SCRIPTED_USER_DEFINED_FUNCTIONS}}
 windows_timer_interval: 1
-role_manager: CassandraRoleManager
+role_manager: {{ROLE_MANAGER}}
 roles_validity_in_ms: {{ROLES_VALIDITY_IN_MS}}
 permissions_validity_in_ms: {{PERMISSIONS_VALIDITY_IN_MS}}
 disk_failure_policy: {{CASSANDRA_DISK_FAILURE_POLICY}}
@@ -143,6 +143,6 @@ otc_coalescing_strategy: {{CASSANDRA_OTC_COALESCING_STRATEGY}}
 credentials_validity_in_ms: {{CREDENTIALS_VALIDITY_IN_MS}}
 credentials_update_interval_in_ms: {{CREDENTIALS_UPDATE_INTERVAL_IN_MS}}
 
-{{#CUSTOM_YAML_BLOCK_BASE64}}
-{{{CUSTOM_YAML_BLOCK}}}
-{{/CUSTOM_YAML_BLOCK_BASE64}}
+{{#AUTHENTICATION_CUSTOM_YAML_BLOCK_BASE64}}
+{{{AUTHENTICATION_CUSTOM_YAML_BLOCK}}}
+{{/AUTHENTICATION_CUSTOM_YAML_BLOCK_BASE64}}

--- a/frameworks/cassandra/src/main/dist/cassandra.yaml
+++ b/frameworks/cassandra/src/main/dist/cassandra.yaml
@@ -18,8 +18,8 @@ max_hints_delivery_threads: {{CASSANDRA_MAX_HINTS_DELIVERY_THREADS}}
 hints_flush_period_in_ms: {{CASSANDRA_HINTS_FLUSH_PERIOD_IN_MS}}
 max_hints_file_size_in_mb: {{CASSANDRA_MAX_HINTS_FILE_SIZE_IN_MB}}
 batchlog_replay_throttle_in_kb: {{CASSANDRA_BATCHLOG_REPLAY_THROTTLE_IN_KB}}
-authenticator: {{AUTHENTICATOR}}
-authorizer: {{AUTHORIZER}}
+authenticator: {{CASSANDRA_AUTHENTICATOR}}
+authorizer: {{CASSANDRA_AUTHORIZER}}
 partitioner: {{CASSANDRA_PARTITIONER}}
 key_cache_save_period: {{CASSANDRA_KEY_CACHE_SAVE_PERIOD}}
 row_cache_size_in_mb: {{CASSANDRA_ROW_CACHE_SIZE_IN_MB}}

--- a/frameworks/cassandra/src/main/dist/cassandra.yaml
+++ b/frameworks/cassandra/src/main/dist/cassandra.yaml
@@ -18,8 +18,8 @@ max_hints_delivery_threads: {{CASSANDRA_MAX_HINTS_DELIVERY_THREADS}}
 hints_flush_period_in_ms: {{CASSANDRA_HINTS_FLUSH_PERIOD_IN_MS}}
 max_hints_file_size_in_mb: {{CASSANDRA_MAX_HINTS_FILE_SIZE_IN_MB}}
 batchlog_replay_throttle_in_kb: {{CASSANDRA_BATCHLOG_REPLAY_THROTTLE_IN_KB}}
-authenticator: {{CASSANDRA_AUTHENTICATOR}}
-authorizer: {{CASSANDRA_AUTHORIZER}}
+authenticator: {{AUTHENTICATOR}}
+authorizer: {{AUTHORIZER}}
 partitioner: {{CASSANDRA_PARTITIONER}}
 key_cache_save_period: {{CASSANDRA_KEY_CACHE_SAVE_PERIOD}}
 row_cache_size_in_mb: {{CASSANDRA_ROW_CACHE_SIZE_IN_MB}}
@@ -142,7 +142,7 @@ max_value_size_in_mb: {{CASSANDRA_MAX_VALUE_SIZE_IN_MB}}
 otc_coalescing_strategy: {{CASSANDRA_OTC_COALESCING_STRATEGY}}
 credentials_validity_in_ms: {{CREDENTIALS_VALIDITY_IN_MS}}
 credentials_update_interval_in_ms: {{CREDENTIALS_UPDATE_INTERVAL_IN_MS}}
-
+permissions_cache_max_entries: {{PERMISSIONS_CACHE_MAX_ENTRIES}}
 {{#AUTHENTICATION_CUSTOM_YAML_BLOCK_BASE64}}
 {{{AUTHENTICATION_CUSTOM_YAML_BLOCK}}}
 {{/AUTHENTICATION_CUSTOM_YAML_BLOCK_BASE64}}

--- a/frameworks/cassandra/src/main/dist/cassandra.yaml
+++ b/frameworks/cassandra/src/main/dist/cassandra.yaml
@@ -142,3 +142,7 @@ max_value_size_in_mb: {{CASSANDRA_MAX_VALUE_SIZE_IN_MB}}
 otc_coalescing_strategy: {{CASSANDRA_OTC_COALESCING_STRATEGY}}
 credentials_validity_in_ms: {{CREDENTIALS_VALIDITY_IN_MS}}
 credentials_update_interval_in_ms: {{CREDENTIALS_UPDATE_INTERVAL_IN_MS}}
+
+{{#CUSTOM_YAML_BLOCK_BASE64}}
+{{{CUSTOM_YAML_BLOCK}}}
+{{/CUSTOM_YAML_BLOCK_BASE64}}

--- a/frameworks/cassandra/src/main/dist/svc.yml
+++ b/frameworks/cassandra/src/main/dist/svc.yml
@@ -11,12 +11,12 @@ pods:
       {{VIRTUAL_NETWORK_NAME}}:
         labels: {{VIRTUAL_NETWORK_PLUGIN_LABELS}}
     {{/ENABLE_VIRTUAL_NETWORK}}
-    {{#TASKCFG_ALL_PASSWORD_SECRET_PATH}}
+    {{#TASKCFG_ALL_IS_PASSWORD_AUTHENTICATOR}}
     secrets:
       publicapikey:
         secret: {{TASKCFG_ALL_PASSWORD_SECRET_PATH}}
         file: new_user_password
-    {{/TASKCFG_ALL_PASSWORD_SECRET_PATH}}
+    {{/TASKCFG_ALL_IS_PASSWORD_AUTHENTICATOR}}
     volume:
       path: container-path
       type: {{CASSANDRA_DISK_TYPE}}
@@ -122,7 +122,7 @@ pods:
         {{/TASKCFG_ALL_SECURITY_TRANSPORT_ENCRYPTION_ENABLED}}
                 mkdir container-path/snapshot ;
                 {{#SECURITY_AUTHENTICATION_ENABLED}}
-                if [ "{{TASKCFG_ALL_AUTHENTICATOR}}" = "PasswordAuthenticator" ]; then
+                if [ "{{TASKCFG_ALL_CASSANDRA_AUTHENTICATOR}}" = "PasswordAuthenticator" ]; then
                 export NEW_USER_PASSWORD=`cat $MESOS_SANDBOX/new_user_password`;
                 ./apache-cassandra-{{CASSANDRA_VERSION}}/bin/cqlsh -u {{TASKCFG_ALL_NEW_SUPERUSER}} -p ${NEW_USER_PASSWORD} {{{CASSANDRA_CQLSH_SSL_FLAGS}}} -e "DESC SCHEMA" "node-${POD_INSTANCE_INDEX}-server.${FRAMEWORK_HOST}" ${CASSANDRA_NATIVE_TRANSPORT_PORT} > container-path/snapshot/schema.cql
                 fi
@@ -212,7 +212,7 @@ pods:
                 export SSL_CERTFILE=$MESOS_SANDBOX/cqlsh.ca ;
         {{/TASKCFG_ALL_SECURITY_TRANSPORT_ENCRYPTION_ENABLED}}
                 {{#SECURITY_AUTHENTICATION_ENABLED}}
-                if [ "{{TASKCFG_ALL_AUTHENTICATOR}}" = "PasswordAuthenticator" ]; then
+                if [ "{{TASKCFG_ALL_CASSANDRA_AUTHENTICATOR}}" = "PasswordAuthenticator" ]; then
                 export NEW_USER_PASSWORD=`cat $MESOS_SANDBOX/new_user_password`;
                 ./apache-cassandra-{{CASSANDRA_VERSION}}/bin/cqlsh -u {{TASKCFG_ALL_NEW_SUPERUSER}} -p ${NEW_USER_PASSWORD} {{{CASSANDRA_CQLSH_SSL_FLAGS}}} -e "source 'container-path/snapshot/schema.cql'" node-${POD_INSTANCE_INDEX}-server.${FRAMEWORK_HOST} ${CASSANDRA_NATIVE_TRANSPORT_PORT}
                 fi
@@ -282,7 +282,7 @@ pods:
                 {{/TASKCFG_ALL_SECURITY_TRANSPORT_ENCRYPTION_ENABLED}}
                 ./bootstrap --resolve=false &&
                 {{#SECURITY_AUTHENTICATION_ENABLED}}
-                if [ "{{TASKCFG_ALL_AUTHENTICATOR}}" = "PasswordAuthenticator" ]; then
+                {{#TASKCFG_ALL_IS_PASSWORD_AUTHENTICATOR}}
                     export NEW_USER_PASSWORD=`cat $MESOS_SANDBOX/new_user_password` &&
                     export NEW_RANDOM_PASSWORD=`cat /dev/urandom | tr -cd 'a-f0-9' | head -c 32` &&
                     cqlsh -u cassandra -p cassandra {{{CASSANDRA_CQLSH_SSL_FLAGS}}} -e "alter keyspace system_traces      WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3};" "node-0-server.${FRAMEWORK_HOST}" {{TASKCFG_ALL_CASSANDRA_NATIVE_TRANSPORT_PORT}} &&
@@ -291,7 +291,7 @@ pods:
                     nodetool repair system_auth &&
                     cqlsh -u cassandra -p cassandra {{{CASSANDRA_CQLSH_SSL_FLAGS}}} -e "CREATE ROLE {{TASKCFG_ALL_NEW_SUPERUSER}} WITH PASSWORD = '${NEW_USER_PASSWORD}' AND SUPERUSER = true AND LOGIN = true;" "node-0-server.${FRAMEWORK_HOST}" {{TASKCFG_ALL_CASSANDRA_NATIVE_TRANSPORT_PORT}} &&
                     cqlsh -u {{TASKCFG_ALL_NEW_SUPERUSER}} -p ${NEW_USER_PASSWORD} {{{CASSANDRA_CQLSH_SSL_FLAGS}}} -e "ALTER ROLE cassandra WITH PASSWORD='${NEW_RANDOM_PASSWORD}' AND SUPERUSER=false;" "node-0-server.${FRAMEWORK_HOST}" {{TASKCFG_ALL_CASSANDRA_NATIVE_TRANSPORT_PORT}}
-                fi
+                {{/TASKCFG_ALL_IS_PASSWORD_AUTHENTICATOR}}
                 {{/SECURITY_AUTHENTICATION_ENABLED}}
                 {{^SECURITY_AUTHENTICATION_ENABLED}}                
                 cqlsh {{{CASSANDRA_CQLSH_SSL_FLAGS}}} -e "alter keyspace system_traces      WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3};" "node-0-server.${FRAMEWORK_HOST}" {{TASKCFG_ALL_CASSANDRA_NATIVE_TRANSPORT_PORT}} &&

--- a/frameworks/cassandra/src/main/dist/svc.yml
+++ b/frameworks/cassandra/src/main/dist/svc.yml
@@ -11,12 +11,12 @@ pods:
       {{VIRTUAL_NETWORK_NAME}}:
         labels: {{VIRTUAL_NETWORK_PLUGIN_LABELS}}
     {{/ENABLE_VIRTUAL_NETWORK}}
-    {{#SECURITY_AUTHENTICATION_ENABLED}}
+    {{#TASKCFG_ALL_PASSWORD_SECRET_PATH}}
     secrets:
       publicapikey:
         secret: {{TASKCFG_ALL_PASSWORD_SECRET_PATH}}
         file: new_user_password
-    {{/SECURITY_AUTHENTICATION_ENABLED}}
+    {{/TASKCFG_ALL_PASSWORD_SECRET_PATH}}
     volume:
       path: container-path
       type: {{CASSANDRA_DISK_TYPE}}
@@ -122,8 +122,10 @@ pods:
         {{/TASKCFG_ALL_SECURITY_TRANSPORT_ENCRYPTION_ENABLED}}
                 mkdir container-path/snapshot ;
                 {{#SECURITY_AUTHENTICATION_ENABLED}}
+                if [ "{{TASKCFG_ALL_AUTHENTICATOR}}" = "PasswordAuthenticator" ]; then
                 export NEW_USER_PASSWORD=`cat $MESOS_SANDBOX/new_user_password`;
                 ./apache-cassandra-{{CASSANDRA_VERSION}}/bin/cqlsh -u {{TASKCFG_ALL_NEW_SUPERUSER}} -p ${NEW_USER_PASSWORD} {{{CASSANDRA_CQLSH_SSL_FLAGS}}} -e "DESC SCHEMA" "node-${POD_INSTANCE_INDEX}-server.${FRAMEWORK_HOST}" ${CASSANDRA_NATIVE_TRANSPORT_PORT} > container-path/snapshot/schema.cql
+                fi
                 {{/SECURITY_AUTHENTICATION_ENABLED}}
                 {{^SECURITY_AUTHENTICATION_ENABLED}}
                 ./apache-cassandra-{{CASSANDRA_VERSION}}/bin/cqlsh {{{CASSANDRA_CQLSH_SSL_FLAGS}}} -e "DESC SCHEMA" "node-${POD_INSTANCE_INDEX}-server.${FRAMEWORK_HOST}" ${CASSANDRA_NATIVE_TRANSPORT_PORT} > container-path/snapshot/schema.cql
@@ -210,8 +212,10 @@ pods:
                 export SSL_CERTFILE=$MESOS_SANDBOX/cqlsh.ca ;
         {{/TASKCFG_ALL_SECURITY_TRANSPORT_ENCRYPTION_ENABLED}}
                 {{#SECURITY_AUTHENTICATION_ENABLED}}
+                if [ "{{TASKCFG_ALL_AUTHENTICATOR}}" = "PasswordAuthenticator" ]; then
                 export NEW_USER_PASSWORD=`cat $MESOS_SANDBOX/new_user_password`;
                 ./apache-cassandra-{{CASSANDRA_VERSION}}/bin/cqlsh -u {{TASKCFG_ALL_NEW_SUPERUSER}} -p ${NEW_USER_PASSWORD} {{{CASSANDRA_CQLSH_SSL_FLAGS}}} -e "source 'container-path/snapshot/schema.cql'" node-${POD_INSTANCE_INDEX}-server.${FRAMEWORK_HOST} ${CASSANDRA_NATIVE_TRANSPORT_PORT}
+                fi
                 {{/SECURITY_AUTHENTICATION_ENABLED}}
                 {{^SECURITY_AUTHENTICATION_ENABLED}}
                 ./apache-cassandra-{{CASSANDRA_VERSION}}/bin/cqlsh {{{CASSANDRA_CQLSH_SSL_FLAGS}}} -e "source 'container-path/snapshot/schema.cql'" node-${POD_INSTANCE_INDEX}-server.${FRAMEWORK_HOST} ${CASSANDRA_NATIVE_TRANSPORT_PORT}
@@ -276,18 +280,18 @@ pods:
                 {{#TASKCFG_ALL_SECURITY_TRANSPORT_ENCRYPTION_ENABLED}}
                 export SSL_CERTFILE=$MESOS_SANDBOX/cqlsh.ca ;
                 {{/TASKCFG_ALL_SECURITY_TRANSPORT_ENCRYPTION_ENABLED}}
-                {{#SECURITY_AUTHENTICATION_ENABLED}}
-                export NEW_USER_PASSWORD=`cat $MESOS_SANDBOX/new_user_password`;                
-                export NEW_RANDOM_PASSWORD=`cat /dev/urandom | tr -cd 'a-f0-9' | head -c 32`;
-                {{/SECURITY_AUTHENTICATION_ENABLED}}                
                 ./bootstrap --resolve=false &&
                 {{#SECURITY_AUTHENTICATION_ENABLED}}
-                cqlsh -u cassandra -p cassandra {{{CASSANDRA_CQLSH_SSL_FLAGS}}} -e "alter keyspace system_traces      WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3};" "node-0-server.${FRAMEWORK_HOST}" {{TASKCFG_ALL_CASSANDRA_NATIVE_TRANSPORT_PORT}} &&
-                cqlsh -u cassandra -p cassandra {{{CASSANDRA_CQLSH_SSL_FLAGS}}} -e "alter keyspace system_auth        WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3};" "node-0-server.${FRAMEWORK_HOST}" {{TASKCFG_ALL_CASSANDRA_NATIVE_TRANSPORT_PORT}} &&
-                cqlsh -u cassandra -p cassandra {{{CASSANDRA_CQLSH_SSL_FLAGS}}} -e "alter keyspace system_distributed WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3};" "node-0-server.${FRAMEWORK_HOST}" {{TASKCFG_ALL_CASSANDRA_NATIVE_TRANSPORT_PORT}} &&
-                nodetool repair system_auth &&
-                cqlsh -u cassandra -p cassandra {{{CASSANDRA_CQLSH_SSL_FLAGS}}} -e "CREATE ROLE {{TASKCFG_ALL_NEW_SUPERUSER}} WITH PASSWORD = '${NEW_USER_PASSWORD}' AND SUPERUSER = true AND LOGIN = true;" "node-0-server.${FRAMEWORK_HOST}" {{TASKCFG_ALL_CASSANDRA_NATIVE_TRANSPORT_PORT}} &&
-                cqlsh -u {{TASKCFG_ALL_NEW_SUPERUSER}} -p ${NEW_USER_PASSWORD} {{{CASSANDRA_CQLSH_SSL_FLAGS}}} -e "ALTER ROLE cassandra WITH PASSWORD='${NEW_RANDOM_PASSWORD}' AND SUPERUSER=false;" "node-0-server.${FRAMEWORK_HOST}" {{TASKCFG_ALL_CASSANDRA_NATIVE_TRANSPORT_PORT}}
+                if [ "{{TASKCFG_ALL_AUTHENTICATOR}}" = "PasswordAuthenticator" ]; then
+                    export NEW_USER_PASSWORD=`cat $MESOS_SANDBOX/new_user_password` &&
+                    export NEW_RANDOM_PASSWORD=`cat /dev/urandom | tr -cd 'a-f0-9' | head -c 32` &&
+                    cqlsh -u cassandra -p cassandra {{{CASSANDRA_CQLSH_SSL_FLAGS}}} -e "alter keyspace system_traces      WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3};" "node-0-server.${FRAMEWORK_HOST}" {{TASKCFG_ALL_CASSANDRA_NATIVE_TRANSPORT_PORT}} &&
+                    cqlsh -u cassandra -p cassandra {{{CASSANDRA_CQLSH_SSL_FLAGS}}} -e "alter keyspace system_auth        WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3};" "node-0-server.${FRAMEWORK_HOST}" {{TASKCFG_ALL_CASSANDRA_NATIVE_TRANSPORT_PORT}} &&
+                    cqlsh -u cassandra -p cassandra {{{CASSANDRA_CQLSH_SSL_FLAGS}}} -e "alter keyspace system_distributed WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3};" "node-0-server.${FRAMEWORK_HOST}" {{TASKCFG_ALL_CASSANDRA_NATIVE_TRANSPORT_PORT}} &&
+                    nodetool repair system_auth &&
+                    cqlsh -u cassandra -p cassandra {{{CASSANDRA_CQLSH_SSL_FLAGS}}} -e "CREATE ROLE {{TASKCFG_ALL_NEW_SUPERUSER}} WITH PASSWORD = '${NEW_USER_PASSWORD}' AND SUPERUSER = true AND LOGIN = true;" "node-0-server.${FRAMEWORK_HOST}" {{TASKCFG_ALL_CASSANDRA_NATIVE_TRANSPORT_PORT}} &&
+                    cqlsh -u {{TASKCFG_ALL_NEW_SUPERUSER}} -p ${NEW_USER_PASSWORD} {{{CASSANDRA_CQLSH_SSL_FLAGS}}} -e "ALTER ROLE cassandra WITH PASSWORD='${NEW_RANDOM_PASSWORD}' AND SUPERUSER=false;" "node-0-server.${FRAMEWORK_HOST}" {{TASKCFG_ALL_CASSANDRA_NATIVE_TRANSPORT_PORT}}
+                fi
                 {{/SECURITY_AUTHENTICATION_ENABLED}}
                 {{^SECURITY_AUTHENTICATION_ENABLED}}                
                 cqlsh {{{CASSANDRA_CQLSH_SSL_FLAGS}}} -e "alter keyspace system_traces      WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3};" "node-0-server.${FRAMEWORK_HOST}" {{TASKCFG_ALL_CASSANDRA_NATIVE_TRANSPORT_PORT}} &&

--- a/frameworks/cassandra/src/main/dist/svc.yml
+++ b/frameworks/cassandra/src/main/dist/svc.yml
@@ -11,12 +11,12 @@ pods:
       {{VIRTUAL_NETWORK_NAME}}:
         labels: {{VIRTUAL_NETWORK_PLUGIN_LABELS}}
     {{/ENABLE_VIRTUAL_NETWORK}}
-    {{#TASKCFG_ALL_IS_PASSWORD_AUTHENTICATOR}}
+    {{#TASKCFG_ALL_PASSWORD_SECRET_PATH}}
     secrets:
       publicapikey:
         secret: {{TASKCFG_ALL_PASSWORD_SECRET_PATH}}
         file: new_user_password
-    {{/TASKCFG_ALL_IS_PASSWORD_AUTHENTICATOR}}
+    {{/TASKCFG_ALL_PASSWORD_SECRET_PATH}}
     volume:
       path: container-path
       type: {{CASSANDRA_DISK_TYPE}}
@@ -282,7 +282,7 @@ pods:
                 {{/TASKCFG_ALL_SECURITY_TRANSPORT_ENCRYPTION_ENABLED}}
                 ./bootstrap --resolve=false &&
                 {{#SECURITY_AUTHENTICATION_ENABLED}}
-                {{#TASKCFG_ALL_IS_PASSWORD_AUTHENTICATOR}}
+                if [ "{{TASKCFG_ALL_CASSANDRA_AUTHENTICATOR}}" = "PasswordAuthenticator" ]; then
                     export NEW_USER_PASSWORD=`cat $MESOS_SANDBOX/new_user_password` &&
                     export NEW_RANDOM_PASSWORD=`cat /dev/urandom | tr -cd 'a-f0-9' | head -c 32` &&
                     cqlsh -u cassandra -p cassandra {{{CASSANDRA_CQLSH_SSL_FLAGS}}} -e "alter keyspace system_traces      WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3};" "node-0-server.${FRAMEWORK_HOST}" {{TASKCFG_ALL_CASSANDRA_NATIVE_TRANSPORT_PORT}} &&
@@ -291,7 +291,7 @@ pods:
                     nodetool repair system_auth &&
                     cqlsh -u cassandra -p cassandra {{{CASSANDRA_CQLSH_SSL_FLAGS}}} -e "CREATE ROLE {{TASKCFG_ALL_NEW_SUPERUSER}} WITH PASSWORD = '${NEW_USER_PASSWORD}' AND SUPERUSER = true AND LOGIN = true;" "node-0-server.${FRAMEWORK_HOST}" {{TASKCFG_ALL_CASSANDRA_NATIVE_TRANSPORT_PORT}} &&
                     cqlsh -u {{TASKCFG_ALL_NEW_SUPERUSER}} -p ${NEW_USER_PASSWORD} {{{CASSANDRA_CQLSH_SSL_FLAGS}}} -e "ALTER ROLE cassandra WITH PASSWORD='${NEW_RANDOM_PASSWORD}' AND SUPERUSER=false;" "node-0-server.${FRAMEWORK_HOST}" {{TASKCFG_ALL_CASSANDRA_NATIVE_TRANSPORT_PORT}}
-                {{/TASKCFG_ALL_IS_PASSWORD_AUTHENTICATOR}}
+                fi
                 {{/SECURITY_AUTHENTICATION_ENABLED}}
                 {{^SECURITY_AUTHENTICATION_ENABLED}}                
                 cqlsh {{{CASSANDRA_CQLSH_SSL_FLAGS}}} -e "alter keyspace system_traces      WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3};" "node-0-server.${FRAMEWORK_HOST}" {{TASKCFG_ALL_CASSANDRA_NATIVE_TRANSPORT_PORT}} &&

--- a/frameworks/cassandra/src/main/java/com/mesosphere/sdk/cassandra/scheduler/Main.java
+++ b/frameworks/cassandra/src/main/java/com/mesosphere/sdk/cassandra/scheduler/Main.java
@@ -55,11 +55,11 @@ public final class Main {
 
     String yamlBase64 = System.getenv(AUTHENTICATION_CUSTOM_YAML_BLOCK_BASE64_ENV);
     if (yamlBase64 != null && yamlBase64.length() > 0) {
-      String esYamlBlock = new String(
+      String yamlBlock = new String(
           Base64.getDecoder().decode(yamlBase64),
           StandardCharsets.UTF_8
       );
-      serviceSpecGenerator.setAllPodsEnv("AUTHENTICATION_CUSTOM_YAML_BLOCK", esYamlBlock);
+      serviceSpecGenerator.setAllPodsEnv("AUTHENTICATION_CUSTOM_YAML_BLOCK", yamlBlock);
     }
 
     return DefaultScheduler.newBuilder(serviceSpecGenerator.build(), schedulerConfig)

--- a/frameworks/cassandra/src/main/java/com/mesosphere/sdk/cassandra/scheduler/Main.java
+++ b/frameworks/cassandra/src/main/java/com/mesosphere/sdk/cassandra/scheduler/Main.java
@@ -28,6 +28,8 @@ public final class Main {
   private static final String AUTHENTICATION_CUSTOM_YAML_BLOCK_BASE64_ENV =
       "TASKCFG_ALL_AUTHENTICATION_CUSTOM_YAML_BLOCK_BASE64";
 
+  private static final String CASSANDRA_AUTHENTICATOR_ENV = "TASKCFG_ALL_CASSANDRA_AUTHENTICATOR";
+
   private Main() {}
 
   public static void main(String[] args) throws Exception {
@@ -55,12 +57,20 @@ public final class Main {
 
     String yamlBase64 = System.getenv(AUTHENTICATION_CUSTOM_YAML_BLOCK_BASE64_ENV);
     if (yamlBase64 != null && yamlBase64.length() > 0) {
-      String esYamlBlock = new String(
+      String yamlBlock = new String(
           Base64.getDecoder().decode(yamlBase64),
           StandardCharsets.UTF_8
       );
-      serviceSpecGenerator.setAllPodsEnv("AUTHENTICATION_CUSTOM_YAML_BLOCK", esYamlBlock);
+      serviceSpecGenerator.setAllPodsEnv("AUTHENTICATION_CUSTOM_YAML_BLOCK", yamlBlock);
     }
+
+    String cassandraAuthenticator = System.getenv(CASSANDRA_AUTHENTICATOR_ENV);
+    String isPasswordAuthenticator = "";
+    if ("PasswordAuthenticator".equals(cassandraAuthenticator)) {
+      isPasswordAuthenticator = "PasswordAuthenticator";
+    }
+    serviceSpecGenerator.setAllPodsEnv("TASKCFG_ALL_IS_PASSWORD_AUTHENTICATOR",
+        isPasswordAuthenticator);
 
     return DefaultScheduler.newBuilder(serviceSpecGenerator.build(), schedulerConfig)
         // Disallow changing the DC/Rack. Earlier versions of the Cassandra service didn't set these envvars so

--- a/frameworks/cassandra/src/main/java/com/mesosphere/sdk/cassandra/scheduler/Main.java
+++ b/frameworks/cassandra/src/main/java/com/mesosphere/sdk/cassandra/scheduler/Main.java
@@ -25,7 +25,7 @@ import java.util.List;
  * Main entry point for the Scheduler.
  */
 public final class Main {
-  private static final String CUSTOM_YAML_BLOCK_BASE64_ENV = "CUSTOM_YAML_BLOCK_BASE64";
+  private static final String CUSTOM_YAML_BLOCK_BASE64_ENV = "TASKCFG_ALL_CUSTOM_YAML_BLOCK_BASE64";
 
   private Main() {}
 

--- a/frameworks/cassandra/src/main/java/com/mesosphere/sdk/cassandra/scheduler/Main.java
+++ b/frameworks/cassandra/src/main/java/com/mesosphere/sdk/cassandra/scheduler/Main.java
@@ -25,7 +25,8 @@ import java.util.List;
  * Main entry point for the Scheduler.
  */
 public final class Main {
-  private static final String CUSTOM_YAML_BLOCK_BASE64_ENV = "TASKCFG_ALL_CUSTOM_YAML_BLOCK_BASE64";
+  private static final String AUTHENTICATION_CUSTOM_YAML_BLOCK_BASE64_ENV =
+      "TASKCFG_ALL_AUTHENTICATION_CUSTOM_YAML_BLOCK_BASE64";
 
   private Main() {}
 
@@ -52,13 +53,13 @@ public final class Main {
             rawServiceSpec, schedulerConfig, yamlSpecFile.getParentFile())
             .setAllPodsEnv("LOCAL_SEEDS", Joiner.on(',').join(localSeeds));
 
-    String yamlBase64 = System.getenv(CUSTOM_YAML_BLOCK_BASE64_ENV);
+    String yamlBase64 = System.getenv(AUTHENTICATION_CUSTOM_YAML_BLOCK_BASE64_ENV);
     if (yamlBase64 != null && yamlBase64.length() > 0) {
       String esYamlBlock = new String(
           Base64.getDecoder().decode(yamlBase64),
           StandardCharsets.UTF_8
       );
-      serviceSpecGenerator.setAllPodsEnv("CUSTOM_YAML_BLOCK", esYamlBlock);
+      serviceSpecGenerator.setAllPodsEnv("AUTHENTICATION_CUSTOM_YAML_BLOCK", esYamlBlock);
     }
 
     return DefaultScheduler.newBuilder(serviceSpecGenerator.build(), schedulerConfig)

--- a/frameworks/cassandra/src/main/java/com/mesosphere/sdk/cassandra/scheduler/Main.java
+++ b/frameworks/cassandra/src/main/java/com/mesosphere/sdk/cassandra/scheduler/Main.java
@@ -13,8 +13,10 @@ import com.google.common.base.Joiner;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -23,6 +25,7 @@ import java.util.List;
  * Main entry point for the Scheduler.
  */
 public final class Main {
+  private static final String CUSTOM_YAML_BLOCK_BASE64_ENV = "CUSTOM_YAML_BLOCK_BASE64";
 
   private Main() {}
 
@@ -44,12 +47,21 @@ public final class Main {
     List<String> localSeeds = CassandraSeedUtils
         .getLocalSeeds(rawServiceSpec.getName(), schedulerConfig);
 
-    return DefaultScheduler.newBuilder(
-        DefaultServiceSpec
-            .newGenerator(rawServiceSpec, schedulerConfig, yamlSpecFile.getParentFile())
-            .setAllPodsEnv("LOCAL_SEEDS", Joiner.on(',').join(localSeeds))
-            .build(),
-        schedulerConfig)
+    DefaultServiceSpec.Generator serviceSpecGenerator =
+        DefaultServiceSpec.newGenerator(
+            rawServiceSpec, schedulerConfig, yamlSpecFile.getParentFile())
+            .setAllPodsEnv("LOCAL_SEEDS", Joiner.on(',').join(localSeeds));
+
+    String yamlBase64 = System.getenv(CUSTOM_YAML_BLOCK_BASE64_ENV);
+    if (yamlBase64 != null && yamlBase64.length() > 0) {
+      String esYamlBlock = new String(
+          Base64.getDecoder().decode(yamlBase64),
+          StandardCharsets.UTF_8
+      );
+      serviceSpecGenerator.setAllPodsEnv("CUSTOM_YAML_BLOCK", esYamlBlock);
+    }
+
+    return DefaultScheduler.newBuilder(serviceSpecGenerator.build(), schedulerConfig)
         // Disallow changing the DC/Rack. Earlier versions of the Cassandra service didn't set these envvars so
         // we need to allow the case where they may have previously been unset:
         .setCustomConfigValidators(Arrays.asList(

--- a/frameworks/cassandra/src/main/java/com/mesosphere/sdk/cassandra/scheduler/Main.java
+++ b/frameworks/cassandra/src/main/java/com/mesosphere/sdk/cassandra/scheduler/Main.java
@@ -28,8 +28,6 @@ public final class Main {
   private static final String AUTHENTICATION_CUSTOM_YAML_BLOCK_BASE64_ENV =
       "TASKCFG_ALL_AUTHENTICATION_CUSTOM_YAML_BLOCK_BASE64";
 
-  private static final String CASSANDRA_AUTHENTICATOR_ENV = "TASKCFG_ALL_CASSANDRA_AUTHENTICATOR";
-
   private Main() {}
 
   public static void main(String[] args) throws Exception {
@@ -57,20 +55,12 @@ public final class Main {
 
     String yamlBase64 = System.getenv(AUTHENTICATION_CUSTOM_YAML_BLOCK_BASE64_ENV);
     if (yamlBase64 != null && yamlBase64.length() > 0) {
-      String yamlBlock = new String(
+      String esYamlBlock = new String(
           Base64.getDecoder().decode(yamlBase64),
           StandardCharsets.UTF_8
       );
-      serviceSpecGenerator.setAllPodsEnv("AUTHENTICATION_CUSTOM_YAML_BLOCK", yamlBlock);
+      serviceSpecGenerator.setAllPodsEnv("AUTHENTICATION_CUSTOM_YAML_BLOCK", esYamlBlock);
     }
-
-    String cassandraAuthenticator = System.getenv(CASSANDRA_AUTHENTICATOR_ENV);
-    String isPasswordAuthenticator = "";
-    if ("PasswordAuthenticator".equals(cassandraAuthenticator)) {
-      isPasswordAuthenticator = "PasswordAuthenticator";
-    }
-    serviceSpecGenerator.setAllPodsEnv("TASKCFG_ALL_IS_PASSWORD_AUTHENTICATOR",
-        isPasswordAuthenticator);
 
     return DefaultScheduler.newBuilder(serviceSpecGenerator.build(), schedulerConfig)
         // Disallow changing the DC/Rack. Earlier versions of the Cassandra service didn't set these envvars so

--- a/frameworks/cassandra/tests/test_auth.py
+++ b/frameworks/cassandra/tests/test_auth.py
@@ -26,7 +26,7 @@ def configure_package(configure_security: None) -> Iterator[None]:
         service_options = {
             "service": {
                 "name": config.SERVICE_NAME,
-                "security": {"authentication": {"enabled": True}, "authorization": {"enabled": True}},
+                "security": {"authentication": {"enabled": True, "superuser": {"password_secret_path": "cassandra/password"}}, "authorization": {"enabled": True}},
             }
         }
 

--- a/frameworks/cassandra/universe/config.json
+++ b/frameworks/cassandra/universe/config.json
@@ -113,13 +113,13 @@
             "description": "DC/OS Apache Cassandra authentication settings",
             "properties": {
                 "enabled": {
-                    "description": "Enable Apache Cassandra's native password authentication",
+                    "description": "Enable authentication",
                     "type": "boolean",
                     "default": false
                 },
                 "superuser": {
                     "type": "object",
-                    "description": "Superuser configuration",
+                    "description": "Provide Superuser configuration for Apache Cassandra's native password authentication",
                     "properties": {
                             "name": {
                                 "type": "string",
@@ -129,24 +129,19 @@
                             "password_secret_path": {
                                 "type": "string",
                                 "description": "The path in the DC/OS Secret Store to retrieve the superuser password from" ,
-                                "default": "cassandra/password"
+                                "default": ""
 			                      }
                         }
-                    },
-                "custom_authenticator": {
+                    },  
+                "authenticator": {
                     "description": " ",
                     "type": "string",
-                    "default": ""
-                },
-                "custom_authorizer": {
-                    "description": " ",
-                    "type": "string",
-                    "default": ""
+                    "default": "PasswordAuthenticator"
                 },
                 "role_manager": {
                     "description": " ",
                     "type": "string",
-                    "default": ""
+                    "default": "CassandraRoleManager"
                 },
                 "authentication_custom_cassandra_yml": {
                     "description": "Custom YAML to be appended to cassandra.yml on each node. This field must be base64 encoded.",
@@ -165,8 +160,13 @@
             "properties": {
                 "enabled": {
                     "type": "boolean",
-                    "description": "Enable Apache Cassandra's native authorization",
+                    "description": "Enable authorization",
                     "default": false
+                },
+                "authorizer": {
+                    "description": "CassandraAuthorizer is set by default for Apache Cassandra's native authorization",
+                    "type": "string",
+                    "default": "CassandraAuthorizer"
                 },
                 "roles_validity_in_ms": {
                     "type": "integer",
@@ -197,6 +197,11 @@
                     "type": "integer",
                     "description": "If enabled, sets refresh interval for the permissions cache. After this interval, cache entries become eligible for refresh. On next access, Cassandra schedules an async reload and returns the old value until the reload completes. If permissions_validity_in_ms is nonzero, permissions_update_interval_in_ms must also be non-zero.",
                     "default": 2000
+                },
+                "permissions_cache_max_entries": {
+                    "type": "integer",
+                    "description": "The maximum number of entries that are held by the standard authentication cache and row-level access control (RLAC) cache.",
+                    "default": 1000
                 }
 
             }

--- a/frameworks/cassandra/universe/config.json
+++ b/frameworks/cassandra/universe/config.json
@@ -130,11 +130,34 @@
                                 "type": "string",
                                 "description": "The path in the DC/OS Secret Store to retrieve the superuser password from" ,
                                 "default": "cassandra/password"
-			    }
+			                      }
                         }
-                    }
-                }
-            
+                    },
+                "custom_authenticator": {
+                    "description": " ",
+                    "type": "string",
+                    "default": ""
+                },
+                "custom_authorizer": {
+                    "description": " ",
+                    "type": "string",
+                    "default": ""
+                },
+                "role_manager": {
+                    "description": " ",
+                    "type": "string",
+                    "default": ""
+                },
+                "authentication_custom_cassandra_yml": {
+                    "description": "Custom YAML to be appended to cassandra.yml on each node. This field must be base64 encoded.",
+                    "type": "string",
+                    "media": {
+                      "binaryEncoding": "base64",
+                      "type": "application/x-yaml"
+                    },
+                    "default": ""
+                  }
+                }     
         },
         "authorization": {
             "type": "object",
@@ -321,15 +344,6 @@
           "type": "string",
           "description": "The name of the cluster managed by the Service",
           "default": "cassandra"
-        },
-        "custom_cassandra_yml": {
-          "description": "Custom YAML to be appended to cassandra.yml on each node. This field must be base64 encoded.",
-          "type": "string",
-          "media": {
-            "binaryEncoding": "base64",
-            "type": "application/x-yaml"
-          },
-          "default": ""
         },
         "jmx_port": {
           "type": "integer",

--- a/frameworks/cassandra/universe/config.json
+++ b/frameworks/cassandra/universe/config.json
@@ -129,7 +129,7 @@
                             "password_secret_path": {
                                 "type": "string",
                                 "description": "The path in the DC/OS Secret Store to retrieve the superuser password from" ,
-                                "default": "cassandra/password"
+                                "default": ""
                             }
                         }
                     },  

--- a/frameworks/cassandra/universe/config.json
+++ b/frameworks/cassandra/universe/config.json
@@ -139,7 +139,7 @@
                     "default": "PasswordAuthenticator"
                 },
                 "role_manager": {
-                    "description": "﻿Part of the Authentication & Authorization backend that implements IRoleManager to maintain grants and memberships between roles, By default, the value set is Apache Cassandra's Out of the box Role Manager: CassandraRoleManager",
+                    "description": "﻿Part of the Authentication & Authorization backend that implements IRoleManager to maintain grants and memberships between roles, By default, the value set is Apache Cassandra's out of the box Role Manager: CassandraRoleManager",
                     "type": "string",
                     "default": "CassandraRoleManager"
                 },

--- a/frameworks/cassandra/universe/config.json
+++ b/frameworks/cassandra/universe/config.json
@@ -129,8 +129,8 @@
                             "password_secret_path": {
                                 "type": "string",
                                 "description": "The path in the DC/OS Secret Store to retrieve the superuser password from" ,
-                                "default": ""
-			                      }
+                                "default": "cassandra/password"
+                            }
                         }
                     },  
                 "authenticator": {

--- a/frameworks/cassandra/universe/config.json
+++ b/frameworks/cassandra/universe/config.json
@@ -322,6 +322,15 @@
           "description": "The name of the cluster managed by the Service",
           "default": "cassandra"
         },
+        "custom_cassandra_yml": {
+          "description": "Custom YAML to be appended to cassandra.yml on each node. This field must be base64 encoded.",
+          "type": "string",
+          "media": {
+            "binaryEncoding": "base64",
+            "type": "application/x-yaml"
+          },
+          "default": ""
+        },
         "jmx_port": {
           "type": "integer",
           "description": "The JMX port that will be used to interface with the Cassandra application.",

--- a/frameworks/cassandra/universe/config.json
+++ b/frameworks/cassandra/universe/config.json
@@ -119,7 +119,7 @@
                 },
                 "superuser": {
                     "type": "object",
-                    "description": "Provide Superuser configuration for Apache Cassandra's native password authentication",
+                    "description": "The super user configuration settings. Only valid when using Apache Cassandra's native PasswordAuthenticator.",
                     "properties": {
                             "name": {
                                 "type": "string",
@@ -128,18 +128,18 @@
                             },
                             "password_secret_path": {
                                 "type": "string",
-                                "description": "The path in the DC/OS Secret Store to retrieve the superuser password from" ,
+                                "description": "The path in the DC/OS Secret Store to retrieve the superuser password from. If using 'PasswordAuthenticator', you must first create the secret in the Secret Store." ,
                                 "default": ""
                             }
                         }
                     },  
                 "authenticator": {
-                    "description": " ",
+                    "description": "The name of the authenticator. By default, the value set is Apache Cassandra's native authenticator: PasswordAuthenticator",
                     "type": "string",
                     "default": "PasswordAuthenticator"
                 },
                 "role_manager": {
-                    "description": " ",
+                    "description": "﻿Part of the Authentication & Authorization backend that implements IRoleManager to maintain grants and memberships between roles, By default, the value set is Apache Cassandra's Out of the box Role Manager: CassandraRoleManager",
                     "type": "string",
                     "default": "CassandraRoleManager"
                 },
@@ -164,7 +164,7 @@
                     "default": false
                 },
                 "authorizer": {
-                    "description": "CassandraAuthorizer is set by default for Apache Cassandra's native authorization",
+                    "description": "The name of the authorizer. By default, the value set is Apache Cassandra's native authorizer: CassandraAuthorizer",
                     "type": "string",
                     "default": "CassandraAuthorizer"
                 },

--- a/frameworks/cassandra/universe/marathon.json.mustache
+++ b/frameworks/cassandra/universe/marathon.json.mustache
@@ -64,10 +64,10 @@
     "SECURITY_AUTHORIZATION_ENABLED": "{{service.security.authorization.enabled}}",
     
     {{#service.security.authentication.enabled}}
-    "TASKCFG_ALL_AUTHENTICATOR": "{{service.security.authentication.authenticator}}",
+    "TASKCFG_ALL_CASSANDRA_AUTHENTICATOR": "{{service.security.authentication.authenticator}}",
     {{/service.security.authentication.enabled}}
     {{^service.security.authentication.enabled}}
-    "TASKCFG_ALL_AUTHENTICATOR": "AllowAllAuthenticator",
+    "TASKCFG_ALL_CASSANDRA_AUTHENTICATOR": "AllowAllAuthenticator",
     {{/service.security.authentication.enabled}}
     
 
@@ -75,10 +75,10 @@
 
 
     {{#service.security.authorization.enabled}}
-    "TASKCFG_ALL_AUTHORIZER": "{{service.security.authorization.authorizer}}",
+    "TASKCFG_ALL_CASSANDRA_AUTHORIZER": "{{service.security.authorization.authorizer}}",
     {{/service.security.authorization.enabled}}
     {{^service.security.authorization.enabled}}
-    "TASKCFG_ALL_AUTHORIZER": "AllowAllAuthorizer",
+    "TASKCFG_ALL_CASSANDRA_AUTHORIZER": "AllowAllAuthorizer",
     {{/service.security.authorization.enabled}}
 
     "TASKCFG_ALL_NEW_SUPERUSER": "{{service.security.authentication.superuser.name}}",

--- a/frameworks/cassandra/universe/marathon.json.mustache
+++ b/frameworks/cassandra/universe/marathon.json.mustache
@@ -85,6 +85,10 @@
     "TASKCFG_ALL_CREDENTIALS_UPDATE_INTERVAL_IN_MS": "{{service.security.authorization.credentials_update_interval_in_ms}}",
     "TASKCFG_ALL_PERMISSIONS_VALIDITY_IN_MS": "{{service.security.authorization.permissions_validity_in_ms}}",
     "TASKCFG_ALL_PERMISSIONS_UPDATE_INTERVAL_IN_MS": "{{service.security.authorization.permissions_update_interval_in_ms}}",
+    "TASKCFG_ALL_AUTHENTICATION_CUSTOM_YAML_BLOCK_BASE64": "{{service.security.authentication.authentication_custom_cassandra_yml}}",
+    "TASKCFG_ALL_CUSTOM_AUTHENTICATOR": "{{service.security.authentication.custom_authenticator}}",
+    "TASKCFG_ALL_CUSTOM_AUTHORIZER": "{{service.security.authentication.custom_authorizer}}",
+    "TASKCFG_ALL_ROLE_MANAGER": "{{service.security.authentication.role_manager}}",
 
     "TASKCFG_ALL_CASSANDRA_CLUSTER_NAME": "{{cassandra.cluster_name}}",
 
@@ -189,7 +193,6 @@
     "TASKCFG_ALL_REMOTE_SEEDS": "{{service.remote_seeds}}",
     "TASKCFG_ALL_CASSANDRA_LOCATION_DATA_CENTER": "{{service.data_center}}",
     "TASKCFG_ALL_CASSANDRA_LOCATION_RACK": "{{service.rack}}",
-    "TASKCFG_ALL_CUSTOM_YAML_BLOCK_BASE64": "{{cassandra.custom_cassandra_yml}}",
     "BOOTSTRAP_URI": "{{resource.assets.uris.bootstrap-zip}}",
     "CASSANDRA_URI": "{{resource.assets.uris.cassandra-tar-gz}}",
     "JAVA_URI": "{{resource.assets.uris.jre-tar-gz}}",

--- a/frameworks/cassandra/universe/marathon.json.mustache
+++ b/frameworks/cassandra/universe/marathon.json.mustache
@@ -64,17 +64,21 @@
     "SECURITY_AUTHORIZATION_ENABLED": "{{service.security.authorization.enabled}}",
     
     {{#service.security.authentication.enabled}}
-    "TASKCFG_ALL_CASSANDRA_AUTHENTICATOR": "PasswordAuthenticator",
+    "TASKCFG_ALL_AUTHENTICATOR": "{{service.security.authentication.authenticator}}",
     {{/service.security.authentication.enabled}}
     {{^service.security.authentication.enabled}}
-    "TASKCFG_ALL_CASSANDRA_AUTHENTICATOR": "AllowAllAuthenticator",
+    "TASKCFG_ALL_AUTHENTICATOR": "AllowAllAuthenticator",
     {{/service.security.authentication.enabled}}
     
+
+
+
+
     {{#service.security.authorization.enabled}}
-    "TASKCFG_ALL_CASSANDRA_AUTHORIZER": "CassandraAuthorizer",
+    "TASKCFG_ALL_AUTHORIZER": "{{service.security.authorization.authorizer}}",
     {{/service.security.authorization.enabled}}
     {{^service.security.authorization.enabled}}
-    "TASKCFG_ALL_CASSANDRA_AUTHORIZER": "AllowAllAuthorizer",
+    "TASKCFG_ALL_AUTHORIZER": "AllowAllAuthorizer",
     {{/service.security.authorization.enabled}}
 
     "TASKCFG_ALL_NEW_SUPERUSER": "{{service.security.authentication.superuser.name}}",
@@ -85,9 +89,8 @@
     "TASKCFG_ALL_CREDENTIALS_UPDATE_INTERVAL_IN_MS": "{{service.security.authorization.credentials_update_interval_in_ms}}",
     "TASKCFG_ALL_PERMISSIONS_VALIDITY_IN_MS": "{{service.security.authorization.permissions_validity_in_ms}}",
     "TASKCFG_ALL_PERMISSIONS_UPDATE_INTERVAL_IN_MS": "{{service.security.authorization.permissions_update_interval_in_ms}}",
+    "TASKCFG_ALL_PERMISSIONS_CACHE_MAX_ENTRIES": "{{service.security.authorization.permissions_cache_max_entries}}",
     "TASKCFG_ALL_AUTHENTICATION_CUSTOM_YAML_BLOCK_BASE64": "{{service.security.authentication.authentication_custom_cassandra_yml}}",
-    "TASKCFG_ALL_CUSTOM_AUTHENTICATOR": "{{service.security.authentication.custom_authenticator}}",
-    "TASKCFG_ALL_CUSTOM_AUTHORIZER": "{{service.security.authentication.custom_authorizer}}",
     "TASKCFG_ALL_ROLE_MANAGER": "{{service.security.authentication.role_manager}}",
 
     "TASKCFG_ALL_CASSANDRA_CLUSTER_NAME": "{{cassandra.cluster_name}}",

--- a/frameworks/cassandra/universe/marathon.json.mustache
+++ b/frameworks/cassandra/universe/marathon.json.mustache
@@ -189,6 +189,7 @@
     "TASKCFG_ALL_REMOTE_SEEDS": "{{service.remote_seeds}}",
     "TASKCFG_ALL_CASSANDRA_LOCATION_DATA_CENTER": "{{service.data_center}}",
     "TASKCFG_ALL_CASSANDRA_LOCATION_RACK": "{{service.rack}}",
+    "TASKCFG_ALL_CUSTOM_YAML_BLOCK_BASE64": "{{cassandra.custom_cassandra_yml}}",
     "BOOTSTRAP_URI": "{{resource.assets.uris.bootstrap-zip}}",
     "CASSANDRA_URI": "{{resource.assets.uris.cassandra-tar-gz}}",
     "JAVA_URI": "{{resource.assets.uris.jre-tar-gz}}",

--- a/frameworks/cassandra/universe/marathon.json.mustache
+++ b/frameworks/cassandra/universe/marathon.json.mustache
@@ -69,10 +69,6 @@
     {{^service.security.authentication.enabled}}
     "TASKCFG_ALL_CASSANDRA_AUTHENTICATOR": "AllowAllAuthenticator",
     {{/service.security.authentication.enabled}}
-    
-
-
-
 
     {{#service.security.authorization.enabled}}
     "TASKCFG_ALL_CASSANDRA_AUTHORIZER": "{{service.security.authorization.authorizer}}",
@@ -92,7 +88,6 @@
     "TASKCFG_ALL_PERMISSIONS_CACHE_MAX_ENTRIES": "{{service.security.authorization.permissions_cache_max_entries}}",
     "TASKCFG_ALL_AUTHENTICATION_CUSTOM_YAML_BLOCK_BASE64": "{{service.security.authentication.authentication_custom_cassandra_yml}}",
     "TASKCFG_ALL_ROLE_MANAGER": "{{service.security.authentication.role_manager}}",
-
     "TASKCFG_ALL_CASSANDRA_CLUSTER_NAME": "{{cassandra.cluster_name}}",
 
     "NODES": "{{nodes.count}}",


### PR DESCRIPTION
## What changes are proposed in this PR? 

Resolves [DCOS-53277](https://jira.mesosphere.com/browse/DCOS-53277)

Current implementation of AuthN+Z is hardcoded to either AllowAllAuthenticator or PasswordAuthenticator + similar values for authz.
added YAML block to configure cassandra.yaml, it will allow customer to provide custom values.

## How were these changes tested?
TC CI tests 