### PR TITLE
[WIP] Add support for scheduler upgrades with new role.

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/framework/FrameworkConfig.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/framework/FrameworkConfig.java
@@ -284,6 +284,7 @@ public final class FrameworkConfig {
   public Set<String> getAllResourceRoles() {
     Set<String> roles = new HashSet<>(preReservedRoles);
     roles.add(role);
+    roles.add(getNonNamespacedRole());
     return roles;
   }
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/framework/FrameworkRunner.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/framework/FrameworkRunner.java
@@ -165,15 +165,10 @@ public class FrameworkRunner {
     // The framework ID is not available when we're being started for the first time.
     frameworkId.ifPresent(fwkInfoBuilder::setId);
 
-    if (frameworkConfig.getPreReservedRoles().isEmpty()) {
-      setRole(fwkInfoBuilder, frameworkConfig.getRole());
-    } else {
-      fwkInfoBuilder.addCapabilitiesBuilder()
+    // We set to MULTI_ROLE by default and add all the necessary roles.
+    fwkInfoBuilder.addCapabilitiesBuilder()
           .setType(Protos.FrameworkInfo.Capability.Type.MULTI_ROLE);
-      fwkInfoBuilder
-          .addRoles(frameworkConfig.getRole())
-          .addAllRoles(frameworkConfig.getPreReservedRoles());
-    }
+    fwkInfoBuilder.addAllRoles(frameworkConfig.getAllResourceRoles());
 
     if (!StringUtils.isEmpty(frameworkConfig.getWebUrl())) {
       fwkInfoBuilder.setWebuiUrl(frameworkConfig.getWebUrl());

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/framework/FrameworkRunner.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/framework/FrameworkRunner.java
@@ -165,14 +165,15 @@ public class FrameworkRunner {
     // The framework ID is not available when we're being started for the first time.
     frameworkId.ifPresent(fwkInfoBuilder::setId);
 
-    // We set to MULTI_ROLE by default and add all the necessary roles.
-    fwkInfoBuilder.addCapabilitiesBuilder()
-          .setType(Protos.FrameworkInfo.Capability.Type.MULTI_ROLE);
-
-    if (frameworkConfig.getPreReservedRoles().isEmpty()) {
-      fwkInfoBuilder.setRole(frameworkConfig.getRole());
-    } else {
+    if (!frameworkConfig.getPreReservedRoles().isEmpty() ||
+        !frameworkConfig.getRole().contentEquals(frameworkConfig.getNonNamespacedRole()))
+    {
+      // We set to MULTI_ROLE by default and add all the necessary roles.
+      fwkInfoBuilder.addCapabilitiesBuilder()
+        .setType(Protos.FrameworkInfo.Capability.Type.MULTI_ROLE);
       fwkInfoBuilder.addAllRoles(frameworkConfig.getAllResourceRoles());
+    } else {
+      fwkInfoBuilder.setRole(frameworkConfig.getRole());
     }
 
     if (!StringUtils.isEmpty(frameworkConfig.getWebUrl())) {

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/framework/FrameworkRunner.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/framework/FrameworkRunner.java
@@ -168,7 +168,12 @@ public class FrameworkRunner {
     // We set to MULTI_ROLE by default and add all the necessary roles.
     fwkInfoBuilder.addCapabilitiesBuilder()
           .setType(Protos.FrameworkInfo.Capability.Type.MULTI_ROLE);
-    fwkInfoBuilder.addAllRoles(frameworkConfig.getAllResourceRoles());
+
+    if (frameworkConfig.getPreReservedRoles().isEmpty()) {
+      fwkInfoBuilder.setRole(frameworkConfig.getRole());
+    } else {
+      fwkInfoBuilder.addAllRoles(frameworkConfig.getAllResourceRoles());
+    }
 
     if (!StringUtils.isEmpty(frameworkConfig.getWebUrl())) {
       fwkInfoBuilder.setWebuiUrl(frameworkConfig.getWebUrl());

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/AbstractScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/AbstractScheduler.java
@@ -176,7 +176,7 @@ public abstract class AbstractScheduler implements MesosEventClient {
           candidateSteps.size(), candidateSteps.size() == 1 ? "" : "s");
       int i = 0;
       for (Protos.Offer offer : offers) {
-        logger.info("  {}: {}", ++i, TextFormat.shortDebugString(offer));
+        logger.info("  {}: role:{} {}", ++i, offer.getAllocationInfo().getRole(), TextFormat.shortDebugString(offer));
       }
     }
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultResourceSet.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/DefaultResourceSet.java
@@ -84,6 +84,10 @@ public final class DefaultResourceSet implements ResourceSet {
     return role;
   }
 
+  public String getPreReservedRole() {
+    return preReservedRole;
+  }
+
   public String getPrincipal() {
     return principal;
   }
@@ -278,6 +282,17 @@ public final class DefaultResourceSet implements ResourceSet {
      */
     public DefaultResourceSet build() {
       return new DefaultResourceSet(this);
+    }
+
+    /**
+     * Sets the role {@code role} and returns a reference to this Builder so that the methods can be chained together.
+     *
+     * @param role the {@code role} to use
+     * @return a reference to this Builder
+     */
+    public Builder role(String role) {
+      this.role = role;
+      return this;
     }
   }
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/NamedVIPSpec.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/NamedVIPSpec.java
@@ -75,6 +75,23 @@ public final class NamedVIPSpec extends PortSpec {
     return new Builder();
   }
 
+  public static Builder newBuilder(NamedVIPSpec copy) {
+    Builder builder = new Builder();
+    builder.protocol(copy.getProtocol())
+      .vipName(copy.getVipName())
+      .vipPort(copy.getVipPort())
+      .envKey(copy.getEnvKey())
+      .portName(copy.getPortName())
+      .visibility(copy.getVisibility())
+      .networkNames(copy.getNetworkNames())
+      .ranges(copy.getRanges())
+      .value(copy.getValue())
+      .role(copy.getRole())
+      .preReservedRole(copy.getPreReservedRole())
+      .principal(copy.getPrincipal());
+    return builder;
+  }
+
   @JsonProperty("protocol")
   public String getProtocol() {
     return protocol;

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/PortSpec.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/PortSpec.java
@@ -68,6 +68,20 @@ public class PortSpec extends DefaultResourceSpec {
     return new Builder();
   }
 
+  public static Builder newBuilder(PortSpec copy) {
+    Builder builder = new Builder();
+    builder.envKey(copy.getEnvKey())
+      .portName(copy.getPortName())
+      .visibility(copy.getVisibility())
+      .networkNames(copy.getNetworkNames())
+      .ranges(copy.getRanges())
+      .value(copy.getValue())
+      .role(copy.getRole())
+      .preReservedRole(copy.getPreReservedRole())
+      .principal(copy.getPrincipal());
+    return builder;
+  }
+
   /**
    * Returns a copy of the provided {@link PortSpec} which has been updated to have the provided {@code value}.
    */

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/framework/FrameworkRunnerTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/framework/FrameworkRunnerTest.java
@@ -152,7 +152,7 @@ public class FrameworkRunnerTest {
     @SuppressWarnings("deprecation")
     private static void checkRole(Optional<String> expectedRole, Protos.FrameworkInfo info) {
         if (expectedRole.isPresent()) {
-            Assert.assertEquals(info.getRole(), expectedRole.get());
+            Assert.assertEquals(expectedRole.get(), info.getRole());
         } else {
             Assert.assertFalse(info.hasRole());
         }

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/framework/FrameworkRunnerTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/framework/FrameworkRunnerTest.java
@@ -86,7 +86,7 @@ public class FrameworkRunnerTest {
         Assert.assertFalse(info.hasId());
         checkRole(Optional.of("path__to__test-service-role"), info);
         Assert.assertEquals(0, info.getRolesCount());
-        Assert.assertEquals(0, info.getCapabilitiesCount());
+        Assert.assertEquals(1, info.getCapabilitiesCount());
         Assert.assertFalse(info.hasWebuiUrl());
     }
 
@@ -107,7 +107,7 @@ public class FrameworkRunnerTest {
         Assert.assertEquals(TestConstants.FRAMEWORK_ID, info.getId());
         checkRole(Optional.of("path__to__test-service-role"), info);
         Assert.assertEquals(0, info.getRolesCount());
-        Assert.assertEquals(0, info.getCapabilitiesCount());
+        Assert.assertEquals(1, info.getCapabilitiesCount());
         Assert.assertFalse(info.hasWebuiUrl());
     }
 

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/framework/FrameworkRunnerTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/framework/FrameworkRunnerTest.java
@@ -86,7 +86,7 @@ public class FrameworkRunnerTest {
         Assert.assertFalse(info.hasId());
         checkRole(Optional.of("path__to__test-service-role"), info);
         Assert.assertEquals(0, info.getRolesCount());
-        Assert.assertEquals(1, info.getCapabilitiesCount());
+        Assert.assertEquals(0, info.getCapabilitiesCount());
         Assert.assertFalse(info.hasWebuiUrl());
     }
 
@@ -107,7 +107,7 @@ public class FrameworkRunnerTest {
         Assert.assertEquals(TestConstants.FRAMEWORK_ID, info.getId());
         checkRole(Optional.of("path__to__test-service-role"), info);
         Assert.assertEquals(0, info.getRolesCount());
-        Assert.assertEquals(1, info.getCapabilitiesCount());
+        Assert.assertEquals(0, info.getCapabilitiesCount());
         Assert.assertFalse(info.hasWebuiUrl());
     }
 

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/framework/FrameworkRunnerTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/framework/FrameworkRunnerTest.java
@@ -136,7 +136,7 @@ public class FrameworkRunnerTest {
         Assert.assertEquals("custom-principal", info.getPrincipal());
         Assert.assertEquals(TestConstants.FRAMEWORK_ID, info.getId());
         checkRole(Optional.empty(), info);
-        Assert.assertEquals(Arrays.asList("path__to__test-service-role", "role1", "role2", "role3"), info.getRolesList());
+        Assert.assertTrue(info.getRolesList().containsAll(Arrays.asList("path__to__test-service-role", "role1", "role2", "role3")));
         Assert.assertEquals(Arrays.asList(
                 getCapability(Protos.FrameworkInfo.Capability.Type.MULTI_ROLE),
                 getCapability(Protos.FrameworkInfo.Capability.Type.GPU_RESOURCES),


### PR DESCRIPTION
- Always subscribe with `MULTI_ROLE` capability.
- Subscribe to Mesos with both the old and new roles.
- Fix the roles in ServiceSpec to match previous configuration on a scheduler upgrade.