### PR TITLE
[DCOS-55732] Add keytab-fix.jar source code to dcos-commons/hdfs

### DIFF
--- a/frameworks/hdfs/keytab-fix/pom.xml
+++ b/frameworks/hdfs/keytab-fix/pom.xml
@@ -1,0 +1,62 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.mesosphere.keytabfix</groupId>
+  <artifactId>keytabfix</artifactId>
+  <packaging>jar</packaging>
+  <version>1.0-SNAPSHOT</version>
+  <name>krbtest</name>
+  <url>http://maven.apache.org</url>
+  
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>3.8.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-auth</artifactId>
+      <version>3.2.0</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+	<groupId>org.apache.maven.plugins</groupId>
+	<artifactId>maven-assembly-plugin</artifactId>
+	<configuration>
+	  <!-- get all project dependencies -->
+	  <descriptorRefs>
+	    <descriptorRef>jar-with-dependencies</descriptorRef>
+	  </descriptorRefs>
+	  <!-- MainClass in mainfest make a executable jar -->
+	  <archive>
+	    <manifest>
+	      <mainClass>com.mesosphere.keytabfix.KeytabFix</mainClass>
+	    </manifest>
+	  </archive>
+        </configuration>
+	<executions>
+	  <execution>
+	    <id>make-assembly</id>
+            <!-- bind to the packaging phase -->
+	    <phase>package</phase> 
+	    <goals>
+	      <goal>single</goal>
+	    </goals>
+	  </execution>
+	</executions>
+      </plugin>
+      <plugin>    
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+            <source>1.8</source>
+            <target>1.8</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/frameworks/hdfs/keytab-fix/src/main/java/com/mesosphere/keytabfix/KerberosUtil.java
+++ b/frameworks/hdfs/keytab-fix/src/main/java/com/mesosphere/keytabfix/KerberosUtil.java
@@ -1,0 +1,452 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mesosphere.keytabfix;
+
+import static org.apache.hadoop.util.PlatformName.IBM_JAVA;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.nio.ByteBuffer;
+import java.nio.charset.IllegalCharsetNameException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.NoSuchElementException;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import org.apache.kerby.kerberos.kerb.type.base.PrincipalName;
+import org.ietf.jgss.GSSException;
+import org.ietf.jgss.Oid;
+
+import javax.security.auth.Subject;
+import javax.security.auth.kerberos.KerberosTicket;
+
+public class KerberosUtil {
+
+  /* Return the Kerberos login module name */
+  public static String getKrb5LoginModuleName() {
+    return (IBM_JAVA)
+      ? "com.ibm.security.auth.module.Krb5LoginModule"
+      : "com.sun.security.auth.module.Krb5LoginModule";
+  }
+
+  public static final Oid GSS_SPNEGO_MECH_OID =
+      getNumericOidInstance("1.3.6.1.5.5.2");
+  public static final Oid GSS_KRB5_MECH_OID =
+      getNumericOidInstance("1.2.840.113554.1.2.2");
+  public static final Oid NT_GSS_KRB5_PRINCIPAL_OID =
+      getNumericOidInstance("1.2.840.113554.1.2.2.1");
+
+  // numeric oids will never generate a GSSException for a malformed oid.
+  // use to initialize statics.
+  private static Oid getNumericOidInstance(String oidName) {
+    try {
+      return new Oid(oidName);
+    } catch (GSSException ex) {
+      throw new IllegalArgumentException(ex);
+    }
+  }
+
+  public static Oid getOidInstance(String oidName) 
+      throws ClassNotFoundException, GSSException, NoSuchFieldException,
+      IllegalAccessException {
+    Class<?> oidClass;
+    if (IBM_JAVA) {
+      if ("NT_GSS_KRB5_PRINCIPAL".equals(oidName)) {
+        // IBM JDK GSSUtil class does not have field for krb5 principal oid
+        return new Oid("1.2.840.113554.1.2.2.1");
+      }
+      oidClass = Class.forName("com.ibm.security.jgss.GSSUtil");
+    } else {
+      oidClass = Class.forName("sun.security.jgss.GSSUtil");
+    }
+    Field oidField = oidClass.getDeclaredField(oidName);
+    return (Oid)oidField.get(oidClass);
+  }
+
+  public static String getDefaultRealm() 
+      throws ClassNotFoundException, NoSuchMethodException, 
+      IllegalArgumentException, IllegalAccessException, 
+      InvocationTargetException {
+    Object kerbConf;
+    Class<?> classRef;
+    Method getInstanceMethod;
+    Method getDefaultRealmMethod;
+    if (IBM_JAVA) {
+      classRef = Class.forName("com.ibm.security.krb5.internal.Config");
+    } else {
+      classRef = Class.forName("sun.security.krb5.Config");
+    }
+    getInstanceMethod = classRef.getMethod("getInstance", new Class[0]);
+    kerbConf = getInstanceMethod.invoke(classRef, new Object[0]);
+    getDefaultRealmMethod = classRef.getDeclaredMethod("getDefaultRealm",
+         new Class[0]);
+    return (String)getDefaultRealmMethod.invoke(kerbConf, new Object[0]);
+  }
+
+  public static String getDefaultRealmProtected() {
+    String realmString = null;
+    try {
+      realmString = getDefaultRealm();
+    } catch (RuntimeException rte) {
+      //silently catch everything
+    } catch (Exception e) {
+      //silently return null
+    }
+    return realmString;
+  }
+
+  /*
+   * For a Service Host Principal specification, map the host's domain
+   * to kerberos realm, as specified by krb5.conf [domain_realm] mappings.
+   * Unfortunately the mapping routines are private to the security.krb5
+   * package, so have to construct a PrincipalName instance to derive the realm.
+   *
+   * Many things can go wrong with Kerberos configuration, and this is not
+   * the place to be throwing exceptions to help debug them.  Nor do we choose
+   * to make potentially voluminous logs on every call to a communications API.
+   * So we simply swallow all exceptions from the underlying libraries and
+   * return null if we can't get a good value for the realmString.
+   *
+   * @param shortprinc A service principal name with host fqdn as instance, e.g.
+   *     "HTTP/myhost.mydomain"
+   * @return String value of Kerberos realm, mapped from host fqdn
+   *     May be default realm, or may be null.
+   */
+  public static String getDomainRealm(String shortprinc) {
+    Class<?> classRef;
+    Object principalName; //of type sun.security.krb5.PrincipalName or IBM equiv
+    String realmString = null;
+    try {
+      if (IBM_JAVA) {
+        classRef = Class.forName("com.ibm.security.krb5.PrincipalName");
+      } else {
+        classRef = Class.forName("sun.security.krb5.PrincipalName");
+      }
+      int tKrbNtSrvHst = classRef.getField("KRB_NT_SRV_HST").getInt(null);
+      principalName = classRef.getConstructor(String.class, int.class).
+          newInstance(shortprinc, tKrbNtSrvHst);
+      realmString = (String)classRef.getMethod("getRealmString", new Class[0]).
+          invoke(principalName, new Object[0]);
+    } catch (RuntimeException rte) {
+      //silently catch everything
+    } catch (Exception e) {
+      //silently return default realm (which may itself be null)
+    }
+    if (null == realmString || realmString.equals("")) {
+      return getDefaultRealmProtected();
+    } else {
+      return realmString;
+    }
+  }
+
+  /* Return fqdn of the current host */
+  static String getLocalHostName() throws UnknownHostException {
+    return InetAddress.getLocalHost().getCanonicalHostName();
+  }
+  
+  /**
+   * Create Kerberos principal for a given service and hostname,
+   * inferring realm from the fqdn of the hostname. It converts
+   * hostname to lower case. If hostname is null or "0.0.0.0", it uses
+   * dynamically looked-up fqdn of the current host instead.
+   * If domain_realm mappings are inadequately specified, it will
+   * use default_realm, per usual Kerberos behavior.
+   * If default_realm also gives a null value, then a principal
+   * without realm will be returned, which by Kerberos definitions is
+   * just another way to specify default realm.
+   *
+   * @param service
+   *          Service for which you want to generate the principal.
+   * @param hostname
+   *          Fully-qualified domain name.
+   * @return Converted Kerberos principal name.
+   * @throws UnknownHostException
+   *           If no IP address for the local host could be found.
+   */
+  public static final String getServicePrincipal(String service,
+      String hostname)
+      throws UnknownHostException {
+    String fqdn = hostname;
+    String shortprinc = null;
+    String realmString = null;
+    if (null == fqdn || fqdn.equals("") || fqdn.equals("0.0.0.0")) {
+      fqdn = getLocalHostName();
+    }
+    // convert hostname to lowercase as kerberos does not work with hostnames
+    // with uppercase characters.
+    fqdn = fqdn.toLowerCase(Locale.US);
+    shortprinc = service + "/" + fqdn;
+    // Obtain the realm name inferred from the domain of the host
+    realmString = getDomainRealm(shortprinc);
+    if (null == realmString || realmString.equals("")) {
+      return shortprinc;
+    } else {
+      return shortprinc + "@" + realmString;
+    }
+  }
+
+  /**
+   * Get all the unique principals present in the keytabfile.
+   * 
+   * @param keytabFileName 
+   *          Name of the keytab file to be read.
+   * @return list of unique principals in the keytab.
+   * @throws IOException 
+   *          If keytab entries cannot be read from the file.
+   */
+  static final String[] getPrincipalNames(String keytabFileName) throws IOException {
+    Keytab keytab = Keytab.loadKeytab(new File(keytabFileName));
+    Set<String> principals = new HashSet<String>();
+    List<PrincipalName> entries = keytab.getPrincipals();
+    for (PrincipalName entry : entries) {
+      principals.add(entry.getName().replace("\\", "/"));
+    }
+    return principals.toArray(new String[0]);
+  }
+
+  /**
+   * Get all the unique principals from keytabfile which matches a pattern.
+   * 
+   * @param keytab Name of the keytab file to be read.
+   * @param pattern pattern to be matched.
+   * @return list of unique principals which matches the pattern.
+   * @throws IOException if cannot get the principal name
+   */
+  public static final String[] getPrincipalNames(String keytab,
+      Pattern pattern) throws IOException {
+    String[] principals = getPrincipalNames(keytab);
+    if (principals.length != 0) {
+      List<String> matchingPrincipals = new ArrayList<String>();
+      for (String principal : principals) {
+        if (pattern.matcher(principal).matches()) {
+          matchingPrincipals.add(principal);
+        }
+      }
+      principals = matchingPrincipals.toArray(new String[0]);
+    }
+    return principals;
+  }
+
+  /**
+   * Check if the subject contains Kerberos keytab related objects.
+   * The Kerberos keytab object attached in subject has been changed
+   * from KerberosKey (JDK 7) to KeyTab (JDK 8)
+   *
+   *
+   * @param subject subject to be checked
+   * @return true if the subject contains Kerberos keytab
+   */
+  public static boolean hasKerberosKeyTab(Subject subject) {
+    return false;//!subject.getPrivateCredentials(KeyTab.class).isEmpty();
+  }
+
+  /**
+   * Check if the subject contains Kerberos ticket.
+   *
+   *
+   * @param subject subject to be checked
+   * @return true if the subject contains Kerberos ticket
+   */
+  public static boolean hasKerberosTicket(Subject subject) {
+    return !subject.getPrivateCredentials(KerberosTicket.class).isEmpty();
+  }
+
+  /**
+   * Extract the TGS server principal from the given gssapi kerberos or spnego
+   * wrapped token.
+   * @param rawToken bytes of the gss token
+   * @return String of server principal
+   * @throws IllegalArgumentException if token is undecodable
+   */
+  public static String getTokenServerName(byte[] rawToken) {
+    // subsequent comments include only relevant portions of the kerberos
+    // DER encoding that will be extracted.
+    DER token = new DER(rawToken);
+    // InitialContextToken ::= [APPLICATION 0] IMPLICIT SEQUENCE {
+    //     mech   OID
+    //     mech-token  (NegotiationToken or InnerContextToken)
+    // }
+    DER oid = token.next();
+    if (oid.equals(DER.SPNEGO_MECH_OID)) {
+      // NegotiationToken ::= CHOICE {
+      //     neg-token-init[0] NegTokenInit
+      // }
+      // NegTokenInit ::= SEQUENCE {
+      //     mech-token[2]     InitialContextToken
+      // }
+      token = token.next().get(0xa0, 0x30, 0xa2, 0x04).next();
+      oid = token.next();
+    }
+    if (!oid.equals(DER.KRB5_MECH_OID)) {
+      throw new IllegalArgumentException("Malformed gss token");
+    }
+    // InnerContextToken ::= {
+    //     token-id[1]
+    //     AP-REQ
+    // }
+    if (token.next().getTag() != 1) {
+      throw new IllegalArgumentException("Not an AP-REQ token");
+    }
+    // AP-REQ ::= [APPLICATION 14] SEQUENCE {
+    //     ticket[3]      Ticket
+    // }
+    DER ticket = token.next().get(0x6e, 0x30, 0xa3, 0x61, 0x30);
+    // Ticket ::= [APPLICATION 1] SEQUENCE {
+    //     realm[1]       String
+    //     sname[2]       PrincipalName
+    // }
+    // PrincipalName ::= SEQUENCE {
+    //     name-string[1] SEQUENCE OF String
+    // }
+    String realm = ticket.get(0xa1, 0x1b).getAsString();
+    DER names = ticket.get(0xa2, 0x30, 0xa1, 0x30);
+    StringBuilder sb = new StringBuilder();
+    while (names.hasNext()) {
+      if (sb.length() > 0) {
+        sb.append('/');
+      }
+      sb.append(names.next().getAsString());
+    }
+    return sb.append('@').append(realm).toString();
+  }
+
+  // basic ASN.1 DER decoder to traverse encoded byte arrays.
+  private static class DER implements Iterator<DER> {
+    static final DER SPNEGO_MECH_OID = getDER(GSS_SPNEGO_MECH_OID);
+    static final DER KRB5_MECH_OID = getDER(GSS_KRB5_MECH_OID);
+
+    private static DER getDER(Oid oid) {
+      try {
+        return new DER(oid.getDER());
+      } catch (GSSException ex) {
+        // won't happen.  a proper OID is encodable.
+        throw new IllegalArgumentException(ex);
+      }
+    }
+
+    private final int tag;
+    private final ByteBuffer bb;
+
+    DER(byte[] buf) {
+      this(ByteBuffer.wrap(buf));
+    }
+
+    DER(ByteBuffer srcbb) {
+      tag = srcbb.get() & 0xff;
+      int length = readLength(srcbb);
+      bb = srcbb.slice();
+      bb.limit(length);
+      srcbb.position(srcbb.position() + length);
+    }
+
+    int getTag() {
+      return tag;
+    }
+
+    // standard ASN.1 encoding.
+    private static int readLength(ByteBuffer bb) {
+      int length = bb.get();
+      if ((length & (byte)0x80) != 0) {
+        int varlength = length & 0x7f;
+        length = 0;
+        for (int i=0; i < varlength; i++) {
+          length = (length << 8) | (bb.get() & 0xff);
+        }
+      }
+      return length;
+    }
+
+    DER choose(int subtag) {
+      while (hasNext()) {
+        DER der = next();
+        if (der.getTag() == subtag) {
+          return der;
+        }
+      }
+      return null;
+    }
+
+    DER get(int... tags) {
+      DER der = this;
+      for (int i=0; i < tags.length; i++) {
+        int expectedTag = tags[i];
+        // lookup for exact match, else scan if it's sequenced.
+        if (der.getTag() != expectedTag) {
+          der = der.hasNext() ? der.choose(expectedTag) : null;
+        }
+        if (der == null) {
+          StringBuilder sb = new StringBuilder("Tag not found:");
+          for (int ii=0; ii <= i; ii++) {
+            sb.append(" 0x").append(Integer.toHexString(tags[ii]));
+          }
+          throw new IllegalStateException(sb.toString());
+        }
+      }
+      return der;
+    }
+
+    String getAsString() {
+      try {
+        return new String(bb.array(), bb.arrayOffset() + bb.position(),
+            bb.remaining(), "UTF-8");
+      } catch (UnsupportedEncodingException e) {
+        throw new IllegalCharsetNameException("UTF-8"); // won't happen.
+      }
+    }
+
+    @Override
+    public int hashCode() {
+      return 31 * tag + bb.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      return (o instanceof DER) &&
+          tag == ((DER)o).tag && bb.equals(((DER)o).bb);
+    }
+
+    @Override
+    public boolean hasNext() {
+      // it's a sequence or an embedded octet.
+      return ((tag & 0x30) != 0 || tag == 0x04) && bb.hasRemaining();
+    }
+
+    @Override
+    public DER next() {
+      if (!hasNext()) {
+        throw new NoSuchElementException();
+      }
+      return new DER(bb);
+    }
+
+    @Override
+    public String toString() {
+      return "[tag=0x"+Integer.toHexString(tag)+" bb="+bb+"]";
+    }
+  }
+}

