### PR TITLE
[DCOS-57609] Rename the file to make autobuilder work again

### DIFF
--- a/Jenkinsfile.dcos-commons-base_
+++ b/Jenkinsfile.dcos-commons-base_
@@ -1,5 +1,6 @@
 #!/usr/bin/env groovy
 // Configuration for https://jenkins.mesosphere.com/service/jenkins/job/dcos-commons-base%20docker%20image/
+// This file's name ends with an underscore due to DCOS-57609
 
 void setBuildStatus(String context, String message, String state) {
     step([


### PR DESCRIPTION
https://jenkins.mesosphere.com/service/jenkins/job/dcos-commons-base%20docker%20image/indexing/console
has already been pointed at the new name.