### PR TITLE
[DCOS-58875] Quick workaround while we fix our CI

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ allprojects {
     // 2. In the GitHub UI, add a Release entry against the tag created in step 1. List any changes in release notes.
     // 3. Create a PR which bumps this from '0.10.0-SNAPSHOT' to '0.11.0-SNAPSHOT' in master to start the 0.11.0 track.
     // --
-    version = '0.58.0-SNAPSHOT'
+    version = '0.57.0-SNAPSHOT'
 
     sourceCompatibility = '1.8'
     targetCompatibility = '1.8'


### PR DESCRIPTION
This is to unbreak the HDFS and cassandra builds while we prepare and test the proper fix for DCOS-58875 described in the ticket.