### PR TITLE
[DCOS-54750] Add DSS volume profile support in Cassandra

### DIFF
--- a/frameworks/cassandra/src/main/dist/svc.yml
+++ b/frameworks/cassandra/src/main/dist/svc.yml
@@ -21,6 +21,10 @@ pods:
       path: container-path
       type: {{CASSANDRA_DISK_TYPE}}
       size: {{CASSANDRA_DISK_MB}}
+      {{#CASSANDRA_VOLUME_PROFILE}}
+      profiles:
+        - {{CASSANDRA_VOLUME_PROFILE}}
+      {{/CASSANDRA_VOLUME_PROFILE}}
     uris:
       - {{CASSANDRA_JAVA_URI}}
       - {{CASSANDRA_PYTHON_URI}}

--- a/frameworks/cassandra/universe/config.json
+++ b/frameworks/cassandra/universe/config.json
@@ -320,6 +320,10 @@
           "description": "Disk type to be used for storing Cassandra data. See documentation. [ROOT, MOUNT]",
           "default": "ROOT"
         },
+        "volume_profile": {
+          "type": "string",
+          "description": "Volume profile to be used for storing Cassandra data."
+        },
         "placement_constraint": {
           "type": "string",
           "description": "Placement constraints for nodes (e.g., [[\"hostname\", \"MAX_PER\", \"1\"]]).",

--- a/frameworks/cassandra/universe/marathon.json.mustache
+++ b/frameworks/cassandra/universe/marathon.json.mustache
@@ -95,6 +95,9 @@
     "CASSANDRA_MEMORY_MB": "{{nodes.mem}}",
     "CASSANDRA_DISK_MB": "{{nodes.disk}}",
     "CASSANDRA_DISK_TYPE": "{{nodes.disk_type}}",
+    {{#nodes.volume_profile}}
+    "CASSANDRA_VOLUME_PROFILE": "{{nodes.volume_profile}}",
+    {{/nodes.volume_profile}}
     "TASKCFG_ALL_CASSANDRA_HEAP_SIZE_MB": "{{nodes.heap.size}}",
     "TASKCFG_ALL_CASSANDRA_HEAP_NEW_MB": "{{nodes.heap.new}}",
     "CASSANDRA_JAVA_URI": "{{resource.assets.uris.cassandra-jre-tar-gz}}",


### PR DESCRIPTION
## What changes are proposed in this PR?

Resolves [DCOS-54750](https://jira.mesosphere.com/browse/DCOS-54750) 
Added code to support DSS Volume profile in disk(volume) of the FW node.

