### PR TITLE
[DCOS_OSS-5905] Remove requirement for msrest in azure_uploader.

### DIFF
--- a/tools/universe/azure_uploader.py
+++ b/tools/universe/azure_uploader.py
@@ -18,25 +18,29 @@ class AzureUploader(object):
         self._storage_account = storage_account
         self._dry_run = dry_run
 
-
     def upload(self, filepath, content_type=None):
         filename = os.path.basename(filepath)
         log.info("Uploading {}...".format(filename))
         cmdlist = ["az", "storage", "blob", "upload", "--validate-content", "-o", "none"]
-        cmdlist += '--account-name {} --container-name {}'.format(self._storage_account, self._container_name).split(" ")
+        cmdlist += "--account-name {} --container-name {}".format(
+            self._storage_account, self._container_name
+        ).split(" ")
         if content_type is not None:
-            cmdlist += '--content-type {}'.format(content_type).split(" ")
-        cmdlist += '--file {} --name {}'.format(filepath, filename).split(" ")
+            cmdlist += "--content-type {}".format(content_type).split(" ")
+        cmdlist += "--file {} --name {}".format(filepath, filename).split(" ")
 
         # Runs Azure CLI command and try to capture possible exceptions
-        output=""
+        output = ""
         if self._dry_run != "True":
             try:
-              output = subprocess.call(cmdlist)
-            except:
-              # Azure CLI doesn't stores any session details. Only a token which expires after 90 days of inactivity.
-              log.error("Common Error: Check if token has expired. Try to relogin with 'az login' and repeat the building")
-              log.error(output)
+                output = subprocess.call(cmdlist)
+            except Exception:
+                # Azure CLI doesn't stores any session details. Only a token which expires after 90 days of inactivity.
+                log.error(
+                    "Common Error: Check if token has expired. Try to relogin with 'az login' and repeat the building"
+                )
+                log.error(output)
+                raise
 
         else:
-            log.info("Uploading '{}' file ({})".format(filename, ' '.join(cmdlist)))
+            log.info("Uploading '{}' file ({})".format(filename, " ".join(cmdlist)))

--- a/tools/universe/azure_uploader.py
+++ b/tools/universe/azure_uploader.py
@@ -3,7 +3,6 @@
 import logging
 import subprocess
 import os
-import msrest
 
 log = logging.getLogger(__name__)
 logging.basicConfig(level=logging.DEBUG, format="%(message)s")
@@ -34,10 +33,9 @@ class AzureUploader(object):
         if self._dry_run != "True":
             try:
               output = subprocess.call(cmdlist)
-            except msrest.exceptions.TokenExpiredError:
-              # Azure CLI doesn't stores any session details. Only a token which expires after 90 days of inactivity.
-              log.error("Session Token has expired. Try to relogin with 'az login' and repeat the building")
             except:
+              # Azure CLI doesn't stores any session details. Only a token which expires after 90 days of inactivity.
+              log.error("Common Error: Check if token has expired. Try to relogin with 'az login' and repeat the building")
               log.error(output)
 
         else:


### PR DESCRIPTION
Temporarily relax the requirement for `msrest` till we resolve the build breaks in our environment.