### PR TITLE
[DCOS-53417] Customize the context of base image build job

### DIFF
--- a/Jenkinsfile.dcos-commons-base
+++ b/Jenkinsfile.dcos-commons-base
@@ -1,5 +1,13 @@
 #!/usr/bin/env groovy
 // Configuration for https://jenkins.mesosphere.com/service/jenkins/job/dcos-commons-base%20docker%20image/
+
+void setBuildStatus(String context) {
+    step([
+            $class: "GitHubCommitStatusSetter",
+            contextSource: [$class: "ManuallyEnteredCommitContextSource", context: context],
+    ])
+}
+
 pipeline {
     agent {
         label 'mesos'
@@ -40,5 +48,9 @@ pipeline {
                 }
             }
         }
+    }
+
+    post {
+        setBuildStatus("mesosphere/${IMAGE}")
     }
 }


### PR DESCRIPTION
If this works at all, we can change the other one.
Based on
https://stackoverflow.com/questions/43214730/how-to-set-github-commit-status-with-jenkinsfile-not-using-a-pull-request-builde/47162309#47162309
customizing only the property we need, the rest should work fine by
default.