### PR TITLE
[DCOS-57175] Add integration test for Kerberized HDFS upgrade

### DIFF
--- a/frameworks/hdfs/tests/test_hdfs_kerberos_upgrade.py
+++ b/frameworks/hdfs/tests/test_hdfs_kerberos_upgrade.py
@@ -19,13 +19,14 @@ pytestmark = [
 
 foldered_name = config.FOLDERED_SERVICE_NAME
 
+
 @pytest.fixture(scope="module", autouse=True)
 def service_account(configure_security):
     """
     Sets up a service account for use with TLS.
     """
     try:
-        name = foldered_name 
+        name = foldered_name
         service_account_info = transport_encryption.setup_service_account(name)
         yield service_account_info
     finally:
@@ -49,30 +50,29 @@ def kerberos(configure_security):
 
 @pytest.mark.auth
 @pytest.mark.sanity
-def test_install_hdfs_kerberised_service(kerberos, service_account):
+def test_install_kerberised_hdfs_service(kerberos, service_account):
     try:
         sdk_upgrade.test_upgrade(
             config.PACKAGE_NAME,
             foldered_name,
             config.DEFAULT_TASK_COUNT,
             from_options={
-             "service": { 
-                 "name": foldered_name,
-                 "service_account": service_account["name"],
-                 "service_account_secret": service_account["secret"],
-                 "security": {
-                     "kerberos": {
-                         "enabled": True,
-                         "debug": True,
-                         "kdc": {"hostname": kerberos.get_host(), "port": int(kerberos.get_port())},
-                         "realm": kerberos.get_realm(),
-                         "keytab_secret": kerberos.get_keytab_path(),
-                     } 
-                 }
-             }
+                "service": {
+                    "name": foldered_name,
+                    "service_account": service_account["name"],
+                    "service_account_secret": service_account["secret"],
+                    "security": {
+                        "kerberos": {
+                            "enabled": True,
+                            "debug": True,
+                            "kdc": {"hostname": kerberos.get_host(), "port": int(kerberos.get_port())},
+                            "realm": kerberos.get_realm(),
+                            "keytab_secret": kerberos.get_keytab_path(),
+                        }
+                    }
+                }
             },
             timeout_seconds=30 * 60,
         )
     finally:
         sdk_install.uninstall(config.PACKAGE_NAME, foldered_name)
-

--- a/frameworks/hdfs/tests/test_hdfs_kerberos_upgrade.py
+++ b/frameworks/hdfs/tests/test_hdfs_kerberos_upgrade.py
@@ -65,11 +65,14 @@ def test_install_kerberised_hdfs_service(kerberos, service_account):
                         "kerberos": {
                             "enabled": True,
                             "debug": True,
-                            "kdc": {"hostname": kerberos.get_host(), "port": int(kerberos.get_port())},
+                            "kdc": {
+                                "hostname": kerberos.get_host(),
+                                "port": int(kerberos.get_port()),
+                            },
                             "realm": kerberos.get_realm(),
                             "keytab_secret": kerberos.get_keytab_path(),
                         }
-                    }
+                    },
                 }
             },
             timeout_seconds=30 * 60,

--- a/frameworks/hdfs/tests/test_hdfs_kerberos_upgrade.py
+++ b/frameworks/hdfs/tests/test_hdfs_kerberos_upgrade.py
@@ -49,7 +49,7 @@ def kerberos(configure_security):
 
 @pytest.mark.auth
 @pytest.mark.sanity
-def test_install_without_additional_principal_to_user_mapping(kerberos, service_account):
+def test_install_hdfs_kerberised_service(kerberos, service_account):
     try:
         sdk_upgrade.test_upgrade(
             config.PACKAGE_NAME,

--- a/frameworks/hdfs/tests/test_hdfs_kerberos_upgrade.py
+++ b/frameworks/hdfs/tests/test_hdfs_kerberos_upgrade.py
@@ -1,0 +1,78 @@
+import pytest
+
+import sdk_utils
+import sdk_auth
+import sdk_install
+import sdk_upgrade
+
+from security import transport_encryption
+
+from tests import config, auth
+
+pytestmark = [
+    sdk_utils.dcos_ee_only,
+    pytest.mark.skipif(
+        sdk_utils.dcos_version_less_than("1.10"),
+        reason="Kerberos tests require DC/OS 1.10 or higher",
+    ),
+]
+
+foldered_name = config.FOLDERED_SERVICE_NAME
+
+@pytest.fixture(scope="module", autouse=True)
+def service_account(configure_security):
+    """
+    Sets up a service account for use with TLS.
+    """
+    try:
+        name = foldered_name 
+        service_account_info = transport_encryption.setup_service_account(name)
+        yield service_account_info
+    finally:
+        transport_encryption.cleanup_service_account(name, service_account_info)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def kerberos(configure_security):
+    try:
+        principals = auth.get_service_principals(foldered_name, sdk_auth.REALM)
+
+        kerberos_env = sdk_auth.KerberosEnvironment()
+        kerberos_env.add_principals(principals)
+        kerberos_env.finalize()
+
+        yield kerberos_env
+
+    finally:
+        kerberos_env.cleanup()
+
+
+@pytest.mark.auth
+@pytest.mark.sanity
+def test_install_without_additional_principal_to_user_mapping(kerberos, service_account):
+    try:
+        sdk_upgrade.test_upgrade(
+            config.PACKAGE_NAME,
+            foldered_name,
+            config.DEFAULT_TASK_COUNT,
+            from_options={
+             "service": { 
+                 "name": foldered_name,
+                 "service_account": service_account["name"],
+                 "service_account_secret": service_account["secret"],
+                 "security": {
+                     "kerberos": {
+                         "enabled": True,
+                         "debug": True,
+                         "kdc": {"hostname": kerberos.get_host(), "port": int(kerberos.get_port())},
+                         "realm": kerberos.get_realm(),
+                         "keytab_secret": kerberos.get_keytab_path(),
+                     } 
+                 }
+             }
+            },
+            timeout_seconds=30 * 60,
+        )
+    finally:
+        sdk_install.uninstall(config.PACKAGE_NAME, foldered_name)
+


### PR DESCRIPTION
## What changes were proposed in this pull request?
Added test script to 
    deploys kdc
    deploys kerberized HDFS
    upgrades it to the latest stub (of the current code)

Resolves [[HDFS] Integration test for Kerberized HDFS upgrade](https://jira.mesosphere.com/browse/DCOS-57175)

## How were these changes tested?
Test script ran on permissive and strict cluster locally and its passes successfully , it install kdc , deploys kerberised hdfs service and upgrades to the stub

## Release Notes
New integration test script now help testing upgrade of kerberised hdfs service
