### PR TITLE
Bump scheduler java runtime to Java 11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # See Dockerfile.base for instructions on how to update this base image.
-FROM takirala/dcos-commons-base:latest
+FROM mesosphere/dcos-commons-base:latest@sha256:da062e485be6d1b3df081ffcda4d800ede6650bcaed86eb67adc9db169cb2082
 
 ENV GO_VERSION=1.10.2
 ENV PATH=$PATH:/usr/local/go/bin
@@ -31,7 +31,7 @@ RUN mkdir /tmp/repo/
 COPY / /tmp/repo/
 # gradlew: Heat up jar cache. pre-commit: Heat up lint tooling cache.
 RUN cd /tmp/repo/ && \
-    ./gradlew testClasses check && \
+    ./gradlew testClasses && \
     git init && \
     pre-commit install-hooks && \
     cd / && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # See Dockerfile.base for instructions on how to update this base image.
-FROM mesosphere/dcos-commons-base:latest@sha256:0bb843992597e25056548125f979417ce6048b018cc004d8ecab4492732302ab
+FROM takirala/dcos-commons-base:latest
 
 ENV GO_VERSION=1.10.2
 ENV PATH=$PATH:/usr/local/go/bin
@@ -31,7 +31,7 @@ RUN mkdir /tmp/repo/
 COPY / /tmp/repo/
 # gradlew: Heat up jar cache. pre-commit: Heat up lint tooling cache.
 RUN cd /tmp/repo/ && \
-    ./gradlew testClasses && \
+    ./gradlew testClasses check && \
     git init && \
     pre-commit install-hooks && \
     cd / && \

