### PR TITLE
Create KDC database on CMD step

### DIFF
--- a/tools-internal/kdc-api-server/Dockerfile.mit-centos7
+++ b/tools-internal/kdc-api-server/Dockerfile.mit-centos7
@@ -18,9 +18,8 @@ ENV KRB5_CONFIG=/kdc/krb5.conf \
 
 RUN yum -y install epel-release && \
     yum install -y krb5-server supervisor && \
-    yum clean all && \
-    echo -e "\n\n" | kdb5_util create -r LOCAL -s
+    yum clean all
 
 COPY --from=0 /go/src/github.com/mesosphere/kdc-api-server/api-server /kdc
 
-CMD /usr/bin/supervisord -c /kdc/supervisord.conf
+CMD echo -e "\n\n" | kdb5_util create -r LOCAL -s ; /usr/bin/supervisord -c /kdc/supervisord.conf

--- a/tools-internal/kdc-api-server/server/server.go
+++ b/tools-internal/kdc-api-server/server/server.go
@@ -403,7 +403,7 @@ func (s *KDCAPIServer) handleListPrincipals(rw http.ResponseWriter, req *http.Re
 			filterExpr.Secret = secretName[0]
 		}
 		useBinary, ok := req.URL.Query()["binary"]
-		if ok && len(secretName[0]) > 0 {
+		if ok && len(useBinary[0]) > 0 {
 			useBinaryFlag := useBinary[0] == "1"
 			filterExpr.Binary = &useBinaryFlag
 		}


### PR DESCRIPTION
To allow mount volume to KDC database folder we have to create KDC database after launching image. So I've moved this step from image building to CMD step. 