### PR TITLE
Copy run_container.sh in the docker container.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,7 @@ COPY conftest.py ${DCOS_COMMONS_DIST_ROOT}/
 COPY testing ${DCOS_COMMONS_DIST_ROOT}/testing
 COPY tools ${DCOS_COMMONS_DIST_ROOT}/tools
 COPY .pre-commit-config.yaml ${DCOS_COMMONS_DIST_ROOT}/
+COPY run_container.sh ${DCOS_COMMONS_DIST_ROOT}
 
 COPY build.gradle ${DCOS_COMMONS_DIST_ROOT}/build.gradle
 RUN grep -oE "version = '.*?'" ${DCOS_COMMONS_DIST_ROOT}/build.gradle | sed 's/version = //' > ${DCOS_COMMONS_DIST_ROOT}/.version

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ COPY conftest.py ${DCOS_COMMONS_DIST_ROOT}/
 COPY testing ${DCOS_COMMONS_DIST_ROOT}/testing
 COPY tools ${DCOS_COMMONS_DIST_ROOT}/tools
 COPY .pre-commit-config.yaml ${DCOS_COMMONS_DIST_ROOT}/
-COPY run_container.sh ${DCOS_COMMONS_DIST_ROOT}
+COPY run_container.sh ${DCOS_COMMONS_DIST_ROOT}/
 
 COPY build.gradle ${DCOS_COMMONS_DIST_ROOT}/build.gradle
 RUN grep -oE "version = '.*?'" ${DCOS_COMMONS_DIST_ROOT}/build.gradle | sed 's/version = //' > ${DCOS_COMMONS_DIST_ROOT}/.version

--- a/tools/distribution/copy-files
+++ b/tools/distribution/copy-files
@@ -69,6 +69,7 @@ def distribute_test_utils(output_path: str):
     output_path = output_path.rstrip("/") + "/"
 
     files = ["conftest.py",
+             "run_container.sh",
              "test.sh",
              "TESTING.md",
              "UPDATING.md", ]


### PR DESCRIPTION
This PR -
1. copies `run_container.sh` in the dcos-commons docker container.
2. adds `run_container.sh` in the `copy-files` list.