### PR TITLE
Fix unit tests for region awareness default flag

### DIFF
--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/SchedulerConfigTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/SchedulerConfigTest.java
@@ -35,7 +35,7 @@ public class SchedulerConfigTest {
     public void testRegionAwareness() {
         Map<String, String> confMap = getMinimalMap();
         SchedulerConfig schedulerConfig = SchedulerConfig.fromEnvStore(EnvStore.fromMap(confMap));
-        Assert.assertFalse(schedulerConfig.isRegionAwarenessEnabled());
+        Assert.assertTrue(schedulerConfig.isRegionAwarenessEnabled());
 
         confMap.put("ALLOW_REGION_AWARENESS", "false");
         schedulerConfig = SchedulerConfig.fromEnvStore(EnvStore.fromMap(confMap));
@@ -47,7 +47,7 @@ public class SchedulerConfigTest {
 
         confMap.remove("ALLOW_REGION_AWARENESS");
         schedulerConfig = SchedulerConfig.fromEnvStore(EnvStore.fromMap(confMap));
-        Assert.assertFalse(schedulerConfig.isRegionAwarenessEnabled());
+        Assert.assertTrue(schedulerConfig.isRegionAwarenessEnabled());
     }
 
     @Test


### PR DESCRIPTION
Follow up for #3198 
It was my bad to miss the failing unit tests in earlier PR.