### PR TITLE
[HDFS] Ignore CLI version warnings in stderr

### DIFF
--- a/frameworks/hdfs/tests/config.py
+++ b/frameworks/hdfs/tests/config.py
@@ -59,6 +59,9 @@ def hdfs_client_write_data(
             # if hdfs had previously successfully completed the write when also outputting some warning on stderr.
             log.info("Ignoring failure: Looks like the data was successfully written in a previous attempt")
             return True
+        elif "but this CLI only supports" in stderr:
+            # Ignore warnings about CLI being outdated compared to DC/OS version
+            return True
         else:
             # Try again
             return False

--- a/frameworks/hdfs/tests/config.py
+++ b/frameworks/hdfs/tests/config.py
@@ -59,7 +59,7 @@ def hdfs_client_write_data(
             # if hdfs had previously successfully completed the write when also outputting some warning on stderr.
             log.info("Ignoring failure: Looks like the data was successfully written in a previous attempt")
             return True
-        elif "but this CLI only supports" in stderr:
+        elif "but this CLI only supports" in stderr and "Exception" not in stderr:
             # Ignore warnings about CLI being outdated compared to DC/OS version
             return True
         else:

--- a/testing/sdk_cmd.py
+++ b/testing/sdk_cmd.py
@@ -250,7 +250,7 @@ wc -l {output_file}"'''.format(
     )
     rc, stdout, stderr = marathon_task_exec(marathon_task_name, output_cmd)
 
-    if rc or stderr:
+    if rc:
         log.warning(
             "Error creating file %s. rc=%s stdout=%s stderr=%s", filename, rc, stdout, stderr
         )


### PR DESCRIPTION
Tests were failing due to warnings like:
```
The attached cluster is running DC/OS 1.14 but this CLI only supports DC/OS 1.12.
```
that were sneaking into the `stderr` causing tests to incorrectly think that failures existed.

This PR ignores those warnings and allows the tests to proceed.