### PR TITLE
[DCOS-56662] Cassandra bump SDK to v 0.57.0-rc-2

### DIFF
--- a/frameworks/cassandra/src/main/dist/svc.yml
+++ b/frameworks/cassandra/src/main/dist/svc.yml
@@ -61,7 +61,6 @@ pods:
         memory: 1024
     tasks:
       server:
-        shm-size: 256
         ipc-mode: SHARE_PARENT
         goal: RUNNING
         resource-set: server-resources

--- a/frameworks/cassandra/src/main/dist/svc.yml
+++ b/frameworks/cassandra/src/main/dist/svc.yml
@@ -5,6 +5,8 @@ scheduler:
 pods:
   node:
     count: {{NODES}}
+    ipc-mode: PRIVATE
+    shm-size: 128
     placement: '{{{PLACEMENT_CONSTRAINT}}}'
     {{#ENABLE_VIRTUAL_NETWORK}}
     networks:
@@ -59,9 +61,14 @@ pods:
         memory: 1024
     tasks:
       server:
+        shm-size: 256
+        ipc-mode: SHARE_PARENT
         goal: RUNNING
         resource-set: server-resources
         cmd: |
+                df -m /dev/shm | grep -w 128 &&
+                stat -Lc %i /proc/self/ns/ipc > /dev/shm/child1 &&
+                sleep $SLEEP_DURATION
                 set -e
 
                 export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jdk*/)

--- a/frameworks/cassandra/universe/config.json
+++ b/frameworks/cassandra/universe/config.json
@@ -11,6 +11,11 @@
           "pattern": "^(\\/?((\\.\\.)|(([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9]))?($|\\/))+$",
           "default": "cassandra"
         },
+        "marathon_enforce_group_role" : {
+          "description": "DELEVELOPMENT ONLY! WILL BE REMOVED IN RELEASE. Whether to allocate using Mesos allocation role or use the legacy role subscription behaviour.",
+          "type": "boolean",
+          "default": false
+        },
         "user": {
           "description": "The user that runs the Cassandra nodes and owns the Mesos sandbox.",
           "type": "string",

--- a/frameworks/cassandra/universe/config.json
+++ b/frameworks/cassandra/universe/config.json
@@ -11,11 +11,6 @@
           "pattern": "^(\\/?((\\.\\.)|(([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9]))?($|\\/))+$",
           "default": "cassandra"
         },
-        "marathon_enforce_group_role" : {
-          "description": "DELEVELOPMENT ONLY! WILL BE REMOVED IN RELEASE. Whether to allocate using Mesos allocation role or use the legacy role subscription behaviour.",
-          "type": "boolean",
-          "default": false
-        },
         "user": {
           "description": "The user that runs the Cassandra nodes and owns the Mesos sandbox.",
           "type": "string",

--- a/frameworks/cassandra/universe/config.json
+++ b/frameworks/cassandra/universe/config.json
@@ -99,6 +99,11 @@
             "type": "application/x-region+string"
           }
         },
+        "sleep": {
+          "description": "The sleep duration in seconds before tasks exit.",
+          "type": "number",
+          "default": 1000
+        },
         "task_failure_backoff": {
           "description": "Configuration for back off of failed/error tasks",
           "type": "object",

--- a/frameworks/cassandra/universe/config.json
+++ b/frameworks/cassandra/universe/config.json
@@ -94,6 +94,35 @@
             "type": "application/x-region+string"
           }
         },
