### PR TITLE
[DCOS-53489] cassandra test_auth failing on DC/OS Open

### DIFF
--- a/frameworks/cassandra/tests/test_auth.py
+++ b/frameworks/cassandra/tests/test_auth.py
@@ -6,7 +6,6 @@ import sdk_jobs
 import sdk_cmd
 import sdk_install
 import sdk_tasks
-import sdk_utils
 import os
 from tests import config
 

--- a/frameworks/cassandra/tests/test_auth.py
+++ b/frameworks/cassandra/tests/test_auth.py
@@ -18,7 +18,7 @@ no_auth_test_for_open_dcos = pytest.mark.skipif(
 )
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="module", autouse=True)
 def configure_package(configure_security: None) -> Iterator[None]:
     test_jobs: List[Dict[str, Any]] = []
     try:

--- a/frameworks/cassandra/tests/test_auth.py
+++ b/frameworks/cassandra/tests/test_auth.py
@@ -6,16 +6,10 @@ import sdk_jobs
 import sdk_cmd
 import sdk_install
 import sdk_tasks
-import os
+import sdk_utils
 from tests import config
 
 log = logging.getLogger(__name__)
-
-
-no_auth_test_for_open_dcos = pytest.mark.skipif(
-    os.environ.get("DCOS_ENTERPRISE", "true").lower() == "true",
-    reason="Feature only supported in DC/OS EE.",
-)
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -55,7 +49,7 @@ def configure_package(configure_security: None) -> Iterator[None]:
             sdk_jobs.remove_job(job)
 
 
-@no_auth_test_for_open_dcos
+@sdk_utils.dcos_ee_only
 @pytest.mark.sanity
 def test_auth() -> None:
     config.verify_client_can_write_read_and_delete_with_auth(
@@ -63,7 +57,7 @@ def test_auth() -> None:
     )
 
 
-@no_auth_test_for_open_dcos
+@sdk_utils.dcos_ee_only
 @pytest.mark.sanity
 def test_unauthorized_users() -> None:
     tasks = sdk_tasks.get_service_tasks(config.SERVICE_NAME, "node-0")[0]

--- a/frameworks/cassandra/tests/test_auth.py
+++ b/frameworks/cassandra/tests/test_auth.py
@@ -6,12 +6,20 @@ import sdk_jobs
 import sdk_cmd
 import sdk_install
 import sdk_tasks
+import sdk_utils
+import os
 from tests import config
 
 log = logging.getLogger(__name__)
 
 
-@pytest.fixture(scope="module", autouse=True)
+no_auth_test_for_open_dcos = pytest.mark.skipif(
+    os.environ.get("DCOS_ENTERPRISE", "true").lower() == "true",
+    reason="Feature only supported in DC/OS EE.",
+)
+
+
+@pytest.fixture(scope="module")
 def configure_package(configure_security: None) -> Iterator[None]:
     test_jobs: List[Dict[str, Any]] = []
     try:
@@ -48,6 +56,7 @@ def configure_package(configure_security: None) -> Iterator[None]:
             sdk_jobs.remove_job(job)
 
 
+@no_auth_test_for_open_dcos
 @pytest.mark.sanity
 def test_auth() -> None:
     config.verify_client_can_write_read_and_delete_with_auth(
@@ -55,6 +64,7 @@ def test_auth() -> None:
     )
 
 
+@no_auth_test_for_open_dcos
 @pytest.mark.sanity
 def test_unauthorized_users() -> None:
     tasks = sdk_tasks.get_service_tasks(config.SERVICE_NAME, "node-0")[0]


### PR DESCRIPTION
## What changes are proposed in this PR? 

Resolves [DCOS-53489](https://jira.mesosphere.com/browse/DCOS-53489)

Recently added integrations test test_auth.py is failing in open DCOS , this change will fix it.

## How were these changes tested?
TC CI tests and manually tested over Open DCOS