### PR TITLE
Feature/improvment build package

### DIFF
--- a/tools/build_package.sh
+++ b/tools/build_package.sh
@@ -42,6 +42,7 @@ custom_artifacts=
 while getopts 'va:' opt; do
     case $opt in
         v) echo "Verbose mode enabled"
+           VERBOSE=true
            set -x
            ;;
         a) custom_artifacts="$custom_artifacts $OPTARG"
@@ -128,6 +129,10 @@ if [ -n "$PUBLISH_SCRIPT" ]; then
     # All the scripts use the same argument format:
     publisher_log_file="/tmp/$(basename ${PUBLISH_SCRIPT}).log"
     echo "Logs of publisher script in $publisher_log_file"
-    $PUBLISH_SCRIPT "${FRAMEWORK_NAME}" "${PACKAGE_VERSION}" "${UNIVERSE_DIR}" ${custom_artifacts} &> $publisher_log_file
+    if [ $VERBOSE ]; then
+        $PUBLISH_SCRIPT "${FRAMEWORK_NAME}" "${PACKAGE_VERSION}" "${UNIVERSE_DIR}" ${custom_artifacts} | tee $publisher_log_file
+    else 
+        $PUBLISH_SCRIPT "${FRAMEWORK_NAME}" "${PACKAGE_VERSION}" "${UNIVERSE_DIR}" ${custom_artifacts} &> $publisher_log_file
+    fi
 fi
 echo "Package Building Successfull"

--- a/tools/build_package.sh
+++ b/tools/build_package.sh
@@ -135,4 +135,4 @@ if [ -n "$PUBLISH_SCRIPT" ]; then
         $PUBLISH_SCRIPT "${FRAMEWORK_NAME}" "${PACKAGE_VERSION}" "${UNIVERSE_DIR}" ${custom_artifacts} &> $publisher_log_file
     fi
 fi
-echo "Package Building Successfull"
+echo "Package Building Successful"

--- a/tools/build_package.sh
+++ b/tools/build_package.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
-set -e -x
+# Script exits if some command returns non-zero value
+set -e
+
 
 user_usage() {
     # This script is generally called by an upstream 'build.sh' which would be invoked directly by users.
@@ -10,7 +12,7 @@ user_usage() {
 
 dev_usage() {
     # Called when a syntax error appears to be an error on the part of the developer.
-    echo "Developer syntax: build_package.sh <framework-name> </abs/path/to/framework> [-a 'path1' -a 'path2' ...] [aws|local|.dcos]"
+    echo "Developer syntax: build_package.sh <framework-name> </abs/path/to/framework> [-v] [-a 'path1' -a 'path2' ...] [aws|local|.dcos]"
 }
 
 # Optional envvars:
@@ -33,13 +35,14 @@ echo "Building $FRAMEWORK_NAME in $FRAMEWORK_DIR:"
 
 # optional args, currently just used for providing paths to service artifacts:
 custom_artifacts=
-while getopts 'a:' opt; do
+while getopts 'va:' opt; do
     case $opt in
-        a)
-            custom_artifacts="$custom_artifacts $OPTARG"
-            ;;
-        \?)
-            dev_usage
+        v) echo "Verbose mode enabled"
+           set -x
+           ;;
+        a) custom_artifacts="$custom_artifacts $OPTARG"
+           ;;
+        \?) dev_usage
             exit 1
             ;;
     esac


### PR DESCRIPTION
I add some changes to make more comfortable the 'tools/build_package.sh' script output.

1. The `set -x` option is disabled except if the `-v` flag is added as an argument.
2. The publisher script output has been redirected to a log file in `/tmp` so that the standard output does not bother the terminal in which it is working
