### PR TITLE
[DCOS-56081] Make "service configuration JSON"-standardizing script more flexible.

### DIFF
--- a/tools/standardize_config_json.py
+++ b/tools/standardize_config_json.py
@@ -94,9 +94,13 @@ def print_diff(original: collections.OrderedDict, new: collections.OrderedDict):
     o = json.dumps(original, indent=2)
     c = json.dumps(new, indent=2)
 
-    diff = difflib.unified_diff(o.split("\n"), c.split("\n"))
+    diff = list(difflib.unified_diff(o.split("\n"), c.split("\n")))
 
-    LOG.info("\n".join(diff))
+    if len(diff) == 0:
+        LOG.info("No changes")
+    else:
+        LOG.info("Applied diff:")
+        LOG.info("\n".join(diff))
 
 
 def process(service_config_json_path: str, sdk_tools_config: dict):

--- a/tools/standardize_config_json.py
+++ b/tools/standardize_config_json.py
@@ -3,7 +3,7 @@
 usage = """Standardizes the ordering of sections in config.json files.
 
 Usage:
-$ ./standardize_config_json.py $path_to_config_json"""
+$ ./standardize_config_json.py $path_to_config_json $path_to_dcos_commons_json"""
 
 import collections
 import difflib

--- a/tools/standardize_config_json.py
+++ b/tools/standardize_config_json.py
@@ -123,10 +123,12 @@ def process(service_config_json_path: str, sdk_tools_config: dict):
 
     write_json_file(service_config_json_path, contents)
 
+    return 0
+
 
 def main(argv):
     parser = argparse.ArgumentParser(
-        description="Standardizes the ordering of sections in SDK service config.json files."
+        description="Standardizes the ordering of sections in SDK service JSON configuration files."
     )
 
     parser.add_argument(
@@ -134,7 +136,7 @@ def main(argv):
         type=str,
         required=True,
         default=None,
-        help="Path to the service configuration JSON file to be standardized",
+        help="Path to the SDK service configuration file to be standardized (e.g. config.json)",
     )
 
     parser.add_argument(
@@ -142,7 +144,7 @@ def main(argv):
         type=str,
         required=False,
         default=None,
-        help="Path to the SDK Tools configuration file",
+        help="Path to the SDK Tools configuration file (e.g. sdk-tools.json)",
     )
 
     args = parser.parse_args()
@@ -151,20 +153,26 @@ def main(argv):
     sdk_tools_config_path = args.sdk_tools_config
 
     if not os.path.isfile(service_config_json_path):
-        LOG.info("'%s' is not a file, was expecting a 'config.json' file", service_config_json_path)
+        LOG.info(
+            "'%s' is not a file, was expecting an SDK service configuration file",
+            service_config_json_path,
+        )
+        return 1
 
     if sdk_tools_config_path:
         if not os.path.isfile(sdk_tools_config_path):
             LOG.info(
-                "'%s' is not a file, was expecting a 'sdk-tools.json' file", sdk_tools_config_path
+                "'%s' is not a file, was expecting an SDK Tools configuration file",
+                sdk_tools_config_path,
             )
+            return 1
 
-        LOG.info("Parsing SDK tooling configuration from '%s'", sdk_tools_config_path)
+        LOG.info("Parsing SDK Tools configuration from '%s'", sdk_tools_config_path)
         sdk_tools_config = json.loads(read_file(sdk_tools_config_path))
     else:
         sdk_tools_config: dict = {}
 
-    process(service_config_json_path, sdk_tools_config.get("standardize_config_json", {}))
+    return process(service_config_json_path, sdk_tools_config.get("standardize_config_json", {}))
 
 
 if __name__ == "__main__":

--- a/tools/standardize_config_json.py
+++ b/tools/standardize_config_json.py
@@ -1,16 +1,16 @@
 #!/usr/bin/env python3
 
-usage = """Standardizes the ordering of sections in config.json files.
-
-Usage:
-$ ./standardize_config_json.py $path_to_config_json $path_to_dcos_commons_json"""
-
 import collections
 import difflib
 import json
 import logging
 import os.path
 import sys
+
+usage = """Standardizes the ordering of sections in config.json files.
+
+Usage:
+$ ./standardize_config_json.py $path_to_config_json $path_to_dcos_commons_json"""
 
 
 logging.basicConfig(

--- a/tools/standardize_config_json.py
+++ b/tools/standardize_config_json.py
@@ -103,14 +103,15 @@ def print_diff(original: collections.OrderedDict, new: collections.OrderedDict):
     LOG.info("\n".join(diff))
 
 
-def process(config_json_path: str, configuration: list):
+def process(config_json_path: str, configuration: dict):
     contents = read_json_file(config_json_path)
     original = read_json_file(config_json_path)
 
     reordered = reorder_service(contents["properties"]["service"]["properties"])
     contents["properties"]["service"]["properties"] = reordered
 
-    for section_name, head_and_tail in configuration["sections"].items():
+    sections = configuration.get("sections", {})
+    for section_name, head_and_tail in sections.items():
         head = head_and_tail["head"]
         tail = head_and_tail["tail"]
         properties = contents["properties"][section_name]["properties"]
@@ -139,13 +140,12 @@ if __name__ == "__main__":
         LOG.info("'%s' is not a file, was expecting a config.json file", config_json_path)
 
     configuration_path = None
-    configuration = None
+    configuration: dict = {}
     LOG.info("config_json_path: %s", config_json_path)
 
     if len(args) == 2:
         configuration_path = args[1]
-
-    LOG.info("configuration_path: %s", configuration_path)
+        LOG.info("configuration_path: %s", configuration_path)
 
     if configuration_path:
         if not os.path.isfile(configuration_path):
@@ -156,4 +156,4 @@ if __name__ == "__main__":
         LOG.info("Parsing dcos-commons tooling configuration from '%s'", configuration_path)
         configuration = json.loads(read_file(configuration_path))
 
-    process(config_json_path, configuration and configuration.get("standardize_config_json"))
+    process(config_json_path, configuration.get("standardize_config_json", {}))

--- a/tools/standardize_config_json.py
+++ b/tools/standardize_config_json.py
@@ -112,11 +112,12 @@ def process(service_config_json_path: str, sdk_tools_config: dict):
 
     sections = sdk_tools_config.get("sections", {})
     for section_name, head_and_tail in sections.items():
-        head = head_and_tail["head"]
-        tail = head_and_tail["tail"]
-        properties = contents["properties"][section_name]["properties"]
-        reordered = reorder(properties, head, tail, reorder_property)
-        contents["properties"][section_name]["properties"] = reordered
+        if section_name in contents["properties"]:
+            head = head_and_tail.get("head")
+            tail = head_and_tail.get("tail")
+            properties = contents["properties"][section_name]["properties"]
+            reordered = reorder(properties, head, tail, reorder_property)
+            contents["properties"][section_name]["properties"] = reordered
 
     print_diff(original, contents)
 


### PR DESCRIPTION
This allows for the script to also standardize project specific sections. Right
now it only standardizes the order of the "service" section.

For example, I'm using it to standardize the order of the "elasticsearch"
section for the Elastic service. By providing a configuration file that looks
like the following:

`dcos_commons.json`:
```
{
  "standardize_config_json": {
    "sections": {
      "elasticsearch": {
        "head": [
          "custom_elasticsearch_yml",
          "health_user",
          "health_user_password",
          "plugins",
          "plugin_http_proxy_host",
          "plugin_http_proxy_port",
          "plugin_https_proxy_host",
          "plugin_https_proxy_port",
          "xpack_http_proxy_host",
          "xpack_http_proxy_port",
          "xpack_graph_enabled",
          "xpack_ml_enabled",
          "xpack_monitoring_collection_enabled",
          "xpack_monitoring_enabled",
          "xpack_security_audit_enabled",
          "xpack_security_enabled",
          "xpack_sql_enabled",
          "xpack_watcher_enabled"
        ],
        "tail": ["http_content_type_required", "xpack_enabled"]
      }
    }
  }
}
```

and calling the standardization script like:

```
./dcos-commons/tools/standardize_config_json.py frameworks/elastic/universe/config.json dcos_commons.json
```

the script will make sure that:
1. the first elements in the "elasticsearch" section are the ones in the "head" section
2. the last elements in the "elasticsearch" section are the ones in the "tail" section
3. the remaining elements (in the middle) will be sorted alphabetically

The "head" section is usually reserved for important settings, and the "tail"
section for deprecated settings.