### PR TITLE
Fixed publish http server launch

### DIFF
--- a/tools/publish_http.py
+++ b/tools/publish_http.py
@@ -193,7 +193,7 @@ httpd.serve_forever()
                 subprocess.check_call("dcos package repo remove {}".format(repo["name"]).split())
         logger.info("Adding repository: {} {}".format(repo_name, repo_url))
         subprocess.check_call(
-            "dcos package repo add --index=0 {} '{}'".format(repo_name, repo_url).split(" ")
+            "dcos package repo add --index=0 {} {}".format(repo_name, repo_url).split(" ")
         )
         return True
 


### PR DESCRIPTION
Bug fixed when the python program "publish_http.py" try to add the repository to a DC/OS cluster with the dcos-cli.