### PR TITLE
[DCOS-53417] Fix the syntax

### DIFF
--- a/Jenkinsfile.dcos-commons-base
+++ b/Jenkinsfile.dcos-commons-base
@@ -51,6 +51,8 @@ pipeline {
     }
 
     post {
-        setBuildStatus("mesosphere/${IMAGE}")
+        always {
+            setBuildStatus("mesosphere/${IMAGE}")
+        }
     }
 }


### PR DESCRIPTION
```
WorkflowScript: 54: The ‘post’ section can only contain build condition names with code blocks. Valid condition names are [always, changed, fixed, regression, aborted, success, unsuccessful, unstable, failure, notBuilt, cleanup] @ line 54, column 9.
           setBuildStatus("mesosphere/${IMAGE}")
           ^

WorkflowScript: 53: post can not be empty @ line 53, column 5.
       post {
```