### PR TITLE
Update ubuntu version from 18.10 to 18.04

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -20,7 +20,7 @@
 # - put the tag into the FROM line in Dockerfile (of the main image)
 #   temporarily, rebuild that one, test, etc.
 #
-FROM ubuntu:18.10@sha256:7d657275047118bb77b052c4c0ae43e8a289ca2879ebfa78a703c93aa8fd686c
+FROM ubuntu:18.04@sha256:ca013ac5c09f9a9f6db8370c1b759a29fe997d64d6591e9a75b71748858f7da0
 
 # Docker and DIND
 # links to commit hashes are listed inside posted Dockerfiles at

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -20,7 +20,7 @@
 # - put the tag into the FROM line in Dockerfile (of the main image)
 #   temporarily, rebuild that one, test, etc.
 #
-FROM ubuntu:18.04@sha256:4d07b5b0cd47c06a3ca847536a3e05901c6bf9d9f52dbb0e6a7fff9141453f11
+FROM ubuntu:18.04@sha256:0925d086715714114c1988f7c947db94064fd385e171a63c07730f1fa014e6f9
 
 # Docker and DIND
 # links to commit hashes are listed inside posted Dockerfiles at

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -20,7 +20,7 @@
 # - put the tag into the FROM line in Dockerfile (of the main image)
 #   temporarily, rebuild that one, test, etc.
 #
-FROM ubuntu:18.04@sha256:ca013ac5c09f9a9f6db8370c1b759a29fe997d64d6591e9a75b71748858f7da0
+FROM ubuntu:18.04@sha256:4d07b5b0cd47c06a3ca847536a3e05901c6bf9d9f52dbb0e6a7fff9141453f11
 
 # Docker and DIND
 # links to commit hashes are listed inside posted Dockerfiles at


### PR DESCRIPTION
It updates `Dockerfile.base` to use Ubuntu 18.04 instead of 18.10 as base image. 18.04 is an LTS version and it would be more stable, whereas current version have many repository removed from the support and that is causing building docker image to fail.