### PR TITLE
Rlimit parameters are added to the Cassandra configuration.

### DIFF
--- a/frameworks/cassandra/src/main/dist/svc.yml
+++ b/frameworks/cassandra/src/main/dist/svc.yml
@@ -31,6 +31,15 @@ pods:
       RLIMIT_NOFILE:
         soft: {{RLIMIT_NOFILE_SOFT}}
         hard: {{RLIMIT_NOFILE_HARD}}
+      RLIMIT_STACK:
+        soft: {{RLIMIT_STACK_SOFT}}
+        hard: {{RLIMIT_STACK_HARD}}
+      RLIMIT_MEMLOCK:
+        soft: {{RLIMIT_MEMLOCK_SOFT}}
+        hard: {{RLIMIT_MEMLOCK_HARD}}
+      RLIMIT_NPROC:
+        soft: {{RLIMIT_NPROC_SOFT}}
+        hard: {{RLIMIT_NPROC_HARD}}
     resource-sets:
       server-resources:
         cpus: {{CASSANDRA_CPUS}}

--- a/frameworks/cassandra/tests/test_rlimit.py
+++ b/frameworks/cassandra/tests/test_rlimit.py
@@ -1,0 +1,66 @@
+import json
+import re
+import pytest
+import sdk_install
+import sdk_cmd
+from tests import config
+
+
+@pytest.fixture(scope="module", autouse=True)
+def configure_package(configure_security):
+    try:
+        sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
+        sdk_install.install(
+            config.PACKAGE_NAME,
+            config.SERVICE_NAME,
+            config.DEFAULT_TASK_COUNT,
+        )
+
+        yield  # let the test session execute
+    finally:
+        sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
+
+
+def get_task_to_rlimits_mapping(limit_type):
+    result = {}
+    exit_code, stdout, _ = sdk_cmd.run_cli("task --json")
+    if exit_code != 0:
+        return None
+
+    tasks_info = json.loads(stdout)
+    for task_info in tasks_info:
+        if "container" in task_info:
+            for rlimit in task_info["container"]["rlimit_info"]["rlimits"]:
+                if rlimit["type"] == limit_type:
+                    result[task_info["id"]] = (rlimit["soft"], rlimit["hard"])
+    return result
+
+
+def test_rlimt_stack():
+    tasks_to_rlimit = get_task_to_rlimits_mapping("RLMT_STACK")
+    for (task, rlimit) in tasks_to_rlimit.items():
+        exit_code, stdout, _ = sdk_cmd.run_cli('task exec {} bash -c "ps -o pid -C java | grep -v grep | grep -v PID | head -1"'.format(task))
+        exit_code, stdout, _ = sdk_cmd.run_cli('task exec {} bash -c "cat /proc/{}/limits | grep stack"'.format(task, stdout))
+        stack_limit = re.sub(' +', ' ', stdout).split(' ')[-3:-1]
+        assert rlimit[0] == int(stack_limit[0])
+        assert rlimit[1] == int(stack_limit[1])
+
+
+def test_rlimt_memlock():
+    tasks_to_rlimit = get_task_to_rlimits_mapping("RLMT_MEMLOCK")
+    for (task, rlimit) in tasks_to_rlimit.items():
+        exit_code, stdout, _ = sdk_cmd.run_cli('task exec {} bash -c "ps -o pid -C java | grep -v grep | grep -v PID | head -1"'.format(task))
+        exit_code, stdout, _ = sdk_cmd.run_cli('task exec {} bash -c "cat /proc/{}/limits | grep memory"'.format(task, stdout))
+        stack_limit = re.sub(' +', ' ', stdout).split(' ')[-3:-1]
+        assert rlimit[0] == int(stack_limit[0]) or int(stack_limit[0]) == 0
+        assert rlimit[1] == int(stack_limit[1]) or int(stack_limit[0]) == 0
+
+
+def test_rlimt_nproc():
+    tasks_to_rlimit = get_task_to_rlimits_mapping("RLMT_NPROC")
+    for (task, rlimit) in tasks_to_rlimit.items():
+        exit_code, stdout, _ = sdk_cmd.run_cli('task exec {} bash -c "ps -o pid -C java | grep -v grep | grep -v PID | head -1"'.format(task))
+        exit_code, stdout, _ = sdk_cmd.run_cli('task exec {} bash -c "cat /proc/{}/limits | grep processes"'.format(task, stdout))
+        stack_limit = re.sub(' +', ' ', stdout).split(' ')[-3:-1]
+        assert rlimit[0] == int(stack_limit[0])
+        assert rlimit[1] == int(stack_limit[1])

