### PR TITLE
[DCOS-55313] Cassandra integration test for S3_ENDPOINT_URL

### DIFF
--- a/frameworks/cassandra/tests/config.py
+++ b/frameworks/cassandra/tests/config.py
@@ -24,6 +24,10 @@ DEFAULT_CASSANDRA_TIMEOUT = 600
 SECRET_VALUE = "password"
 # Soak artifact scripts may override the service name to test
 
+MINIO_AWS_ACCESS_KEY_ID = "minio"
+MINIO_AWS_SECRET_ACCESS_KEY = "minio123"
+MINIO_BUCKET_NAME = "miniobackup"
+
 DEFAULT_NODE_ADDRESS = os.getenv(
     "CASSANDRA_NODE_ADDRESS", sdk_hosts.autoip_host(SERVICE_NAME, "node-0-server")
 )

--- a/frameworks/cassandra/tests/test_backup_and_restore.py
+++ b/frameworks/cassandra/tests/test_backup_and_restore.py
@@ -148,7 +148,7 @@ def test_backup_and_restore_to_s3_compatible_storage() -> None:
         "AWS_ACCESS_KEY_ID": os.getenv("AWS_ACCESS_KEY_ID"),
         "AWS_SECRET_ACCESS_KEY": os.getenv("AWS_SECRET_ACCESS_KEY"),
         "AWS_REGION": os.getenv("AWS_REGION", "us-west-2"),
-        "S3_BUCKET_NAME": os.getenv("AWS_BUCKET_NAME", "miniobackup"),
+        "S3_BUCKET_NAME": config.MINIO_BUCKET_NAME,
         "SNAPSHOT_NAME": str(uuid.uuid1()),
         "CASSANDRA_KEYSPACES": '"testspace1 testspace2"',
         "S3_ENDPOINT_URL": minio_endpoint_url,

--- a/frameworks/cassandra/tests/test_backup_and_restore.py
+++ b/frameworks/cassandra/tests/test_backup_and_restore.py
@@ -23,6 +23,10 @@ no_strict_for_azure = pytest.mark.skipif(
 def configure_package(configure_security: None) -> Iterator[None]:
     test_jobs: List[Dict[str, Any]] = []
     try:
+        sdk_cmd.run_cli("package install minio --yes")
+        sdk_cmd.run_cli("package install marathon-lb --yes")
+        sdk_marathon.wait_for_deployment("marathon-lb", 1200, None)
+        sdk_marathon.wait_for_deployment("minio", 1200, None)
         test_jobs = config.get_all_jobs(node_address=config.get_foldered_node_address())
         # destroy/reinstall any prior leftover jobs, so that they don't touch the newly installed service:
         for job in test_jobs:
@@ -47,6 +51,8 @@ def configure_package(configure_security: None) -> Iterator[None]:
 
         yield  # let the test session execute
     finally:
+        sdk_cmd.run_cli("package uninstall minio --yes")
+        sdk_cmd.run_cli("package uninstall marathon-lb --yes")
         sdk_install.uninstall(config.PACKAGE_NAME, config.get_foldered_service_name())
 
         # remove job definitions from metronome

--- a/frameworks/cassandra/tests/test_backup_and_restore.py
+++ b/frameworks/cassandra/tests/test_backup_and_restore.py
@@ -53,7 +53,9 @@ def configure_package(configure_security: None) -> Iterator[None]:
     finally:
         sdk_cmd.run_cli("package uninstall minio --yes")
         sdk_cmd.run_cli("package uninstall marathon-lb --yes")
-        transport_encryption.cleanup_service_account("marathon-lb", service_account_info)
+        if os.environ.get("SECURITY") == "strict":
+            transport_encryption.cleanup_service_account("marathon-lb", service_account_info)
+
         sdk_install.uninstall(config.PACKAGE_NAME, config.get_foldered_service_name())
 
         # remove job definitions from metronome
@@ -143,9 +145,7 @@ def test_backup_and_restore_to_s3_compatible_storage() -> None:
     sdk_marathon.wait_for_deployment("marathon-lb", 1200, None)
     sdk_marathon.wait_for_deployment("minio", 1200, None)
     host = sdk_marathon.get_scheduler_host("marathon-lb")
-    print("host", host)
     _, public_node_ip, _ = sdk_cmd.agent_ssh(host, "curl -s ifconfig.co")
-    print("public_node_ip", public_node_ip)
     minio_endpoint_url = "http://" + public_node_ip + ":9000"
     os.environ["AWS_ACCESS_KEY_ID"] = config.MINIO_AWS_ACCESS_KEY_ID
     os.environ["AWS_SECRET_ACCESS_KEY"] = config.MINIO_AWS_SECRET_ACCESS_KEY

--- a/frameworks/cassandra/tests/test_backup_and_restore.py
+++ b/frameworks/cassandra/tests/test_backup_and_restore.py
@@ -11,7 +11,6 @@ import subprocess
 import sdk_security
 import sdk_utils
 
-# import json
 from tests import config
 
 
@@ -132,9 +131,9 @@ def test_backup_and_restore_to_s3_compatible_storage() -> None:
             assert (
                 False
             ), 'AWS credentials are required for this test. Disable test with e.g. TEST_TYPES="sanity and not aws"'
-        temp_secret_Access_key = os.getenv("AWS_SECRET_ACCESS_KEY")
-        is_strict = sdk_utils.is_strict_mode()
-        if is_strict:
+        temp_secret_access_key = os.getenv("AWS_SECRET_ACCESS_KEY")
+        options = ""
+        if sdk_utils.is_strict_mode():
             sdk_security.create_service_account(
                 service_account_name="marathon-lb-sa",
                 service_account_secret="marathon-lb/service-account-secret",
@@ -152,24 +151,14 @@ def test_backup_and_restore_to_s3_compatible_storage() -> None:
                 }
             }
 
-            sdk_install.install(
-                "marathon-lb",
-                "marathon-lb",
-                expected_running_tasks=0,
-                additional_options=options,
-                package_version="1.14.0",
-                wait_for_deployment=False,
-            )
-
-        else:
-            sdk_install.install(
-                "marathon-lb",
-                "marathon-lb",
-                expected_running_tasks=0,
-                package_version="1.14.0",
-                wait_for_deployment=False,
-            )
-
+        sdk_install.install(
+            "marathon-lb",
+            "marathon-lb",
+            expected_running_tasks=0,
+            additional_options=options,
+            package_version="1.14.0",
+            wait_for_deployment=False,
+        )
         host = sdk_marathon.get_scheduler_host("marathon-lb")
         _, public_node_ip, _ = sdk_cmd.agent_ssh(host, "curl -s ifconfig.co")
         minio_endpoint_url = "http://" + public_node_ip + ":9000"
@@ -207,4 +196,4 @@ def test_backup_and_restore_to_s3_compatible_storage() -> None:
         sdk_install.uninstall("minio", "minio")
         sdk_install.uninstall("marathon-lb", "marathon-lb")
         os.environ["AWS_ACCESS_KEY_ID"] = temp_key_id
-        os.environ["AWS_SECRET_ACCESS_KEY"] = temp_secret_Access_key
+        os.environ["AWS_SECRET_ACCESS_KEY"] = temp_secret_access_key


### PR DESCRIPTION
## What changes are proposed in this PR? 

Added integration test to check backup functionality of Cassandra over S3 compatible storage, in this test case S3 compatible storage is minio.
  
Resolves [DCOS-55313](https://jira.mesosphere.com/browse/DCOS-55313)

## How were these changes tested?
N/A