### PR TITLE
[DCOS-57593][HDFS] Add base tech cli commands

### DIFF
--- a/frameworks/hdfs/build.sh
+++ b/frameworks/hdfs/build.sh
@@ -11,6 +11,7 @@ $REPO_ROOT_DIR/build.sh -b
 
 # Build/test our scheduler.zip
 ${REPO_ROOT_DIR}/gradlew -p ${FRAMEWORK_DIR} check distZip
+$FRAMEWORK_DIR/cli/build.sh
 
 # Build package with our scheduler.zip and the local SDK artifacts we built:
 $REPO_ROOT_DIR/tools/build_package.sh \
@@ -19,7 +20,7 @@ $REPO_ROOT_DIR/tools/build_package.sh \
     -a "$FRAMEWORK_DIR/build/distributions/$(basename $FRAMEWORK_DIR)-scheduler.zip" \
     -a "$FRAMEWORK_DIR/tools/zone-resolver.sh" \
     -a "$REPO_ROOT_DIR/sdk/bootstrap/bootstrap.zip" \
-    -a "$REPO_ROOT_DIR/sdk/cli/dcos-service-cli-linux" \
-    -a "$REPO_ROOT_DIR/sdk/cli/dcos-service-cli-darwin" \
-    -a "$REPO_ROOT_DIR/sdk/cli/dcos-service-cli.exe" \
+    -a "$FRAMEWORK_DIR/cli/dcos-service-cli-linux" \
+    -a "$FRAMEWORK_DIR/cli/dcos-service-cli-darwin" \
+    -a "$FRAMEWORK_DIR/cli/dcos-service-cli.exe" \
     $@

--- a/frameworks/hdfs/cli/build.sh
+++ b/frameworks/hdfs/cli/build.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -e
+
+# Builds the custom CLI used by the Kafka service.
+# Produces 3 artifacts: dcos-service-cli[-linux|-darwin|.exe]
+
+CUR_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd $CUR_DIR
+
+# required env:
+export REPO_ROOT_DIR=$(dirname $(dirname $(dirname $CUR_DIR)))
+export REPO_NAME=$(basename $REPO_ROOT_DIR)
+$REPO_ROOT_DIR/tools/build_go_exe.sh frameworks/hdfs/cli/ dcos-service-cli linux darwin windows

--- a/frameworks/hdfs/cli/main.go
+++ b/frameworks/hdfs/cli/main.go
@@ -5,6 +5,7 @@ import (
 	"github.com/mesosphere/dcos-commons/cli"
 	"github.com/mesosphere/dcos-commons/cli/client"
 	"gopkg.in/alecthomas/kingpin.v3-unstable"
+	"os"
 	"strings"
 )
 
