### PR TITLE
Allow override KDC Marathon App ID and REALM via env vars

### DIFF
--- a/testing/sdk_auth.py
+++ b/testing/sdk_auth.py
@@ -27,8 +27,8 @@ import sdk_security
 
 log = logging.getLogger(__name__)
 
-KERBEROS_APP_ID = "kdc"
-REALM = "LOCAL"
+KERBEROS_APP_ID = os.getenv("KERBEROS_APP_ID", "kdc")
+REALM = os.getenv("REALM", "LOCAL")
 
 # Note: Some of the helper functions in this module are wrapped in basic retry logic to provide some
 # resiliency towards possible intermittent network failures.

--- a/testing/sdk_auth.py
+++ b/testing/sdk_auth.py
@@ -59,8 +59,8 @@ def _get_kdc_task(task_name: str) -> dict:
         )
 
     # we need to convert task_name in case it is foldered to adopt to Marathon conventions
-    # e.g. /folder/kdc app id becomes kdc.folder taskid
-    foldered_task_name = '.'.join(task_name.split('/')[::-1]).rstrip('.')
+    # e.g. /folder/kdc Marathon App ID becomes kdc.folder Mesos Task ID
+    foldered_task_name = ".".join(task_name.split("/")[::-1]).rstrip(".")
 
     return dict(_get_kdc_task_inner(task_name=foldered_task_name))
 
@@ -218,7 +218,8 @@ class KerberosEnvironment:
 
         # (re-)create a service account for the KDC service
         sdk_security.create_service_account(
-            service_account_name=KDC_SERVICE_ACCOUNT, service_account_secret=KDC_SERVICE_ACCOUNT_SECRET
+            service_account_name=KDC_SERVICE_ACCOUNT,
+            service_account_secret=KDC_SERVICE_ACCOUNT_SECRET,
         )
         sdk_security._grant(
             KDC_SERVICE_ACCOUNT,
@@ -430,7 +431,8 @@ class KerberosEnvironment:
             self._temp_working_dir.cleanup()
 
         sdk_security.delete_service_account(
-            service_account_name=KDC_SERVICE_ACCOUNT, service_account_secret=KDC_SERVICE_ACCOUNT_SECRET
+            service_account_name=KDC_SERVICE_ACCOUNT,
+            service_account_secret=KDC_SERVICE_ACCOUNT_SECRET,
         )
 
         # TODO: separate secrets handling into another module

--- a/testing/sdk_auth.py
+++ b/testing/sdk_auth.py
@@ -56,7 +56,11 @@ def _get_kdc_task(task_name: str) -> dict:
             )
         )
 
-    return dict(_get_kdc_task_inner(task_name=task_name))
+    # we need to convert task_name in case it is foldered to adopt to Marathon conventions
+    # e.g. /folder/kdc app id becomes kdc.folder taskid
+    foldered_task_name = '.'.join(task_name.split('/')[::-1]).rstrip('.')
+
+    return dict(_get_kdc_task_inner(task_name=foldered_task_name))
 
 
 @retrying.retry(stop_max_attempt_number=2, wait_fixed=1000)

--- a/tools/kdc/kdc.py
+++ b/tools/kdc/kdc.py
@@ -61,6 +61,7 @@ import sdk_auth
 import sdk_cmd
 import sdk_security
 
+KERBEROS_APP_ID = os.getenv("KERBEROS_APP_ID", "kdc")
 
 logging.basicConfig(format="[%(asctime)s|%(name)s|%(levelname)s]: %(message)s", level=logging.INFO)
 
@@ -117,7 +118,7 @@ def create_keytab_secret(args: dict, kerberos=None):
 def teardown(args: dict):
     log.info("Tearing down KDC")
 
-    sdk_cmd.run_cli(" ".join(["marathon", "app", "remove", "kdc"]))
+    sdk_cmd.run_cli(" ".join(["marathon", "app", "remove", KERBEROS_APP_ID]))
 
     sdk_security.install_enterprise_cli()
     if args.binary_secret:


### PR DESCRIPTION
Current KDC configuration in `sdk_auth` loads app definition from a JSON file and ignores `id` field overriding it with hard-coded constant `KERBEROS_APP_ID`. This PR allows overrides of `KERBEROS_APP_ID` and `REALM` at least via env vars.