### PR TITLE
Making upload ACL permissions from `public-read` to configurable

### DIFF
--- a/tools/universe/s3_uploader.py
+++ b/tools/universe/s3_uploader.py
@@ -20,6 +20,7 @@ class S3Uploader(object):
         self._aws_region = os.environ.get("AWS_UPLOAD_REGION", "")
         self._reauth_attempted = False
         self._dry_run = dry_run
+        self._acl = os.environ.get("AWS_UPLOAD_ACL", "public-read")
 
     def get_s3_directory(self):
         return self._s3_directory
@@ -29,7 +30,7 @@ class S3Uploader(object):
         cmdlist = ["aws s3"]
         if self._aws_region:
             cmdlist.append("--region={}".format(self._aws_region))
-        cmdlist.append("cp --acl public-read")
+        cmdlist.append("cp --acl {}".format(self._acl))
         if self._dry_run:
             cmdlist.append("--dryrun")
         if content_type is not None:


### PR DESCRIPTION
According to [DCOS-45814](https://jira.mesosphere.com/browse/DCOS-45814), and more specifically Marvin's comment, we should switch away from `public-read` ACL and use `bucket-owner-full-control` instead.

This PR is intended to be used during the transitional phase of the projects, allowing non-braking changes. Whoever wants to use the new ACLs should first

```
export AWS_UPLOAD_ACL=bucket-owner-full-control
``` 