### PR TITLE
Add DinD support for test.sh script

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -22,12 +22,38 @@
 #
 FROM ubuntu:18.10@sha256:1da669e3481b6c2c8bb25ad287b75202871b1511249000e3bc35679d02e007f4
 
+# Docker and DIND
+# links to commit hashes are listed inside posted Dockerfiles at
+# https://hub.docker.com/r/library/docker/
+# NOTE: must match engine version that is directly pulled from
+# Alpine's Dockerfile:
+# - go to https://hub.docker.com/r/library/docker/
+# - click on the matching alpine version tag (eg, 17.12.0-dind)
+# - pull the DIND_COMMIT hash from the Dockerfile that opens
+ARG DOCKER_VERSION=5:18.09.8
+ARG DIND_COMMIT=37498f009d8bf25fbb6199e8ccd34bed84f2874b
+
+COPY dind-wrapper.sh /usr/local/bin/dind-wrapper.sh
 RUN apt-get update && \
-    apt-get install -y python3-software-properties software-properties-common && \
+    apt-get install -y \
+        wget \
+        gnupg && \
+    wget -O - "https://download.docker.com/linux/ubuntu/gpg" \
+        | apt-key add -qq - \
+    && echo "deb [arch=amd64] \
+        https://download.docker.com/linux/ubuntu \
+        bionic \
+        stable" > /etc/apt/sources.list.d/docker.list \
+    && wget -O /usr/local/bin/dind "https://raw.githubusercontent.com/docker/docker/${DIND_COMMIT}/hack/dind" \
+    && chmod a+x /usr/local/bin/dind \
+    && chmod a+x /usr/local/bin/dind-wrapper.sh
+
+RUN apt-get install -y python3-software-properties software-properties-common && \
     add-apt-repository -y ppa:openjdk-r/ppa && \
     apt-get update && \
     apt-get install -y \
     curl \
+    docker-ce="${DOCKER_VERSION}~3-0~ubuntu-bionic" \
     git \
     jq \
     libcairo2-dev \

--- a/dind-wrapper.sh
+++ b/dind-wrapper.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+
+echo "==> Launching the Docker daemon..."
+if docker info > /dev/null 2>&1; then
+    echo "=== Docker already running";
+else
+    /usr/local/bin/dind dockerd $DIND_DOCKER_ARGS > /var/log/docker.log 2>&1 &
+    for i in `seq 300`; do
+        echo "=== waiting for docker to start...";
+        if docker info > /dev/null 2>&1; then
+            break;
+        fi;
+        sleep 1;
+    done;
+    if docker info > /dev/null 2>&1; then
+        echo "=== Docker started!";
+    else
+        echo "=== Docker failed to start";
+        exit 1;
+    fi;
+fi
+
+exec $@


### PR DESCRIPTION
## High-level description

In order to make sure that all the build dependencies are at the exact version required by SDK, edge-lb's SDK is built inside dcos-commons container. Creating `.dcos` bundles require running docker daemon though, as per:

https://github.com/mesosphere/dcos-commons/blob/5211125494a87311de423e9f99d8d3c45070bdf6/tools/publish_dcos_file.py#L104-L129

And this was breaking our build process, as there is no running docker container support in dcos-commons build container yet, hence this PR. Existing scripts/builds will not be affected as there needs to be a command-line option to enable DinD behavior.

In theory, we could modify the scripts to write compilation artifacts somewhere while still inside `dcos-commons` build container and then have the .dcos build step pick them up afterward after exiting the container. Unfortunately modifying the build scripts would be pretty complex, there are multiple gotchas there I think.

## Corresponding Ticket

These DC/OS JIRA ticket(s) must be updated (ideally closed) at the moment this PR lands:

  - https://jira.mesosphere.com/browse/DCOS-57058 `Build issues after updating our devkit container to Debian Buster in PR #455`