### PR TITLE
[DCOS-53557][COPS-4781] Expose Kibana web server through an nginx proxy.

### DIFF
--- a/frameworks/elastic/build-kibana.sh
+++ b/frameworks/elastic/build-kibana.sh
@@ -33,7 +33,13 @@ case "$PUBLISH_STEP" in
         ;;
 esac
 
-if [ -n "$PUBLISH_SCRIPT" ]; then
-    TEMPLATE_DOCUMENTATION_PATH="https://docs.mesosphere.com/services/elastic/" \
-        $PUBLISH_SCRIPT kibana "${PACKAGE_VERSION}" ${UNIVERSE_DIR}
+if [ -n "{$PUBLISH_SCRIPT}" ]; then
+  export TEMPLATE_DOCUMENTATION_PATH="https://docs.mesosphere.com/services/elastic/"
+
+  exec "${PUBLISH_SCRIPT}" \
+       kibana \
+       "${PACKAGE_VERSION}" \
+       "${UNIVERSE_DIR}" \
+       "${FRAMEWORK_DIR}/kibana/init.sh" \
+       "${FRAMEWORK_DIR}/kibana/nginx.conf.tmpl"
 fi

--- a/frameworks/elastic/kibana/init.sh
+++ b/frameworks/elastic/kibana/init.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -exo pipefail
+
+export PATH="${PATH}:/usr/sbin"
+
+################################ nginx proxy ###################################
+
+mkdir "${MESOS_SANDBOX}/nginx"
+
+readonly ENV_VARS="\${MESOS_SANDBOX},\${PORT_KIBANA},\${PORT_PROXY},\${FRAMEWORK_NAME},\${MARATHON_APP_LABEL_DCOS_SERVICE_SCHEME}"
+
+envsubst "${ENV_VARS}" < "${MESOS_SANDBOX}/nginx.conf.tmpl" > "${MESOS_SANDBOX}/nginx/nginx.conf"
+
+nginx -c "${MESOS_SANDBOX}/nginx/nginx.conf"
+
+################################# kibana #######################################
+
+readonly KIBANA_PATH="${MESOS_SANDBOX}/kibana-${ELASTIC_VERSION}-linux-x86_64"
+readonly KIBANA_YML_PATH="${KIBANA_PATH}/config/kibana.yml"
+
+cat <<-EOF > "${KIBANA_YML_PATH}"
+	elasticsearch.url: "${ELASTICSEARCH_URL}"
+	elasticsearch.username: "${KIBANA_USER}"
+	elasticsearch.password: "${KIBANA_PASSWORD}"
+
+	server.host: 0.0.0.0
+	server.port: "${PORT_KIBANA}"
+	server.basePath: "/service/${FRAMEWORK_NAME}"
+	server.rewriteBasePath: true
+
+	logging.verbose: true
+
+	xpack.security.encryptionKey: "${MESOS_FRAMEWORK_ID}"
+	xpack.reporting.encryptionKey: "${MESOS_FRAMEWORK_ID}"
+EOF
+
+if [ "${KIBANA_ELASTICSEARCH_TLS}" = "true" ]; then
+  cat <<-EOF >> "${KIBANA_YML_PATH}"
+		elasticsearch.ssl.certificateAuthorities: ${MESOS_SANDBOX}/.ssl/ca-bundle.crt
+	EOF
+fi
+
+exec "${MESOS_SANDBOX}/kibana-$ELASTIC_VERSION-linux-x86_64/bin/kibana"

