### PR TITLE
[DCOS-61858] Quota Framework Uninstall Fixes

### DIFF
--- a/Jenkinsfile.dcos-commons
+++ b/Jenkinsfile.dcos-commons
@@ -14,7 +14,7 @@ void setBuildStatus(String context, String message, String state) {
 
 pipeline {
     agent {
-        label 'mesos'
+        label 'dcos-commons'
     }
  
     environment {

--- a/Jenkinsfile.dcos-commons-base_
+++ b/Jenkinsfile.dcos-commons-base_
@@ -15,7 +15,7 @@ void setBuildStatus(String context, String message, String state) {
 
 pipeline {
     agent {
-        label 'mesos'
+        label 'dcos-commons'
     }
  
     environment {

--- a/frameworks/helloworld/src/main/dist/svc.yml
+++ b/frameworks/helloworld/src/main/dist/svc.yml
@@ -21,7 +21,6 @@ pods:
           type: ROOT
           size: {{HELLO_DISK}}
         env:
-          PARSE_EMPTY_KEY_AS_BLANK_TEST:
           SLEEP_DURATION: {{SLEEP_DURATION}}
         health-check:
           cmd: stat hello-container-path/output

--- a/frameworks/helloworld/tests/test_quota_deployment.py
+++ b/frameworks/helloworld/tests/test_quota_deployment.py
@@ -26,6 +26,7 @@ def configure_package(configure_security):
         sdk_marathon.delete_group(group_id=ENFORCED_ROLE)
 
 
+@pytest.mark.quota_test
 @pytest.mark.quota
 @pytest.mark.dcos_min_version("1.14")
 @pytest.mark.sanity
@@ -55,6 +56,7 @@ def test_nonenforced_group_role_defaults(options):
     assert service_roles["framework-role"] == LEGACY_ROLE
 
 
+@pytest.mark.quota_test
 @pytest.mark.quota
 @pytest.mark.dcos_min_version("1.14")
 @pytest.mark.sanity
@@ -74,6 +76,7 @@ def test_nonenforced_group_role_service_role_set():
     assert service_roles["framework-role"] == ENFORCED_ROLE
 
 
+@pytest.mark.quota_test
 @pytest.mark.quota
 @pytest.mark.dcos_min_version("1.14")
 @pytest.mark.sanity
@@ -99,6 +102,7 @@ def test_nonenforced_group_role_service_role_legacy_role_set():
     assert ENFORCED_ROLE in service_roles["framework-roles"]
 
 
+@pytest.mark.quota_test
 @pytest.mark.quota
 @pytest.mark.dcos_min_version("1.14")
 @pytest.mark.sanity
@@ -118,6 +122,7 @@ def test_enforced_group_role_defaults():
     assert service_roles["framework-role"] == ENFORCED_ROLE
 
 
+@pytest.mark.quota_test
 @pytest.mark.quota
 @pytest.mark.dcos_min_version("1.14")
 @pytest.mark.sanity
@@ -141,6 +146,7 @@ def test_enforced_group_role_legacy_role_set():
     assert ENFORCED_ROLE in service_roles["framework-roles"]
 
 
+@pytest.mark.quota_test
 @pytest.mark.quota
 @pytest.mark.dcos_min_version("1.14")
 @pytest.mark.sanity
@@ -162,6 +168,7 @@ def test_nonenforced_group_legacy_service_role_non_migration():
     assert service_roles["framework-role"] == LEGACY_ROLE
 
 
+@pytest.mark.quota_test
 @pytest.mark.quota
 @pytest.mark.dcos_min_version("1.14")
 @pytest.mark.sanity

--- a/frameworks/helloworld/tests/test_quota_downgrade.py
+++ b/frameworks/helloworld/tests/test_quota_downgrade.py
@@ -32,6 +32,7 @@ def configure_package(configure_security):
         sdk_marathon.delete_group(group_id=ENFORCED_ROLE)
 
 
+@pytest.mark.quota_test
 @pytest.mark.quota_downgrade
 @pytest.mark.dcos_min_version("1.14")
 @pytest.mark.sanity
@@ -58,6 +59,7 @@ def test_initial_install():
     assert service_roles["framework-role"] == ENFORCED_ROLE
 
 
+@pytest.mark.quota_test
 @pytest.mark.quota_downgrade
 @pytest.mark.dcos_min_version("1.14")
 @pytest.mark.sanity
@@ -81,6 +83,7 @@ def test_disable_enforce_role():
     assert service_roles["framework-role"] == ENFORCED_ROLE
 
 
+@pytest.mark.quota_test
 @pytest.mark.quota_downgrade
 @pytest.mark.dcos_min_version("1.14")
 @pytest.mark.sanity
@@ -116,6 +119,7 @@ def test_switch_to_legacy_role():
     assert ENFORCED_ROLE in service_roles["framework-roles"]
 
 
+@pytest.mark.quota_test
 @pytest.mark.quota_downgrade
 @pytest.mark.dcos_min_version("1.14")
 @pytest.mark.sanity
@@ -160,6 +164,7 @@ def test_replace_pods_to_legacy_role():
     assert ENFORCED_ROLE in service_roles["framework-roles"]
 
 
+@pytest.mark.quota_test
 @pytest.mark.quota_downgrade
 @pytest.mark.dcos_min_version("1.14")
 @pytest.mark.sanity
@@ -167,17 +172,18 @@ def test_replace_pods_to_legacy_role():
 def test_disable_quota_role():
 
     # Add new pods to service which should be launched with the new role.
-    marathon_config = sdk_marathon.get_config(SERVICE_NAME)
-
     # Turn off legacy role.
-    marathon_config["env"]["ENABLE_ROLE_MIGRATION"] = "false"
 
-    # Update the app
-    sdk_marathon.update_app(marathon_config)
-
-    # Wait for scheduler to restart.
-    sdk_plan.wait_for_completed_deployment(SERVICE_NAME)
-
+    options = {
+        "service": {"name": SERVICE_NAME, "role": "slave_public", "enable_role_migration": False}
+    }
+    sdk_upgrade.update_or_upgrade_or_downgrade(
+        config.PACKAGE_NAME,
+        SERVICE_NAME,
+        expected_running_tasks=3,
+        to_options=options,
+        to_version=None,
+    )
     # Get the current service state to verify roles have applied.
     service_roles = sdk_utils.get_service_roles(SERVICE_NAME)
     current_task_roles = service_roles["task-roles"]
@@ -194,6 +200,7 @@ def test_disable_quota_role():
     assert service_roles["framework-role"] == LEGACY_ROLE
 
 
+@pytest.mark.quota_test
 @pytest.mark.quota_downgrade
 @pytest.mark.dcos_min_version("1.14")
 @pytest.mark.sanity
@@ -228,6 +235,7 @@ def test_add_pods_post_update():
     assert service_roles["framework-role"] == LEGACY_ROLE
 
 
+@pytest.mark.quota_test
 @pytest.mark.quota_downgrade
 @pytest.mark.dcos_min_version("1.14")
 @pytest.mark.sanity

--- a/frameworks/helloworld/tests/test_quota_upgrade.py
+++ b/frameworks/helloworld/tests/test_quota_upgrade.py
@@ -32,6 +32,7 @@ def configure_package(configure_security):
         sdk_marathon.delete_group(group_id=ENFORCED_ROLE)
 
 
+@pytest.mark.quota_test
 @pytest.mark.quota_upgrade
 @pytest.mark.dcos_min_version("1.14")
 @pytest.mark.sanity
@@ -57,6 +58,7 @@ def test_initial_upgrade():
     assert service_roles["framework-role"] == LEGACY_ROLE
 
 
+@pytest.mark.quota_test
 @pytest.mark.quota_upgrade
 @pytest.mark.dcos_min_version("1.14")
 @pytest.mark.sanity
@@ -94,6 +96,7 @@ def test_update_scheduler_role():
     assert ENFORCED_ROLE in service_roles["framework-roles"]
 
 
+@pytest.mark.quota_test
 @pytest.mark.quota_upgrade
 @pytest.mark.dcos_min_version("1.14")
 @pytest.mark.sanity
@@ -138,6 +141,7 @@ def test_replace_pods_to_new_role():
     assert ENFORCED_ROLE in service_roles["framework-roles"]
 
 
+@pytest.mark.quota_test
 @pytest.mark.quota_upgrade
 @pytest.mark.dcos_min_version("1.14")
 @pytest.mark.sanity
@@ -177,6 +181,7 @@ def test_add_pods_post_update():
     assert ENFORCED_ROLE in service_roles["framework-roles"]
 
 
+@pytest.mark.quota_test
 @pytest.mark.quota_upgrade
 @pytest.mark.dcos_min_version("1.14")
 @pytest.mark.sanity
@@ -184,16 +189,20 @@ def test_add_pods_post_update():
 def test_disable_legacy_role_post_update():
 
     # Add new pods to service which should be launched with the new role.
-    marathon_config = sdk_marathon.get_config(SERVICE_NAME)
-
     # Turn off legacy role.
-    marathon_config["env"]["ENABLE_ROLE_MIGRATION"] = "false"
 
-    # Update the app
-    sdk_marathon.update_app(marathon_config)
-
-    # Wait for scheduler to restart.
-    sdk_plan.wait_for_completed_deployment(SERVICE_NAME)
+    options = {
+        "service": {"name": SERVICE_NAME, "role": "quota", "enable_role_migration": False},
+        "hello": {"count": 2},
+        "world": {"count": 3}
+    }
+    sdk_upgrade.update_or_upgrade_or_downgrade(
+        config.PACKAGE_NAME,
+        SERVICE_NAME,
+        expected_running_tasks=5,
+        to_options=options,
+        to_version=None,
+    )
 
     # Get the current service state to verify roles have applied.
     service_roles = sdk_utils.get_service_roles(SERVICE_NAME)
@@ -211,6 +220,7 @@ def test_disable_legacy_role_post_update():
     assert service_roles["framework-role"] == ENFORCED_ROLE
 
 
+@pytest.mark.quota_test
 @pytest.mark.quota_upgrade
 @pytest.mark.dcos_min_version("1.14")
 @pytest.mark.sanity

--- a/frameworks/helloworld/tests/test_quota_upgrade.py
+++ b/frameworks/helloworld/tests/test_quota_upgrade.py
@@ -194,7 +194,7 @@ def test_disable_legacy_role_post_update():
     options = {
         "service": {"name": SERVICE_NAME, "role": "quota", "enable_role_migration": False},
         "hello": {"count": 2},
-        "world": {"count": 3}
+        "world": {"count": 3},
     }
     sdk_upgrade.update_or_upgrade_or_downgrade(
         config.PACKAGE_NAME,

--- a/sdk/scheduler/build.gradle
+++ b/sdk/scheduler/build.gradle
@@ -118,6 +118,7 @@ ext {
     elVer = "2.2.4"
     bouncyCastleVer = "1.62"
     dropWizardMetricsVer = "3.2.5"
+    jaxbDepsVer = "2.3.2"
 }
 
 dependencies {
@@ -149,6 +150,15 @@ dependencies {
     compile "org.glassfish.jersey.containers:jersey-container-servlet-core:${jerseyVer}"
     compile "org.glassfish.jersey.media:jersey-media-json-jackson:${jerseyVer}"
     compile "org.glassfish.jersey.media:jersey-media-multipart:${jerseyVer}"
+
+    // JAXB was removed from the default JDK libraries after Java-9 and
+    // and at runtime on JDK-11 we get a ClassNotFoundException
+    // as org.glassfish.jersey still requires it. Here we explicitly
+    // add JAXB as as dependency.
+    // Reference: https://openjdk.java.net/jeps/320
+    compile "jakarta.xml.bind:jakarta.xml.bind-api:${jaxbDepsVer}"
+    compile "org.glassfish.jaxb:jaxb-runtime:${jaxbDepsVer}"
+
     compile 'org.eclipse.jetty:jetty-servlet:9.4.9.v20180320'
     compile "javax.el:javax.el-api:${elVer}"
     compile "org.glassfish.web:javax.el:${elVer}"

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/framework/FrameworkScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/framework/FrameworkScheduler.java
@@ -21,6 +21,7 @@ import org.slf4j.Logger;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
@@ -241,8 +242,9 @@ public class FrameworkScheduler implements Scheduler {
   private Protos.Offer filterBadResources(Protos.Offer offer) {
     Collection<Protos.Resource> goodResources = new ArrayList<>();
     Collection<Protos.Resource> badResources = new ArrayList<>();
+    Optional<Protos.FrameworkID> frameworkId = frameworkStore.fetchFrameworkId();
     for (Protos.Resource resource : offer.getResourcesList()) {
-      if (ResourceUtils.isProcessable(resource, frameworkRolesWhitelist)) {
+      if (ResourceUtils.isProcessable(resource, frameworkRolesWhitelist, frameworkId)) {
         goodResources.add(resource);
       } else {
         badResources.add(resource);

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/ResourceBuilder.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/ResourceBuilder.java
@@ -60,6 +60,7 @@ public final class ResourceBuilder {
     this.frameworkId = Optional.empty();
   }
 
+  //TODO@kjoshi These are temporary wrapper functions till everything is moved over.
   public static ResourceBuilder fromSpec(
       ResourceSpec spec, Optional<String> resourceId, Optional<String> resourceNamespace, Optional<String> frameworkId)
   {
@@ -68,6 +69,22 @@ public final class ResourceBuilder {
     return builder;
   }
 
+  //TODO@kjoshi Remove *all* callers of this function once we've moved over.
+  public static ResourceBuilder fromSpec(
+      VolumeSpec spec,
+      Optional<String> resourceId,
+      Optional<String> resourceNamespace,
+      Optional<String> persistenceId,
+      Optional<Protos.ResourceProviderID> providerId,
+      Optional<Protos.Resource.DiskInfo.Source> diskSource,
+      Optional<String> frameworkId)
+  {
+    ResourceBuilder builder = fromSpec(spec, resourceId, resourceNamespace, persistenceId, providerId, diskSource);
+    frameworkId.ifPresent(builder::setFrameworkId);
+    return builder;
+  }
+
+  //--------------------------------------------------------------------------------------------------------------
   //TODO@kjoshi Remove *all* callers of this function once we've moved over.
   public static ResourceBuilder fromSpec(
       ResourceSpec spec, Optional<String> resourceId, Optional<String> resourceNamespace)
@@ -81,6 +98,7 @@ public final class ResourceBuilder {
     return builder;
   }
 
+  //TODO@kjoshi Remove *all* callers of this function once we've moved over.
   public static ResourceBuilder fromSpec(
       VolumeSpec spec,
       Optional<String> resourceId,
@@ -116,7 +134,8 @@ public final class ResourceBuilder {
       return fromSpec(
           getResourceSpec(resource),
           ResourceUtils.getResourceId(resource),
-          ResourceUtils.getNamespace(resource));
+          ResourceUtils.getNamespace(resource),
+          ResourceUtils.getFrameworkId(resource));
     } else {
       return fromSpec(
           getVolumeSpec(resource),
@@ -124,7 +143,8 @@ public final class ResourceBuilder {
           ResourceUtils.getNamespace(resource),
           ResourceUtils.getPersistenceId(resource),
           ResourceUtils.getProviderId(resource),
-          ResourceUtils.getDiskSource(resource));
+          ResourceUtils.getDiskSource(resource),
+          ResourceUtils.getFrameworkId(resource));
     }
   }
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/ResourceBuilder.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/ResourceBuilder.java
@@ -148,6 +148,7 @@ public final class ResourceBuilder {
     }
   }
 
+  // TODO@kjoshi investigate if this needs to be changed as well.
   public static ResourceBuilder fromUnreservedValue(String resourceName, Protos.Value value) {
     return new ResourceBuilder(resourceName, value, Constants.ANY_ROLE);
   }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/ResourceBuilder.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/ResourceBuilder.java
@@ -60,16 +60,19 @@ public final class ResourceBuilder {
     this.frameworkId = Optional.empty();
   }
 
-  //TODO@kjoshi These are temporary wrapper functions till everything is moved over.
   public static ResourceBuilder fromSpec(
       ResourceSpec spec, Optional<String> resourceId, Optional<String> resourceNamespace, Optional<String> frameworkId)
   {
-    ResourceBuilder builder = fromSpec(spec, resourceId, resourceNamespace);
+    ResourceBuilder builder =
+        new ResourceBuilder(spec.getName(), spec.getValue(), spec.getPreReservedRole())
+            .setRole(Optional.of(spec.getRole()))
+            .setPrincipal(Optional.of(spec.getPrincipal()));
+    resourceId.ifPresent(builder::setResourceId);
+    resourceNamespace.ifPresent(builder::setResourceNamespace);
     frameworkId.ifPresent(builder::setFrameworkId);
     return builder;
   }
 
-  //TODO@kjoshi Remove *all* callers of this function once we've moved over.
   public static ResourceBuilder fromSpec(
       VolumeSpec spec,
       Optional<String> resourceId,
@@ -79,35 +82,7 @@ public final class ResourceBuilder {
       Optional<Protos.Resource.DiskInfo.Source> diskSource,
       Optional<String> frameworkId)
   {
-    ResourceBuilder builder = fromSpec(spec, resourceId, resourceNamespace, persistenceId, providerId, diskSource);
-    frameworkId.ifPresent(builder::setFrameworkId);
-    return builder;
-  }
-
-  //--------------------------------------------------------------------------------------------------------------
-  //TODO@kjoshi Remove *all* callers of this function once we've moved over.
-  public static ResourceBuilder fromSpec(
-      ResourceSpec spec, Optional<String> resourceId, Optional<String> resourceNamespace)
-  {
-    ResourceBuilder builder =
-        new ResourceBuilder(spec.getName(), spec.getValue(), spec.getPreReservedRole())
-            .setRole(Optional.of(spec.getRole()))
-            .setPrincipal(Optional.of(spec.getPrincipal()));
-    resourceId.ifPresent(builder::setResourceId);
-    resourceNamespace.ifPresent(builder::setResourceNamespace);
-    return builder;
-  }
-
-  //TODO@kjoshi Remove *all* callers of this function once we've moved over.
-  public static ResourceBuilder fromSpec(
-      VolumeSpec spec,
-      Optional<String> resourceId,
-      Optional<String> resourceNamespace,
-      Optional<String> persistenceId,
-      Optional<Protos.ResourceProviderID> providerId,
-      Optional<Protos.Resource.DiskInfo.Source> diskSource)
-  {
-    ResourceBuilder resourceBuilder = fromSpec(spec, resourceId, resourceNamespace);
+    ResourceBuilder resourceBuilder = fromSpec(spec, resourceId, resourceNamespace, frameworkId);
 
     providerId.ifPresent(resourceBuilder::setProviderId);
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/ResourceBuilder.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/ResourceBuilder.java
@@ -103,7 +103,6 @@ public final class ResourceBuilder {
     }
   }
 
-  // TODO@kjoshi investigate if this needs to be changed as well.
   public static ResourceBuilder fromExistingResource(Protos.Resource resource) {
     if (!resource.hasDisk()) {
       return fromSpec(
@@ -123,7 +122,6 @@ public final class ResourceBuilder {
     }
   }
 
-  // TODO@kjoshi investigate if this needs to be changed as well.
   public static ResourceBuilder fromUnreservedValue(String resourceName, Protos.Value value) {
     return new ResourceBuilder(resourceName, value, Constants.ANY_ROLE);
   }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/ResourceUtils.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/ResourceUtils.java
@@ -154,7 +154,10 @@ public final class ResourceUtils {
    * <li>Static against "pre-reserved-role" (we can reserve against it)</li>
    * <li>Dynamic against "pre-reserved-role" (DOESN'T belong to us at all! Likely created by Marathon)</li></ul>
    *
-   * <p>This function should return {@code false} for all reservations of the last type.
+   * <ul><li>Resources with framework-id labels against "our-role" or "pre-reserved-role/our-role"</li>
+   * <li>If a framework-id label is present on a resource which isn't ours, reject the resource</li></ul>
+   *
+   * <p>This function should return {@code false} for cases which don't belong to us.
    *
    * @param resource the resource to be examined
    * @param ourRoles the expected roles used by this framework, see also

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/ResourceUtils.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/ResourceUtils.java
@@ -62,6 +62,21 @@ public final class ResourceUtils {
         .collect(Collectors.toList());
   }
 
+  /**
+   * Returns a list of unique framework IDs associated with {@link Resource}s.
+   *
+   * @param resources Collection of resources from which to extract the unique resource IDs
+   * @return List of unique framework IDs
+   */
+  public static List<String> getFrameworkIds(Collection<Protos.Resource> resources) {
+    return resources.stream()
+        .map(ResourceUtils::getFrameworkId)
+        .filter(Optional::isPresent)
+        .map(Optional::get)
+        .distinct()
+        .collect(Collectors.toList());
+  }
+
   public static String getRole(Protos.Resource resource) {
     return new MesosResource(resource).getRole();
   }
@@ -93,6 +108,10 @@ public final class ResourceUtils {
 
   public static Optional<String> getResourceId(Protos.Resource resource) {
     return getReservation(resource).flatMap(AuxLabelAccess::getResourceId);
+  }
+
+  public static Optional<String> getFrameworkId(Protos.Resource resource) {
+    return getReservation(resource).flatMap(AuxLabelAccess::getFrameworkId);
   }
 
   public static boolean hasResourceId(Protos.Resource resource) {

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/ExecutorResourceMapper.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/ExecutorResourceMapper.java
@@ -37,17 +37,21 @@ public class ExecutorResourceMapper {
 
   private final List<OfferEvaluationStage> evaluationStages;
 
+  private final Optional<String> frameworkId;
+
   ExecutorResourceMapper(
       PodSpec podSpec,
       Collection<ResourceSpec> resourceSpecs,
       Collection<Protos.Resource> executorResources,
-      Optional<String> resourceNamespace)
+      Optional<String> resourceNamespace,
+      Optional<String> frameworkId)
   {
     logger = LoggingUtils.getLogger(getClass(), resourceNamespace);
     this.volumeSpecs = podSpec.getVolumes();
     this.resourceSpecs = resourceSpecs;
     this.executorResources = executorResources;
     this.resourceNamespace = resourceNamespace;
+    this.frameworkId = frameworkId;
     this.evaluationStages = getEvaluationStagesInternal();
   }
 
@@ -152,7 +156,7 @@ public class ExecutorResourceMapper {
           (VolumeSpec) resourceSpec, Collections.emptyList(), resourceNamespace);
     } else {
       return new ResourceEvaluationStage(
-          resourceSpec, Collections.emptyList(), Optional.empty(), resourceNamespace);
+          resourceSpec, Collections.emptyList(), Optional.empty(), resourceNamespace, frameworkId);
     }
   }
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/ExecutorResourceMapper.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/ExecutorResourceMapper.java
@@ -81,7 +81,8 @@ public class ExecutorResourceMapper {
         matchingResource = ResourceMapperUtils.findMatchingResourceSpec(
             resource,
             remainingResourceSpecs,
-            resourceNamespace);
+            resourceNamespace,
+            frameworkId);
       }
 
       if (matchingResource.isPresent()) {
@@ -145,7 +146,8 @@ public class ExecutorResourceMapper {
           resourceSpec,
           Collections.emptyList(),
           resourceId,
-          resourceLabels.getResourceNamespace()
+          resourceLabels.getResourceNamespace(),
+          resourceLabels.getFrameworkId()
       );
     }
   }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/ExecutorResourceMapper.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/ExecutorResourceMapper.java
@@ -140,7 +140,8 @@ public class ExecutorResourceMapper {
           resourceLabels.getResourceNamespace(),
           resourceLabels.getPersistenceId(),
           resourceLabels.getProviderId(),
-          resourceLabels.getDiskSource());
+          resourceLabels.getDiskSource(),
+          resourceLabels.getFrameworkId());
     } else {
       return new ResourceEvaluationStage(
           resourceSpec,
@@ -155,7 +156,7 @@ public class ExecutorResourceMapper {
   private OfferEvaluationStage newCreateEvaluationStage(ResourceSpec resourceSpec) {
     if (resourceSpec instanceof VolumeSpec) {
       return VolumeEvaluationStage.getNew(
-          (VolumeSpec) resourceSpec, Collections.emptyList(), resourceNamespace);
+          (VolumeSpec) resourceSpec, Collections.emptyList(), resourceNamespace, frameworkId);
     } else {
       return new ResourceEvaluationStage(
           resourceSpec, Collections.emptyList(), Optional.empty(), resourceNamespace, frameworkId);

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/NamedVIPEvaluationStage.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/NamedVIPEvaluationStage.java
@@ -22,9 +22,10 @@ public class NamedVIPEvaluationStage extends PortEvaluationStage {
       NamedVIPSpec namedVIPSpec,
       Collection<String> taskNames,
       Optional<String> resourceId,
-      Optional<String> resourceNamespace)
+      Optional<String> resourceNamespace,
+      Optional<String> frameworkId)
   {
-    super(namedVIPSpec, taskNames, resourceId, resourceNamespace);
+    super(namedVIPSpec, taskNames, resourceId, resourceNamespace, frameworkId);
     this.namedVIPSpec = namedVIPSpec;
   }
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluationUtils.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluationUtils.java
@@ -57,6 +57,7 @@ class OfferEvaluationUtils {
     }
   }
 
+  //TODO@kjoshi: Remove all callers of this function.
   static ReserveEvaluationOutcome evaluateSimpleResource(
       Logger logger,
       OfferEvaluationStage offerEvaluationStage,
@@ -64,6 +65,26 @@ class OfferEvaluationUtils {
       Optional<String> resourceId,
       Optional<String> resourceNamespace,
       MesosResourcePool mesosResourcePool)
+  {
+    return evaluateSimpleResource(
+      logger,
+      offerEvaluationStage,
+      resourceSpec,
+      resourceId,
+      resourceNamespace,
+      mesosResourcePool,
+      Optional.empty()
+    );
+  }
+
+  static ReserveEvaluationOutcome evaluateSimpleResource(
+      Logger logger,
+      OfferEvaluationStage offerEvaluationStage,
+      ResourceSpec resourceSpec,
+      Optional<String> resourceId,
+      Optional<String> resourceNamespace,
+      MesosResourcePool mesosResourcePool,
+      Optional<String> frameworkId)
   {
 
     Optional<MesosResource> mesosResourceOptional;
@@ -110,7 +131,11 @@ class OfferEvaluationUtils {
 
       if (!resourceId.isPresent()) {
         // Initial reservation of resources
-        Protos.Resource resource = ResourceBuilder.fromSpec(resourceSpec, Optional.empty(), resourceNamespace)
+        Protos.Resource resource = ResourceBuilder.fromSpec(
+                                                            resourceSpec,
+                                                            Optional.empty(),
+                                                            resourceNamespace,
+                                                            frameworkId)
             .setMesosResource(mesosResource)
             .build();
         offerRecommendation = new ReserveOfferRecommendation(mesosResourcePool.getOffer(), resource);
@@ -173,7 +198,7 @@ class OfferEvaluationUtils {
         }
 
         mesosResource = mesosResourceOptional.get();
-        Protos.Resource resource = ResourceBuilder.fromSpec(resourceSpec, resourceId, resourceNamespace)
+        Protos.Resource resource = ResourceBuilder.fromSpec(resourceSpec, resourceId, resourceNamespace, frameworkId)
             .setValue(mesosResource.getValue())
             .build();
         // Reservation of additional resources
@@ -200,7 +225,7 @@ class OfferEvaluationUtils {
             AttributeStringUtils.toString(resourceSpec.getValue()),
             AttributeStringUtils.toString(unreserve));
 
-        Protos.Resource resource = ResourceBuilder.fromSpec(resourceSpec, resourceId, resourceNamespace)
+        Protos.Resource resource = ResourceBuilder.fromSpec(resourceSpec, resourceId, resourceNamespace, frameworkId)
             .setValue(unreserve)
             .build();
         // Unreservation of no longer needed resources

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluationUtils.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluationUtils.java
@@ -57,26 +57,6 @@ class OfferEvaluationUtils {
     }
   }
 
-  //TODO@kjoshi: Remove all callers of this function.
-  static ReserveEvaluationOutcome evaluateSimpleResource(
-      Logger logger,
-      OfferEvaluationStage offerEvaluationStage,
-      ResourceSpec resourceSpec,
-      Optional<String> resourceId,
-      Optional<String> resourceNamespace,
-      MesosResourcePool mesosResourcePool)
-  {
-    return evaluateSimpleResource(
-      logger,
-      offerEvaluationStage,
-      resourceSpec,
-      resourceId,
-      resourceNamespace,
-      mesosResourcePool,
-      Optional.empty()
-    );
-  }
-
   static ReserveEvaluationOutcome evaluateSimpleResource(
       Logger logger,
       OfferEvaluationStage offerEvaluationStage,

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluator.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluator.java
@@ -467,7 +467,8 @@ public class OfferEvaluator {
                 spec,
                 Collections.emptyList(),
                 Optional.empty(),
-                resourceNamespace))
+                resourceNamespace,
+                frameworkId))
             .forEach(evaluationStages::add);
       }
 
@@ -495,7 +496,7 @@ public class OfferEvaluator {
                 (PortSpec) resourceSpec, taskNamesToUpdateProtos, Optional.empty(), resourceNamespace));
           } else {
             evaluationStages.add(new ResourceEvaluationStage(
-                resourceSpec, taskNamesToUpdateProtos, Optional.empty(), resourceNamespace));
+                resourceSpec, taskNamesToUpdateProtos, Optional.empty(), resourceNamespace, frameworkId));
           }
         }
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluator.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluator.java
@@ -496,10 +496,11 @@ public class OfferEvaluator {
                 (NamedVIPSpec) resourceSpec,
                 taskNamesToUpdateProtos,
                 Optional.empty(),
-                resourceNamespace));
+                resourceNamespace,
+                frameworkId));
           } else if (resourceSpec instanceof PortSpec) {
             evaluationStages.add(new PortEvaluationStage(
-                (PortSpec) resourceSpec, taskNamesToUpdateProtos, Optional.empty(), resourceNamespace));
+                (PortSpec) resourceSpec, taskNamesToUpdateProtos, Optional.empty(), resourceNamespace, frameworkId));
           } else {
             evaluationStages.add(new ResourceEvaluationStage(
                 resourceSpec, taskNamesToUpdateProtos, Optional.empty(), resourceNamespace, frameworkId));

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluator.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluator.java
@@ -424,7 +424,7 @@ public class OfferEvaluator {
 
     for (VolumeSpec volumeSpec : podInstanceRequirement.getPodInstance().getPod().getVolumes()) {
       evaluationStages.add(VolumeEvaluationStage.getNew(
-          volumeSpec, Collections.emptyList(), resourceNamespace));
+          volumeSpec, Collections.emptyList(), resourceNamespace, frameworkId));
     }
 
     // TLS evaluation stages should be added for all tasks regardless of the tasks to launch list to ensure
@@ -509,7 +509,7 @@ public class OfferEvaluator {
 
         for (VolumeSpec volumeSpec : resourceSet.getVolumes()) {
           evaluationStages.add(VolumeEvaluationStage.getNew(
-              volumeSpec, taskNamesToUpdateProtos, resourceNamespace));
+              volumeSpec, taskNamesToUpdateProtos, resourceNamespace, frameworkId));
         }
       }
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluator.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluator.java
@@ -574,7 +574,8 @@ public class OfferEvaluator {
             resourceSpecForRoleAndPrincipal.getPrincipal(),
             resourceSpecForRoleAndPrincipal.getPreReservedRole()),
         executorInfo.getResourcesList(),
-        resourceNamespace);
+        resourceNamespace,
+        frameworkId);
     executorResourceMapper.getOrphanedResources()
         .forEach(resource -> evaluationStages.add(new DestroyEvaluationStage(resource)));
     executorResourceMapper.getOrphanedResources()

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluator.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluator.java
@@ -114,7 +114,6 @@ public class OfferEvaluator {
       throws InvalidRequirementException, IOException
   {
     if (!this.frameworkId.isPresent()) {
-      //TODO@kjoshi enable this once all offer-evaluation paths have framework-id propagated.
       //On construction of OfferEvaluator above, we haven't subscribed to Mesos.
       //At this point, we're evaluating offers which means we must have subscribed to Mesos.
       //Retrieve the FrameworkID at this point.

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluator.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluator.java
@@ -113,13 +113,13 @@ public class OfferEvaluator {
   public List<OfferRecommendation> evaluate(PodInstanceRequirement podInstanceRequirement, List<Protos.Offer> offers)
       throws InvalidRequirementException, IOException
   {
-    // if (!this.frameworkId.isPresent()) {
-    //   //TODO@kjoshi enable this once all offer-evaluation paths have framework-id propagated.
-    //   //On construction of OfferEvaluator above, we haven't subscribed to Mesos.
-    //   //At this point, we're evaluating offers which means we must have subscribed to Mesos.
-    //   //Retrieve the FrameworkID at this point.
-    //   this.frameworkId = Optional.of(frameworkStore.fetchFrameworkId().get().getValue());
-    // }
+    if (!this.frameworkId.isPresent()) {
+      //TODO@kjoshi enable this once all offer-evaluation paths have framework-id propagated.
+      //On construction of OfferEvaluator above, we haven't subscribed to Mesos.
+      //At this point, we're evaluating offers which means we must have subscribed to Mesos.
+      //Retrieve the FrameworkID at this point.
+      this.frameworkId = Optional.of(frameworkStore.fetchFrameworkId().get().getValue());
+    }
 
     // All tasks in the service (used by some PlacementRules):
     Map<String, Protos.TaskInfo> allTasks = stateStore.fetchTasks().stream()

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluator.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluator.java
@@ -84,7 +84,7 @@ public class OfferEvaluator {
 
   private final Optional<String> resourceNamespace;
 
-  private final Optional<String> frameworkId;
+  private Optional<String> frameworkId;
 
   public OfferEvaluator(
       FrameworkStore frameworkStore,
@@ -107,14 +107,20 @@ public class OfferEvaluator {
     this.schedulerConfig = schedulerConfig;
     this.resourceNamespace = resourceNamespace;
     this.offerOutcomeTrackerV2 = offerOutcomeTrackerV2;
-
-    //TODO@kjoshi propagate this above OfferEvaluator.
     this.frameworkId = Optional.empty();
   }
 
   public List<OfferRecommendation> evaluate(PodInstanceRequirement podInstanceRequirement, List<Protos.Offer> offers)
       throws InvalidRequirementException, IOException
   {
+    // if (!this.frameworkId.isPresent()) {
+    //   //TODO@kjoshi enable this once all offer-evaluation paths have framework-id propagated.
+    //   //On construction of OfferEvaluator above, we haven't subscribed to Mesos.
+    //   //At this point, we're evaluating offers which means we must have subscribed to Mesos.
+    //   //Retrieve the FrameworkID at this point.
+    //   this.frameworkId = Optional.of(frameworkStore.fetchFrameworkId().get().getValue());
+    // }
+
     // All tasks in the service (used by some PlacementRules):
     Map<String, Protos.TaskInfo> allTasks = stateStore.fetchTasks().stream()
         .collect(Collectors.toMap(Protos.TaskInfo::getName, Function.identity()));

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/PodInfoBuilder.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/PodInfoBuilder.java
@@ -211,11 +211,12 @@ public class PodInfoBuilder {
       Optional<String> resourceNamespace,
       Optional<String> persistenceId,
       Optional<Protos.ResourceProviderID> providerId,
-      Optional<Protos.Resource.DiskInfo.Source> diskSource)
+      Optional<Protos.Resource.DiskInfo.Source> diskSource,
+      Optional<String> frameworkId)
   {
 
     Protos.Resource.Builder builder = ResourceBuilder
-        .fromSpec(volumeSpec, resourceId, resourceNamespace, persistenceId, providerId, diskSource)
+        .fromSpec(volumeSpec, resourceId, resourceNamespace, persistenceId, providerId, diskSource, frameworkId)
         .build()
         .toBuilder();
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/PortEvaluationStage.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/PortEvaluationStage.java
@@ -68,16 +68,6 @@ public class PortEvaluationStage implements OfferEvaluationStage {
     this.frameworkId = frameworkId;
   }
 
-  //TODO@kjoshi fix all callers of this function.
-  public PortEvaluationStage(
-      PortSpec portSpec,
-      Collection<String> taskNames,
-      Optional<String> resourceId,
-      Optional<String> resourceNamespace)
-  {
-    this(portSpec, taskNames, resourceId, resourceNamespace, Optional.empty());
-  }
-
   @Override
   public EvaluationOutcome evaluate(MesosResourcePool mesosResourcePool,
                                     PodInfoBuilder podInfoBuilder)

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/PortEvaluationStage.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/PortEvaluationStage.java
@@ -50,11 +50,14 @@ public class PortEvaluationStage implements OfferEvaluationStage {
 
   private final boolean useHostPorts;
 
+  private final Optional<String> frameworkId;
+
   public PortEvaluationStage(
       PortSpec portSpec,
       Collection<String> taskNames,
       Optional<String> resourceId,
-      Optional<String> resourceNamespace)
+      Optional<String> resourceNamespace,
+      Optional<String> frameworkId)
   {
     this.logger = LoggingUtils.getLogger(getClass(), resourceNamespace);
     this.portSpec = portSpec;
@@ -62,6 +65,17 @@ public class PortEvaluationStage implements OfferEvaluationStage {
     this.resourceId = resourceId;
     this.resourceNamespace = resourceNamespace;
     this.useHostPorts = requireHostPorts(portSpec.getNetworkNames());
+    this.frameworkId = frameworkId;
+  }
+
+  //TODO@kjoshi fix all callers of this function.
+  public PortEvaluationStage(
+      PortSpec portSpec,
+      Collection<String> taskNames,
+      Optional<String> resourceId,
+      Optional<String> resourceNamespace)
+  {
+    this(portSpec, taskNames, resourceId, resourceNamespace, Optional.empty());
   }
 
   @Override
@@ -127,7 +141,7 @@ public class PortEvaluationStage implements OfferEvaluationStage {
 
       Optional<String> resourceIdResult = reserveEvaluationOutcome.getResourceId();
       setProtos(podInfoBuilder,
-          ResourceBuilder.fromSpec(updatedPortSpec, resourceIdResult, resourceNamespace).build());
+          ResourceBuilder.fromSpec(updatedPortSpec, resourceIdResult, resourceNamespace, frameworkId).build());
       return EvaluationOutcome.pass(
           this,
           evaluationOutcome.getOfferRecommendations(),
@@ -139,7 +153,7 @@ public class PortEvaluationStage implements OfferEvaluationStage {
           .build();
     } else {
       setProtos(podInfoBuilder,
-          ResourceBuilder.fromSpec(updatedPortSpec, resourceId, resourceNamespace).build());
+          ResourceBuilder.fromSpec(updatedPortSpec, resourceId, resourceNamespace, frameworkId).build());
       return EvaluationOutcome.pass(
           this,
           "Port %s doesn't require resource reservation, " +

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/PortEvaluationStage.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/PortEvaluationStage.java
@@ -123,7 +123,8 @@ public class PortEvaluationStage implements OfferEvaluationStage {
               updatedPortSpec,
               resourceId,
               resourceNamespace,
-              mesosResourcePool);
+              mesosResourcePool,
+              frameworkId);
       EvaluationOutcome evaluationOutcome = reserveEvaluationOutcome.getEvaluationOutcome();
       if (!evaluationOutcome.isPassing()) {
         return evaluationOutcome;

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/ResourceEvaluationStage.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/ResourceEvaluationStage.java
@@ -90,7 +90,8 @@ public class ResourceEvaluationStage implements OfferEvaluationStage {
             resourceSpec,
             requiredResourceId,
             resourceNamespace,
-            mesosResourcePool);
+            mesosResourcePool,
+            frameworkId);
 
     EvaluationOutcome evaluationOutcome = reserveEvaluationOutcome.getEvaluationOutcome();
     if (!evaluationOutcome.isPassing()) {

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/ResourceEvaluationStage.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/ResourceEvaluationStage.java
@@ -31,8 +31,7 @@ public class ResourceEvaluationStage implements OfferEvaluationStage {
 
   private final Optional<String> resourceNamespace;
 
-  //TODO@kjoshi make this final once all the code has been patched up.
-  private Optional<String> frameworkId = Optional.empty();
+  private final Optional<String> frameworkId;
 
   /**
    * Creates a new instance for basic resource evaluation.
@@ -57,29 +56,6 @@ public class ResourceEvaluationStage implements OfferEvaluationStage {
     this.requiredResourceId = requiredResourceId;
     this.resourceNamespace = resourceNamespace;
     this.frameworkId = frameworkId;
-  }
-
-  //TODO@kjoshi remove this constructor once all invocations have been switched to the new one.
-  /**
-   * Creates a new instance for basic resource evaluation.
-   *
-   * @param resourceSpec       the resource spec to be evaluated
-   * @param taskNames          the name of the tasks which will use this resource: multiple when they share a
-   *                           ResourceSet
-   * @param requiredResourceId any previously reserved resource ID to be required, or empty for a new reservation
-   * @param resourceNamespace  the namespace label, if any, to store in the resource
-   */
-  public ResourceEvaluationStage(
-      ResourceSpec resourceSpec,
-      Collection<String> taskNames,
-      Optional<String> requiredResourceId,
-      Optional<String> resourceNamespace)
-  {
-    this.logger = LoggingUtils.getLogger(getClass(), resourceNamespace);
-    this.resourceSpec = resourceSpec;
-    this.taskNames = taskNames;
-    this.requiredResourceId = requiredResourceId;
-    this.resourceNamespace = resourceNamespace;
   }
 
   @Override

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/ResourceEvaluationStage.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/ResourceEvaluationStage.java
@@ -31,6 +31,35 @@ public class ResourceEvaluationStage implements OfferEvaluationStage {
 
   private final Optional<String> resourceNamespace;
 
+  //TODO@kjoshi make this final once all the code has been patched up.
+  private Optional<String> frameworkId = Optional.empty();
+
+  /**
+   * Creates a new instance for basic resource evaluation.
+   *
+   * @param resourceSpec       the resource spec to be evaluated
+   * @param taskNames          the name of the tasks which will use this resource: multiple when they share a
+   *                           ResourceSet
+   * @param requiredResourceId any previously reserved resource ID to be required, or empty for a new reservation
+   * @param resourceNamespace  the namespace label, if any, to store in the resource
+   * @param frameworkId        the frameworkId label to store in the resource
+   */
+  public ResourceEvaluationStage(
+      ResourceSpec resourceSpec,
+      Collection<String> taskNames,
+      Optional<String> requiredResourceId,
+      Optional<String> resourceNamespace,
+      Optional<String> frameworkId)
+  {
+    this.logger = LoggingUtils.getLogger(getClass(), resourceNamespace);
+    this.resourceSpec = resourceSpec;
+    this.taskNames = taskNames;
+    this.requiredResourceId = requiredResourceId;
+    this.resourceNamespace = resourceNamespace;
+    this.frameworkId = frameworkId;
+  }
+
+  //TODO@kjoshi remove this constructor once all invocations have been switched to the new one.
   /**
    * Creates a new instance for basic resource evaluation.
    *
@@ -66,7 +95,7 @@ public class ResourceEvaluationStage implements OfferEvaluationStage {
 
       OfferEvaluationUtils.setProtos(
           podInfoBuilder,
-          ResourceBuilder.fromSpec(resourceSpec, requiredResourceId, resourceNamespace).build(),
+          ResourceBuilder.fromSpec(resourceSpec, requiredResourceId, resourceNamespace, frameworkId).build(),
           Optional.empty());
       return EvaluationOutcome.pass(
           this,
@@ -100,7 +129,7 @@ public class ResourceEvaluationStage implements OfferEvaluationStage {
       OfferEvaluationUtils.setProtos(
           podInfoBuilder,
           ResourceBuilder.fromSpec(
-              resourceSpec, reserveEvaluationOutcome.getResourceId(), resourceNamespace).build(),
+              resourceSpec, reserveEvaluationOutcome.getResourceId(), resourceNamespace, frameworkId).build(),
           Optional.of(taskName));
     }
     // If it's instead an executor-level resource, we need to update the (shared) executor info:
@@ -108,7 +137,7 @@ public class ResourceEvaluationStage implements OfferEvaluationStage {
       OfferEvaluationUtils.setProtos(
           podInfoBuilder,
           ResourceBuilder.fromSpec(
-              resourceSpec, reserveEvaluationOutcome.getResourceId(), resourceNamespace).build(),
+              resourceSpec, reserveEvaluationOutcome.getResourceId(), resourceNamespace, frameworkId).build(),
           Optional.empty());
     }
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/ResourceLabels.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/ResourceLabels.java
@@ -25,7 +25,14 @@ class ResourceLabels {
 
   private final Optional<Protos.Resource.DiskInfo.Source> diskSource;
 
-  ResourceLabels(ResourceSpec resourceSpec, String resourceId, Optional<String> resourceNamespace) {
+  private final Optional<String> frameworkId;
+
+  ResourceLabels(
+      ResourceSpec resourceSpec,
+      String resourceId,
+      Optional<String> resourceNamespace,
+      Optional<String> frameworkId)
+  {
     this(
         resourceSpec,
         resourceSpec,
@@ -33,7 +40,8 @@ class ResourceLabels {
         resourceNamespace,
         Optional.empty(),
         Optional.empty(),
-        Optional.empty());
+        Optional.empty(),
+        frameworkId);
   }
 
   /**
@@ -55,7 +63,8 @@ class ResourceLabels {
       Optional<String> resourceNamespace,
       Optional<String> persistenceId,
       Optional<Protos.ResourceProviderID> providerId,
-      Optional<Protos.Resource.DiskInfo.Source> diskSource)
+      Optional<Protos.Resource.DiskInfo.Source> diskSource,
+      Optional<String> frameworkId)
   {
     this.original = original;
     this.updated = updated;
@@ -64,6 +73,7 @@ class ResourceLabels {
     this.persistenceId = persistenceId;
     this.providerId = providerId;
     this.diskSource = diskSource;
+    this.frameworkId = frameworkId;
   }
 
   public ResourceSpec getOriginal() {
@@ -92,6 +102,10 @@ class ResourceLabels {
 
   public Optional<Protos.Resource.DiskInfo.Source> getDiskSource() {
     return diskSource;
+  }
+
+  public Optional<String> getFrameworkId() {
+    return frameworkId;
   }
 
   @Override

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/ResourceMapperUtils.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/ResourceMapperUtils.java
@@ -68,7 +68,7 @@ class ResourceMapperUtils {
             resourceSpec,
             ResourceUtils.getResourceId(taskResource).get(),
             getNamespaceLabel(ResourceUtils.getNamespace(taskResource), resourceNamespace),
-            getFrameworkIdLabel(ResourceUtils.getNamespace(taskResource), frameworkId)));
+            getFrameworkIdLabel(ResourceUtils.getFrameworkId(taskResource), frameworkId)));
   }
 
   /**

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/TaskResourceMapper.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/TaskResourceMapper.java
@@ -99,7 +99,8 @@ class TaskResourceMapper {
           matchingResource = ResourceMapperUtils.findMatchingResourceSpec(
               taskResource,
               remainingResourceSpecs,
-              resourceNamespace);
+              resourceNamespace,
+              frameworkId);
           break;
       }
       if (matchingResource.isPresent()) {
@@ -171,7 +172,10 @@ class TaskResourceMapper {
               resourceId.get(),
               ResourceMapperUtils.getNamespaceLabel(
                   ResourceUtils.getNamespace(taskResource),
-                  resourceNamespace)));
+                  resourceNamespace),
+              ResourceMapperUtils.getFrameworkIdLabel(
+                  ResourceUtils.getFrameworkId(taskResource),
+                  frameworkId)));
         }
       } else if (RangeUtils.isInAny(ranges.getRangeList(), portSpec.getPort())) {
         // For fixed ports, we can just check for a resource whose ranges include that port.
@@ -180,7 +184,10 @@ class TaskResourceMapper {
             resourceId.get(),
             ResourceMapperUtils.getNamespaceLabel(
                 ResourceUtils.getNamespace(taskResource),
-                resourceNamespace)));
+                resourceNamespace),
+            ResourceMapperUtils.getFrameworkIdLabel(
+                ResourceUtils.getFrameworkId(taskResource),
+                frameworkId)));
       }
     }
     return Optional.empty();
@@ -197,7 +204,7 @@ class TaskResourceMapper {
         resourceLabels.getPersistenceId(),
         resourceLabels.getProviderId(),
         resourceLabels.getDiskSource(),
-        frameworkId);
+        resourceLabels.getFrameworkId());
   }
 
   private OfferEvaluationStage newCreateEvaluationStage(

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/TaskResourceMapper.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/TaskResourceMapper.java
@@ -45,14 +45,18 @@ class TaskResourceMapper {
 
   private final List<OfferEvaluationStage> evaluationStages;
 
+  private final Optional<String> frameworkId;
+
   TaskResourceMapper(
       Collection<String> taskSpecNames,
       ResourceSet resourceSet,
       Protos.TaskInfo taskInfo,
-      Optional<String> resourceNamespace)
+      Optional<String> resourceNamespace,
+      Optional<String> frameworkId)
   {
     logger = LoggingUtils.getLogger(getClass(), resourceNamespace);
     this.resourceNamespace = resourceNamespace;
+    this.frameworkId = frameworkId;
     // Multiple tasks may share a resource set. When a resource set is updated, we want to ensure that all tasks
     // attached to the resource set receive the update.
     this.taskSpecNames = taskSpecNames;
@@ -61,7 +65,6 @@ class TaskResourceMapper {
     this.resourceSpecs.addAll(resourceSet.getVolumes());
     this.taskPortFinder = new TaskPortLookup(taskInfo);
     this.resources = taskInfo.getResourcesList();
-
     // ONLY call this AFTER initializing all members above:
     this.evaluationStages = getEvaluationStagesInternal();
   }
@@ -193,7 +196,8 @@ class TaskResourceMapper {
         resourceLabels.getResourceNamespace(),
         resourceLabels.getPersistenceId(),
         resourceLabels.getProviderId(),
-        resourceLabels.getDiskSource());
+        resourceLabels.getDiskSource(),
+        frameworkId);
   }
 
   private OfferEvaluationStage newCreateEvaluationStage(
@@ -206,7 +210,8 @@ class TaskResourceMapper {
         resourceNamespace,
         Optional.empty(),
         Optional.empty(),
-        Optional.empty());
+        Optional.empty(),
+        frameworkId);
   }
 
   private static OfferEvaluationStage toEvaluationStage(
@@ -216,7 +221,8 @@ class TaskResourceMapper {
       Optional<String> resourceNamespace,
       Optional<String> persistenceId,
       Optional<Protos.ResourceProviderID> providerId,
-      Optional<Protos.Resource.DiskInfo.Source> diskSource)
+      Optional<Protos.Resource.DiskInfo.Source> diskSource,
+      Optional<String> frameworkId)
   {
     if (resourceSpec instanceof NamedVIPSpec) {
       return new NamedVIPEvaluationStage(
@@ -241,7 +247,8 @@ class TaskResourceMapper {
           resourceSpec,
           taskSpecNames,
           resourceId,
-          resourceNamespace);
+          resourceNamespace,
+          frameworkId);
     }
   }
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/TaskResourceMapper.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/TaskResourceMapper.java
@@ -249,7 +249,8 @@ class TaskResourceMapper {
           resourceNamespace,
           persistenceId,
           providerId,
-          diskSource);
+          diskSource,
+          frameworkId);
     } else {
       return new ResourceEvaluationStage(
           resourceSpec,

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/TaskResourceMapper.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/TaskResourceMapper.java
@@ -233,13 +233,14 @@ class TaskResourceMapper {
   {
     if (resourceSpec instanceof NamedVIPSpec) {
       return new NamedVIPEvaluationStage(
-          (NamedVIPSpec) resourceSpec, taskSpecNames, resourceId, resourceNamespace);
+          (NamedVIPSpec) resourceSpec, taskSpecNames, resourceId, resourceNamespace, frameworkId);
     } else if (resourceSpec instanceof PortSpec) {
       return new PortEvaluationStage(
           (PortSpec) resourceSpec,
           taskSpecNames,
           resourceId,
-          resourceNamespace);
+          resourceNamespace,
+          frameworkId);
     } else if (resourceSpec instanceof VolumeSpec) {
       return VolumeEvaluationStage.getExisting(
           (VolumeSpec) resourceSpec,

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/VolumeEvaluationStage.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/VolumeEvaluationStage.java
@@ -160,7 +160,8 @@ public final class VolumeEvaluationStage implements OfferEvaluationStage {
               volumeSpec,
               resourceId,
               resourceNamespace,
-              mesosResourcePool);
+              mesosResourcePool,
+              frameworkId);
       EvaluationOutcome evaluationOutcome = reserveEvaluationOutcome.getEvaluationOutcome();
       if (!evaluationOutcome.isPassing()) {
         return evaluationOutcome;

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/VolumeEvaluationStage.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/VolumeEvaluationStage.java
@@ -49,10 +49,13 @@ public final class VolumeEvaluationStage implements OfferEvaluationStage {
 
   private final Optional<Protos.Resource.DiskInfo.Source> diskSource;
 
+  private final Optional<String> frameworkId;
+
   public static VolumeEvaluationStage getNew(
       VolumeSpec volumeSpec,
       Collection<String> taskNames,
-      Optional<String> resourceNamespace)
+      Optional<String> resourceNamespace,
+      Optional<String> frameworkId)
   {
     return new VolumeEvaluationStage(
         volumeSpec,
@@ -61,8 +64,10 @@ public final class VolumeEvaluationStage implements OfferEvaluationStage {
         resourceNamespace,
         Optional.empty(),
         Optional.empty(),
-        Optional.empty());
+        Optional.empty(),
+        frameworkId);
   }
+
 
   public static VolumeEvaluationStage getExisting(
       VolumeSpec volumeSpec,
@@ -71,7 +76,8 @@ public final class VolumeEvaluationStage implements OfferEvaluationStage {
       Optional<String> resourceNamespace,
       Optional<String> persistenceId,
       Optional<Protos.ResourceProviderID> providerId,
-      Optional<Protos.Resource.DiskInfo.Source> diskSource)
+      Optional<Protos.Resource.DiskInfo.Source> diskSource,
+      Optional<String> frameworkId)
   {
     return new VolumeEvaluationStage(
         volumeSpec,
@@ -80,7 +86,8 @@ public final class VolumeEvaluationStage implements OfferEvaluationStage {
         resourceNamespace,
         persistenceId,
         providerId,
-        diskSource);
+        diskSource,
+        frameworkId);
   }
 
   private VolumeEvaluationStage(
@@ -90,7 +97,8 @@ public final class VolumeEvaluationStage implements OfferEvaluationStage {
       Optional<String> resourceNamespace,
       Optional<String> persistenceId,
       Optional<Protos.ResourceProviderID> providerId,
-      Optional<Protos.Resource.DiskInfo.Source> diskSource)
+      Optional<Protos.Resource.DiskInfo.Source> diskSource,
+      Optional<String> frameworkId)
   {
     this.logger = LoggingUtils.getLogger(getClass(), resourceNamespace);
     this.volumeSpec = volumeSpec;
@@ -100,6 +108,7 @@ public final class VolumeEvaluationStage implements OfferEvaluationStage {
     this.persistenceId = persistenceId;
     this.providerId = providerId;
     this.diskSource = diskSource;
+    this.frameworkId = frameworkId;
   }
 
   private boolean createsVolume() {
@@ -129,7 +138,8 @@ public final class VolumeEvaluationStage implements OfferEvaluationStage {
           resourceNamespace,
           persistenceId,
           providerId,
-          diskSource);
+          diskSource,
+          frameworkId);
       podInfoBuilder.getExecutorBuilder().get().addResources(volume);
 
       return EvaluationOutcome.pass(
@@ -164,7 +174,8 @@ public final class VolumeEvaluationStage implements OfferEvaluationStage {
           resourceNamespace,
           persistenceId,
           Optional.empty(),
-          Optional.empty())
+          Optional.empty(),
+          frameworkId)
           .setMesosResource(mesosResource)
           .build();
     } else {
@@ -192,7 +203,8 @@ public final class VolumeEvaluationStage implements OfferEvaluationStage {
           resourceNamespace,
           persistenceId,
           ResourceUtils.getProviderId(mesosResource.getResource()),
-          ResourceUtils.getDiskSource(mesosResource.getResource()))
+          ResourceUtils.getDiskSource(mesosResource.getResource()),
+          frameworkId)
           .setValue(mesosResource.getValue())
           .setMesosResource(mesosResource)
           .build();

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/taskdata/AuxLabelAccess.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/taskdata/AuxLabelAccess.java
@@ -58,7 +58,30 @@ public final class AuxLabelAccess {
   }
 
   /**
-   * Assigns a resource ID label to the provided reservation.
+   * Assigns a framework ID label to the provided reservation.
+   *
+   * @param reservationBuilder the reservation where labels should be added
+   * @param frameworkId         a unique id representing the framework
+   */
+  public static void setFrameworkId(
+      Protos.Resource.ReservationInfo.Builder reservationBuilder,
+      String frameworkId)
+  {
+    Map<String, String> map = LabelUtils.toMap(reservationBuilder.getLabels());
+    map.put(LabelConstants.FRAMEWORK_ID_RESERVATION_LABEL, frameworkId);
+    reservationBuilder.setLabels(LabelUtils.toProto(map));
+  }
+
+  /**
+   * Returns the unique resource id which can be used for uniquely identifying this reservation, or an empty optional
+   * if none is present. This label should always be present in reservations which were created by the SDK.
+   */
+  public static Optional<String> getFrameworkId(Protos.Resource.ReservationInfo reservation) {
+    return getLabel(reservation.getLabels(), LabelConstants.FRAMEWORK_ID_RESERVATION_LABEL);
+  }
+
+  /**
+   * Assigns a service namespace to the pvrovided reservation.
    *
    * @param reservationBuilder the reservation where labels should be added
    * @param namespace          a namespace to be assigned

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/taskdata/LabelConstants.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/taskdata/LabelConstants.java
@@ -72,6 +72,11 @@ final class LabelConstants {
    */
   static final String RESOURCE_ID_RESERVATION_LABEL = "resource_id";
 
+  /**
+   * Label used to uniquely map resources to framework-ids.
+   */
+  static final String FRAMEWORK_ID_RESERVATION_LABEL = "framework_id";
+
   // ReservationInfo
 
   /**

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/DefaultScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/DefaultScheduler.java
@@ -483,7 +483,6 @@ public class DefaultScheduler extends AbstractScheduler {
   public UnexpectedResourcesResponse getUnexpectedResources(Collection<Protos.Offer> unusedOffers) {
     // First, determine which resource IDs we want to keep. Anything not listed here will be destroyed.
     final Set<String> resourceIdsToKeep;
-    final String registeredFrameworkId = frameworkStore.fetchFrameworkId().get().getValue();
     try {
       resourceIdsToKeep = stateStore.fetchTasks().stream()
           // A known task's resources should be kept if:
@@ -511,13 +510,8 @@ public class DefaultScheduler extends AbstractScheduler {
 
         // Resource is a SDK resource.
         boolean unusedResourceId = resourceId.isPresent() && !resourceIdsToKeep.contains(resourceId.get());
-        // Resource belongs to this framework, irregardless if whether it is used by any currently stored task.
-        boolean isCurrentFrameworkResource = resourceFrameworkId.isPresent() &&
-                                             registeredFrameworkId.equals(resourceFrameworkId.get());
-        // Need to support clearing of old resources when migrating between roles for quota-enablement.
-        boolean isMigrationMode = schedulerConfig.enableRoleMigration();
 
-        if (unusedResourceId && (isCurrentFrameworkResource || isMigrationMode)) {
+        if (unusedResourceId) {
           // This resource has a resource ID label, indicating that it's a reservation created by the SDK.
           // Mark it for automatic garbage collection.
           unexpectedResourcesForOffer.add(resource);

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/DefaultScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/DefaultScheduler.java
@@ -475,6 +475,7 @@ public class DefaultScheduler extends AbstractScheduler {
    */
   @Override
   public UnexpectedResourcesResponse getUnexpectedResources(Collection<Protos.Offer> unusedOffers) {
+    //TODO@kjoshi fix this.
     // First, determine which resource IDs we want to keep. Anything not listed here will be destroyed.
     final Set<String> resourceIdsToKeep;
     try {
@@ -568,6 +569,7 @@ public class DefaultScheduler extends AbstractScheduler {
         this.configStore,
         this.schedulerConfig,
         this.planCustomizer,
-        this.namespace);
+        this.namespace,
+        this.frameworkStore);
   }
 }

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerBuilder.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerBuilder.java
@@ -407,7 +407,8 @@ public class SchedulerBuilder {
           configStore,
           schedulerConfig,
           Optional.ofNullable(planCustomizer),
-          namespace);
+          namespace,
+          new FrameworkStore(persister));
     }
 
     if (StateStoreUtils.isUninstalling(stateStore)) {
@@ -421,7 +422,8 @@ public class SchedulerBuilder {
             configStore,
             schedulerConfig,
             Optional.ofNullable(planCustomizer),
-            namespace);
+            namespace,
+            new FrameworkStore(persister));
       } else {
         // This is an illegal state for a single-service scheduler. SchedulerConfig's uninstall bit should have
         // also been enabled. If we got here, it means that the user likely tampered with the scheduler env

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/uninstall/UninstallScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/uninstall/UninstallScheduler.java
@@ -21,6 +21,7 @@ import com.mesosphere.sdk.scheduler.plan.PlanManager;
 import com.mesosphere.sdk.scheduler.plan.Step;
 import com.mesosphere.sdk.specification.ServiceSpec;
 import com.mesosphere.sdk.state.ConfigStore;
+import com.mesosphere.sdk.state.FrameworkStore;
 import com.mesosphere.sdk.state.StateStore;
 import com.mesosphere.sdk.state.StateStoreUtils;
 
@@ -70,6 +71,8 @@ public class UninstallScheduler extends AbstractScheduler {
 
   private final SchedulerConfig schedulerConfig;
 
+  private final FrameworkStore frameworkStore;
+
   /**
    * Creates a new {@link UninstallScheduler} using the provided components. The {@link UninstallScheduler} builds an
    * uninstall {@link Plan} which will clean up the service's reservations, TLS artifacts, zookeeper data, and any
@@ -81,7 +84,8 @@ public class UninstallScheduler extends AbstractScheduler {
       ConfigStore<ServiceSpec> configStore,
       SchedulerConfig schedulerConfig,
       Optional<PlanCustomizer> planCustomizer,
-      Optional<String> namespace)
+      Optional<String> namespace,
+      FrameworkStore frameworkStore)
   {
     this(
         serviceSpec,
@@ -91,7 +95,8 @@ public class UninstallScheduler extends AbstractScheduler {
         planCustomizer,
         namespace,
         Optional.empty(),
-        new TimeFetcher());
+        new TimeFetcher(),
+        frameworkStore);
   }
 
   @VisibleForTesting
@@ -103,12 +108,14 @@ public class UninstallScheduler extends AbstractScheduler {
       Optional<PlanCustomizer> planCustomizer,
       Optional<String> namespace,
       Optional<SecretsClient> customSecretsClientForTests,
-      TimeFetcher timeFetcher)
+      TimeFetcher timeFetcher,
+      FrameworkStore frameworkStore)
   {
     super(serviceSpec, schedulerConfig, stateStore, null, planCustomizer, namespace);
     this.logger = LoggingUtils.getLogger(getClass(), namespace);
     this.configStore = configStore;
     this.schedulerConfig = schedulerConfig;
+    this.frameworkStore = frameworkStore;
 
     if (!StateStoreUtils.isUninstalling(stateStore)) {
       logger.info("Service has been told to uninstall. Marking this in the " +

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/uninstall/UninstallScheduler.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/uninstall/UninstallScheduler.java
@@ -73,8 +73,6 @@ public class UninstallScheduler extends AbstractScheduler {
 
   private final FrameworkStore frameworkStore;
 
-  private final Collection<ResourceCleanupStep> allResouceCleanupSteps;
-
   /**
    * Creates a new {@link UninstallScheduler} using the provided components. The {@link UninstallScheduler} builds an
    * uninstall {@link Plan} which will clean up the service's reservations, TLS artifacts, zookeeper data, and any
@@ -129,7 +127,6 @@ public class UninstallScheduler extends AbstractScheduler {
     // Construct a plan for uninstalling any remaining resources
     UninstallPlanFactory planFactory = new UninstallPlanFactory(
         serviceSpec, stateStore, schedulerConfig, namespace, customSecretsClientForTests);
-    this.allResouceCleanupSteps = planFactory.getResourceCleanupSteps();
     this.recorder = new UninstallRecorder(stateStore, planFactory.getResourceCleanupSteps());
     this.deregisterStubStep = planFactory.getDeregisterStep();
 
@@ -253,22 +250,6 @@ public class UninstallScheduler extends AbstractScheduler {
   @Override
   public UnexpectedResourcesResponse getUnexpectedResources(Collection<Protos.Offer> unusedOffers) {
 
-    /*
-     * Pre  DC/OS 2.0 the SDK framework generated its own roles based on the name of the service.
-     * Post DC/OS 2.0 the SDK framework can share its role with many other services.
-     *
-     * Pre DC/OS 2.0 it was sufficient to remove all resources offered with a ResourceId since the service name
-     * and correspondingly the service-role used ot subscribe to MESOS with was unique.
-     *
-     * Post DC/OS 2.0 this can lead to a severe bug where a SDK framework can DESTORY & UNRESERVE resources
-     * that belong in the same same role which *do not belong* to framework under uninstall.
-     *
-     * To prevent this scenario, we filter out any ResourceIds that do not belong to this frameowork.
-     */
-
-    Collection<String> allResourceCleanupIds = allResouceCleanupSteps.stream()
-        .map(step -> step.getResourceId()).collect(Collectors.toSet());
-
     Collection<OfferResources> unexpected = unusedOffers.stream()
         .map(offer -> new OfferResources(offer).addAll(offer.getResourcesList().stream()
             // Omit any unreserved resources, and any unrefined pre-reserved resources.
@@ -276,8 +257,6 @@ public class UninstallScheduler extends AbstractScheduler {
             // potentially unreserving any resources that weren't originally created by the SDK.
             // This is in addition to separate filtering in FrameworkScheduler of reserved Marathon volumes.
             .filter(resource -> ResourceUtils.hasResourceId(resource))
-            // Ensure we're only selecting ResourceId's that we own here.
-            .filter(resource -> allResourceCleanupIds.contains(ResourceUtils.getResourceId(resource).get()))
             .collect(Collectors.toList())))
         .collect(Collectors.toList());
     try {

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/ResourceBuilderTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/ResourceBuilderTest.java
@@ -462,7 +462,8 @@ public class ResourceBuilderTest extends DefaultCapabilitiesTestSuite {
                 namespace,
                 persistenceId,
                 Optional.empty(),
-                Optional.empty())
+                Optional.empty(),
+                frameworkId)
                 .build();
         Protos.Resource reconstructedResource = ResourceBuilder.fromExistingResource(originalResource).build();
 
@@ -499,7 +500,8 @@ public class ResourceBuilderTest extends DefaultCapabilitiesTestSuite {
                 namespace,
                 persistenceId,
                 Optional.empty(),
-                Optional.of(TestConstants.MOUNT_DISK_SOURCE))
+                Optional.of(TestConstants.MOUNT_DISK_SOURCE),
+                frameworkId)
                 .build();
         Protos.Resource reconstructedResource = ResourceBuilder.fromExistingResource(originalResource).build();
 

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/ResourceBuilderTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/ResourceBuilderTest.java
@@ -427,7 +427,7 @@ public class ResourceBuilderTest extends DefaultCapabilitiesTestSuite {
                 .principal(TestConstants.PRINCIPAL)
                 .build();
         Optional<String> resourceId = Optional.of(UUID.randomUUID().toString());
-        Protos.Resource originalResource = ResourceBuilder.fromSpec(resourceSpec, resourceId, namespace).build();
+        Protos.Resource originalResource = ResourceBuilder.fromSpec(resourceSpec, resourceId, namespace, frameworkId).build();
         Protos.Resource reconstructedResource = ResourceBuilder.fromExistingResource(originalResource).build();
 
         Assert.assertEquals(originalResource, reconstructedResource);

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/ResourceBuilderTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/ResourceBuilderTest.java
@@ -22,6 +22,8 @@ import java.util.UUID;
  */
 @SuppressWarnings("deprecation")
 public class ResourceBuilderTest extends DefaultCapabilitiesTestSuite {
+    private static final String FRAMEWORK_ID = "01234567-890a-bcde-f012-34567890abcd";
+
     /*
         name: "cpus"
         type: SCALAR
@@ -57,30 +59,34 @@ public class ResourceBuilderTest extends DefaultCapabilitiesTestSuite {
         role: "*"
         reservations {
           principal: "test-principal"
-          labels {
+          labels [
             labels {
               key: "resource_id"
               value: "e9edd178-f7dd-4472-b58b-3a3ff7ed51ac"
+            },
+            labels {
+              key: "framework_id"
+              value: "01234567-890a-bcde-f012-34567890abcd"
             }
-          }
+          ]
           role: "test-role"
         }
     */
     @Test
     public void testNewFromResourceSpec() {
-        testNewFromResourceSpec(Optional.empty());
-        testNewFromResourceSpec(Optional.of("/path/to/namespace"));
+        testNewFromResourceSpec(Optional.empty(), Optional.empty());
+        testNewFromResourceSpec(Optional.of("/path/to/namespace"), Optional.of(FRAMEWORK_ID));
 
         ResourceRefinementCapabilityContext context = new ResourceRefinementCapabilityContext(Capabilities.getInstance());
         try {
-            testNewFromResourceSpec(Optional.empty());
-            testNewFromResourceSpec(Optional.of("/path/to/namespace"));
+            testNewFromResourceSpec(Optional.empty(), Optional.empty());
+            testNewFromResourceSpec(Optional.of("/path/to/namespace"), Optional.of(FRAMEWORK_ID));
         } finally {
             context.reset();
         }
     }
 
-    private static void testNewFromResourceSpec(Optional<String> namespace) {
+    private static void testNewFromResourceSpec(Optional<String> namespace, Optional<String> frameworkId) {
         ResourceSpec resourceSpec = DefaultResourceSpec.newBuilder()
                 .name("cpus")
                 .value(VALUE)
@@ -88,16 +94,16 @@ public class ResourceBuilderTest extends DefaultCapabilitiesTestSuite {
                 .preReservedRole(Constants.ANY_ROLE)
                 .principal(TestConstants.PRINCIPAL)
                 .build();
-        ResourceBuilder resourceBuilder = ResourceBuilder.fromSpec(resourceSpec, Optional.empty(), namespace);
+        ResourceBuilder resourceBuilder = ResourceBuilder.fromSpec(resourceSpec, Optional.empty(), namespace, frameworkId);
 
         Protos.Resource resource = resourceBuilder.build();
-        validateScalarResource(resource, Optional.empty(), namespace);
+        validateScalarResource(resource, Optional.empty(), namespace, frameworkId);
     }
 
     @Test
     public void testRefineStaticResource() {
-        testRefineStaticResource(Optional.empty());
-        testRefineStaticResource(Optional.of("foo"));
+        testRefineStaticResource(Optional.empty(), Optional.empty());
+        testRefineStaticResource(Optional.of("foo"), Optional.of(FRAMEWORK_ID));
     }
 
     /*
@@ -112,17 +118,21 @@ public class ResourceBuilderTest extends DefaultCapabilitiesTestSuite {
         }
         reservations {
           principal: "test-principal"
-          labels {
+          labels [
             labels {
               key: "resource_id"
               value: "a395f14b-3cc8-4009-9dc4-51838b423aed"
+            },
+            labels {
+              key: "framework_id"
+              value: "01234567-890a-bcde-f012-34567890abcd"
             }
-          }
+          ]
           role: "test-role"
           type: DYNAMIC
         }
     */
-    private static void testRefineStaticResource(Optional<String> namespace) {
+    private static void testRefineStaticResource(Optional<String> namespace, Optional<String> frameworkId) {
         ResourceRefinementCapabilityContext context = new ResourceRefinementCapabilityContext(Capabilities.getInstance());
         try {
             ResourceSpec resourceSpec = DefaultResourceSpec.newBuilder()
@@ -132,11 +142,11 @@ public class ResourceBuilderTest extends DefaultCapabilitiesTestSuite {
                     .preReservedRole(TestConstants.PRE_RESERVED_ROLE)
                     .principal(TestConstants.PRINCIPAL)
                     .build();
-            ResourceBuilder resourceBuilder = ResourceBuilder.fromSpec(resourceSpec, Optional.empty(), namespace);
+            ResourceBuilder resourceBuilder = ResourceBuilder.fromSpec(resourceSpec, Optional.empty(), namespace, frameworkId);
 
             Protos.Resource resource = resourceBuilder.build();
             Assert.assertEquals(2, resource.getReservationsCount());
-            validateScalarResourceRefined(resource, Optional.empty(), namespace);
+            validateScalarResourceRefined(resource, Optional.empty(), namespace, frameworkId);
             Assert.assertEquals(Protos.Resource.ReservationInfo.Type.STATIC, resource.getReservations(0).getType());
             Assert.assertEquals(TestConstants.PRE_RESERVED_ROLE, resource.getReservations(0).getRole());
         } finally {
@@ -146,19 +156,19 @@ public class ResourceBuilderTest extends DefaultCapabilitiesTestSuite {
 
     @Test
     public void testExistingFromResourceSpec() {
-        testExistingFromResourceSpec(Optional.empty());
-        testExistingFromResourceSpec(Optional.of("bar"));
+        testExistingFromResourceSpec(Optional.empty(), Optional.empty());
+        testExistingFromResourceSpec(Optional.of("bar"), Optional.of(FRAMEWORK_ID));
 
         ResourceRefinementCapabilityContext context = new ResourceRefinementCapabilityContext(Capabilities.getInstance());
         try {
-            testExistingFromResourceSpec(Optional.empty());
-            testExistingFromResourceSpec(Optional.of("bar"));
+            testExistingFromResourceSpec(Optional.empty(), Optional.empty());
+            testExistingFromResourceSpec(Optional.of("bar"), Optional.of(FRAMEWORK_ID));
         } finally {
             context.reset();
         }
     }
 
-    private static void testExistingFromResourceSpec(Optional<String> namespace) {
+    private static void testExistingFromResourceSpec(Optional<String> namespace, Optional<String> frameworkId) {
         Optional<String> resourceId = Optional.of(UUID.randomUUID().toString());
         ResourceSpec resourceSpec = DefaultResourceSpec.newBuilder()
                 .name("cpus")
@@ -168,7 +178,7 @@ public class ResourceBuilderTest extends DefaultCapabilitiesTestSuite {
                 .principal(TestConstants.PRINCIPAL)
                 .build();
         validateScalarResource(
-                ResourceBuilder.fromSpec(resourceSpec, resourceId, namespace).build(), resourceId, namespace);
+                ResourceBuilder.fromSpec(resourceSpec, resourceId, namespace, frameworkId).build(), resourceId, namespace, frameworkId);
     }
 
     /*
@@ -190,30 +200,34 @@ public class ResourceBuilderTest extends DefaultCapabilitiesTestSuite {
         }
         reservations {
           principal: "test-principal"
-          labels {
+          labels [
             labels {
               key: "resource_id"
               value: "0457e8d3-a892-48ed-b845-d38488876592"
+            },
+            labels {
+              key: "framework_id"
+              value: "01234567-890a-bcde-f012-34567890abcd"
             }
-          }
+          ]
           role: "test-role"
         }
     */
     @Test
     public void testNewFromRootVolumeSpec() {
-        testNewFromRootVolumeSpec(Optional.empty());
-        testNewFromRootVolumeSpec(Optional.of("foo"));
+        testNewFromRootVolumeSpec(Optional.empty(), Optional.empty());
+        testNewFromRootVolumeSpec(Optional.of("foo"), Optional.of(FRAMEWORK_ID));
 
         ResourceRefinementCapabilityContext context = new ResourceRefinementCapabilityContext(Capabilities.getInstance());
         try {
-            testNewFromRootVolumeSpec(Optional.empty());
-            testNewFromRootVolumeSpec(Optional.of("foo"));
+            testNewFromRootVolumeSpec(Optional.empty(), Optional.empty());
+            testNewFromRootVolumeSpec(Optional.of("foo"), Optional.of(FRAMEWORK_ID));
         } finally {
             context.reset();
         }
     }
 
-    private static void testNewFromRootVolumeSpec(Optional<String> namespace) {
+    private static void testNewFromRootVolumeSpec(Optional<String> namespace, Optional<String> frameworkId) {
         VolumeSpec volumeSpec = DefaultVolumeSpec.createRootVolume(
                 10,
                 TestConstants.CONTAINER_PATH,
@@ -226,27 +240,28 @@ public class ResourceBuilderTest extends DefaultCapabilitiesTestSuite {
                 namespace,
                 Optional.empty(),
                 Optional.empty(),
-                Optional.empty());
+                Optional.empty(),
+                frameworkId);
 
         Protos.Resource resource = resourceBuilder.build();
-        validateDisk(resource, Optional.empty(), namespace);
+        validateDisk(resource, Optional.empty(), namespace, frameworkId);
     }
 
     @Test
     public void testExistingFromRootVolumeSpec() {
-        testExistingFromRootVolumeSpec(Optional.empty());
-        testExistingFromRootVolumeSpec(Optional.of("/path/to/namespace"));
+        testExistingFromRootVolumeSpec(Optional.empty(), Optional.empty());
+        testExistingFromRootVolumeSpec(Optional.of("/path/to/namespace"), Optional.of(FRAMEWORK_ID));
 
         ResourceRefinementCapabilityContext context = new ResourceRefinementCapabilityContext(Capabilities.getInstance());
         try {
-            testExistingFromRootVolumeSpec(Optional.empty());
-            testExistingFromRootVolumeSpec(Optional.of("/path/to/namespace"));
+            testExistingFromRootVolumeSpec(Optional.empty(), Optional.empty());
+            testExistingFromRootVolumeSpec(Optional.of("/path/to/namespace"), Optional.of(FRAMEWORK_ID));
         } finally {
             context.reset();
         }
     }
 
-    private static void testExistingFromRootVolumeSpec(Optional<String> namespace) {
+    private static void testExistingFromRootVolumeSpec(Optional<String> namespace, Optional<String> frameworkId) {
         VolumeSpec volumeSpec = DefaultVolumeSpec.createRootVolume(
                 10,
                 TestConstants.CONTAINER_PATH,
@@ -261,10 +276,11 @@ public class ResourceBuilderTest extends DefaultCapabilitiesTestSuite {
                 namespace,
                 persistenceId,
                 Optional.empty(),
-                Optional.empty());
+                Optional.empty(),
+                frameworkId);
 
         Protos.Resource resource = resourceBuilder.build();
-        validateDisk(resource, resourceId, namespace);
+        validateDisk(resource, resourceId, namespace, frameworkId);
         Assert.assertEquals(persistenceId.get(), resource.getDisk().getPersistence().getId());
     }
 
@@ -293,30 +309,34 @@ public class ResourceBuilderTest extends DefaultCapabilitiesTestSuite {
         }
         reservations {
           principal: "test-principal"
-          labels {
+          labels [
             labels {
               key: "resource_id"
               value: "9d400c17-ec13-4236-9453-d5642b2884c5"
+            },
+            labels {
+              key: "framework_id"
+              value: "01234567-890a-bcde-f012-34567890abcd"
             }
-          }
+          ]
           role: "test-role"
         }
     */
     @Test
     public void testNewFromMountVolumeSpec() {
-        testNewFromMountVolumeSpec(Optional.empty());
-        testNewFromMountVolumeSpec(Optional.of("foo"));
+        testNewFromMountVolumeSpec(Optional.empty(), Optional.empty());
+        testNewFromMountVolumeSpec(Optional.of("foo"), Optional.of(FRAMEWORK_ID));
 
         ResourceRefinementCapabilityContext context = new ResourceRefinementCapabilityContext(Capabilities.getInstance());
         try {
-            testNewFromMountVolumeSpec(Optional.empty());
-            testNewFromMountVolumeSpec(Optional.of("foo"));
+            testNewFromMountVolumeSpec(Optional.empty(), Optional.empty());
+            testNewFromMountVolumeSpec(Optional.of("foo"), Optional.of(FRAMEWORK_ID));
         } finally {
             context.reset();
         }
     }
 
-    private static void testNewFromMountVolumeSpec(Optional<String> namespace) {
+    private static void testNewFromMountVolumeSpec(Optional<String> namespace, Optional<String> frameworkId) {
         VolumeSpec volumeSpec = DefaultVolumeSpec.createMountVolume(
                 10,
                 TestConstants.CONTAINER_PATH,
@@ -330,10 +350,11 @@ public class ResourceBuilderTest extends DefaultCapabilitiesTestSuite {
                 namespace,
                 Optional.empty(),
                 Optional.empty(),
-                Optional.of(TestConstants.MOUNT_DISK_SOURCE));
+                Optional.of(TestConstants.MOUNT_DISK_SOURCE),
+                frameworkId);
 
         Protos.Resource resource = resourceBuilder.build();
-        validateDisk(resource, Optional.empty(), namespace);
+        validateDisk(resource, Optional.empty(), namespace, frameworkId);
 
         Protos.Resource.DiskInfo diskInfo = resource.getDisk();
         Assert.assertTrue(diskInfo.hasSource());
@@ -342,19 +363,19 @@ public class ResourceBuilderTest extends DefaultCapabilitiesTestSuite {
 
     @Test
     public void testExistingFromMountVolumeSpec() {
-        testExistingFromMountVolumeSpec(Optional.empty());
-        testExistingFromMountVolumeSpec(Optional.of("some/namespace"));
+        testExistingFromMountVolumeSpec(Optional.empty(), Optional.empty());
+        testExistingFromMountVolumeSpec(Optional.of("some/namespace"), Optional.of(FRAMEWORK_ID));
 
         ResourceRefinementCapabilityContext context = new ResourceRefinementCapabilityContext(Capabilities.getInstance());
         try {
-            testExistingFromMountVolumeSpec(Optional.empty());
-            testExistingFromMountVolumeSpec(Optional.of("some/namespace"));
+            testExistingFromMountVolumeSpec(Optional.empty(), Optional.empty());
+            testExistingFromMountVolumeSpec(Optional.of("some/namespace"), Optional.of(FRAMEWORK_ID));
         } finally {
             context.reset();
         }
     }
 
-    private static void testExistingFromMountVolumeSpec(Optional<String> namespace) {
+    private static void testExistingFromMountVolumeSpec(Optional<String> namespace, Optional<String> frameworkId) {
         VolumeSpec volumeSpec = DefaultVolumeSpec.createMountVolume(
                 10,
                 TestConstants.CONTAINER_PATH,
@@ -370,10 +391,11 @@ public class ResourceBuilderTest extends DefaultCapabilitiesTestSuite {
                 namespace,
                 persistenceId,
                 Optional.empty(),
-                Optional.of(TestConstants.MOUNT_DISK_SOURCE));
+                Optional.of(TestConstants.MOUNT_DISK_SOURCE),
+                frameworkId);
 
         Protos.Resource resource = resourceBuilder.build();
-        validateDisk(resource, resourceId, namespace);
+        validateDisk(resource, resourceId, namespace, frameworkId);
 
         Protos.Resource.DiskInfo diskInfo = resource.getDisk();
         Assert.assertTrue(diskInfo.hasSource());
@@ -384,19 +406,19 @@ public class ResourceBuilderTest extends DefaultCapabilitiesTestSuite {
 
     @Test
     public void testFromExistingScalarResource() {
-        testFromExistingScalarResource(Optional.empty());
-        testFromExistingScalarResource(Optional.of("baz"));
+        testFromExistingScalarResource(Optional.empty(), Optional.empty());
+        testFromExistingScalarResource(Optional.of("baz"), Optional.of(FRAMEWORK_ID));
 
         ResourceRefinementCapabilityContext context = new ResourceRefinementCapabilityContext(Capabilities.getInstance());
         try {
-            testFromExistingScalarResource(Optional.empty());
-            testFromExistingScalarResource(Optional.of("baz"));
+            testFromExistingScalarResource(Optional.empty(), Optional.empty());
+            testFromExistingScalarResource(Optional.of("baz"), Optional.of(FRAMEWORK_ID));
         } finally {
             context.reset();
         }
     }
 
-    private static void testFromExistingScalarResource(Optional<String> namespace) {
+    private static void testFromExistingScalarResource(Optional<String> namespace, Optional<String> frameworkId) {
         ResourceSpec resourceSpec = DefaultResourceSpec.newBuilder()
                 .name("cpus")
                 .value(VALUE)
@@ -413,19 +435,19 @@ public class ResourceBuilderTest extends DefaultCapabilitiesTestSuite {
 
     @Test
     public void testFromExistingRootVolume() {
-        testFromExistingRootVolume(Optional.empty());
-        testFromExistingRootVolume(Optional.of("foo/bar"));
+        testFromExistingRootVolume(Optional.empty(), Optional.empty());
+        testFromExistingRootVolume(Optional.of("foo/bar"), Optional.of(FRAMEWORK_ID));
 
         ResourceRefinementCapabilityContext context = new ResourceRefinementCapabilityContext(Capabilities.getInstance());
         try {
-            testFromExistingRootVolume(Optional.empty());
-            testFromExistingRootVolume(Optional.of("foo/bar"));
+            testFromExistingRootVolume(Optional.empty(), Optional.empty());
+            testFromExistingRootVolume(Optional.of("foo/bar"), Optional.of(FRAMEWORK_ID));
         } finally {
             context.reset();
         }
     }
 
-    private static void testFromExistingRootVolume(Optional<String> namespace) {
+    private static void testFromExistingRootVolume(Optional<String> namespace, Optional<String> frameworkId) {
         VolumeSpec volumeSpec = DefaultVolumeSpec.createRootVolume(
                 10,
                 TestConstants.CONTAINER_PATH,
@@ -449,19 +471,19 @@ public class ResourceBuilderTest extends DefaultCapabilitiesTestSuite {
 
     @Test
     public void testFromExistingMountVolume() {
-        testFromExistingMountVolume(Optional.empty());
-        testFromExistingMountVolume(Optional.of("namespace/path"));
+        testFromExistingMountVolume(Optional.empty(), Optional.empty());
+        testFromExistingMountVolume(Optional.of("namespace/path"), Optional.of(FRAMEWORK_ID));
 
         ResourceRefinementCapabilityContext context = new ResourceRefinementCapabilityContext(Capabilities.getInstance());
         try {
-            testFromExistingMountVolume(Optional.empty());
-            testFromExistingMountVolume(Optional.of("namespace/path"));
+            testFromExistingMountVolume(Optional.empty(), Optional.empty());
+            testFromExistingMountVolume(Optional.of("namespace/path"), Optional.of(FRAMEWORK_ID));
         } finally {
             context.reset();
         }
     }
 
-    private static void testFromExistingMountVolume(Optional<String> namespace) {
+    private static void testFromExistingMountVolume(Optional<String> namespace, Optional<String> frameworkId) {
         VolumeSpec volumeSpec = DefaultVolumeSpec.createMountVolume(
                 10,
                 TestConstants.CONTAINER_PATH,
@@ -484,7 +506,7 @@ public class ResourceBuilderTest extends DefaultCapabilitiesTestSuite {
         Assert.assertEquals(originalResource, reconstructedResource);
     }
 
-    private static void validateDisk(Protos.Resource resource, Optional<String> resourceId, Optional<String> namespace) {
+    private static void validateDisk(Protos.Resource resource, Optional<String> resourceId, Optional<String> namespace, Optional<String> frameworkId) {
         Assert.assertTrue(resource.hasDisk());
 
         Protos.Resource.DiskInfo diskInfo = resource.getDisk();
@@ -499,21 +521,21 @@ public class ResourceBuilderTest extends DefaultCapabilitiesTestSuite {
         Assert.assertEquals(TestConstants.CONTAINER_PATH, volume.getContainerPath());
         Assert.assertEquals(Protos.Volume.Mode.RW, volume.getMode());
 
-        validateScalarResource(resource, resourceId, namespace);
+        validateScalarResource(resource, resourceId, namespace, frameworkId);
     }
 
     private static void validateScalarResource(
-            Protos.Resource resource, Optional<String> resourceId, Optional<String> namespace) {
+            Protos.Resource resource, Optional<String> resourceId, Optional<String> namespace, Optional<String> frameworkId) {
         if (Capabilities.getInstance().supportsPreReservedResources()) {
-            validateScalarResourceRefined(resource, resourceId, namespace);
+            validateScalarResourceRefined(resource, resourceId, namespace, frameworkId);
         } else {
-            validateScalarResourceLegacy(resource, resourceId, namespace);
+            validateScalarResourceLegacy(resource, resourceId, namespace, frameworkId);
         }
     }
 
     @SuppressWarnings("deprecation")
     private static void validateScalarResourceRefined(
-            Protos.Resource resource, Optional<String> resourceId, Optional<String> namespace) {
+            Protos.Resource resource, Optional<String> resourceId, Optional<String> namespace, Optional<String> frameworkId) {
         Assert.assertEquals(Protos.Value.Type.SCALAR, resource.getType());
         Assert.assertEquals(Constants.ANY_ROLE, resource.getRole());
         Assert.assertFalse(resource.hasReservation());
@@ -522,11 +544,11 @@ public class ResourceBuilderTest extends DefaultCapabilitiesTestSuite {
         Assert.assertEquals(TestConstants.PRINCIPAL, reservationInfo.getPrincipal());
         Assert.assertEquals(TestConstants.ROLE, reservationInfo.getRole());
 
-        validateLabels(reservationInfo, resourceId, namespace);
+        validateLabels(reservationInfo, resourceId, namespace, frameworkId);
     }
 
     @SuppressWarnings("deprecation")
-    private static void validateScalarResourceLegacy(Protos.Resource resource, Optional<String> resourceId, Optional<String> namespace) {
+    private static void validateScalarResourceLegacy(Protos.Resource resource, Optional<String> resourceId, Optional<String> namespace, Optional<String> frameworkId) {
         Assert.assertEquals(Protos.Value.Type.SCALAR, resource.getType());
         Assert.assertEquals(TestConstants.ROLE, resource.getRole());
         Assert.assertTrue(resource.hasReservation());
@@ -536,19 +558,24 @@ public class ResourceBuilderTest extends DefaultCapabilitiesTestSuite {
         Assert.assertEquals(TestConstants.PRINCIPAL, reservationInfo.getPrincipal());
         Assert.assertFalse(reservationInfo.hasRole());
 
-        validateLabels(reservationInfo, resourceId, namespace);
+        validateLabels(reservationInfo, resourceId, namespace, frameworkId);
     }
 
     private static void validateLabels(
-            Protos.Resource.ReservationInfo reservationInfo, Optional<String> resourceId, Optional<String> namespace) {
+            Protos.Resource.ReservationInfo reservationInfo, Optional<String> resourceId, Optional<String> namespace, Optional<String> frameworkId) {
         if (resourceId.isPresent()) {
             Assert.assertEquals(resourceId.get(), AuxLabelAccess.getResourceId(reservationInfo).get());
         } else {
             Assert.assertEquals(36, AuxLabelAccess.getResourceId(reservationInfo).get().length());
         }
         if (namespace.isPresent()) {
-            Assert.assertEquals(2, reservationInfo.getLabels().getLabelsCount());
             Assert.assertEquals(namespace.get(), AuxLabelAccess.getResourceNamespace(reservationInfo).get());
+        } else {
+            // Just the resource id label:
+            Assert.assertEquals(1, reservationInfo.getLabels().getLabelsCount());
+        }
+        if (frameworkId.isPresent()) {
+            Assert.assertEquals(frameworkId.get(), AuxLabelAccess.getFrameworkId(reservationInfo).get());
         } else {
             // Just the resource id label:
             Assert.assertEquals(1, reservationInfo.getLabels().getLabelsCount());

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/ResourceUtilsTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/ResourceUtilsTest.java
@@ -6,6 +6,7 @@ import com.mesosphere.sdk.testutils.TestConstants;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Optional;
 
 import org.apache.mesos.Protos;
 import org.junit.Assert;
@@ -19,32 +20,50 @@ public class ResourceUtilsTest extends DefaultCapabilitiesTestSuite {
                     UNEXPECTED_RESOURCE_1_ID,
                     UNEXPECTED_RESOURCE_1_ID);
 
+    private static final String UNEXPECTED_RESOURCE_2_ID = "unexpected-volume-id-2";
+    private static final Protos.Resource UNEXPECTED_RESOURCE_2 =
+            ResourceTestUtils.getReservedRootVolume(
+                    1000.0,
+                    UNEXPECTED_RESOURCE_2_ID,
+                    UNEXPECTED_RESOURCE_2_ID,
+                    "unknown-framework-id");
+
+    private static final String EXPECTED_RESOURCE_1_ID = "expected-volume-id-1";
+    private static final Protos.Resource EXPECTED_RESOURCE_1 =
+            ResourceTestUtils.getReservedRootVolume(
+                    1000.0,
+                    EXPECTED_RESOURCE_1_ID,
+                    EXPECTED_RESOURCE_1_ID,
+                    TestConstants.FRAMEWORK_ID.getValue());
+
+
+
     @Test
     public void resourceNotProcessableForEmptyRoles() {
-        Assert.assertFalse(ResourceUtils.isProcessable(UNEXPECTED_RESOURCE_1, Collections.emptySet()));
+        Assert.assertFalse(ResourceUtils.isProcessable(UNEXPECTED_RESOURCE_1, Collections.emptySet(), Optional.of(TestConstants.FRAMEWORK_ID)));
     }
 
     @Test
     public void resourceNotProcessableForDifferentRole() {
-        Assert.assertFalse(ResourceUtils.isProcessable(UNEXPECTED_RESOURCE_1, Collections.singleton("different-role")));
+        Assert.assertFalse(ResourceUtils.isProcessable(UNEXPECTED_RESOURCE_1, Collections.singleton("different-role"), Optional.of(TestConstants.FRAMEWORK_ID)));
     }
 
     @Test
     public void resourceNotProcessableForDifferentRoles() {
         Assert.assertFalse(ResourceUtils.isProcessable(
-                UNEXPECTED_RESOURCE_1, Arrays.asList("different-role-0", "different-role-1")));
+                UNEXPECTED_RESOURCE_1, Arrays.asList("different-role-0", "different-role-1"), Optional.of(TestConstants.FRAMEWORK_ID)));
     }
 
     @Test
     public void resourceProcessableForExactRoles() {
         Assert.assertTrue(ResourceUtils.isProcessable(
-                UNEXPECTED_RESOURCE_1, Collections.singleton(TestConstants.ROLE)));
+                UNEXPECTED_RESOURCE_1, Collections.singleton(TestConstants.ROLE), Optional.of(TestConstants.FRAMEWORK_ID)));
     }
 
     @Test
     public void resourceProcessableForSubsetOfRoles() {
         Assert.assertTrue(ResourceUtils.isProcessable(
-                UNEXPECTED_RESOURCE_1, Arrays.asList(TestConstants.ROLE, "another-role")));
+                UNEXPECTED_RESOURCE_1, Arrays.asList(TestConstants.ROLE, "another-role"), Optional.of(TestConstants.FRAMEWORK_ID)));
     }
 
     @SuppressWarnings("deprecation")
@@ -52,6 +71,18 @@ public class ResourceUtilsTest extends DefaultCapabilitiesTestSuite {
     public void resourceProcessableForPartialSubsetOfRoles() {
         Protos.Resource alienResource = UNEXPECTED_RESOURCE_1.toBuilder().setRole("alien-role").build();
         Assert.assertFalse(ResourceUtils.isProcessable(
-                alienResource, Arrays.asList(TestConstants.ROLE, "another-role")));
+                alienResource, Arrays.asList(TestConstants.ROLE, "another-role"), Optional.of(TestConstants.FRAMEWORK_ID)));
+    }
+
+    @Test
+    public void resourceNotProcessableForDifferentFrameworkId() {
+        Assert.assertFalse(ResourceUtils.isProcessable(
+                UNEXPECTED_RESOURCE_2, Collections.singleton(TestConstants.ROLE), Optional.of(TestConstants.FRAMEWORK_ID)));
+    }
+
+    @Test
+    public void resourceProcessableForSameFrameworkId() {
+        Assert.assertTrue(ResourceUtils.isProcessable(
+                EXPECTED_RESOURCE_1, Collections.singleton(TestConstants.ROLE), Optional.of(TestConstants.FRAMEWORK_ID)));
     }
 }

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/NamedVIPEvaluationStageTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/NamedVIPEvaluationStageTest.java
@@ -177,6 +177,7 @@ public class NamedVIPEvaluationStageTest extends DefaultCapabilitiesTestSuite {
                 getNamedVIPSpec(taskPort, networks),
                 Collections.singleton(TestConstants.TASK_NAME),
                 resourceId,
+                Optional.empty(),
                 Optional.empty());
     }
 

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluationUtilsTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluationUtilsTest.java
@@ -110,6 +110,11 @@ public class OfferEvaluationUtilsTest extends DefaultCapabilitiesTestSuite {
             } else {
                 Assert.assertFalse(ResourceUtils.getNamespace(resource).isPresent());
             }
+            if (frameworkId.isPresent()) {
+                Assert.assertEquals(frameworkId.get(), ResourceUtils.getFrameworkId(resource).get());
+            } else {
+                Assert.assertFalse(ResourceUtils.getFrameworkId(resource).isPresent());
+            }
         }
     }
 
@@ -144,6 +149,11 @@ public class OfferEvaluationUtilsTest extends DefaultCapabilitiesTestSuite {
             Assert.assertEquals(namespace.get(), ResourceUtils.getNamespace(resource).get());
         } else {
             Assert.assertFalse(ResourceUtils.getNamespace(resource).isPresent());
+        }
+        if (frameworkId.isPresent()) {
+            Assert.assertEquals(frameworkId.get(), ResourceUtils.getFrameworkId(resource).get());
+        } else {
+            Assert.assertFalse(ResourceUtils.getFrameworkId(resource).isPresent());
         }
     }
 
@@ -204,6 +214,11 @@ public class OfferEvaluationUtilsTest extends DefaultCapabilitiesTestSuite {
             Assert.assertEquals(namespace.get(), ResourceUtils.getNamespace(resource).get());
         } else {
             Assert.assertFalse(ResourceUtils.getNamespace(resource).isPresent());
+        }
+        if (frameworkId.isPresent()) {
+            Assert.assertEquals(frameworkId.get(), ResourceUtils.getFrameworkId(resource).get());
+        } else {
+            Assert.assertFalse(ResourceUtils.getFrameworkId(resource).isPresent());
         }
     }
 

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluationUtilsTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluationUtilsTest.java
@@ -34,6 +34,7 @@ public class OfferEvaluationUtilsTest extends DefaultCapabilitiesTestSuite {
     private static final String RESOURCE_NAME = "blocks";
     private static final String ROLE = "svc-role";
     private static final String PRINCIPAL = "svc-principal";
+    private static final String FRAMEWORK_ID = "01234567-890a-bcde-f012-34567890abcd";
 
     @Mock OfferEvaluationStage mockStage;
     @Mock MesosResourcePool mockPool;
@@ -46,14 +47,14 @@ public class OfferEvaluationUtilsTest extends DefaultCapabilitiesTestSuite {
 
     @Test
     public void testResourceInsufficient() {
-        testResourceInsufficient(Optional.empty(), Optional.empty());
-        testResourceInsufficient(Optional.empty(), Optional.of("foo"));
+        testResourceInsufficient(Optional.empty(), Optional.empty(), Optional.empty());
+        testResourceInsufficient(Optional.empty(), Optional.of("foo"), Optional.of(FRAMEWORK_ID));
 
-        testResourceInsufficient(Optional.of(UUID.randomUUID().toString()), Optional.empty());
-        testResourceInsufficient(Optional.of(UUID.randomUUID().toString()), Optional.of("foo"));
+        testResourceInsufficient(Optional.of(UUID.randomUUID().toString()), Optional.empty(), Optional.empty());
+        testResourceInsufficient(Optional.of(UUID.randomUUID().toString()), Optional.of("foo"), Optional.of(FRAMEWORK_ID));
     }
 
-    private void testResourceInsufficient(Optional<String> resourceId, Optional<String> namespace) {
+    private void testResourceInsufficient(Optional<String> resourceId, Optional<String> namespace, Optional<String> frameworkId) {
         Protos.Value desired = getValue(5);
 
         if (resourceId.isPresent()) {
@@ -72,20 +73,20 @@ public class OfferEvaluationUtilsTest extends DefaultCapabilitiesTestSuite {
 
     @Test
     public void testResourceSufficient() {
-        testResourceSufficient(Optional.empty(), Optional.empty());
-        testResourceSufficient(Optional.empty(), Optional.of("foo"));
+        testResourceSufficient(Optional.empty(), Optional.empty(), Optional.empty());
+        testResourceSufficient(Optional.empty(), Optional.of("foo"), Optional.of(FRAMEWORK_ID));
 
-        testResourceSufficient(Optional.of(UUID.randomUUID().toString()), Optional.empty());
-        testResourceSufficient(Optional.of(UUID.randomUUID().toString()), Optional.of("foo"));
+        testResourceSufficient(Optional.of(UUID.randomUUID().toString()), Optional.empty(), Optional.empty());
+        testResourceSufficient(Optional.of(UUID.randomUUID().toString()), Optional.of("foo"), Optional.of(FRAMEWORK_ID));
     }
 
-    private void testResourceSufficient(Optional<String> resourceId, Optional<String> namespace) {
+    private void testResourceSufficient(Optional<String> resourceId, Optional<String> namespace, Optional<String> frameworkId) {
         Protos.Value desired = getValue(5);
 
         ResourceSpec resourceSpec = getResourceSpec(desired);
         if (resourceId.isPresent()) {
             when(mockPool.consumeReserved(RESOURCE_NAME, desired, resourceId.get()))
-                    .thenReturn(Optional.of(getMesosResource(resourceSpec, resourceId.get(), namespace)));
+                    .thenReturn(Optional.of(getMesosResource(resourceSpec, resourceId.get(), namespace, frameworkId)));
         } else {
             when(mockPool.consumeReservableMerged(RESOURCE_NAME, desired, Constants.ANY_ROLE))
                     .thenReturn(Optional.of(getMesosResource(desired)));
@@ -114,11 +115,11 @@ public class OfferEvaluationUtilsTest extends DefaultCapabilitiesTestSuite {
 
     @Test
     public void testResourceIncreaseSufficient() {
-        testResourceIncreaseSufficient(Optional.empty());
-        testResourceIncreaseSufficient(Optional.of("foo"));
+        testResourceIncreaseSufficient(Optional.empty(), Optional.empty());
+        testResourceIncreaseSufficient(Optional.of("foo"), Optional.of(FRAMEWORK_ID));
     }
 
-    private void testResourceIncreaseSufficient(Optional<String> namespace) {
+    private void testResourceIncreaseSufficient(Optional<String> namespace, Optional<String> frameworkId) {
         String resourceId = UUID.randomUUID().toString();
         Protos.Value current = getValue(4);
         Protos.Value desired = getValue(5);
@@ -126,7 +127,7 @@ public class OfferEvaluationUtilsTest extends DefaultCapabilitiesTestSuite {
 
         ResourceSpec resourceSpec = getResourceSpec(desired);
         when(mockPool.consumeReserved(RESOURCE_NAME, desired, resourceId))
-                .thenReturn(Optional.of(getMesosResource(getResourceSpec(current), resourceId, namespace)));
+                .thenReturn(Optional.of(getMesosResource(getResourceSpec(current), resourceId, namespace, frameworkId)));
         when(mockPool.consumeReservableMerged(RESOURCE_NAME, toAdd, Constants.ANY_ROLE))
                 .thenReturn(Optional.of(getMesosResource(toAdd)));
 
@@ -148,11 +149,11 @@ public class OfferEvaluationUtilsTest extends DefaultCapabilitiesTestSuite {
 
     @Test
     public void testResourceIncreaseInsufficient() {
-        testResourceIncreaseInsufficient(Optional.empty());
-        testResourceIncreaseInsufficient(Optional.of("foo"));
+        testResourceIncreaseInsufficient(Optional.empty(), Optional.empty());
+        testResourceIncreaseInsufficient(Optional.of("foo"), Optional.of(FRAMEWORK_ID));
     }
 
-    private void testResourceIncreaseInsufficient(Optional<String> namespace) {
+    private void testResourceIncreaseInsufficient(Optional<String> namespace, Optional<String> frameworkId) {
         String resourceId = UUID.randomUUID().toString();
         Protos.Value current = getValue(4);
         Protos.Value desired = getValue(5);
@@ -160,7 +161,7 @@ public class OfferEvaluationUtilsTest extends DefaultCapabilitiesTestSuite {
 
         ResourceSpec resourceSpec = getResourceSpec(desired);
         when(mockPool.consumeReserved(RESOURCE_NAME, desired, resourceId))
-                .thenReturn(Optional.of(getMesosResource(getResourceSpec(current), resourceId, namespace)));
+                .thenReturn(Optional.of(getMesosResource(getResourceSpec(current), resourceId, namespace, frameworkId)));
         when(mockPool.consumeReservableMerged(RESOURCE_NAME, toAdd, Constants.ANY_ROLE))
                 .thenReturn(Optional.empty());
 
@@ -174,11 +175,11 @@ public class OfferEvaluationUtilsTest extends DefaultCapabilitiesTestSuite {
 
     @Test
     public void testResourceDecrease() {
-        testResourceDecrease(Optional.empty());
-        testResourceDecrease(Optional.of("foo"));
+        testResourceDecrease(Optional.empty(), Optional.empty());
+        testResourceDecrease(Optional.of("foo"), Optional.of(FRAMEWORK_ID));
     }
 
-    private void testResourceDecrease(Optional<String> namespace) {
+    private void testResourceDecrease(Optional<String> namespace, Optional<String> frameworkId) {
         String resourceId = UUID.randomUUID().toString();
         Protos.Value current = getValue(5);
         Protos.Value desired = getValue(4);
@@ -186,7 +187,7 @@ public class OfferEvaluationUtilsTest extends DefaultCapabilitiesTestSuite {
 
         ResourceSpec resourceSpec = getResourceSpec(desired);
         when(mockPool.consumeReserved(RESOURCE_NAME, desired, resourceId))
-                .thenReturn(Optional.of(getMesosResource(getResourceSpec(current), resourceId, namespace)));
+                .thenReturn(Optional.of(getMesosResource(getResourceSpec(current), resourceId, namespace, frameworkId)));
         when(mockPool.consumeReservableMerged(RESOURCE_NAME, desired, Constants.ANY_ROLE))
                 .thenReturn(Optional.of(getMesosResource(toSubtract)));
 
@@ -221,8 +222,8 @@ public class OfferEvaluationUtilsTest extends DefaultCapabilitiesTestSuite {
                 .build();
     }
 
-    private static MesosResource getMesosResource(ResourceSpec resourceSpec, String resourceId, Optional<String> namespace) {
-        return new MesosResource(ResourceBuilder.fromSpec(resourceSpec, Optional.of(resourceId), namespace).build());
+    private static MesosResource getMesosResource(ResourceSpec resourceSpec, String resourceId, Optional<String> namespace, Optional<String> frameworkId) {
+        return new MesosResource(ResourceBuilder.fromSpec(resourceSpec, Optional.of(resourceId), namespace, frameworkId).build());
     }
 
     private static MesosResource getMesosResource(Protos.Value value) {

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluationUtilsTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluationUtilsTest.java
@@ -64,7 +64,7 @@ public class OfferEvaluationUtilsTest extends DefaultCapabilitiesTestSuite {
         }
 
         ReserveEvaluationOutcome outcome = OfferEvaluationUtils.evaluateSimpleResource(
-                LOGGER, mockStage, getResourceSpec(desired), resourceId, namespace, mockPool);
+                LOGGER, mockStage, getResourceSpec(desired), resourceId, namespace, mockPool, frameworkId);
         Assert.assertFalse(outcome.getEvaluationOutcome().isPassing());
 
         Assert.assertTrue(outcome.getEvaluationOutcome().getOfferRecommendations().isEmpty());
@@ -93,7 +93,7 @@ public class OfferEvaluationUtilsTest extends DefaultCapabilitiesTestSuite {
         }
 
         ReserveEvaluationOutcome outcome = OfferEvaluationUtils.evaluateSimpleResource(
-                LOGGER, mockStage, resourceSpec, resourceId, namespace, mockPool);
+                LOGGER, mockStage, resourceSpec, resourceId, namespace, mockPool, frameworkId);
         Assert.assertTrue(outcome.getEvaluationOutcome().isPassing());
 
         if (resourceId.isPresent()) {
@@ -132,7 +132,7 @@ public class OfferEvaluationUtilsTest extends DefaultCapabilitiesTestSuite {
                 .thenReturn(Optional.of(getMesosResource(toAdd)));
 
         ReserveEvaluationOutcome outcome = OfferEvaluationUtils.evaluateSimpleResource(
-                LOGGER, mockStage, resourceSpec, Optional.of(resourceId), namespace, mockPool);
+                LOGGER, mockStage, resourceSpec, Optional.of(resourceId), namespace, mockPool, frameworkId);
         Assert.assertTrue(outcome.getEvaluationOutcome().isPassing());
 
         OfferRecommendation recommendation = outcome.getEvaluationOutcome().getOfferRecommendations().get(0);
@@ -166,7 +166,7 @@ public class OfferEvaluationUtilsTest extends DefaultCapabilitiesTestSuite {
                 .thenReturn(Optional.empty());
 
         ReserveEvaluationOutcome outcome = OfferEvaluationUtils.evaluateSimpleResource(
-                LOGGER, mockStage, resourceSpec, Optional.of(resourceId), namespace, mockPool);
+                LOGGER, mockStage, resourceSpec, Optional.of(resourceId), namespace, mockPool, frameworkId);
         Assert.assertFalse(outcome.getEvaluationOutcome().isPassing());
 
         Assert.assertTrue(outcome.getEvaluationOutcome().getOfferRecommendations().isEmpty());
@@ -192,7 +192,7 @@ public class OfferEvaluationUtilsTest extends DefaultCapabilitiesTestSuite {
                 .thenReturn(Optional.of(getMesosResource(toSubtract)));
 
         ReserveEvaluationOutcome outcome = OfferEvaluationUtils.evaluateSimpleResource(
-                LOGGER, mockStage, resourceSpec, Optional.of(resourceId), namespace, mockPool);
+                LOGGER, mockStage, resourceSpec, Optional.of(resourceId), namespace, mockPool, frameworkId);
         Assert.assertTrue(outcome.getEvaluationOutcome().isPassing());
 
         OfferRecommendation recommendation = outcome.getEvaluationOutcome().getOfferRecommendations().get(0);

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluatorTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluatorTest.java
@@ -48,6 +48,7 @@ public class OfferEvaluatorTest extends OfferEvaluatorTestBase {
         Assert.assertEquals(TestConstants.PRINCIPAL, reservation.getPrincipal());
         Assert.assertEquals(36, getResourceId(reserveResource).length());
         Assert.assertFalse(reserveResource.hasDisk());
+        Assert.assertEquals(TestConstants.FRAMEWORK_ID.getValue(), getFrameworkId(reserveResource));
 
         // Validate LAUNCH Operation
         Protos.Offer.Operation launchOperation = recommendations.get(4).getOperation().get();
@@ -161,6 +162,7 @@ public class OfferEvaluatorTest extends OfferEvaluatorTestBase {
         Assert.assertEquals(TestConstants.ROLE, ResourceUtils.getRole(reserveResource));
         Assert.assertEquals(TestConstants.PRINCIPAL, reservation.getPrincipal());
         Assert.assertEquals(resourceId, getResourceId(reserveResource));
+        Assert.assertEquals(TestConstants.FRAMEWORK_ID.getValue(), getFrameworkId(reserveResource));
 
         // Validate LAUNCH Operation
         Protos.Offer.Operation launchOperation = recommendations.get(1).getOperation().get();
@@ -221,6 +223,7 @@ public class OfferEvaluatorTest extends OfferEvaluatorTestBase {
         Assert.assertEquals(TestConstants.ROLE, ResourceUtils.getRole(reserveResource));
         Assert.assertEquals(TestConstants.PRINCIPAL, reservation.getPrincipal());
         Assert.assertEquals(resourceId, getResourceId(reserveResource));
+        Assert.assertEquals(TestConstants.FRAMEWORK_ID.getValue(), getFrameworkId(reserveResource));
 
         // Validate LAUNCH Operation
         Protos.Offer.Operation launchOperation = recommendations.get(1).getOperation().get();
@@ -264,6 +267,7 @@ public class OfferEvaluatorTest extends OfferEvaluatorTestBase {
         Assert.assertEquals(TestConstants.ROLE, ResourceUtils.getRole(unreserveResource));
         Assert.assertEquals(TestConstants.PRINCIPAL, reservation.getPrincipal());
         Assert.assertEquals(resourceId, getResourceId(unreserveResource));
+        Assert.assertEquals(TestConstants.FRAMEWORK_ID.getValue(), getFrameworkId(unreserveResource));
 
         // Validate LAUNCH Operation
         Protos.Offer.Operation launchOperation = recommendations.get(1).getOperation().get();

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluatorTestBase.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluatorTestBase.java
@@ -34,7 +34,7 @@ public class OfferEvaluatorTestBase extends DefaultCapabilitiesTestSuite {
         MockitoAnnotations.initMocks(this);
         Persister persister = MemPersister.newBuilder().build();
         frameworkStore = new FrameworkStore(persister);
-        frameworkStore.storeFrameworkId(Protos.FrameworkID.newBuilder().setValue("framework-id").build());
+        frameworkStore.storeFrameworkId(Protos.FrameworkID.newBuilder().setValue(TestConstants.FRAMEWORK_ID.getValue()).build());
         stateStore = new StateStore(persister);
         targetConfig = UUID.randomUUID();
         evaluator = new OfferEvaluator(
@@ -95,6 +95,10 @@ public class OfferEvaluatorTestBase extends DefaultCapabilitiesTestSuite {
 
     protected static String getResourceId(Resource resource) {
         return ResourceUtils.getResourceId(resource).get();
+    }
+
+    protected static String getFrameworkId(Resource resource)  {
+        return ResourceUtils.getFrameworkId(resource).get();
     }
 
     protected static String getPrincipal(Resource resource) {

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluatorVolumesTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/OfferEvaluatorVolumesTest.java
@@ -54,6 +54,7 @@ public class OfferEvaluatorVolumesTest extends OfferEvaluatorTestBase {
         Assert.assertEquals(TestConstants.PRINCIPAL, reservation.getPrincipal());
         Assert.assertEquals(36, getResourceId(reserveResource).length());
         Assert.assertFalse(reserveResource.hasDisk());
+        Assert.assertEquals(TestConstants.FRAMEWORK_ID.getValue(), ResourceUtils.getFrameworkId(reserveResource).get());
 
         // Validate DISK RESERVE Operation
         reserveOperation = recommendations.get(4).getOperation().get();
@@ -67,6 +68,7 @@ public class OfferEvaluatorVolumesTest extends OfferEvaluatorTestBase {
         Assert.assertEquals(TestConstants.PRINCIPAL, reservation.getPrincipal());
         Assert.assertEquals(36, getResourceId(reserveResource).length());
         Assert.assertFalse(reserveResource.hasDisk());
+        Assert.assertEquals(TestConstants.FRAMEWORK_ID.getValue(), ResourceUtils.getFrameworkId(reserveResource).get());
 
         // Validate CREATE Operation
         String resourceId = getResourceId(reserveResource);
@@ -223,6 +225,7 @@ public class OfferEvaluatorVolumesTest extends OfferEvaluatorTestBase {
         Assert.assertEquals(TestConstants.MOUNT_DISK_SOURCE, createResource.getDisk().getSource());
         Assert.assertEquals(TestConstants.PRINCIPAL, createResource.getDisk().getPersistence().getPrincipal());
         Assert.assertTrue(createResource.getDisk().hasVolume());
+        Assert.assertEquals(TestConstants.FRAMEWORK_ID.getValue(), ResourceUtils.getFrameworkId(reserveResource).get());
 
         // Validate LAUNCH Operation
         String persistenceId = createResource.getDisk().getPersistence().getId();

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/PortEvaluationStageTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/PortEvaluationStageTest.java
@@ -158,7 +158,7 @@ public class PortEvaluationStageTest extends DefaultCapabilitiesTestSuite {
         PodInstanceRequirement podInstanceRequirement = getPodInstanceRequirement(portSpec);
         PodInfoBuilder podInfoBuilder = getPodInfoBuilder(podInstanceRequirement);
         PortEvaluationStage portEvaluationStage = new PortEvaluationStage(
-                portSpec, Collections.singleton(TestConstants.TASK_NAME), Optional.empty(), Optional.empty());
+                portSpec, Collections.singleton(TestConstants.TASK_NAME), Optional.empty(), Optional.empty(), Optional.of(TestConstants.FRAMEWORK_ID.getValue()));
         EvaluationOutcome outcome = portEvaluationStage.evaluate(
                 new MesosResourcePool(offer, Optional.of(Constants.ANY_ROLE)), podInfoBuilder);
         Assert.assertTrue(outcome.isPassing());
@@ -202,7 +202,7 @@ public class PortEvaluationStageTest extends DefaultCapabilitiesTestSuite {
         PodInstanceRequirement podInstanceRequirement = getPodInstanceRequirement(portSpec);
         PodInfoBuilder podInfoBuilder = getPodInfoBuilder(podInstanceRequirement);
         PortEvaluationStage portEvaluationStage = new PortEvaluationStage(
-                portSpec, Collections.singleton(TestConstants.TASK_NAME), Optional.empty(), Optional.empty());
+                portSpec, Collections.singleton(TestConstants.TASK_NAME), Optional.empty(), Optional.empty(), Optional.of(TestConstants.FRAMEWORK_ID.getValue()));
         EvaluationOutcome outcome = portEvaluationStage.evaluate(
                 new MesosResourcePool(offer, Optional.of(Constants.ANY_ROLE)), podInfoBuilder);
         Assert.assertTrue(outcome.isPassing());
@@ -258,14 +258,14 @@ public class PortEvaluationStageTest extends DefaultCapabilitiesTestSuite {
                 podInfoBuilder.getAssignedOverlayPorts().size() == 1);
 
         PortEvaluationStage portEvaluationStage_ = new PortEvaluationStage(
-                portSpec, Collections.singleton(TestConstants.TASK_NAME), Optional.empty(), Optional.empty());
+                portSpec, Collections.singleton(TestConstants.TASK_NAME), Optional.empty(), Optional.empty(), Optional.of(TestConstants.FRAMEWORK_ID.getValue()));
         EvaluationOutcome outcome0 = portEvaluationStage_.evaluate(
                 new MesosResourcePool(offer, Optional.of(Constants.ANY_ROLE)), podInfoBuilder);
         Assert.assertTrue(outcome0.isPassing());
         Assert.assertEquals(0, outcome0.getOfferRecommendations().size());
 
         PortEvaluationStage portEvaluationStage = new PortEvaluationStage(
-                dynamPortSpec, Collections.singleton(TestConstants.TASK_NAME), Optional.empty(), Optional.empty());
+                dynamPortSpec, Collections.singleton(TestConstants.TASK_NAME), Optional.empty(), Optional.empty(), Optional.of(TestConstants.FRAMEWORK_ID.getValue()));
         EvaluationOutcome outcome1 = portEvaluationStage.evaluate(
                 new MesosResourcePool(offer, Optional.of(Constants.ANY_ROLE)), podInfoBuilder);
         Assert.assertTrue(outcome1.isPassing());
@@ -306,7 +306,8 @@ public class PortEvaluationStageTest extends DefaultCapabilitiesTestSuite {
                 getPortSpec(podInstance),
                 Collections.singleton(TestConstants.TASK_NAME),
                 Optional.empty(),
-                Optional.empty());
+                Optional.empty(),
+                Optional.of(TestConstants.FRAMEWORK_ID.getValue()));
 
         EvaluationOutcome outcome = portEvaluationStage.evaluate(
                 new MesosResourcePool(offer, Optional.of(Constants.ANY_ROLE)), podInfoBuilder);
@@ -351,7 +352,8 @@ public class PortEvaluationStageTest extends DefaultCapabilitiesTestSuite {
                 getPortSpec(podInstance),
                 Collections.singleton(TestConstants.TASK_NAME),
                 Optional.empty(),
-                Optional.empty());
+                Optional.empty(),
+                Optional.of(TestConstants.FRAMEWORK_ID.getValue()));
         EvaluationOutcome outcome = portEvaluationStage.evaluate(
                 new MesosResourcePool(offer, Optional.of(Constants.ANY_ROLE)),
                 podInfoBuilder);
@@ -379,7 +381,8 @@ public class PortEvaluationStageTest extends DefaultCapabilitiesTestSuite {
                 getPortSpec(podInstance),
                 Collections.singleton(TestConstants.TASK_NAME),
                 Optional.empty(),
-                Optional.empty());
+                Optional.empty(),
+                Optional.of(TestConstants.FRAMEWORK_ID.getValue()));
         EvaluationOutcome outcome = portEvaluationStage.evaluate(
                 new MesosResourcePool(offer, Optional.of(Constants.ANY_ROLE)),
                 podInfoBuilder);
@@ -410,7 +413,8 @@ public class PortEvaluationStageTest extends DefaultCapabilitiesTestSuite {
                 getPortSpec(podInstance),
                 Collections.singleton(TestConstants.TASK_NAME),
                 Optional.empty(),
-                Optional.empty());
+                Optional.empty(),
+                Optional.of(TestConstants.FRAMEWORK_ID.getValue()));
 
         EvaluationOutcome outcome = portEvaluationStage.evaluate(
                 new MesosResourcePool(offer, Optional.of(Constants.ANY_ROLE)), podInfoBuilder);
@@ -477,7 +481,8 @@ public class PortEvaluationStageTest extends DefaultCapabilitiesTestSuite {
                 portSpec,
                 Collections.singleton(TestConstants.TASK_NAME),
                 Optional.empty(),
-                Optional.empty());
+                Optional.empty(),
+                Optional.of(TestConstants.FRAMEWORK_ID.getValue()));
 
         MesosResourcePool mesosResourcePool = new MesosResourcePool(offer, Optional.of(Constants.ANY_ROLE));
         EvaluationOutcome outcome = portEvaluationStage.evaluate(mesosResourcePool, podInfoBuilder);
@@ -557,7 +562,8 @@ public class PortEvaluationStageTest extends DefaultCapabilitiesTestSuite {
             portSpec,
             Collections.singleton(TestConstants.TASK_NAME),
             Optional.empty(),
-            Optional.empty());
+            Optional.empty(),
+            Optional.of(TestConstants.FRAMEWORK_ID.getValue()));
 
         //this should fail since no slave_public port is present in the offer
         MesosResourcePool mesosResourcePool = new MesosResourcePool(offer, Optional.of(Constants.ANY_ROLE));
@@ -597,7 +603,8 @@ public class PortEvaluationStageTest extends DefaultCapabilitiesTestSuite {
             portSpec,
             Collections.singleton(TestConstants.TASK_NAME),
             Optional.empty(),
-            Optional.empty());
+            Optional.empty(),
+            Optional.of(TestConstants.FRAMEWORK_ID.getValue()));
 
         MesosResourcePool mesosResourcePool = new MesosResourcePool(offer, Optional.of("slave_public"));
         EvaluationOutcome outcome = portEvaluationStage.evaluate(mesosResourcePool, podInfoBuilder);
@@ -642,7 +649,8 @@ public class PortEvaluationStageTest extends DefaultCapabilitiesTestSuite {
             portSpec,
             Collections.singleton(TestConstants.TASK_NAME),
             Optional.empty(),
-            Optional.empty());
+            Optional.empty(),
+            Optional.of(TestConstants.FRAMEWORK_ID.getValue()));
 
         MesosResourcePool mesosResourcePool = new MesosResourcePool(offer, Optional.of("slave_public"));
         EvaluationOutcome outcome = portEvaluationStage.evaluate(mesosResourcePool, podInfoBuilder);
@@ -687,7 +695,8 @@ public class PortEvaluationStageTest extends DefaultCapabilitiesTestSuite {
             portSpec,
             Collections.singleton(TestConstants.TASK_NAME),
             Optional.empty(),
-            Optional.empty());
+            Optional.empty(),
+            Optional.of(TestConstants.FRAMEWORK_ID.getValue()));
 
         MesosResourcePool mesosResourcePool = new MesosResourcePool(offer, Optional.of("slave_public"));
         EvaluationOutcome outcome = portEvaluationStage.evaluate(mesosResourcePool, podInfoBuilder);
@@ -732,7 +741,8 @@ public class PortEvaluationStageTest extends DefaultCapabilitiesTestSuite {
             portSpec,
             Collections.singleton(TestConstants.TASK_NAME),
             Optional.empty(),
-            Optional.empty());
+            Optional.empty(),
+            Optional.of(TestConstants.FRAMEWORK_ID.getValue()));
 
         MesosResourcePool mesosResourcePool = new MesosResourcePool(offer, Optional.of("slave_public"));
         EvaluationOutcome outcome = portEvaluationStage.evaluate(mesosResourcePool, podInfoBuilder);
@@ -776,7 +786,8 @@ public class PortEvaluationStageTest extends DefaultCapabilitiesTestSuite {
             portSpec,
             Collections.singleton(TestConstants.TASK_NAME),
             Optional.empty(),
-            Optional.empty());
+            Optional.empty(),
+            Optional.of(TestConstants.FRAMEWORK_ID.getValue()));
 
         MesosResourcePool mesosResourcePool = new MesosResourcePool(offer, Optional.of("slave_public"));
         EvaluationOutcome outcome = portEvaluationStage.evaluate(mesosResourcePool, podInfoBuilder);
@@ -820,7 +831,8 @@ public class PortEvaluationStageTest extends DefaultCapabilitiesTestSuite {
             portSpec,
             Collections.singleton(TestConstants.TASK_NAME),
             Optional.empty(),
-            Optional.empty());
+            Optional.empty(),
+            Optional.of(TestConstants.FRAMEWORK_ID.getValue()));
 
         MesosResourcePool mesosResourcePool = new MesosResourcePool(offer, Optional.of("slave_public"));
         EvaluationOutcome outcome = portEvaluationStage.evaluate(mesosResourcePool, podInfoBuilder);
@@ -864,7 +876,8 @@ public class PortEvaluationStageTest extends DefaultCapabilitiesTestSuite {
             portSpec,
             Collections.singleton(TestConstants.TASK_NAME),
             Optional.empty(),
-            Optional.empty());
+            Optional.empty(),
+            Optional.of(TestConstants.FRAMEWORK_ID.getValue()));
 
         MesosResourcePool mesosResourcePool = new MesosResourcePool(offer, Optional.of("slave_public"));
         EvaluationOutcome outcome = portEvaluationStage.evaluate(mesosResourcePool, podInfoBuilder);

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/VolumeEvaluationStageTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/VolumeEvaluationStageTest.java
@@ -29,6 +29,7 @@ public class VolumeEvaluationStageTest extends DefaultCapabilitiesTestSuite {
         VolumeEvaluationStage volumeEvaluationStage = VolumeEvaluationStage.getNew(
                 getVolumeSpec(podInstanceRequirement.getPodInstance()),
                 Collections.singleton(getTaskName(podInstanceRequirement.getPodInstance())),
+                Optional.empty(),
                 Optional.empty());
         EvaluationOutcome outcome =
                 volumeEvaluationStage.evaluate(
@@ -82,6 +83,7 @@ public class VolumeEvaluationStageTest extends DefaultCapabilitiesTestSuite {
         VolumeEvaluationStage volumeEvaluationStage = VolumeEvaluationStage.getNew(
                 getVolumeSpec(podInstanceRequirement.getPodInstance()),
                 Collections.singleton(getTaskName(podInstanceRequirement.getPodInstance())),
+                Optional.empty(),
                 Optional.empty());
         EvaluationOutcome outcome =
                 volumeEvaluationStage.evaluate(

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/uninstall/UninstallSchedulerTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/scheduler/uninstall/UninstallSchedulerTest.java
@@ -11,6 +11,7 @@ import com.mesosphere.sdk.scheduler.MesosEventClient.UnexpectedResourcesResponse
 import com.mesosphere.sdk.scheduler.plan.*;
 import com.mesosphere.sdk.specification.*;
 import com.mesosphere.sdk.state.ConfigStore;
+import com.mesosphere.sdk.state.FrameworkStore;
 import com.mesosphere.sdk.state.StateStore;
 import com.mesosphere.sdk.storage.MemPersister;
 import com.mesosphere.sdk.testutils.*;
@@ -82,6 +83,7 @@ public class UninstallSchedulerTest extends DefaultCapabilitiesTestSuite {
     }
 
     private StateStore stateStore;
+    private FrameworkStore frameworkStore;
 
     @Mock private ConfigStore<ServiceSpec> mockConfigStore;
     @Mock private SchedulerDriver mockSchedulerDriver;
@@ -93,7 +95,10 @@ public class UninstallSchedulerTest extends DefaultCapabilitiesTestSuite {
         MockitoAnnotations.initMocks(this);
         Driver.setDriver(mockSchedulerDriver);
 
-        stateStore = new StateStore(MemPersister.newBuilder().build());
+        MemPersister persister = MemPersister.newBuilder().build();
+        stateStore = new StateStore(persister);
+        frameworkStore = new FrameworkStore(persister);
+
         stateStore.storeTasks(Collections.singletonList(TASK_A));
 
         // Have the mock plan customizer default to returning the plan unchanged.
@@ -253,7 +258,8 @@ public class UninstallSchedulerTest extends DefaultCapabilitiesTestSuite {
                 Optional.empty(),
                 Optional.empty(),
                 Optional.of(mockSecretsClient),
-                new TestTimeFetcher());
+                new TestTimeFetcher(),
+                frameworkStore);
         uninstallScheduler.registered(false);
         // Starts with a near-empty plan with only the deregistered call incomplete
         Plan plan = getUninstallPlan(uninstallScheduler);
@@ -345,7 +351,8 @@ public class UninstallSchedulerTest extends DefaultCapabilitiesTestSuite {
                 Optional.of(getReversingPlanCustomizer()),
                 Optional.empty(),
                 Optional.of(mockSecretsClient),
-                new TestTimeFetcher());
+                new TestTimeFetcher(),
+                frameworkStore);
 
         Plan plan = getUninstallPlan(uninstallScheduler);
 
@@ -400,7 +407,8 @@ public class UninstallSchedulerTest extends DefaultCapabilitiesTestSuite {
                 Optional.of(mockPlanCustomizer),
                 Optional.empty(),
                 Optional.of(mockSecretsClient),
-                timeFetcher);
+                timeFetcher,
+                frameworkStore);
         uninstallScheduler.registered(false);
         return uninstallScheduler;
     }

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/testutils/ResourceTestUtils.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/testutils/ResourceTestUtils.java
@@ -67,6 +67,7 @@ public class ResourceTestUtils {
                 Optional.empty(),
                 Optional.of(persistenceId),
                 Optional.empty(),
+                Optional.empty(),
                 Optional.empty())
                 .build();
     }
@@ -160,6 +161,7 @@ public class ResourceTestUtils {
         }
         AuxLabelAccess.setResourceId(reservationBuilder, resourceId);
         AuxLabelAccess.setResourceNamespace(reservationBuilder, TestConstants.SERVICE_NAME);
+        AuxLabelAccess.setFrameworkId(reservationBuilder, TestConstants.FRAMEWORK_ID.getValue());
         return builder;
     }
 

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/testutils/ResourceTestUtils.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/testutils/ResourceTestUtils.java
@@ -72,6 +72,24 @@ public class ResourceTestUtils {
                 .build();
     }
 
+    public static Protos.Resource getReservedRootVolume(double diskSize, String resourceId, String persistenceId, String frameworkId) {
+        VolumeSpec volumeSpec = DefaultVolumeSpec.createRootVolume(
+                diskSize,
+                TestConstants.CONTAINER_PATH,
+                TestConstants.ROLE,
+                Constants.ANY_ROLE,
+                TestConstants.PRINCIPAL);
+        return ResourceBuilder.fromSpec(
+                volumeSpec,
+                Optional.of(resourceId),
+                Optional.empty(),
+                Optional.of(persistenceId),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.of(frameworkId))
+                .build();
+    }
+
     public static Protos.Resource getReservedCpus(double value, String resourceId) {
         return addReservation(getUnreservedCpus(value).toBuilder(), resourceId).build();
     }

--- a/testing/sdk_security.py
+++ b/testing/sdk_security.py
@@ -282,6 +282,7 @@ def _get_integration_test_foldered_role(service_name: str) -> List[str]:
     role_basename = service_name.strip("/").replace("/", "__")
     return [
         "test__integration__{}-role".format(role_basename),
+        "test",
         "quota",
         "quota__{}-role".format(role_basename),
     ]


### PR DESCRIPTION
**Background**

This series of patches fixes the uninstall bug found in DCOS-61858 where frameworks under the same group & quota'ed role where sharing a service-principal.  Upon uninstallation, the framework being uninstalled `DESTROYED` and `UNRESERVED` resources belonging to other frameworks in the same role.

This bug occurs on DC/OS 2.0 and later clusters where the service-principal is shared.

**Resolution**

This series of patches applies the `framework_id` label to all resources created by the framework. 
The framework scheduler now filters out any offer with resources that have a mismatched `framework_id` label.

The bulk of this PR is propagating the `framework_id` from where the scheduler subscribes to Mesos, to where OfferEvaluation and the resources are built.

This patch-set also adds a debug reservations endpoint (DCOS-44705) for easier debugging of which reservations are owned by the current set of running tasks.