### PR TITLE
Fix the deprecated warnings of PMD gradle plugin

### DIFF
--- a/gradle/quality.gradle
+++ b/gradle/quality.gradle
@@ -13,11 +13,11 @@ tasks.withType(Checkstyle) {
 }
 
 pmd {
+    ignoreFailures = true
     ruleSets = [
-        'java-basic',
-        'java-braces',
-        'java-clone',
-        'java-finalizers',
-        'java-imports'
+        'category/java/bestpractices.xml',
+        'category/java/codestyle.xml',
+        'category/java/errorprone.xml',
+        'category/java/multithreading.xml'
     ]
 }


### PR DESCRIPTION
Fix the deprecated warning of PMD Gradle plugin (PMD project):

`
 Use Rule name category/java/errorprone.xml/AvoidBranchingStatementAsLastInLoop
 instead of the deprecated Rule name 
 rulesets/java/basic.xml/AvoidBranchingStatementAsLastInLoop.
 PMD 7.0.0 will remove support for this deprecated Rule name usage.
 Use Rule name category/java/errorprone.xml/AvoidDecimalLiteralsInBigDecimalConstructor
 instead of the deprecated Rule name 
 rulesets/java/basic.xml/AvoidDecimalLiteralsInBigDecimalConstructor.
 PMD 7.0.0 will remove support for this deprecated Rule name usage.
`