### PR TITLE
[DCOS-58875] dcos-commons image version extraction is broken on master

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,5 +66,6 @@ COPY .pre-commit-config.yaml ${DCOS_COMMONS_DIST_ROOT}/
 
 COPY build.gradle ${DCOS_COMMONS_DIST_ROOT}/build.gradle
 RUN grep -oE "version = '.*?'" ${DCOS_COMMONS_DIST_ROOT}/build.gradle | sed 's/version = //' > ${DCOS_COMMONS_DIST_ROOT}/.version
+RUN if grep --quiet SNAPSHOT ${DCOS_COMMONS_DIST_ROOT}/.version; then echo "'latest'" > ${DCOS_COMMONS_DIST_ROOT}/.version; fi
 
 COPY tools/container/venvs /venvs


### PR DESCRIPTION
* Add Docker file SDK version replacement in a case of 'SNAPSHOT'