--- a/frameworks/hdfs/keytab-fix/src/main/java/com/mesosphere/keytabfix/Keytab.java
+++ b/frameworks/hdfs/keytab-fix/src/main/java/com/mesosphere/keytabfix/Keytab.java
@@ -1,0 +1,252 @@
+/**
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+package com.mesosphere.keytabfix;
+
+import org.apache.kerby.kerberos.kerb.type.base.EncryptionKey;
+import org.apache.kerby.kerberos.kerb.type.base.EncryptionType;
+import org.apache.kerby.kerberos.kerb.type.base.PrincipalName;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Keytab management util.
+ */
+public final class Keytab implements KrbKeytab {
+
+    public static final int V501 = 0x0501;
+    public static final int V502 = 0x0502;
+
+    private int version = V502;
+
+    private Map<PrincipalName, List<KeytabEntry>> principalEntries;
+
+    public Keytab() {
+        this.principalEntries = new HashMap<PrincipalName, List<KeytabEntry>>();
+    }
+
+    public static Keytab loadKeytab(File keytabFile) throws IOException {
+        Keytab keytab = new Keytab();
+        keytab.load(keytabFile);
+        return keytab;
+    }
+
+    public static Keytab loadKeytab(InputStream inputStream) throws IOException {
+        Keytab keytab = new Keytab();
+        keytab.load(inputStream);
+        return keytab;
+    }
+
+    @Override
+    public List<PrincipalName> getPrincipals() {
+        return new ArrayList<PrincipalName>(principalEntries.keySet());
+    }
+
+    @Override
+    public void addKeytabEntries(List<KeytabEntry> entries) {
+        for (KeytabEntry entry : entries) {
+            addEntry(entry);
+        }
+    }
+
+    @Override
+    public void removeKeytabEntries(PrincipalName principal) {
+        principalEntries.remove(principal);
+    }
+
+    @Override
+    public void removeKeytabEntries(PrincipalName principal, int kvno) {
+        List<KeytabEntry> entries = getKeytabEntries(principal);
+        for (KeytabEntry entry : entries) {
+            if (entry.getKvno() == kvno) {
+                removeKeytabEntry(entry);
+            }
+        }
+    }
+
+    @Override
+    public void removeKeytabEntry(KeytabEntry entry) {
+        PrincipalName principal = entry.getPrincipal();
+        List<KeytabEntry> entries = principalEntries.get(principal);
+        if (entries != null) {
+            Iterator<KeytabEntry> iter = entries.iterator();
+            while (iter.hasNext()) {
+                KeytabEntry tmp = iter.next();
+                if (entry.equals(tmp)) {
+                    iter.remove();
+                    break;
+                }
+            }
+        }
+    }
+
+    @Override
+    public List<KeytabEntry> getKeytabEntries(PrincipalName principal) {
+        List<KeytabEntry> results = new ArrayList<KeytabEntry>();
+
+        List<KeytabEntry> internal = principalEntries.get(principal);
+        if (internal == null) {
+            return results;
+        }
+
+        for (KeytabEntry entry : internal) {
+            results.add(entry);
+        }
+
+        return results;
+    }
+
+    @Override
+    public EncryptionKey getKey(PrincipalName principal, EncryptionType keyType) {
+        List<KeytabEntry> entries = getKeytabEntries(principal);
+        for (KeytabEntry ke : entries) {
+            if (ke.getKey().getKeyType() == keyType) {
+                return ke.getKey();
+            }
+        }
+
+        return null;
+    }
+
+    @Override
+    public void load(File keytabFile) throws IOException {
+    	
+    	InputStream is = null;
+        if (!keytabFile.exists() || !keytabFile.canRead()) {
+            throw new IllegalArgumentException("Invalid keytab file: " + keytabFile.getAbsolutePath());
+        }
+        
+        try {
+        	is = Files.newInputStream(keytabFile.toPath());
+            load(is);
+        }
+        finally {
+        	if(is != null) {
+        		is.close(); 	
+        	}        	
+        }
+    }
+
+    @Override
+    public void load(InputStream inputStream) throws IOException {
+        if (inputStream == null) {
+            throw new IllegalArgumentException("Invalid and null input stream");
+        }
+
+        KeytabInputStream kis = new KeytabInputStream(inputStream);
+        doLoad(kis);
+    }
+
+    private void doLoad(KeytabInputStream kis) throws IOException {
+        this.version = readVersion(kis);
+
+        List<KeytabEntry> entries = readEntries(kis);
+        addKeytabEntries(entries);
+        
+    }
+
+    @Override
+    public void addEntry(KeytabEntry entry) {
+        PrincipalName principal = entry.getPrincipal();
+        List<KeytabEntry> entries = principalEntries.get(principal);
+        if (entries == null) {
+            entries = new ArrayList<KeytabEntry>();
+            principalEntries.put(principal, entries);
+        }
+        entries.add(entry);
+    }
+
+    private int readVersion(KeytabInputStream kis) throws IOException {
+        return kis.readShort();
+    }
+
+    private List<KeytabEntry> readEntries(KeytabInputStream kis) throws IOException {
+        List<KeytabEntry> entries = new ArrayList<KeytabEntry>();
+
+        int bytesLeft = kis.available();
+        while (bytesLeft > 0) {
+            int entrySize = kis.readInt();
+            if (kis.available() < entrySize) {
+                throw new IOException("Bad input stream with less data than expected: " + entrySize);
+            }
+            KeytabEntry entry = readEntry(kis, entrySize);
+            entries.add(entry);
+            int bytesReadForEntry = bytesLeft - kis.available() - 4;
+            if (bytesReadForEntry != entrySize) {
+                kis.skipBytes(entrySize - bytesReadForEntry); // reposition to the next keytab entry
+            }
+            //kis.readInt(); //TODO: This is a tricky fix, actual fix will be correct the bytesReadForEntry
+            // calculation. It should not consider first 4 byte specifying size as read bytes for entry.
+            bytesLeft = kis.available();
+        }
+
+        return entries;
+    }
+
+    private KeytabEntry readEntry(KeytabInputStream kis, int entrySize) throws IOException {
+        KeytabEntry entry = new KeytabEntry();
+        entry.load(kis, version, entrySize);
+        return entry;
+    }
+
+    @Override
+    public void store(File keytabFile) throws IOException {
+        try (OutputStream outputStream = Files.newOutputStream(keytabFile.toPath())) {
+            store(outputStream);
+        }
+    }
+
+    @Override
+    public void store(OutputStream outputStream) throws IOException {
+        if (outputStream == null) {
+            throw new IllegalArgumentException("Invalid and null output stream");
+        }
+
+        KeytabOutputStream kos = new KeytabOutputStream(outputStream);
+
+        writeVersion(kos);
+        writeEntries(kos);
+    }
+
+    private void writeVersion(KeytabOutputStream kos) throws IOException {
+        byte[] bytes = new byte[2];
+        bytes[0] = (byte) 0x05;
+        bytes[1] = version == V502 ? (byte) 0x02 : (byte) 0x01;
+
+        kos.write(bytes);
+    }
+
+    private void writeEntries(KeytabOutputStream kos) throws IOException {
+        for (Map.Entry<PrincipalName, List<KeytabEntry>> entryList : principalEntries.entrySet()) {
+            for (KeytabEntry entry : entryList.getValue()) {
+                entry.store(kos);
+            }
+        }
+    }
+
+}

