### PR TITLE
Cassandra: set JAVA_HOME before running bootstrap in svc.yml

### DIFF
--- a/frameworks/cassandra/src/main/dist/svc.yml
+++ b/frameworks/cassandra/src/main/dist/svc.yml
@@ -60,8 +60,8 @@ pods:
         cmd: |
                 set -e
 
-                ./bootstrap
                 export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jdk*/)
+                ./bootstrap
                 ARGS='-f'
 
                 if [ -n "$STATSD_UDP_HOST" ]; then
@@ -233,8 +233,8 @@ pods:
       restore-snapshot:
         goal: ONCE
         cmd: >
-                ./bootstrap --resolve=false ;
                 export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jdk*/) ;
+                ./bootstrap --resolve=false ;
                 for f in $(find container-path/snapshot/ -maxdepth 1 -mindepth 1 -type d ! -name "system_*" ! -name "system") ; do
                     for t in $(find "$f" -maxdepth 1 -mindepth 1 -type d) ; do
                         ./apache-cassandra-{{CASSANDRA_VERSION}}/bin/sstableloader \


### PR DESCRIPTION
Cassandra runs the `bootstrap` command to configure a container and install any necessary certificates.

Previously `JAVA_HOME` was set after running `bootstrap` and the following message is seen in the container's `stderr` logs:
```
No JAVA_HOME provided. Cannot install certs.
```
The historical reasons for why this is the case is unknown.
This patch fixes the issue.