+        "task_failure_backoff": {
+          "description": "Configuration for back off of failed/error tasks",
+          "type": "object",
+          "properties" : {
+            "enabled": {
+              "description": "Enable backoff delay",
+              "type": "boolean",
+              "default": true
+            },
+            "backoff_factor": {
+              "description": "The rate of advancing the backoff delay on a failing task",
+              "type": "number",
+              "default": 1.15
+            },
+            "initial_backoff": {
+              "description": "Initial backoff delay for a task that failed for the first time (in seconds)",
+              "type": "integer",
+              "default": 60
+            },
+            "max_launch_delay": {
+              "description": "Maximum launch delay for any task (in seconds)",
+              "type": "integer",
+              "default": 300
+            }
+          },
+          "required": [
+            "enabled"
+          ]
+        },
         "security": {
           "description": "Cassandra security settings",
           "type": "object",

--- a/frameworks/cassandra/universe/marathon.json.mustache
+++ b/frameworks/cassandra/universe/marathon.json.mustache
@@ -118,6 +118,7 @@
     {{#service.region}}
     "SERVICE_REGION": "{{service.region}}",
     {{/service.region}}
+    "SLEEP_DURATION": "{{service.sleep}}",
     "TASKCFG_ALL_CASSANDRA_USER": "{{service.user}}",
     "TASKCFG_ALL_JMX_PORT": "{{cassandra.jmx_port}}",
     "TASKCFG_ALL_CASSANDRA_NUM_TOKENS": "{{cassandra.num_tokens}}",

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/RawTask.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/RawTask.java
@@ -19,8 +19,6 @@ public final class RawTask {
 
   private final String labelsCsv;
 
-  private final String ipcmode;
-
   private final Map<String, String> env;
 
   private final WriteOnceLinkedHashMap<String, RawConfig> configs;
@@ -30,8 +28,6 @@ public final class RawTask {
   private final Double gpus;
 
   private final Integer memory;
-
-  private final Integer shmsize;
 
   private final WriteOnceLinkedHashMap<String, RawPort> ports;
 
@@ -55,14 +51,12 @@ public final class RawTask {
       @JsonProperty("goal") String goal,
       @JsonProperty("essential") Boolean essential,
       @JsonProperty("cmd") String cmd,
-      @JsonProperty("ipc-mode") String ipcmode,
       @JsonProperty("labels") String labels,
       @JsonProperty("env") Map<String, String> env,
       @JsonProperty("configs") WriteOnceLinkedHashMap<String, RawConfig> configs,
       @JsonProperty("cpus") Double cpus,
       @JsonProperty("gpus") Double gpus,
       @JsonProperty("memory") Integer memory,
-      @JsonProperty("shm-size") Integer shmsize,
       @JsonProperty("ports") WriteOnceLinkedHashMap<String, RawPort> ports,
       @JsonProperty("health-check") RawHealthCheck healthCheck,
       @JsonProperty("readiness-check") RawReadinessCheck readinessCheck,
@@ -76,14 +70,12 @@ public final class RawTask {
     this.goal = goal;
     this.essential = essential;
     this.cmd = cmd;
-    this.ipcmode = ipcmode;
     this.labelsCsv = labels;
     this.env = env;
     this.configs = configs;
     this.cpus = cpus;
     this.gpus = gpus;
     this.memory = memory;
-    this.shmsize = shmsize;
     this.ports = ports;
     this.healthCheck = healthCheck;
     this.readinessCheck = readinessCheck;
@@ -105,10 +97,6 @@ public final class RawTask {
 
   public Integer getMemory() {
     return memory;
-  }
-
-  public Integer getShmsize() {
-    return shmsize;
   }
 
   public String getResourceSet() {
@@ -141,10 +129,6 @@ public final class RawTask {
 
   public String getCmd() {
     return cmd;
-  }
-
-  public String getIpcmode() {
-    return ipcmode;
   }
 
   public String getLabelsCsv() {

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/RawTask.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/RawTask.java
@@ -19,6 +19,8 @@ public final class RawTask {
 
   private final String labelsCsv;
 
+  private final String ipcmode;
+
   private final Map<String, String> env;
 
   private final WriteOnceLinkedHashMap<String, RawConfig> configs;
@@ -28,6 +30,8 @@ public final class RawTask {
   private final Double gpus;
 
   private final Integer memory;
+
+  private final Integer shmsize;
 
   private final WriteOnceLinkedHashMap<String, RawPort> ports;
 
@@ -51,12 +55,14 @@ public final class RawTask {
       @JsonProperty("goal") String goal,
       @JsonProperty("essential") Boolean essential,
       @JsonProperty("cmd") String cmd,
+      @JsonProperty("ipc-mode") String ipcmode,
       @JsonProperty("labels") String labels,
       @JsonProperty("env") Map<String, String> env,
       @JsonProperty("configs") WriteOnceLinkedHashMap<String, RawConfig> configs,
       @JsonProperty("cpus") Double cpus,
       @JsonProperty("gpus") Double gpus,
       @JsonProperty("memory") Integer memory,
+      @JsonProperty("shm-size") Integer shmsize,
       @JsonProperty("ports") WriteOnceLinkedHashMap<String, RawPort> ports,
       @JsonProperty("health-check") RawHealthCheck healthCheck,
       @JsonProperty("readiness-check") RawReadinessCheck readinessCheck,
@@ -70,12 +76,14 @@ public final class RawTask {
     this.goal = goal;
     this.essential = essential;
     this.cmd = cmd;
+    this.ipcmode = ipcmode;
     this.labelsCsv = labels;
     this.env = env;
     this.configs = configs;
     this.cpus = cpus;
     this.gpus = gpus;
     this.memory = memory;
+    this.shmsize = shmsize;
     this.ports = ports;
     this.healthCheck = healthCheck;
     this.readinessCheck = readinessCheck;
@@ -97,6 +105,10 @@ public final class RawTask {
 
   public Integer getMemory() {
     return memory;
+  }
+
+  public Integer getShmsize() {
+    return shmsize;
   }
 
   public String getResourceSet() {
@@ -129,6 +141,10 @@ public final class RawTask {
 
   public String getCmd() {
     return cmd;
+  }
+
+  public String getIpcmode() {
+    return ipcmode;
   }
 
   public String getLabelsCsv() {


### PR DESCRIPTION
## What changes were proposed in this pull request?
Resolves: [[DCOS-56662] [Cassandra] Bump SDK to version 0.57.0](https://jira.mesosphere.com/browse/DCOS-56662)
Changes include below features part of 0.57.0-rc2 sdk update:

- Task Backoff Delay
- Shared Hierarchial Memory Support 
- Quota Support
For more details please refer: https://github.com/mesosphere/dcos-commons/releases/tag/0.57.0-rc2

## How were these changes tested?
All the changes were implemented one by one and tested whether respective changes reflecting or not locally , service installed and tested its normal behaviour

Below are the screen shot for quota support and backoff delay
![quotasupport](https://user-images.githubusercontent.com/37998364/61717256-5bd9dd80-ad7e-11e9-9416-66b8457e4613.png)
![back-off delay](https://user-images.githubusercontent.com/37998364/61717460-ba06c080-ad7e-11e9-9bcb-f3ea6f46a10c.png)

