### PR TITLE
Fix documentation-path in package_builder

### DIFF
--- a/tools/universe/package_builder.py
+++ b/tools/universe/package_builder.py
@@ -140,7 +140,7 @@ class UniversePackageBuilder(object):
         documentation_path = "{}/service-docs/{}/".format(_docs_root, self._package.get_name())
         package_version = str(self._package.get_version())
         if package_version != "stub-universe":
-            documentation_path = "{}v{}/".format(documentation_path, package_version)
+            documentation_path = "{}{}/".format(documentation_path, package_version)
 
         return documentation_path
 


### PR DESCRIPTION
## What changes are proposed in this pull request?
When building stubs (that ultimately make it to universe), the `package.json` file included URLs like `https://docs.mesosphere.com/services/kafka/v2.6.0-5.1.2/` which would lead to `Page not found`s. Removing the `v` fixes the links to point to the right service pages.

See associated fixes: https://github.com/mesosphere/universe/pull/2297