--- a/frameworks/hdfs/keytab-fix/src/main/java/com/mesosphere/keytabfix/KeytabEntry.java
+++ b/frameworks/hdfs/keytab-fix/src/main/java/com/mesosphere/keytabfix/KeytabEntry.java
@@ -1,0 +1,150 @@
+/**
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+package com.mesosphere.keytabfix;
+
+import org.apache.kerby.kerberos.kerb.type.KerberosTime;
+import org.apache.kerby.kerberos.kerb.type.base.EncryptionKey;
+import org.apache.kerby.kerberos.kerb.type.base.PrincipalName;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+public class KeytabEntry {
+    private PrincipalName principal;
+    private KerberosTime timestamp;
+    private int kvno;
+    private EncryptionKey key;
+
+    public KeytabEntry(PrincipalName principal, KerberosTime timestamp,
+                       int kvno, EncryptionKey key) {
+        this.principal = principal;
+        this.timestamp = timestamp;
+        this.kvno = kvno;
+        this.key = key;
+    }
+
+    public KeytabEntry() {
+
+    }
+
+    void load(KeytabInputStream kis, int version, int entrySize) throws IOException {
+        int bytesLeft = kis.available();
+        this.principal = kis.readPrincipal(version);
+
+        this.timestamp = kis.readTime();
+
+        this.kvno = kis.readByte();
+
+        this.key = kis.readKey();
+
+        int entryBytesRead = bytesLeft - kis.available();
+
+        // Some implementations of Kerberos recognize a 32-bit key version at the end of an entry, if record length is
+        // at least 4 bytes longer than the entry and the value of those 32 bits is not 0. If present, this key version
+        // supersedes the 8-bit key version.
+        if (entryBytesRead + 4 <= entrySize) {
+            int tmp = kis.readInt();
+
+            if (tmp != 0) {
+                this.kvno = tmp;
+            }
+        } else if (entryBytesRead != entrySize) {
+            throw new IOException(
+                    String.format("Bad input stream with less data read [%d] than expected [%d] for keytab entry.",
+                            entryBytesRead, entrySize));
+        }
+    }
+
+    void store(KeytabOutputStream kos) throws IOException {
+        byte[] body = null;
+
+        // compute entry body content first so that to get and write the size
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        KeytabOutputStream subKos = new KeytabOutputStream(baos);
+        writeBody(subKos, 0); // todo: consider the version
+        subKos.flush();
+        body = baos.toByteArray();
+
+        kos.writeInt(body.length);
+        kos.write(body);
+    }
+
+    public EncryptionKey getKey() {
+        return key;
+    }
+
+    public int getKvno() {
+        return kvno;
+    }
+
+    public PrincipalName getPrincipal() {
+        return principal;
+    }
+
+    public KerberosTime getTimestamp() {
+        return timestamp;
+    }
+
+    void writeBody(KeytabOutputStream kos, int version) throws IOException {
+        kos.writePrincipal(principal, version);
+
+        kos.writeTime(timestamp);
+
+        kos.writeByte(kvno);
+
+        kos.writeKey(key, version);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        KeytabEntry that = (KeytabEntry) o;
+
+        if (kvno != that.kvno) {
+            return false;
+        }
+        if (!key.equals(that.key)) {
+            return false;
+        }
+        if (!principal.equals(that.principal)) {
+            return false;
+        }
+        if (!timestamp.equals(that.timestamp)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = principal.hashCode();
+        result = 31 * result + timestamp.hashCode();
+        result = 31 * result + kvno;
+        result = 31 * result + key.hashCode();
+        return result;
+    }
+}

--- a/frameworks/hdfs/keytab-fix/src/main/java/com/mesosphere/keytabfix/KeytabFix.java
+++ b/frameworks/hdfs/keytab-fix/src/main/java/com/mesosphere/keytabfix/KeytabFix.java
@@ -1,0 +1,27 @@
+package com.mesosphere.keytabfix;
+
+import java.io.File;
+import java.io.IOException;
+
+public class KeytabFix {
+	public static void main(String[] args) throws IOException {
+		String keytabPath = "";
+		if(args.length > 0) {
+			keytabPath = args[0];
+		} else {
+			System.err.println("Keytab File is not specified!\nUsage: KeytabFix file.keytab");
+			System.exit(1);
+		}
+		File keytabFile = new File(keytabPath);
+		if(!keytabFile.exists()){
+			System.err.println("Keytab File does not exists: " + keytabPath);
+			System.exit(1);
+		}
+		System.out.println("Fixing KeyTab File..."+keytabPath);
+		String keytabOut = "hdfs.keytab";
+		Keytab keytab = Keytab.loadKeytab(keytabFile);
+		
+		keytab.store(new File(keytabOut));
+		System.out.println("Fixed KeyTab File is: "+keytabOut);
+	}
+}

--- a/frameworks/hdfs/keytab-fix/src/main/java/com/mesosphere/keytabfix/KeytabInputStream.java
+++ b/frameworks/hdfs/keytab-fix/src/main/java/com/mesosphere/keytabfix/KeytabInputStream.java
@@ -1,0 +1,67 @@
+/**
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+package com.mesosphere.keytabfix;
+
+import org.apache.kerby.kerberos.kerb.type.KerberosTime;
+import org.apache.kerby.kerberos.kerb.type.base.NameType;
+import org.apache.kerby.kerberos.kerb.type.base.PrincipalName;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+public class KeytabInputStream extends KrbInputStream {
+    public KeytabInputStream(InputStream in) {
+        super(in);
+    }
+
+    public KerberosTime readTime() throws IOException {
+        long value = readInt();
+        KerberosTime time = new KerberosTime(value * 1000);
+        return time;
+    }
+
+    @Override
+    public PrincipalName readPrincipal(int version) throws IOException {
+        int numComponents = readShort();
+        if (version == Keytab.V501) {
+            numComponents -= 1;
+        }
+
+        String realm = readCountedString();
+        List<String> nameStrings = new ArrayList<String>();
+        for (int i = 0; i < numComponents; i++) { // sub 1 if version 0x501
+            String component = readCountedString();
+            nameStrings.add(component);
+        }
+        int type = readInt(); // not present if version 0x501
+        NameType nameType = NameType.fromValue(type);
+        PrincipalName principal = new PrincipalName(nameStrings, nameType);
+        principal.setRealm(realm);
+
+        return principal;
+    }
+
+    @Override
+    public int readOctetsCount() throws IOException {
+        return readShort();
+    }
+}

--- a/frameworks/hdfs/keytab-fix/src/main/java/com/mesosphere/keytabfix/KeytabOutputStream.java
+++ b/frameworks/hdfs/keytab-fix/src/main/java/com/mesosphere/keytabfix/KeytabOutputStream.java
@@ -1,0 +1,66 @@
+/**
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *  
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License. 
+ *  
+ */
+package com.mesosphere.keytabfix;
+
+import org.apache.kerby.kerberos.kerb.KrbOutputStream;
+import org.apache.kerby.kerberos.kerb.type.base.EncryptionKey;
+import org.apache.kerby.kerberos.kerb.type.base.PrincipalName;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.List;
+
+public class KeytabOutputStream extends KrbOutputStream {
+    public KeytabOutputStream(OutputStream out) {
+        super(out);
+    }
+
+    public void writePrincipal(PrincipalName principal, int version) throws IOException {
+        List<String> nameStrings = principal.getNameStrings();
+        int numComponents = principal.getNameStrings().size();
+        String realm = principal.getRealm();
+
+        writeShort(numComponents);
+
+        writeCountedString(realm);
+
+        for (String nameCom : nameStrings) {
+        	if(nameCom == null) {
+        		writeCountedString("null");
+        	} else {
+        		writeCountedString(nameCom);
+        	}
+        }
+
+        writeInt(principal.getNameType().getValue()); // todo: consider the version
+    }
+
+    @Override
+    public void writeKey(EncryptionKey key, int version) throws IOException {
+        writeShort(key.getKeyType().getValue());
+        writeCountedOctets(key.getKeyData());
+    }
+
+    @Override
+    public void writeCountedOctets(byte[] data) throws IOException {
+        writeShort(data.length);
+        write(data);
+    }
+}