--- a/frameworks/cassandra/universe/config.json
+++ b/frameworks/cassandra/universe/config.json
@@ -253,6 +253,58 @@
                   "minimum": 128000
                 }
               }
+            },
+            "rlimit_stack": {
+              "description": "Specifies RLIMIT_STACK, a value one greater than the maximum size of the initial thread's stack, in bytes.",
+              "type": "object",
+              "properties": {
+                "soft" : {
+                  "type": "integer",
+                  "description": "The  soft  limit  is  the  value that the kernel enforces for the corresponding resource.",
+                  "default": 102400,
+                  "minimum": 102400
+                },
+                "hard" : {
+                  "type": "integer",
+                  "description": "The  hard  limit  acts as a ceiling for the soft limit.",
+                  "default": 102400,
+                  "minimum": 102400
+                }
+              }
+            },
+            "rlimit_memlock": {
+              "description": "Specifies RLIMIT_MEMLOCK, the maximum number of bytes of memory that may be locked into RAM.",
+              "type": "object",
+              "properties": {
+                "soft" : {
+                  "type": "integer",
+                  "description": "The  soft  limit  is  the  value that the kernel enforces for the corresponding resource.",
+                  "default": -1
+                },
+                "hard" : {
+                  "type": "integer",
+                  "description": "The  hard  limit  acts as a ceiling for the soft limit.",
+                  "default": -1
+                }
+              }
+            },
+            "rlimit_nproc": {
+              "description": "Specifies RLMT_NPROC, The maximum number of processes (or, more precisely on Linux, threads) that can be created for the real user ID of the calling process.",
+              "type": "object",
+              "properties": {
+                "soft" : {
+                  "type": "integer",
+                  "description": "The  soft  limit  is  the  value that the kernel enforces for the corresponding resource.",
+                  "default": 32768,
+                  "minimum": 32768
+                },
+                "hard" : {
+                  "type": "integer",
+                  "description": "The  hard  limit  acts as a ceiling for the soft limit.",
+                  "default": 32768,
+                  "minimum": 32768
+                }
+              }
             }
           }
         }

--- a/frameworks/cassandra/universe/marathon.json.mustache
+++ b/frameworks/cassandra/universe/marathon.json.mustache
@@ -203,6 +203,12 @@
 
     "RLIMIT_NOFILE_SOFT": "{{service.rlimits.rlimit_nofile.soft}}",
     "RLIMIT_NOFILE_HARD": "{{service.rlimits.rlimit_nofile.hard}}",
+    "RLIMIT_STACK_SOFT": "{{service.rlimits.rlimit_stack.soft}}",
+    "RLIMIT_STACK_HARD": "{{service.rlimits.rlimit_stack.hard}}",
+    "RLIMIT_MEMLOCK_SOFT": "{{service.rlimits.rlimit_memlock.soft}}",
+    "RLIMIT_MEMLOCK_HARD": "{{service.rlimits.rlimit_memlock.hard}}",
+    "RLIMIT_NPROC_SOFT": "{{service.rlimits.rlimit_nproc.soft}}",
+    "RLIMIT_NPROC_HARD": "{{service.rlimits.rlimit_nproc.hard}}",
     
     "TASKCFG_ALL_CASSANDRA_ENABLE_USER_DEFINED_FUNCTIONS": "{{cassandra.enable_user_defined_functions}}",
     "TASKCFG_ALL_CASSANDRA_ENABLE_SCRIPTED_USER_DEFINED_FUNCTIONS": "{{cassandra.enable_scripted_user_defined_functions}}"


### PR DESCRIPTION
As per documentation of Cassandra I keep default values as follows:
<cassandra_user> - memlock unlimited (done set default -1)
<cassandra_user> - nofile 1048576 (Not touched as its already implemented in master)
<cassandra_user> - nproc 32768 ( done)
<cassandra_user> - Stack (for stack its not mentioned in document, so I use default values on which service successfully UP and running) All these values are user configurable.  