--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ allprojects {
     apply plugin: 'jacoco'
     apply plugin: 'idea'
     apply plugin: 'maven-publish'
+    // Run `./gradlew htmlDependencyReport` to view the dependency report
     apply plugin: 'project-report'
 
     // Double quotes are required for $rootDir to be resolved:

--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ allprojects {
     apply plugin: 'jacoco'
     apply plugin: 'idea'
     apply plugin: 'maven-publish'
+    apply plugin: 'project-report'
 
     // Double quotes are required for $rootDir to be resolved:
     apply from: "$rootDir/gradle/quality.gradle"

--- a/frameworks/cassandra/universe/resource.json
+++ b/frameworks/cassandra/universe/resource.json
@@ -1,7 +1,7 @@
 {
   "assets": {
     "uris": {
-      "jre-tar-gz": "{{jre-url}}",
+      "jre-tar-gz": "{{scheduler-jre-url}}",
       "cassandra-jre-tar-gz": "{{jre-url}}",
       "cassandra-python-tar-gz": "https://downloads.mesosphere.com/cassandra/assets/python-2.7.14.tar.gz",
       "cassandra-openssl-tar-gz": "https://downloads.mesosphere.com/cassandra/assets/openssl-1.0.2n-libs.tar.gz",

--- a/frameworks/hdfs/universe/resource.json
+++ b/frameworks/hdfs/universe/resource.json
@@ -1,7 +1,7 @@
 {
   "assets": {
     "uris": {
-      "jre-tar-gz": "{{jre-url}}",
+      "jre-tar-gz": "{{scheduler-jre-url}}",
       "libmesos-bundle-tar-gz": "{{libmesos-bundle-url}}",
       "keytab-zip": "https://downloads.mesosphere.com/hdfs/assets/keytab-fix-1.0.tar.gz",
       "hdfs-tar-gz": "https://downloads.mesosphere.com/hdfs/assets/hadoop-3.2.0.tar.gz",

--- a/frameworks/helloworld/tests/tls/keystore/build.gradle
+++ b/frameworks/helloworld/tests/tls/keystore/build.gradle
@@ -7,7 +7,7 @@ group 'com.mesosphere.sdk'
 version '0.1-SNAPSHOT'
 
 ext {
-    dropwizardVer = '1.1.2'
+    dropwizardVer = '1.3.9'
 }
 
 dependencies {

--- a/frameworks/helloworld/universe/resource.json
+++ b/frameworks/helloworld/universe/resource.json
@@ -1,7 +1,7 @@
 {
   "assets": {
     "uris": {
-      "jre-tar-gz": "{{jre-url}}",
+      "jre-tar-gz": "{{scheduler-jre-url}}",
       "libmesos-bundle-tar-gz": "{{libmesos-bundle-url}}",
       "bootstrap-zip": "{{artifact-dir}}/bootstrap.zip",
       "scheduler-zip": "{{artifact-dir}}/hello-world-scheduler.zip",

--- a/gradle/quality.gradle
+++ b/gradle/quality.gradle
@@ -1,15 +1,5 @@
-apply plugin: 'findbugs'
 apply plugin: 'checkstyle'
 apply plugin: 'pmd'
-
-tasks.withType(FindBugs) {
-  excludeFilter = file("$rootProject.projectDir/gradle/findbugs/excludeFilter.xml")
-  maxHeapSize = '1024m'
-  reports {
-    xml.enabled = false
-    html.enabled = true
-  }
-}
 
 checkstyle {
     configDir = file("$rootProject.projectDir/gradle/checkstyle")

--- a/sdk/scheduler/build.gradle
+++ b/sdk/scheduler/build.gradle
@@ -116,7 +116,7 @@ ext {
     httpClientVer = "4.5.2"
     jerseyVer = "2.23"
     elVer = "2.2.4"
-    bouncyCastleVer = "1.57"
+    bouncyCastleVer = "1.62"
     dropWizardMetricsVer = "3.2.5"
 }
 
@@ -174,7 +174,7 @@ dependencies {
 
     testCompile 'org.hamcrest:hamcrest-all:1.3' // note: must be above junit
     testCompile 'junit:junit:4.12'
-    testCompile 'org.mockito:mockito-core:2.10.0'
+    testCompile 'org.mockito:mockito-core:2.27.0'
     testCompile "org.apache.curator:curator-test:${curatorVer}"
 }
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/taskdata/AttributeStringUtils.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/taskdata/AttributeStringUtils.java
@@ -3,11 +3,16 @@ package com.mesosphere.sdk.offer.taskdata;
 import com.google.protobuf.TextFormat;
 import org.apache.mesos.Protos;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.StringJoiner;
+import java.util.StringTokenizer;
 import java.util.stream.Collectors;
 
 /**
- * Tools for converting {@link Attribute}s into strings. Spec is defined by Mesos documentation at:
+ * Tools for converting {@link Protos.Attribute}s into strings. Spec is defined by Mesos documentation at:
  * http://mesos.apache.org/documentation/latest/attributes-resources/
  */
 public final class AttributeStringUtils {
@@ -102,7 +107,7 @@ public final class AttributeStringUtils {
    *                                  serialized
    */
   public static String toString(Protos.Value value) throws IllegalArgumentException {
-    StringBuffer buf = new StringBuffer();
+    StringBuilder buf = new StringBuilder();
     switch (value.getType()) {
       case RANGES:
         // "ports:[21000-24000,30000-34000]"

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/taskdata/AttributeStringUtils.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/taskdata/AttributeStringUtils.java
@@ -3,11 +3,7 @@ package com.mesosphere.sdk.offer.taskdata;
 import com.google.protobuf.TextFormat;
 import org.apache.mesos.Protos;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.StringJoiner;
-import java.util.StringTokenizer;
+import java.util.*;
 import java.util.stream.Collectors;
 
 /**
@@ -123,7 +119,7 @@ public final class AttributeStringUtils {
       case SCALAR:
         // according to mesos.proto: "Mesos keeps three decimal digits of precision ..."
         // let's just ensure that we're producing consistent strings.
-        buf.append(String.format("%.3f", value.getScalar().getValue()));
+        buf.append(String.format(Locale.ROOT, "%.3f", value.getScalar().getValue()));
         break;
       case SET:
         // "bugs(debug_role):{a,b,c}"

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/state/SchemaVersionStoreTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/state/SchemaVersionStoreTest.java
@@ -96,7 +96,7 @@ public class SchemaVersionStoreTest {
     @Test(expected=IllegalArgumentException.class)
     public void testStoreOtherFailure() throws Exception {
         final int val = 3;
-        doThrow(Exception.class).when(mockPersister).set(NODE_PATH, String.valueOf(val).getBytes(CHARSET));
+        doThrow(PersisterException.class).when(mockPersister).set(NODE_PATH, String.valueOf(val).getBytes(CHARSET));
         storeWithMock.store(SchemaVersion.UNKNOWN);
     }
 

--- a/sdk/testing/build.gradle
+++ b/sdk/testing/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
     compile project(':scheduler')
     compile 'junit:junit:4.12'
-    compile 'org.mockito:mockito-core:2.10.0'
+    compile 'org.mockito:mockito-core:2.27.0'
 }
 
 task sourceJar(type: Jar) {

--- a/sdk/testing/src/main/java/com/mesosphere/sdk/testing/CosmosRenderer.java
+++ b/sdk/testing/src/main/java/com/mesosphere/sdk/testing/CosmosRenderer.java
@@ -41,6 +41,7 @@ public class CosmosRenderer {
     RESOURCE_TEMPLATE_PARAMS = new HashMap<>();
     RESOURCE_TEMPLATE_PARAMS.put("artifact-dir", "https://test-url/artifacts");
     RESOURCE_TEMPLATE_PARAMS.put("jre-url", "https://test-url/jre.tgz");
+    RESOURCE_TEMPLATE_PARAMS.put("scheduler-jre-url", "https://test-url/jre.tgz");
     RESOURCE_TEMPLATE_PARAMS.put("libmesos-bundle-url", "https://test-url/libmesos-bundle.tgz");
     RESOURCE_TEMPLATE_PARAMS.put("dcos-sdk-version", "99.99.99-SNAPSHOT");
   }

--- a/test.sh
+++ b/test.sh
@@ -540,7 +540,14 @@ fi
 ######################### Prepare and run command ##############################
 ################################################################################
 
-docker pull "${docker_image}"
+if [[ "$(docker images -q ${docker_image} 2> /dev/null)" == "" ]]; then
+  echo "Docker image ${docker_image} does not exist locally"
+  # TODO delete this line:
+  docker images 
+  docker pull "${docker_image}"
+else
+  echo "Using local/cached image ${docker_image}"
+fi
 
 set +x
 

--- a/test.sh
+++ b/test.sh
@@ -540,14 +540,7 @@ fi
 ######################### Prepare and run command ##############################
 ################################################################################
 
-if [[ "$(docker images -q ${docker_image} 2> /dev/null)" == "" ]]; then
-  echo "Docker image ${docker_image} does not exist locally"
-  # TODO delete this line:
-  docker images 
-  docker pull "${docker_image}"
-else
-  echo "Using local/cached image ${docker_image}"
-fi
+[ ! -z $(docker images -q "${docker_image}") ] || docker pull "${docker_image}"
 
 set +x
 

--- a/tools/universe/package_builder.py
+++ b/tools/universe/package_builder.py
@@ -17,6 +17,9 @@ logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.DEBUG, format="%(message)s")
 
 _jre_url = "https://downloads.mesosphere.com/java/openjdk-jre-8u212b03-hotspot-linux-x64.tar.gz"
+_scheduler_jre_url = (
+    "https://downloads.mesosphere.com/java/openjdk-jre-11.0.3.7-hotspot-linux-x64.tar.gz"
+)
 _libmesos_bundle_url = (
     "https://downloads.mesosphere.com/libmesos-bundle/libmesos-bundle-1.14-beta.tar.gz"
 )
@@ -177,6 +180,7 @@ class UniversePackageBuilder(object):
             "documentation-path": self._get_documentation_path(),
             "issues-path": self._get_issues_path(),
             "jre-url": _jre_url,
+            "scheduler-jre-url": _scheduler_jre_url,
             "libmesos-bundle-url": _libmesos_bundle_url,
         }
 


### PR DESCRIPTION
This PR bumps the jre for schedulers to java 11 and the framework jre is still at java 8.

Also credits to initial work @kaiwalyajoshi did via #3027 