### PR TITLE
[DCOS-63182] Check TaskId exists for auxiliary pod tasks before reset of Backoff.

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/http/queries/PodQueries.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/http/queries/PodQueries.java
@@ -296,7 +296,9 @@ public final class PodQueries {
       // Whenever a pod is restarted/replaced, clear all the delays associated with its tasks
       podTasks.get().forEach(x -> {
         try {
-          Backoff.getInstance().clearDelay(CommonIdUtils.toTaskName(x.getInfo().getTaskId()));
+          if (x.getInfo().hasTaskId() && (x.getInfo().getTaskId().getValue().length() > 0)) {
+            Backoff.getInstance().clearDelay(CommonIdUtils.toTaskName(x.getInfo().getTaskId()));
+          }
         } catch (TaskException te) {
           LOGGER.error("Failed to clear delay for task [{}] before pod {}",
                   x.getInfo().getName(), recoveryType == RecoveryType.PERMANENT ? "replace" : "restart", te);


### PR DESCRIPTION
Services such as Cassandra can have pods with many auxiliary tasks, for these auxiliary tasks that are usually `PENDING`, check that the `TaskId` actually exists before making the call to reset backoff.

Otherwise we get the following exception in the scheduler logs.
```
com.mesosphere.sdk.offer.TaskException: ID '' is malformed. Expected '__' to extract name from ID. IDs should be generated with CommonIdUtils.
	at com.mesosphere.sdk.offer.CommonIdUtils.extract(CommonIdUtils.java:220) ~[scheduler-0.58.0-SNAPSHOT.jar:?]
	at com.mesosphere.sdk.offer.CommonIdUtils.extractTaskNameFromId(CommonIdUtils.java:203) ~[scheduler-0.58.0-SNAPSHOT.jar:?]
	at com.mesosphere.sdk.offer.CommonIdUtils.toTaskName(CommonIdUtils.java:96) ~[scheduler-0.58.0-SNAPSHOT.jar:?]
	at com.mesosphere.sdk.http.queries.PodQueries.lambda$restartPod$2(PodQueries.java:299) ~[scheduler-0.58.0-SNAPSHOT.jar:?]
	at java.util.ArrayList.forEach(Unknown Source) [?:?]
	at com.mesosphere.sdk.http.queries.PodQueries.restartPod(PodQueries.java:297) [scheduler-0.58.0-SNAPSHOT.jar:?]
	at com.mesosphere.sdk.http.queries.PodQueries.restart(PodQueries.java:268) [scheduler-0.58.0-SNAPSHOT.jar:?]
	at com.mesosphere.sdk.http.endpoints.PodResource.replace(PodResource.java:112) [scheduler-0.58.0-SNAPSHOT.jar:?]
[...omitted...]
```