### PR TITLE
[TOOLING] DCOS-61702: Use dcos-commons jenkins mesos-plugin tag for Jenkins builds.

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -31,7 +31,7 @@ FROM ubuntu:18.10@sha256:7d657275047118bb77b052c4c0ae43e8a289ca2879ebfa78a703c93
 # - click on the matching alpine version tag (eg, 17.12.0-dind)
 # - pull the DIND_COMMIT hash from the Dockerfile that opens
 ARG DOCKER_VERSION=5:18.09.8
-ARG DIND_COMMIT=37498f009d8bf25fbb6199e8ccd34bed84f2874b
+ARG DIND_COMMIT=3b5fac462d21ca164b3778647420016315289034
 
 COPY dind-wrapper.sh /usr/local/bin/dind-wrapper.sh
 RUN apt-get update && \

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -31,7 +31,7 @@ FROM ubuntu:18.10@sha256:7d657275047118bb77b052c4c0ae43e8a289ca2879ebfa78a703c93
 # - click on the matching alpine version tag (eg, 17.12.0-dind)
 # - pull the DIND_COMMIT hash from the Dockerfile that opens
 ARG DOCKER_VERSION=5:18.09.8
-ARG DIND_COMMIT=3b5fac462d21ca164b3778647420016315289034
+ARG DIND_COMMIT=37498f009d8bf25fbb6199e8ccd34bed84f2874b
 
 COPY dind-wrapper.sh /usr/local/bin/dind-wrapper.sh
 RUN apt-get update && \

--- a/Jenkinsfile.dcos-commons
+++ b/Jenkinsfile.dcos-commons
@@ -14,7 +14,7 @@ void setBuildStatus(String context, String message, String state) {
 
 pipeline {
     agent {
-        label 'mesos'
+        label 'dcos-commons'
     }
  
     environment {

--- a/Jenkinsfile.dcos-commons-base_
+++ b/Jenkinsfile.dcos-commons-base_
@@ -15,7 +15,7 @@ void setBuildStatus(String context, String message, String state) {
 
 pipeline {
     agent {
-        label 'mesos'
+        label 'dcos-commons'
     }
  
     environment {

--- a/Jenkinsfile.dcos-commons-base_
+++ b/Jenkinsfile.dcos-commons-base_
@@ -23,16 +23,16 @@ pipeline {
         DOCKERFILE = "Dockerfile.base"
  
         // Get credentials for publishing to Docker hub.
-        //DOCKER = credentials('docker-hub-credentials')
+        DOCKER = credentials('docker-hub-credentials')
     }
  
     stages {
-        //stage('docker login') {
-            //steps {
-                //// Login to the Docker registry.
-                //sh("docker login -u ${DOCKER_USR} -p ${DOCKER_PSW}")
-            //}
-        //}
+        stage('docker login') {
+            steps {
+                // Login to the Docker registry.
+                sh("docker login -u ${DOCKER_USR} -p ${DOCKER_PSW}")
+            }
+        }
  
         stage('build') {
             steps {
@@ -44,18 +44,18 @@ pipeline {
             }
         }
  
-        //stage('publish') {
-            //// Only run this step on the master branch.
-            //when {
-                //branch 'master'
-            //}
+        stage('publish') {
+            // Only run this step on the master branch.
+            when {
+                branch 'master'
+            }
   
-            //steps {
-                //script {
-                    //sh("docker push mesosphere/${IMAGE}:latest")
-                //}
-            //}
-        //}
+            steps {
+                script {
+                    sh("docker push mesosphere/${IMAGE}:latest")
+                }
+            }
+        }
     }
 
     post {

--- a/Jenkinsfile.dcos-commons-base_
+++ b/Jenkinsfile.dcos-commons-base_
@@ -23,16 +23,16 @@ pipeline {
         DOCKERFILE = "Dockerfile.base"
  
         // Get credentials for publishing to Docker hub.
-        DOCKER = credentials('docker-hub-credentials')
+        //DOCKER = credentials('docker-hub-credentials')
     }
  
     stages {
-        stage('docker login') {
-            steps {
-                // Login to the Docker registry.
-                sh("docker login -u ${DOCKER_USR} -p ${DOCKER_PSW}")
-            }
-        }
+        //stage('docker login') {
+            //steps {
+                //// Login to the Docker registry.
+                //sh("docker login -u ${DOCKER_USR} -p ${DOCKER_PSW}")
+            //}
+        //}
  
         stage('build') {
             steps {
@@ -44,18 +44,18 @@ pipeline {
             }
         }
  
-        stage('publish') {
-            // Only run this step on the master branch.
-            when {
-                branch 'master'
-            }
+        //stage('publish') {
+            //// Only run this step on the master branch.
+            //when {
+                //branch 'master'
+            //}
   
-            steps {
-                script {
-                    sh("docker push mesosphere/${IMAGE}:latest")
-                }
-            }
-        }
+            //steps {
+                //script {
+                    //sh("docker push mesosphere/${IMAGE}:latest")
+                //}
+            //}
+        //}
     }
 
     post {


### PR DESCRIPTION
The [`mesosphere:dcos-commons-base`](https://github.com/mesosphere/dcos-commons/blob/master/Jenkinsfile.dcos-commons-base_#L42) and [`mesosphere:dcos-commons`](https://github.com/mesosphere/dcos-commons/blob/master/Jenkinsfile.dcos-commons#L41) images are built with the `--squash` argument to the `docker build` command.

`docker build --squash` requires[ experimental features](https://docs.docker.com/engine/reference/commandline/build/#squash-an-images-layers---squash-experimental) to be enabled, in the Mesosphere build environment this specifically requires the [DinD images to have experimental support enabled](https://github.com/mesosphere/dcos-jenkins-dind-agent/tree/0.6.0-experimental).

This patch switches the build tooling to a jenkins mesos plugin tag that has `--squash` support.