### PR TITLE
Ignore authenticated backup and restore Azure test on DC/OS Open

### DIFF
--- a/frameworks/cassandra/tests/test_auth.py
+++ b/frameworks/cassandra/tests/test_auth.py
@@ -105,6 +105,7 @@ def test_backup_and_restore_to_s3_with_auth() -> None:
     )
 
 
+@sdk_utils.dcos_ee_only
 @pytest.mark.azure
 @no_strict_for_azure
 @pytest.mark.sanity


### PR DESCRIPTION
fixing failed backup and restore azure test by ignoring it from open DC/OS.