@@ -67,7 +68,11 @@ func (args *HdfsCliArgs) runHdfs(a *kingpin.Application, e *kingpin.ParseElement
 	hdfsCommand := fmt.Sprintf("export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jdk*/); $HDFS_VERSION/bin/hdfs %s", args.String())
 	fullCommand := append(dcosExecCommand, hdfsCommand)
 
-	value, _ := client.RunCLICommand(fullCommand...)
+	value, error := client.RunCLICommand(fullCommand...)
+	if error != nil {
+		client.PrintMessage(error.Error())
+		os.Exit(1)
+	}
 
 	client.PrintMessage(value)
 	return nil

--- a/frameworks/hdfs/cli/main.go
+++ b/frameworks/hdfs/cli/main.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"fmt"
+	"github.com/mesosphere/dcos-commons/cli"
+	"github.com/mesosphere/dcos-commons/cli/client"
+	"gopkg.in/alecthomas/kingpin.v3-unstable"
+	"strings"
+)
+
+func main() {
+	app := cli.New()
+	arguments := cli.GetArguments()
+
+	cli.HandleDefaultSections(app)
+
+	hdfsCliCommandIndex := HandleHdfsSection(app, arguments)
+
+	if hdfsCliCommandIndex != -1 {
+		// Parse only arguments before `hdfs` CLI command.
+		// Subcommands and flags after `hdfs` command belongs to HDFS CLI
+		kingpin.MustParse(app.Parse(arguments[:hdfsCliCommandIndex+1]))
+	} else {
+		kingpin.MustParse(app.Parse(arguments))
+	}
+}
+
+func HandleHdfsSection(app *kingpin.Application, arguments []string) int {
+	const hdfs = "hdfs"
+
+	cmd := app.Command(hdfs, "Run HDFS CLI command")
+
+	i := firstArgumentIndex(hdfs, arguments)
+	if i != -1 {
+		hdfsCliArgs := &HdfsCliArgs{}
+		hdfsCliArgs.arguments = arguments[i+1:]
+		cmd.Action(hdfsCliArgs.runHdfs)
+	}
+	return i
+}
+
+// linear search for the first argument
+// if equal target command return index
+func firstArgumentIndex(targetCommand string, arguments []string) int {
+	for i, v := range arguments {
+		if !strings.HasPrefix(v, "-") { // ignore flags
+			if targetCommand == v {
+				return i
+			} else {
+				return -1
+			}
+		}
+	}
+	return -1
+}
+
+type HdfsCliArgs struct {
+	arguments []string
+}
+
+func (args *HdfsCliArgs) String() string {
+	return strings.Join(args.arguments, " ")
+}
+
+func (args *HdfsCliArgs) runHdfs(a *kingpin.Application, e *kingpin.ParseElement, c *kingpin.ParseContext) error {
+	dcosExecCommand := []string{"task", "exec", "name-0-node", "bash", "-c"}
+	hdfsCommand := fmt.Sprintf("export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jdk*/); $HDFS_VERSION/bin/hdfs %s", args.String())
+	fullCommand := append(dcosExecCommand, hdfsCommand)
+
+	value, _ := client.RunCLICommand(fullCommand...)
+
+	client.PrintMessage(value)
+	return nil
+}

--- a/frameworks/hdfs/cli/main_test.go
+++ b/frameworks/hdfs/cli/main_test.go
@@ -1,0 +1,14 @@
+package main
+
+import "testing"
+import "github.com/stretchr/testify/assert"
+
+func TestFirstArgumentIndex(t *testing.T) {
+
+	assert.Equal(t, firstArgumentIndex("hdfs", []string{"hdfs", "--flag"}), 0)
+	assert.Equal(t, firstArgumentIndex("hdfs", []string{"--flag", "hdfs"}), 1)
+	assert.Equal(t, firstArgumentIndex("hdfs", []string{"-f", "hdfs"}), 1)
+	assert.Equal(t, firstArgumentIndex("hdfs", []string{"--flag", "argument", "hdfs"}), -1)
+	assert.Equal(t, firstArgumentIndex("hdfs", []string{"--flag", "hdfs", "argument"}), 1)
+	assert.Equal(t, firstArgumentIndex("hdfs", []string{}), -1)
+}

--- a/frameworks/hdfs/cli/vendor
+++ b/frameworks/hdfs/cli/vendor
@@ -1,0 +1,1 @@
+../../../sdk/cli/vendor

--- a/frameworks/hdfs/src/main/dist/svc.yml
+++ b/frameworks/hdfs/src/main/dist/svc.yml
@@ -7,7 +7,6 @@ pods:
     count: 3
     uris:
       - {{HDFS_URI}}
-      - {{HDFS_BIN_URI}}
       - {{HDFS_JAVA_URI}}
       - {{BOOTSTRAP_URI}}
       - {{KEYTAB_URI}}
@@ -154,7 +153,6 @@ pods:
     count: 2
     uris:
       - {{HDFS_URI}}
-      - {{HDFS_BIN_URI}}
       - {{HDFS_JAVA_URI}}
       - {{BOOTSTRAP_URI}}
       - {{ZONE_RESOLVER}}
@@ -462,7 +460,6 @@ pods:
     count: {{DATA_COUNT}}
     uris:
       - {{HDFS_URI}}
