### PR TITLE
Override dcos-commons' gradle.settings file.

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -360,6 +360,10 @@ if [ -n "${project}" ]; then
   # Mount $PROJECT_ROOT/frameworks into $WORK_DIR/frameworks.
   container_volumes="${container_volumes} -v ${PROJECT_ROOT}/frameworks:${WORK_DIR}/frameworks"
 
+  # Override dcos-commons' settings.gradle file.
+  gradle_settings_file="${PROJECT_ROOT}/frameworks/${framework}/settings.gradle"
+  container_volumes="${container_volumes} -v ${gradle_settings_file}:${WORK_DIR}/settings.gradle"
+
   # In the case of a project using dcos-commons as a submodule, the dcos-commons
   # git directory will be located in '.git/modules/dcos-commons' under the
   # project root instead of being located in the checked out dcos-commons


### PR DESCRIPTION
This is needed because projects using dcos-commons as a submodule will use its tooling, most commonly the `run_container.sh/test.sh` script, which runs a container that has its Docker `WORKDIR` set to dcos-commons' directory, which contains the dcos-commons `settings.gradle` file listing projects available in the monorepo. For example, as of today, it looks like this:

```text
rootProject.name = 'dcos-commons'

include 'frameworks/cassandra'
project(':frameworks/cassandra').name = 'cassandra'

include 'frameworks/hdfs'
project(':frameworks/hdfs').name = 'hdfs'

include 'frameworks/helloworld'
project(':frameworks/helloworld').name = 'helloworld'

include 'frameworks/helloworld/tests/tls/keystore'
project(':frameworks/helloworld/tests/tls/keystore').name = 'keystore-app'

include 'sdk/scheduler'
project(':sdk/scheduler').name = 'scheduler'

include 'sdk/testing'
project(':sdk/testing').name = 'testing'
```

When gradle is run from the container, it picks up these settings and then only recognizes projects referenced in there. So, if we use dcos-commons from, for example, the Elastic service, we need to overwrite `settings.gradle` in the `WORKDIR` so that it looks like:

```text
rootProject.name = 'dcos-commons'

include 'frameworks/elastic'
project(':frameworks/elastic').name = 'elastic'
```

This is what this PR attempts to accomplish. 