### PR TITLE
DCOS-60595: Add 'test' as one of the roles to configure for strict-mode clusters.

### DIFF
--- a/testing/sdk_security.py
+++ b/testing/sdk_security.py
@@ -282,6 +282,7 @@ def _get_integration_test_foldered_role(service_name: str) -> List[str]:
     role_basename = service_name.strip("/").replace("/", "__")
     return [
         "test__integration__{}-role".format(role_basename),
+        "test",
         "quota",
         "quota__{}-role".format(role_basename),
     ]


### PR DESCRIPTION
This is required since [MARATHON-8706](https://jira.mesosphere.com/browse/MARATHON-8707) was enabled on [DC/OS 2.0](https://github.com/dcos/dcos/pull/6416) and later clusters, especially on master.

Most SDK frameworks test with a canonical foldered name such as `/test/integration/<foo>` where `enforceRole` will be set on the top-level group `test`, and the scheduler will require the `test` role.