--- a/frameworks/elastic/kibana/nginx.conf.tmpl
+++ b/frameworks/elastic/kibana/nginx.conf.tmpl
@@ -1,0 +1,58 @@
+worker_processes  1;
+
+error_log  ${MESOS_SANDBOX}/nginx/error.log debug;
+pid        ${MESOS_SANDBOX}/nginx/nginx.pid;
+
+events {
+  worker_connections 1024;
+}
+
+http {
+  include       /etc/nginx/mime.types;
+  default_type  application/octet-stream;
+
+  # Use dcos-net resolver address so that l4lb DNS names can be resolved.
+  resolver 198.51.100.1 ipv6=off;
+
+  fastcgi_temp_path     ${MESOS_SANDBOX}/nginx/fastcgi_temp;
+  uwsgi_cache_path      ${MESOS_SANDBOX}/nginx/uwsgi_cache levels=1:2 use_temp_path=on keys_zone=uwsgi:10m;
+  uwsgi_temp_path       ${MESOS_SANDBOX}/nginx/uwsgi_temp;
+  scgi_cache_path       ${MESOS_SANDBOX}/nginx/scgi_cache levels=1:2 use_temp_path=on keys_zone=scgi:10m;
+  scgi_temp_path        ${MESOS_SANDBOX}/nginx/scgi_temp;
+  client_body_temp_path ${MESOS_SANDBOX}/nginx/client_temp;
+  proxy_cache_path      ${MESOS_SANDBOX}/nginx/proxy_cache levels=1:2 use_temp_path=on keys_zone=proxy:10m;
+  proxy_temp_path       ${MESOS_SANDBOX}/nginx/proxy_temp;
+
+  log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+                  '$status $body_bytes_sent "$http_referer" '
+                  '"$http_user_agent" "$http_x_forwarded_for"';
+
+  access_log ${MESOS_SANDBOX}/nginx/access.log  main;
+
+  rewrite_log on;
+
+  sendfile off;
+
+  keepalive_timeout 65;
+
+  server {
+    listen ${PORT_PROXY};
+
+    # Note we have to define 'upstream' variables below because otherwise, Nginx
+    # will try to resolve the DNS name during bootstrap, which will fail because
+    # the service is not up yet.
+
+    location = /service/${FRAMEWORK_NAME}/ {
+      set $upstream ${MARATHON_APP_LABEL_DCOS_SERVICE_SCHEME}://0.0.0.0:${PORT_KIBANA};
+      rewrite ^(.*)/$ $1/app/kibana break;
+      proxy_set_header Authorization "";
+      proxy_pass $upstream;
+    }
+
+    location /service/${FRAMEWORK_NAME}/ {
+      set $upstream ${MARATHON_APP_LABEL_DCOS_SERVICE_SCHEME}://0.0.0.0:${PORT_KIBANA};
+      proxy_set_header Authorization "";
+      proxy_pass $upstream;
+    }
+  }
+}

--- a/frameworks/elastic/kibana/nginx.conf.tmpl
+++ b/frameworks/elastic/kibana/nginx.conf.tmpl
@@ -27,7 +27,7 @@ http {
                   '$status $body_bytes_sent "$http_referer" '
                   '"$http_user_agent" "$http_x_forwarded_for"';
 
-  access_log ${MESOS_SANDBOX}/nginx/access.log  main;
+  access_log ${MESOS_SANDBOX}/nginx/access.log main;
 
   rewrite_log on;
 
@@ -38,21 +38,34 @@ http {
   server {
     listen ${PORT_PROXY};
 
-    # Note we have to define 'upstream' variables below because otherwise, Nginx
-    # will try to resolve the DNS name during bootstrap, which will fail because
-    # the service is not up yet.
-
-    location = /service/${FRAMEWORK_NAME}/ {
-      set $upstream ${MARATHON_APP_LABEL_DCOS_SERVICE_SCHEME}://0.0.0.0:${PORT_KIBANA};
-      rewrite ^(.*)/$ $1/app/kibana break;
-      proxy_set_header Authorization "";
-      proxy_pass $upstream;
+    # The Kibana web server will incorrectly do redirects to an invalid path
+    # with a doubled "/service/${FRAMEWORK_NAME}" in some cases. This causes at
+    # least a couple of different issues.
+    #
+    # The following location block fixes this.
+    location /service/${FRAMEWORK_NAME}/service/${FRAMEWORK_NAME}/ {
+      port_in_redirect off;
+      rewrite ^/service/${FRAMEWORK_NAME}/(.*)$ /$1 permanent;
     }
 
     location /service/${FRAMEWORK_NAME}/ {
-      set $upstream ${MARATHON_APP_LABEL_DCOS_SERVICE_SCHEME}://0.0.0.0:${PORT_KIBANA};
+      proxy_set_header X-Real-IP "$remote_addr";
+      proxy_set_header X-Forwarded-For "$proxy_add_x_forwarded_for";
+      proxy_set_header Host "$http_host";
+
+      # Admin Router adds an "Authorization" header to requests to its backends.
+      # Kibana tries to interpret "Authorization" headers to authenticate
+      # requests to it, but since the header here contains a DC/OS-related
+      # token, Kibana will fail to process it and log a message like
+      # "Unsupported authentication schema: token=...".
+      #
+      # Hence, we remove the "Authorization" header before it hits the Kibana
+      # web server.
+      #
+      # For more details see DCOS-46801.
       proxy_set_header Authorization "";
-      proxy_pass $upstream;
+
+      proxy_pass ${MARATHON_APP_LABEL_DCOS_SERVICE_SCHEME}://0.0.0.0:${PORT_KIBANA};
     }
   }
 }

--- a/frameworks/elastic/tests/test_sanity.py
+++ b/frameworks/elastic/tests/test_sanity.py
@@ -220,6 +220,7 @@ def test_security_toggle_with_kibana(default_populated_index: None) -> None:
     )
 
     # Verify that it works.
+    config.check_kibana_adminrouter_integration("service/{}/".format(kibana_package_name))
     config.check_kibana_adminrouter_integration("service/{}/app/kibana".format(kibana_package_name))
 
     # Uninstall it.
@@ -286,8 +287,8 @@ def test_security_toggle_with_kibana(default_populated_index: None) -> None:
         insert_strict_options=False,
     )
 
