### PR TITLE
Stop using dashes in check name to see if it helps.

### DIFF
--- a/Jenkinsfile.dcos-commons
+++ b/Jenkinsfile.dcos-commons
@@ -53,7 +53,7 @@ pipeline {
 
     post {
         always {
-            setBuildStatus("mesosphere/${IMAGE}")
+            setBuildStatus("mesosphere/dcos_commons_docker_image")
         }
     }
 }

--- a/Jenkinsfile.dcos-commons-base
+++ b/Jenkinsfile.dcos-commons-base
@@ -53,7 +53,7 @@ pipeline {
 
     post {
         always {
-            setBuildStatus("mesosphere/${IMAGE}")
+            setBuildStatus("mesosphere/dcos_commons_base_docker_image")
         }
     }
 }


### PR DESCRIPTION
It seems that status checks completion events are missed. There is a
theory that dashes are involved.