### PR TITLE
[DCOS-54121] Cassandra upgrade to 3.11.4

### DIFF
--- a/frameworks/cassandra/tests/config.py
+++ b/frameworks/cassandra/tests/config.py
@@ -15,7 +15,7 @@ log = logging.getLogger(__name__)
 
 PACKAGE_NAME = "cassandra"
 
-CASSANDRA_DOCKER_IMAGE = "cassandra:3.11.3"
+CASSANDRA_DOCKER_IMAGE = "cassandra:3.11.4"
 
 SERVICE_NAME = os.environ.get("SOAK_SERVICE_NAME") or "cassandra"
 

--- a/frameworks/cassandra/universe/marathon.json.mustache
+++ b/frameworks/cassandra/universe/marathon.json.mustache
@@ -39,7 +39,7 @@
     "SERVICE_USER": "{{service.user}}",
     "SERVICE_PRINCIPAL": "{{service.service_account}}",
     "FRAMEWORK_LOG_LEVEL": "{{service.log_level}}",
-    "CASSANDRA_VERSION": "3.11.3",
+    "CASSANDRA_VERSION": "3.11.4",
     "S3CLI_VERSION": "s3cli-0.0.55-linux-amd64",
 
     {{#service.service_account_secret}}

--- a/frameworks/cassandra/universe/resource.json
+++ b/frameworks/cassandra/universe/resource.json
@@ -7,7 +7,7 @@
       "cassandra-openssl-tar-gz": "https://downloads.mesosphere.com/cassandra/assets/openssl-1.0.2n-libs.tar.gz",
       "libmesos-bundle-tar-gz": "{{libmesos-bundle-url}}",
       "scheduler-zip": "{{artifact-dir}}/cassandra-scheduler.zip",
-      "cassandra-tar-gz": "https://downloads.mesosphere.com/cassandra/assets/apache-cassandra-3.11.3-bin-dcos.tar.gz",
+      "cassandra-tar-gz": "https://infinity-artifacts.s3.amazonaws.com/cassandra/apache-cassandra-3.11.4-bin.tar.gz",
       "bootstrap-zip": "{{artifact-dir}}/bootstrap.zip"
     }
   },

--- a/frameworks/cassandra/universe/resource.json
+++ b/frameworks/cassandra/universe/resource.json
@@ -7,7 +7,7 @@
       "cassandra-openssl-tar-gz": "https://downloads.mesosphere.com/cassandra/assets/openssl-1.0.2n-libs.tar.gz",
       "libmesos-bundle-tar-gz": "{{libmesos-bundle-url}}",
       "scheduler-zip": "{{artifact-dir}}/cassandra-scheduler.zip",
-      "cassandra-tar-gz": "https://infinity-artifacts.s3.amazonaws.com/cassandra/apache-cassandra-3.11.4-bin.tar.gz",
+      "cassandra-tar-gz": "https://downloads.mesosphere.com/cassandra/assets/apache-cassandra-3.11.3-bin-dcos.tar.gz",
       "bootstrap-zip": "{{artifact-dir}}/bootstrap.zip"
     }
   },

--- a/frameworks/cassandra/universe/resource.json
+++ b/frameworks/cassandra/universe/resource.json
@@ -7,7 +7,7 @@
       "cassandra-openssl-tar-gz": "https://downloads.mesosphere.com/cassandra/assets/openssl-1.0.2n-libs.tar.gz",
       "libmesos-bundle-tar-gz": "{{libmesos-bundle-url}}",
       "scheduler-zip": "{{artifact-dir}}/cassandra-scheduler.zip",
-      "cassandra-tar-gz": "https://downloads.mesosphere.com/cassandra/assets/apache-cassandra-3.11.3-bin-dcos.tar.gz",
+      "cassandra-tar-gz": "https://downloads.mesosphere.com/cassandra/assets/apache-cassandra-3.11.4-bin-dcos.tar.gz",
       "bootstrap-zip": "{{artifact-dir}}/bootstrap.zip"
     }
   },


### PR DESCRIPTION
## What does this PR aim to do?
- Upgrade Cassandra base tech version for cassandra package release.

## How were the changes tested?
- By running a CI build.