-    # Verify that it works. Notice that with security enabled, one has to access
-    # /service/kibana/login instead of /service/kibana.
+    # Verify that it works.
+    config.check_kibana_adminrouter_integration("service/{}/".format(kibana_package_name))
     config.check_kibana_adminrouter_integration("service/{}/login".format(kibana_package_name))
 
     # Uninstall it.

--- a/frameworks/elastic/tests/test_tls.py
+++ b/frameworks/elastic/tests/test_tls.py
@@ -93,15 +93,13 @@ def kibana_application(elastic_service: Dict[str, Any]) -> Iterator[Dict[str, An
     )
 
     service_options = {
-        "service": {
-            "name": service_name,
-        },
+        "service": {"name": service_name},
         "kibana": {
             "elasticsearch_tls": True,
             "elasticsearch_url": elasticsearch_url,
             "elasticsearch_xpack_security_enabled": True,
             "password": elastic_service["passwords"]["kibana"],
-        }
+        },
     }
 
     try:
@@ -156,9 +154,9 @@ def test_crud_over_tls(elastic_service: Dict[str, Any]) -> None:
 @pytest.mark.tls
 @pytest.mark.sanity
 def test_kibana_tls(kibana_application: Dict[str, Any]) -> None:
-    config.check_kibana_adminrouter_integration(
-        "service/{}/login".format(kibana_application["service"]["name"])
-    )
+    service_name = kibana_application["service"]["name"]
+    config.check_kibana_adminrouter_integration("service/{}/".format(service_name))
+    config.check_kibana_adminrouter_integration("service/{}/login".format(service_name))
 
 
 @pytest.mark.tls