--- a/frameworks/hdfs/keytab-fix/src/main/java/com/mesosphere/keytabfix/KrbInputStream.java
+++ b/frameworks/hdfs/keytab-fix/src/main/java/com/mesosphere/keytabfix/KrbInputStream.java
@@ -1,0 +1,82 @@
+/**
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *  
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License. 
+ *  
+ */
+package com.mesosphere.keytabfix;
+
+import org.apache.kerby.kerberos.kerb.type.KerberosTime;
+import org.apache.kerby.kerberos.kerb.type.base.EncryptionKey;
+import org.apache.kerby.kerberos.kerb.type.base.EncryptionType;
+import org.apache.kerby.kerberos.kerb.type.base.PrincipalName;
+
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+public abstract class KrbInputStream extends DataInputStream {
+    public KrbInputStream(InputStream in) {
+        super(in);
+    }
+
+    public KerberosTime readTime() throws IOException {
+        long value = readInt();
+        KerberosTime time = new KerberosTime(value * 1000);
+        return time;
+    }
+
+    public abstract PrincipalName readPrincipal(int version) throws IOException;
+
+    public EncryptionKey readKey() throws IOException {
+        int eType = readShort();
+        EncryptionType encType = EncryptionType.fromValue(eType);
+        byte[] keyData = readCountedOctets();
+        if (encType == EncryptionType.NONE || keyData == null) {
+            return null;
+        }
+
+        EncryptionKey key = new EncryptionKey(encType, keyData);
+        return key;
+    }
+
+    public String readCountedString() throws IOException {
+        byte[] countedOctets = readCountedOctets();
+        if (countedOctets != null) {
+            // ASCII
+            return new String(countedOctets, StandardCharsets.UTF_8);
+        }
+        return null;
+    }
+
+    public byte[] readCountedOctets() throws IOException {
+        int len = readOctetsCount();
+        if (len == 0) {
+            return null;
+        }
+        if (len < 0 || len > available()) {
+            throw new IOException("Unexpected octets len: " + len);
+        }
+
+        byte[] data = new byte[len];
+        readFully(data);
+
+        return data;
+    }
+
+    public abstract int readOctetsCount() throws IOException;
+}

