### PR TITLE
[DCOS-53417] Add repo name

### DIFF
--- a/Jenkinsfile.dcos-commons-base
+++ b/Jenkinsfile.dcos-commons-base
@@ -5,6 +5,7 @@ void setBuildStatus(String context) {
     step([
             $class: "GitHubCommitStatusSetter",
             contextSource: [$class: "ManuallyEnteredCommitContextSource", context: context],
+            reposSource: [$class: "ManuallyEnteredRepositorySource", url: "https://github.com/mesosphere/dcos-commons"]
     ])
 }
 


### PR DESCRIPTION
Somehow the default resolves to an empty string:
```
[Set GitHub commit status (universal)] PENDING on repos [] (sha:c4cb692) with context:mesosphere/dcos-commons-base
```