### PR TITLE
[DCOS-63215] Bump PyInstaller to 3.6

### DIFF
--- a/frozen_requirements.txt
+++ b/frozen_requirements.txt
@@ -93,7 +93,7 @@ pycparser==2.19
 pyflakes==2.1.1
 Pygments==2.3.1
 PyGObject==3.30.4
-PyInstaller==3.3
+PyInstaller==3.6
 PyJWT==1.7.1
 pylint==2.3.1
 PyNaCl==1.3.0


### PR DESCRIPTION
Resolves [PyInstaller advisory](https://github.com/pyinstaller/pyinstaller/security/advisories/GHSA-7fcj-pq9j-wh2r) on Windows. 

SDK is not affected by this advisory as its frameworks don't run on Windows, the patch to fix it is minor and we're applying it.