### PR TITLE
[DCOS-42593] Decrease the max zk payload to a conservative limit of 1000 X 1000B

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/state/StateStore.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/state/StateStore.java
@@ -233,15 +233,14 @@ public class StateStore {
       logger.warn("Grouped {} TaskInfo writes in to {} batches", tasks.size(), batchedTasks.size());
     }
     IntStream
-      .range(0, batchedTasks.size())
-      .forEachOrdered(idx -> {
-        Map<String, byte[]> taskBytesMap = batchedTasks.get(idx);
-        try {
+        .range(0, batchedTasks.size())
+        .forEachOrdered(idx -> {
+          Map<String, byte[]> taskBytesMap = batchedTasks.get(idx);
+          try {
             logger.info("Batch {} payload is {}B", idx, taskBytesMap.values().stream().mapToInt(b -> b.length).sum());
             persister.setMany(taskBytesMap);
           } catch (PersisterException e) {
-            throw new StateStoreException(e,
-                    String.format("Failed to store %d TaskInfos", taskBytesMap.size()));
+            throw new StateStoreException(e, String.format("Failed to store %d TaskInfos", taskBytesMap.size()));
           }
         });
   }


### PR DESCRIPTION
Yet another attempt to fix [DCOS-42593](https://jira.mesosphere.com/browse/DCOS-42593). While we can be more confident that the fix should work this time, it's not fully clear why zk limit is still exceeded in the last release. We were able to capture the following in the previous MWT logs:
```
     "[myid:1] WARN  [NIOServerCxn.Factory:0.0.0.0/0.0.0.0:2181:NIOServerCnxn@383] - Exception causing close of session @kibana-highlighted-field@0x400005b9961014b@/kibana-highlighted-field@: Len error 1049509"
```

1049509 is just 933 bytes more than the value of 1024 * 1024. I presume this is some zk internal overhead that is being added. In that case, changing our limit to 1000 * 1000 is more conservative but should fix the length error. I am still trying to write a test with hello-world that would validate this behaviour programmatically but that can happen asynchronously with this PR which is targeted for next MWT.


_Note_

In one of the older MWT runs, we got the error :
```
Sep 27 12:21:00 vm-t1rb java[5140]: [myid:1] WARN  [NIOServerCxn.Factory:0.0.0.0/0.0.0.0:2181:NIOServerCnxn@383] - Exception causing close of session 0x2000008b09600fa: Len error 2163858
```
and considering that the latest MWT run had only `1049509`, it makes me believe this is a zk internal overhead.