### PR TITLE
Update base docker image to latest sha

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # See Dockerfile.base for instructions on how to update this base image.
-FROM mesosphere/dcos-commons-base:latest@sha256:98312edb57fe9c82b0a6a0527aaf67b6cbe4b258ff7abab203d5b6c1d98ed7d4
+FROM mesosphere/dcos-commons-base:latest@sha256:0bb843992597e25056548125f979417ce6048b018cc004d8ecab4492732302ab
 
 ENV GO_VERSION=1.10.2
 ENV PATH=$PATH:/usr/local/go/bin


### PR DESCRIPTION
This is just getting ahead of renovatebot (which runs on saturdays) - the base docker image currently in use was created on August 2nd. However, there have been more commits afters Aug 2nd and we want the base image to be latest.

See https://github.com/mesosphere/dcos-commons/pull/3158 for why we are not on latest base image.