### PR TITLE
Revert helloworld minDcosReleaseVersion to 1.11

### DIFF
--- a/frameworks/helloworld/universe/package.json
+++ b/frameworks/helloworld/universe/package.json
@@ -2,7 +2,7 @@
   "packagingVersion": "4.0",
   "upgradesFrom": ["*"],
   "downgradesTo": ["*"],
-  "minDcosReleaseVersion": "1.13",
+  "minDcosReleaseVersion": "1.11",
   "name": "hello-world",
   "version":  "{{package-version}}",
   "maintainer": "support@mesosphere.io",


### PR DESCRIPTION
This was causing failures in nightlies when the tests try to install helloworld with version as `stub-universe`.

The python tests have enough checks in place in to ensure seccomp is only tests 1.13 and above. this may still cause problems if someone tried to do a manual install for seccomp but i guess we can live with this until we find a better fix.