### PR TITLE
Revert "Added run_container.sh to copy files list."

### DIFF
--- a/tools/distribution/copy-files
+++ b/tools/distribution/copy-files
@@ -69,7 +69,6 @@ def distribute_test_utils(output_path: str):
     output_path = output_path.rstrip("/") + "/"
 
     files = ["conftest.py",
-             "run_container.sh",
              "test.sh",
              "TESTING.md",
              "UPDATING.md", ]


### PR DESCRIPTION
Reverts mesosphere/dcos-commons#3186

Reverting as its causing issue with SDK bump in Datastax, also its not fulfilling the purpose which was to solve error in dcos-zookeeper while bumping to latest SDK version.

I am facing issue after this changes , also confirmed with @takirala that dse update SDK is working with images before this changes :- 

```
$ docker run --rm -ti -v $(pwd):$(pwd) mesosphere/dcos-commons:latest copy-files $(pwd) --update-sdk 0.57.0
INFO:__main__:Copying /dcos-commons-dist/conftest.py to /home/vivek/datastax-service/
INFO:__main__:Copying /dcos-commons-dist/run_container.sh to /home/vivek/datastax-service/
cp: cannot stat '/dcos-commons-dist/run_container.sh': No such file or directory
Traceback (most recent call last):
  File "/build-tools/copy-files", line 140, in <module>
    main()
  File "/build-tools/copy-files", line 133, in main
    distribute_test_utils(args.output_path)
  File "/build-tools/copy-files", line 78, in distribute_test_utils
    copy_dist_file(f, output_path)
  File "/build-tools/copy-files", line 47, in copy_dist_file
    subprocess.check_output(["cp", source_file, output_path])
  File "/usr/lib/python3.6/subprocess.py", line 356, in check_output
    **kwargs).stdout
  File "/usr/lib/python3.6/subprocess.py", line 438, in run
    output=stdout, stderr=stderr)
subprocess.CalledProcessError: Command '['cp', '/dcos-commons-dist/run_container.sh', '/home/vivek/datastax-service/']' returned non-zero exit status 1.
```

also I check its still happening in zookeeper, purpose of PR #3186 was to rectify this issue but its still happening  ;
```
$ docker run --rm -ti -v $(pwd):$(pwd) mesosphere/dcos-commons:latest copy-files $(pwd) --update-sdk 0.57.0
INFO:__main__:Copying /dcos-commons-dist/conftest.py to /home/vivek/dcos-zookeeper/
INFO:__main__:Copying /dcos-commons-dist/run_container.sh to /home/vivek/dcos-zookeeper/
cp: cannot stat '/dcos-commons-dist/run_container.sh': No such file or directory
Traceback (most recent call last):
  File "/build-tools/copy-files", line 140, in <module>
    main()
  File "/build-tools/copy-files", line 133, in main
    distribute_test_utils(args.output_path)
  File "/build-tools/copy-files", line 78, in distribute_test_utils
    copy_dist_file(f, output_path)
  File "/build-tools/copy-files", line 47, in copy_dist_file
    subprocess.check_output(["cp", source_file, output_path])
  File "/usr/lib/python3.6/subprocess.py", line 356, in check_output
    **kwargs).stdout
  File "/usr/lib/python3.6/subprocess.py", line 438, in run
    output=stdout, stderr=stderr)
subprocess.CalledProcessError: Command '['cp', '/dcos-commons-dist/run_container.sh', '/home/vivek/dcos-zookeeper/']' returned non-zero exit status 1.
```