-      - {{HDFS_BIN_URI}}
       - {{HDFS_JAVA_URI}}
       - {{BOOTSTRAP_URI}}
       - {{KEYTAB_URI}}

--- a/frameworks/hdfs/tests/test_cli.py
+++ b/frameworks/hdfs/tests/test_cli.py
@@ -1,0 +1,40 @@
+import logging
+
+import pytest
+import sdk_cmd
+import sdk_install
+
+
+from tests import config
+
+log = logging.getLogger(__name__)
+
+foldered_name = config.FOLDERED_SERVICE_NAME
+
+
+@pytest.fixture(scope="module", autouse=True)
+def configure_package(configure_security):
+    try:
+        sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
+        sdk_install.install(
+            config.PACKAGE_NAME,
+            config.SERVICE_NAME,
+            config.DEFAULT_TASK_COUNT,
+            timeout_seconds=30 * 60,
+        )
+
+        yield
+    finally:
+        sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
+
+
+@pytest.mark.sanity
+def test_cli():
+    sdk_cmd.run_cli("package install {} --yes --cli".format(config.PACKAGE_NAME))
+    dirpath = "/test"
+    sdk_cmd.svc_cli(config.PACKAGE_NAME, config.SERVICE_NAME, "hdfs dfs -mkdir {}".format(dirpath))
+    _, stdout, _ = sdk_cmd.svc_cli(config.PACKAGE_NAME, config.SERVICE_NAME, "hdfs dfs -ls /")
+
+    output = "Found 1 items"
+    assert output in stdout
+    assert dirpath in stdout

--- a/frameworks/hdfs/universe/marathon.json.mustache
+++ b/frameworks/hdfs/universe/marathon.json.mustache
@@ -67,7 +67,6 @@
     {{/data_node.volume_profile}}
     "LIBMESOS_URI": "{{resource.assets.uris.libmesos-bundle-tar-gz}}",
     "HDFS_URI": "{{resource.assets.uris.hdfs-tar-gz}}",
-    "HDFS_BIN_URI": "{{resource.assets.uris.hdfs-bin-tar-gz}}",
     "HDFS_JAVA_URI": "{{resource.assets.uris.hdfs-jre-tar-gz}}",
     "KEYTAB_URI": "{{resource.assets.uris.keytab-zip}}",
     "BOOTSTRAP_URI": "{{resource.assets.uris.bootstrap-zip}}",

--- a/frameworks/hdfs/universe/resource.json
+++ b/frameworks/hdfs/universe/resource.json
@@ -5,7 +5,6 @@
       "libmesos-bundle-tar-gz": "{{libmesos-bundle-url}}",
       "keytab-zip": "https://downloads.mesosphere.com/hdfs/assets/keytab-fix.tar.gz",
       "hdfs-tar-gz": "https://downloads.mesosphere.com/hdfs/assets/hadoop-3.2.0.tar.gz",
-      "hdfs-bin-tar-gz": "https://downloads.mesosphere.com/hdfs/assets/hdfs-bin.tar.gz",
       "hdfs-jre-tar-gz": "{{jre-url}}",
       "bootstrap-zip": "{{artifact-dir}}/bootstrap.zip",
       "scheduler-zip": "{{artifact-dir}}/hdfs-scheduler.zip",


### PR DESCRIPTION
Added new command `hdfs` that allows to run HDFS CLI commands via DC/OS CLI
```
$ dcos hdfs hdfs dfs -mkdir /dir
$ dcos hdfs hdfs dfs -ls /
Found 1 items
drwxr-xr-x   - nobody supergroup          0 2019-09-02 10:11 /dir
```
List of HDFS CLI commands: https://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-hdfs/HDFSCommands.html

- added new command to hdfs framework - frameworks/hdfs/cli/main.go, remaining arguments after `hdfs` command will be considered as subcommands and flags for HDFS CLI
- added building CLI tool as part HDFS framework build
- `test_cli.py` test creates a directory in HDFS via command line commands and verifys it