--- a/frameworks/elastic/universe-kibana/marathon.json.mustache
+++ b/frameworks/elastic/universe-kibana/marathon.json.mustache
@@ -63,12 +63,7 @@
   "healthChecks": [
     {
       "protocol": "MESOS_HTTP",
-      {{^kibana.elasticsearch_xpack_security_enabled}}
-      "path": "/service/{{service.name}}/app/kibana",
-      {{/kibana.elasticsearch_xpack_security_enabled}}
-      {{#kibana.elasticsearch_xpack_security_enabled}}
-      "path": "/service/{{service.name}}/login",
-      {{/kibana.elasticsearch_xpack_security_enabled}}
+      "path": "/service/{{service.name}}/",
       "gracePeriodSeconds": 900,
       "intervalSeconds": 30,
       "portIndex": 0,

--- a/frameworks/elastic/universe-kibana/marathon.json.mustache
+++ b/frameworks/elastic/universe-kibana/marathon.json.mustache
@@ -4,15 +4,21 @@
   "mem": {{kibana.mem}},
   "instances": 1,
   "user": "{{service.user}}",
-  "cmd": "echo -e \"elasticsearch.url: $ELASTICSEARCH_URL\nelasticsearch.username: $KIBANA_USER\nelasticsearch.password: $KIBANA_PASSWORD\nserver.host: 0.0.0.0\nserver.port: $PORT_KIBANA\nserver.basePath: /service/$FRAMEWORK_NAME\nserver.rewriteBasePath: false\" > $MESOS_SANDBOX/kibana-$ELASTIC_VERSION-linux-x86_64/config/kibana.yml && echo -e \"\nxpack.security.encryptionKey: $MESOS_FRAMEWORK_ID\nxpack.reporting.encryptionKey: $MESOS_FRAMEWORK_ID\n\" >> $MESOS_SANDBOX/kibana-$ELASTIC_VERSION-linux-x86_64/config/kibana.yml && if [ \"$KIBANA_ELASTICSEARCH_TLS\" = true ]; then echo -e \"\nelasticsearch.ssl.certificateAuthorities: $MESOS_SANDBOX/.ssl/ca-bundle.crt\n\" >> $MESOS_SANDBOX/kibana-$ELASTIC_VERSION-linux-x86_64/config/kibana.yml; fi && env && $MESOS_SANDBOX/kibana-$ELASTIC_VERSION-linux-x86_64/bin/kibana",
+  "container": {
+    "type": "MESOS",
+    "docker": {
+      "image": "{{resource.assets.container.docker.nginx}}"
+    }
+  },
+  "cmd": "./init.sh",
   "labels": {
     "DCOS_SERVICE_NAME": "{{service.name}}",
-    "DCOS_SERVICE_PORT_INDEX": "0",
-    "DCOS_SERVICE_SCHEME": "http"
+    "DCOS_SERVICE_PORT_INDEX": "1",
+    "DCOS_SERVICE_SCHEME": "http",
+    "DCOS_SERVICE_REWRITE_REQUEST_URLS": "false"
   },
   "env": {
     "ELASTIC_VERSION": "{{elastic-version}}",
-    "ELASTIC_STATSD_VERSION": "{{elastic-statsd-version}}",
     "FRAMEWORK_NAME": "{{service.name}}",
     "FRAMEWORK_USER": "{{service.user}}",
     "ELASTICSEARCH_URL": "{{kibana.elasticsearch_url}}",
@@ -23,7 +29,19 @@
     "KIBANA_PASSWORD": "{{kibana.password}}"
   },
   "fetch": [
-    { "uri": "{{resource.assets.uris.kibana-tar-gz}}", "cache": true }
+    {
+      "uri": "{{resource.assets.uris.kibana-tar-gz}}",
+      "cache": true
+    },
+    {
+      "uri": "{{artifact-dir}}/nginx.conf.tmpl",
+      "cache": true
+    },
+    {
+      "uri": "{{artifact-dir}}/init.sh",
+      "cache": true,
+      "executable": true
+    }
   ],
   "upgradeStrategy":{
     "minimumHealthCapacity": 0,
@@ -35,16 +53,21 @@
       "protocol": "tcp",
       "name": "kibana",
       "labels": { "VIP_0": "/web.{{service.name}}:80" }
+    },
+    {
+      "name": "proxy",
+      "port": 0,
+      "protocol": "tcp"
     }
   ],
   "healthChecks": [
     {
       "protocol": "MESOS_HTTP",
       {{^kibana.elasticsearch_xpack_security_enabled}}
-      "path": "/app/kibana",
+      "path": "/service/{{service.name}}/app/kibana",
       {{/kibana.elasticsearch_xpack_security_enabled}}
       {{#kibana.elasticsearch_xpack_security_enabled}}
-      "path": "/login",
+      "path": "/service/{{service.name}}/login",
       {{/kibana.elasticsearch_xpack_security_enabled}}
       "gracePeriodSeconds": 900,
       "intervalSeconds": 30,

--- a/frameworks/elastic/universe-kibana/resource.json
+++ b/frameworks/elastic/universe-kibana/resource.json
@@ -1,7 +1,14 @@
 {
   "assets": {
     "uris": {
-      "kibana-tar-gz": "https://downloads.mesosphere.com/elastic/assets/kibana-{{elastic-version}}-linux-x86_64.tar.gz"
+      "kibana-tar-gz": "https://downloads.mesosphere.com/elastic/assets/kibana-{{elastic-version}}-linux-x86_64.tar.gz",
+      "init-sh": "{{artifact-dir}}/nginx.conf.tmpl",
+      "nginx-conf-tmpl": "{{artifact-dir}}/init.sh"
+    },
+    "container": {
+      "docker": {
+        "nginx": "nginx:1.15.12"
+      }
     }
   },
   "images": {


### PR DESCRIPTION
This was done to address the issue surfaced by COPS-4781: accessing the Kibana service URL resulted in a redirect to an invalid URL. Namely:

```
GET /service/kibana/ => /service/kibana/service/kibana/app/kibana
```

The expected redirect should have been:

```
GET /service/kibana/ => /service/kibana/app/kibana
```

This happened because of a breaking change in Kibana 6.x which caused requests to the Kibana web server hitting the root path (`/`) resulted in an invalid redirect, depicted above.

This could be the place where this bug was introduced:
https://github.com/elastic/kibana/pull/21408/files#diff-230bb53cded88451213fc31d8a4b0774L103

The solution here was to add an nginx proxy in between Admin Router and the Kibana web server, that rewrites requests that would hit the Kibana web server on the root path to hit it on `/app/kibana` instead.

I also took the opportunity to extract the Kibana Marathon app command to an actual bash script, which is much more maintainable than the previous one-line `cmd` directive.