### PR TITLE
Parse NULL as empty for TaskSpec env map

### DIFF
--- a/frameworks/helloworld/src/main/dist/svc.yml
+++ b/frameworks/helloworld/src/main/dist/svc.yml
@@ -21,6 +21,7 @@ pods:
           type: ROOT
           size: {{HELLO_DISK}}
         env:
+          PARSE_EMPTY_KEY_AS_BLANK_TEST:
           SLEEP_DURATION: {{SLEEP_DURATION}}
         health-check:
           cmd: stat hello-container-path/output

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/RawTask.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/specification/yaml/RawTask.java
@@ -1,6 +1,8 @@
 package com.mesosphere.sdk.specification.yaml;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
 import org.apache.mesos.Protos;
 
 import java.util.Collections;
@@ -20,7 +22,8 @@ public final class RawTask {
 
   private final String labelsCsv;
 
-  private final Map<String, String> env;
+  @JsonSetter(contentNulls = Nulls.AS_EMPTY)
+  private Map<String, String> env;
 
   private final WriteOnceLinkedHashMap<String, RawConfig> configs;
 
@@ -57,7 +60,6 @@ public final class RawTask {
       @JsonProperty("essential") Boolean essential,
       @JsonProperty("cmd") String cmd,
       @JsonProperty("labels") String labels,
-      @JsonProperty("env") Map<String, String> env,
       @JsonProperty("configs") WriteOnceLinkedHashMap<String, RawConfig> configs,
       @JsonProperty("cpus") Double cpus,
       @JsonProperty("gpus") Double gpus,
@@ -78,7 +80,6 @@ public final class RawTask {
     this.essential = essential;
     this.cmd = cmd;
     this.labelsCsv = labels;
-    this.env = env;
     this.configs = configs;
     this.cpus = cpus;
     this.gpus = gpus;


### PR DESCRIPTION
Due to recent upgrade of jackson library(#3160), yaml fields with empty values are being parsed as null references instead of blank string references. This behaviour led to problems during upgrade for edgelb and dse (mesosphere/dcos-edge-lb/pull/482 and mesosphere/datastax-service/pull/380)