### PR TITLE
[DCOS-51986] Add media attribute to service account and secret settings.

### DIFF
--- a/frameworks/cassandra/universe/config.json
+++ b/frameworks/cassandra/universe/config.json
@@ -19,12 +19,18 @@
         "service_account": {
           "description": "The service account for DC/OS service authentication. This is typically left empty to use the default unless service authentication is needed. The value given here is passed as the principal of Mesos framework.",
           "type": "string",
-          "default": ""
+          "default": "",
+          "media": {
+            "type": "application/x-service-account+string"
+          }
         },
         "service_account_secret": {
           "description": "Name of the Secret Store credentials to use for DC/OS service authentication. This should be left empty unless service authentication is needed.",
           "type": "string",
-          "default": ""
+          "default": "",
+          "media": {
+            "type": "application/x-secret+string"
+          }
         },
         "virtual_network_enabled": {
           "description": "Enable virtual networking",

--- a/frameworks/hdfs/universe/config.json
+++ b/frameworks/hdfs/universe/config.json
@@ -19,12 +19,18 @@
         "service_account": {
           "description": "The service account for DC/OS service authentication. This is typically left empty to use the default unless service authentication is needed. The value given here is passed as the principal of Mesos framework.",
           "type": "string",
-          "default": ""
+          "default": "",
+          "media": {
+            "type": "application/x-service-account+string"
+           }
         },
         "service_account_secret": {
           "description": "Name of the Secret Store credentials to use for DC/OS service authentication. This should be left empty unless service authentication is needed.",
           "type": "string",
-          "default": ""
+          "default": "",
+          "media": {
+            "type": "application/x-secret+string"
+           }
         },
         "virtual_network_enabled": {
           "description": "Enable virtual networking",
@@ -111,7 +117,10 @@
                 },
                 "keytab_secret": {
                   "type": "string",
-                  "description": "A DC/OS Secret Store path.  The contents of this secret should be a keytab containing the credentials for all HDFS servers."
+                  "description": "A DC/OS Secret Store path.  The contents of this secret should be a keytab containing the credentials for all HDFS servers.",
+		  "media": {
+                    "type": "application/x-secret+string"
+                   }
                 },
                 "debug": {
                   "type": "boolean",

--- a/frameworks/hdfs/universe/config.json
+++ b/frameworks/hdfs/universe/config.json
@@ -22,7 +22,7 @@
           "default": "",
           "media": {
             "type": "application/x-service-account+string"
-           }
+          }
         },
         "service_account_secret": {
           "description": "Name of the Secret Store credentials to use for DC/OS service authentication. This should be left empty unless service authentication is needed.",
@@ -30,7 +30,7 @@
           "default": "",
           "media": {
             "type": "application/x-secret+string"
-           }
+          }
         },
         "virtual_network_enabled": {
           "description": "Enable virtual networking",
@@ -120,7 +120,7 @@
                   "description": "A DC/OS Secret Store path.  The contents of this secret should be a keytab containing the credentials for all HDFS servers.",
 		  "media": {
                     "type": "application/x-secret+string"
-                   }
+                  }
                 },
                 "debug": {
                   "type": "boolean",


### PR DESCRIPTION
## What changes were proposed in this pull request?
Added Media Attribute change for Service Account and Secret , post this change autosuggestion will appear as drop down for the service account and secret present on the cluster. 
Resolves [DCOS-51986: Add appropriate media attribute for secrets and service accounts to json ](https://jira.mesosphere.com/browse/DCOS-51986)

## How were these changes tested?
Changes were tested on CCM cluster by locally building the stub , screen shot for the same been attached to JIRA ticket 

## Release Notes

Enabled Autocomplete widgets for Service Account and Secret , Enables users to quickly find and select from a pre-populated list of values.
