### PR TITLE
Create SDK 60 branch

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ allprojects {
     // 2. In the GitHub UI, add a Release entry against the tag created in step 1. List any changes in release notes.
     // 3. Create a PR which bumps this from '0.10.0-SNAPSHOT' to '0.11.0-SNAPSHOT' in master to start the 0.11.0 track.
     // --
-    version = '0.56.2-SNAPSHOT'
+    version = '0.60.0-SNAPSHOT'
 
     sourceCompatibility = '1.8'
     targetCompatibility = '1.8'

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerBuilder.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerBuilder.java
@@ -470,29 +470,12 @@ public class SchedulerBuilder {
     // Plans may be generated from the config content.
     boolean hasCompletedDeployment = StateStoreUtils.getDeploymentWasCompleted(stateStore);
     if (!hasCompletedDeployment) {
-      /*
-       * TODO(takirala): Remove this check after we have reached 0.60.x or so. See DCOS-38586.
-       * As of SDK 0.51.0+, the deployment-completed bit is immediately set when deployment completes, rather than
-       * here at startup, but we still need to check it here when upgrading from services using SDK 0.40.x.
-       *
-       * In SDK 40.x schedulers we do not set the deploy bit, and thus when SDK upgrades from 40.x to 50.x,
-       * SDK sees that the previous deploy plan has not been completed and try to parse the OLD config target and OLD
-       * ServiceSpec and try to validate it against the NEW yamlPlans loaded from the svc.yml. If the NEW plans have
-       * tasks that were absent in the OLD ServiceSpec, we fail fast as we see something unexpected. To workaround this,
-       * we only send the deploy plan. See DCOS-49350 for more details. This entire code-block CAN/SHOULD be deleted in
-       * SDK 0.60.x
-       */
       try {
         // Check for completion against the PRIOR service spec. For example, if the new service spec has n+1
         // nodes, then we want to check that the prior n nodes had successfully deployed.
         ServiceSpec lastServiceSpec = configStore.fetch(configStore.getTargetConfig());
-        Map<String, RawPlan> rawPlanMap = yamlPlans.containsKey(Constants.DEPLOY_PLAN_NAME) ?
-                Collections.singletonMap(
-                        Constants.DEPLOY_PLAN_NAME,
-                        yamlPlans.get(Constants.DEPLOY_PLAN_NAME)
-                ) : yamlPlans;
         Optional<Plan> deployPlan = getDeployPlan(
-                getPlans(stateStore, configStore, lastServiceSpec, namespace, rawPlanMap));
+                getPlans(stateStore, configStore, lastServiceSpec, namespace, yamlPlans));
         if (deployPlan.isPresent()) {
           logger.info("Previous deploy plan state: {}", deployPlan.get().toString());
           if (deployPlan.get().isComplete()) {


### PR DESCRIPTION
`sdk-60-poc` will be used as the test branch for all future work related to SDK on USI. it will have usi as a moving dependency on usi. 

The failing CI is due to lack of SDK 60 docker image.