### PR TITLE
Allow region awareness by default

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerConfig.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerConfig.java
@@ -641,7 +641,7 @@ public final class SchedulerConfig {
    * Returns whether region awareness should be enabled. In 1.11, this is an explicit opt-in by users.
    */
   public boolean isRegionAwarenessEnabled() {
-    return envStore.getOptionalBoolean(ALLOW_REGION_AWARENESS_ENV, false);
+    return envStore.getOptionalBoolean(ALLOW_REGION_AWARENESS_ENV, true);
   }
 
   /**


### PR DESCRIPTION
Whenever a next release cut happens, I think we can enable region awareness by default.