--- a/frameworks/hdfs/keytab-fix/src/main/java/com/mesosphere/keytabfix/KrbKeytab.java
+++ b/frameworks/hdfs/keytab-fix/src/main/java/com/mesosphere/keytabfix/KrbKeytab.java
@@ -1,0 +1,57 @@
+/**
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *  
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License. 
+ *  
+ */
+package com.mesosphere.keytabfix;
+
+import org.apache.kerby.kerberos.kerb.type.base.EncryptionKey;
+import org.apache.kerby.kerberos.kerb.type.base.EncryptionType;
+import org.apache.kerby.kerberos.kerb.type.base.PrincipalName;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.List;
+
+public interface KrbKeytab {
+
+    List<PrincipalName> getPrincipals();
+
+    void addKeytabEntries(List<KeytabEntry> entries);
+
+    void removeKeytabEntries(PrincipalName principal);
+
+    void removeKeytabEntries(PrincipalName principal, int kvno);
+
+    void removeKeytabEntry(KeytabEntry entry);
+
+    List<KeytabEntry> getKeytabEntries(PrincipalName principal);
+
+    EncryptionKey getKey(PrincipalName principal, EncryptionType keyType);
+
+    void load(File keytabFile) throws IOException;
+
+    void load(InputStream inputStream) throws IOException;
+
+    void addEntry(KeytabEntry entry);
+
+    void store(File keytabFile) throws IOException;
+
+    void store(OutputStream outputStream) throws IOException;
+}


### PR DESCRIPTION
This branch contains the code to fix Kerberos keytab file. There was a bug in the code in a sense there was miscalculation of number of bytes read for an entry. This is addressed in this PR: https://github.com/apache/directory-kerby/pull/44. There is a ticket in Apache Hadoop repository: https://issues.apache.org/jira/browse/HADOOP-16283. It contains the fix for aforementioned bug. Once this ticket is resolved, we no longer need this Java code.