### PR TITLE
[DCOS-53604] Added extra mesos task labels

### DIFF
--- a/frameworks/elastic/universe-kibana/marathon.json.mustache
+++ b/frameworks/elastic/universe-kibana/marathon.json.mustache
@@ -15,7 +15,9 @@
     "DCOS_SERVICE_NAME": "{{service.name}}",
     "DCOS_SERVICE_PORT_INDEX": "1",
     "DCOS_SERVICE_SCHEME": "http",
-    "DCOS_SERVICE_REWRITE_REQUEST_URLS": "false"
+    "DCOS_SERVICE_REWRITE_REQUEST_URLS": "false",
+    "MARATHON_SINGLE_INSTANCE_APP": "true",
+    "DCOS_PACKAGE_FRAMEWORK_NAME": "{{service.name}}"
   },
   "env": {
     "ELASTIC_VERSION": "{{elastic-version}}",


### PR DESCRIPTION
Added two more task labels for Kibana 
ref: https://jira.mesosphere.com/browse/DCOS-53604
_MARATHON_SINGLE_INSTANCE_APP_ is set to true so that user cannot scale same app to 2 instances (scaling won't work as Kibana is not HA)