### PR TITLE
[DCOS-61505] Controlling metrics period

### DIFF
--- a/frameworks/cassandra/src/main/dist/metrics-reporter-config.yaml
+++ b/frameworks/cassandra/src/main/dist/metrics-reporter-config.yaml
@@ -1,6 +1,6 @@
 statsd:
-  - period: 10
-    timeunit: 'SECONDS'
+  - period: {{METRICS_PERIOD_MIN}}
+    timeunit: 'MINUTES'
     hosts:
       - host: {{STATSD_UDP_HOST}}
         port: {{STATSD_UDP_PORT}}

--- a/frameworks/cassandra/universe/config.json
+++ b/frameworks/cassandra/universe/config.json
@@ -1124,6 +1124,11 @@
           "type": "boolean",
           "description": "Enables materialized view creation on this node. Materialized views are considered experimental and are not recommended for production use.",
           "default": false
+        },
+        "metrics_period_min": {
+          "type": "integer",
+          "description": "Specifies how frequently the metrics plugin will push the values to the DC/OS StatsD endpoint. Consider increasing this value if you are having a large number of tables in your database.",
+          "default": 1
         }
       },
       "additionalProperties": false,

--- a/frameworks/cassandra/universe/marathon.json.mustache
+++ b/frameworks/cassandra/universe/marathon.json.mustache
@@ -62,7 +62,7 @@
 
     "SECURITY_AUTHENTICATION_ENABLED": "{{service.security.authentication.enabled}}",
     "SECURITY_AUTHORIZATION_ENABLED": "{{service.security.authorization.enabled}}",
-    
+
     {{#service.security.authentication.enabled}}
     "TASKCFG_ALL_CASSANDRA_AUTHENTICATOR": "{{service.security.authentication.authenticator}}",
     {{/service.security.authentication.enabled}}
@@ -78,8 +78,8 @@
     {{/service.security.authorization.enabled}}
 
     "TASKCFG_ALL_NEW_SUPERUSER": "{{service.security.authentication.superuser.name}}",
-    "TASKCFG_ALL_PASSWORD_SECRET_PATH": "{{service.security.authentication.superuser.password_secret_path}}",    
-    "TASKCFG_ALL_ROLES_UPDATE_INTERVAL_IN_MS": "{{service.security.authorization.roles_update_interval_in_ms}}",    
+    "TASKCFG_ALL_PASSWORD_SECRET_PATH": "{{service.security.authentication.superuser.password_secret_path}}",
+    "TASKCFG_ALL_ROLES_UPDATE_INTERVAL_IN_MS": "{{service.security.authorization.roles_update_interval_in_ms}}",
     "TASKCFG_ALL_ROLES_VALIDITY_IN_MS": "{{service.security.authorization.roles_validity_in_ms}}",
     "TASKCFG_ALL_CREDENTIALS_VALIDITY_IN_MS": "{{service.security.authorization.credentials_validity_in_ms}}",
     "TASKCFG_ALL_CREDENTIALS_UPDATE_INTERVAL_IN_MS": "{{service.security.authorization.credentials_update_interval_in_ms}}",
@@ -126,7 +126,7 @@
     {{#service.security.custom_domain}}
     "SERVICE_TLD": "{{service.security.custom_domain}}",
     {{/service.security.custom_domain}}
-    
+
     {{#service.region}}
     "SERVICE_REGION": "{{service.region}}",
     {{/service.region}}
@@ -262,9 +262,11 @@
 
     "RLIMIT_NOFILE_SOFT": "{{service.rlimits.rlimit_nofile.soft}}",
     "RLIMIT_NOFILE_HARD": "{{service.rlimits.rlimit_nofile.hard}}",
-    
+
     "TASKCFG_ALL_CASSANDRA_ENABLE_USER_DEFINED_FUNCTIONS": "{{cassandra.enable_user_defined_functions}}",
-    "TASKCFG_ALL_CASSANDRA_ENABLE_SCRIPTED_USER_DEFINED_FUNCTIONS": "{{cassandra.enable_scripted_user_defined_functions}}"
+    "TASKCFG_ALL_CASSANDRA_ENABLE_SCRIPTED_USER_DEFINED_FUNCTIONS": "{{cassandra.enable_scripted_user_defined_functions}}",
+
+    "METRICS_PERIOD_MIN": "{{cassandra.metrics_period_min}}"
   },
   "fetch": [
     { "uri": "{{resource.assets.uris.bootstrap-zip}}", "cache": true },

--- a/frameworks/cassandra/universe/marathon.json.mustache
+++ b/frameworks/cassandra/universe/marathon.json.mustache
@@ -266,7 +266,7 @@
     "TASKCFG_ALL_CASSANDRA_ENABLE_USER_DEFINED_FUNCTIONS": "{{cassandra.enable_user_defined_functions}}",
     "TASKCFG_ALL_CASSANDRA_ENABLE_SCRIPTED_USER_DEFINED_FUNCTIONS": "{{cassandra.enable_scripted_user_defined_functions}}",
 
-    "METRICS_PERIOD_MIN": "{{cassandra.metrics_period_min}}"
+    "TASKCFG_ALL_METRICS_PERIOD_MIN": "{{cassandra.metrics_period_min}}"
   },
   "fetch": [
     { "uri": "{{resource.assets.uris.bootstrap-zip}}", "cache": true },


### PR DESCRIPTION
This commit introduces the metrics_period_min configuration parameter that allows adjusting
the metrics flushing interval to statsd. This can be used to reduce the load on telegraf
in the case of large data sets.