### PR TITLE
Added support for custom_domain for Cassandra FW

### DIFF
--- a/frameworks/cassandra/tests/test_custom_domain.py
+++ b/frameworks/cassandra/tests/test_custom_domain.py
@@ -1,0 +1,55 @@
+import logging
+
+import pytest
+
+import sdk_hosts
+import sdk_install
+import sdk_networks
+
+from tests import config
+
+
+log = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def configure_package(configure_security):
+    try:
+        sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
+
+        yield  # let the test session execute
+    finally:
+        sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
+
+
+@pytest.mark.sanity
+def test_custom_domain():
+    task_count = 3
+    custom_domain = sdk_hosts.get_crypto_id_domain()
+    sdk_install.install(
+        config.PACKAGE_NAME,
+        config.SERVICE_NAME,
+        task_count,
+        additional_options={
+            "service": {
+                "security": {
+                    "custom_domain": custom_domain
+                }
+            }
+        }
+    )
+
+    # Verify the endpoint entry is correct
+    assert set(["native-client"]) == set(sdk_networks.get_endpoint_names(config.PACKAGE_NAME, config.SERVICE_NAME))
+    test_endpoint = sdk_networks.get_endpoint(config.PACKAGE_NAME, config.SERVICE_NAME, "native-client")
+    assert set(["address", "dns"]) == set(test_endpoint.keys())
+
+    assert len(test_endpoint["address"]) == task_count
+    # Expect ip:port:
+    for entry in test_endpoint["address"]:
+        assert len(entry.split(":")) == 2
+
+    assert len(test_endpoint["dns"]) == task_count
+    # Expect custom domain:
+    for entry in test_endpoint["dns"]:
+        assert custom_domain in entry

--- a/frameworks/cassandra/universe/config.json
+++ b/frameworks/cassandra/universe/config.json
@@ -205,6 +205,10 @@
                 }
 
             }
+        },
+        "custom_domain": {
+          "type": "string",
+          "description": "A custom domain to be used in place of autoip.dcos.thisdcos.directory. This can be used to expose the service securely outside of the cluster, but requires setting up external DNS. See the service documentation for details."
         }
                 }
         },

--- a/frameworks/cassandra/universe/marathon.json.mustache
+++ b/frameworks/cassandra/universe/marathon.json.mustache
@@ -107,6 +107,11 @@
     "VIRTUAL_NETWORK_NAME": "{{service.virtual_network_name}}",
     "VIRTUAL_NETWORK_PLUGIN_LABELS": "{{service.virtual_network_plugin_labels}}",
     {{/service.virtual_network_enabled}}
+
+    {{#service.security.custom_domain}}
+    "SERVICE_TLD": "{{service.security.custom_domain}}",
+    {{/service.security.custom_domain}}
+    
     {{#service.region}}
     "SERVICE_REGION": "{{service.region}}",
     {{/service.region}}


### PR DESCRIPTION
## What changes were proposed in this pull request?
Added the support for custom domain in the Cassandra Framework. Added Integration test "test-custom-domain.py" in the tests.

Resolves [DCOS-54764](https://jira.mesosphere.com/browse/DCOS-54764)

## How were these changes tested?
Built Cassandra and launched it on a Cluster. It worked without any issue.
-Manual Testing by setting custom_domain parameter
-Automated testing with the help of "test-custom-domain.py" Integration test.

## Release Notes
Cassandra can now support custom domain feature.
