### PR TITLE
[DCOS-56669] Bump SDK to version 0.57.0.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ allprojects {
     // 2. In the GitHub UI, add a Release entry against the tag created in step 1. List any changes in release notes.
     // 3. Create a PR which bumps this from '0.10.0-SNAPSHOT' to '0.11.0-SNAPSHOT' in master to start the 0.11.0 track.
     // --
-    version = '0.58.0-SNAPSHOT'
+    version = '0.57.0'
 
     sourceCompatibility = '1.8'
     targetCompatibility = '1.8'

--- a/frameworks/hdfs/universe/marathon.json.mustache
+++ b/frameworks/hdfs/universe/marathon.json.mustache
@@ -37,7 +37,7 @@
     "PACKAGE_BUILD_TIME_STR": "{{package-build-time-str}}",
     "FRAMEWORK_NAME": "{{service.name}}",
     "FRAMEWORK_LOG_LEVEL": "{{service.log_level}}",
-    "TASKCFG_ALL_HDFS_VERSION": "hadoop-3.2.0",
+    "TASKCFG_ALL_HDFS_VERSION": "hadoop-3.2.1",
     "DEPLOY_STRATEGY": "{{service.deploy_strategy}}",
     "SERVICE_PRINCIPAL": "{{service.service_account}}",
     "JOURNAL_CPUS": "{{journal_node.cpus}}",

--- a/frameworks/hdfs/universe/resource.json
+++ b/frameworks/hdfs/universe/resource.json
@@ -4,7 +4,7 @@
       "jre-tar-gz": "{{scheduler-jre-url}}",
       "libmesos-bundle-tar-gz": "{{libmesos-bundle-url}}",
       "keytab-zip": "https://downloads.mesosphere.com/hdfs/assets/keytab-fix-1.0.tar.gz",
-      "hdfs-tar-gz": "https://infinity-artifacts.s3-us-west-2.amazonaws.com/hdfs/hadoop-3.2.1.tar.gz",
+      "hdfs-tar-gz": "https://downloads.mesosphere.com/hdfs/assets/hadoop-3.2.1.tar.gz",
       "hdfs-jre-tar-gz": "{{jre-url}}",
       "bootstrap-zip": "{{artifact-dir}}/bootstrap.zip",
       "scheduler-zip": "{{artifact-dir}}/hdfs-scheduler.zip",

--- a/frameworks/hdfs/universe/resource.json
+++ b/frameworks/hdfs/universe/resource.json
@@ -4,7 +4,7 @@
       "jre-tar-gz": "{{scheduler-jre-url}}",
       "libmesos-bundle-tar-gz": "{{libmesos-bundle-url}}",
       "keytab-zip": "https://downloads.mesosphere.com/hdfs/assets/keytab-fix-1.0.tar.gz",
-      "hdfs-tar-gz": "https://downloads.mesosphere.com/hdfs/assets/hadoop-3.2.0.tar.gz",
+      "hdfs-tar-gz": "https://infinity-artifacts.s3-us-west-2.amazonaws.com/hdfs/hadoop-3.2.1.tar.gz",
       "hdfs-jre-tar-gz": "{{jre-url}}",
       "bootstrap-zip": "{{artifact-dir}}/bootstrap.zip",
       "scheduler-zip": "{{artifact-dir}}/hdfs-scheduler.zip",


### PR DESCRIPTION
## What changes were proposed in this pull request?
Upgrade sdk version to 0.57.0 

For detailed description on changes refer : https://github.com/mesosphere/dcos-commons/releases/tag/0.57.0

Resolves [Bump SDK to version 0.57.0](https://jira.mesosphere.com/browse/DCOS-56669)

## How were these changes tested?
Build code locally and tried running service
