### PR TITLE
D2iQ-65350: Add configureable logrotate options.

### DIFF
--- a/frameworks/helloworld/universe/config.json
+++ b/frameworks/helloworld/universe/config.json
@@ -50,6 +50,22 @@
           ],
           "default": "INFO"
         },
+        "logrotate_options": {
+          "description": "The logrotate options for the DC/OS service.",
+          "type": "object",
+          "properties": {
+            "stdout_max_size":{
+                "description": "Logrotate stdout max size. Sizes must be an integer of less than 2^64 and must be suffixed with a unit such as B (bytes), KB, MB, GB, or TB. There should be no whitespace between the integer and unit.",
+                "type": "string",
+                "default":"2MB"
+            },
+            "stderr_max_size":{
+                "description": "Logrotate stderr max size. Sizes must be an integer of less than 2^64 and must be suffixed with a unit such as B (bytes), KB, MB, GB, or TB. There should be no whitespace between the integer and unit.",
+                "type": "string",
+                "default":"2MB"
+            }
+          }
+        },
         "region": {
           "description": "The region that the service's tasks should run in.",
           "type": "string",

--- a/frameworks/helloworld/universe/marathon.json.mustache
+++ b/frameworks/helloworld/universe/marathon.json.mustache
@@ -113,6 +113,9 @@
     "SERVICE_TLD": "{{service.custom_service_tld}}",
     {{/service.custom_service_tld}}
 
+    "CONTAINER_LOGGER_LOGROTATE_MAX_STDOUT_SIZE": "{{service.logrotate_options.stdout_max_size}}",
+    "CONTAINER_LOGGER_LOGROTATE_MAX_STDERR_SIZE": "{{service.logrotate_options.stderr_max_size}}",
+
     "KEYSTORE_APP_VERSION": "{{tls.keystore_app_version}}",
     "NGINX_CONTAINER_VERSION": "{{tls.nginx_container_version}}",
     "TEST_BOOLEAN": "{{service.test_boolean}}",


### PR DESCRIPTION
This patch allows default log sizes to be configureable for [logrotate](https://docs.d2iq.com/mesosphere/dcos/1.13/monitoring/logging/configure-task-logs/#logrotate-options).

This patch only allows the following env-vars to be altered:
```
CONTAINER_LOGGER_LOGROTATE_MAX_STDOUT_SIZE
CONTAINER_LOGGER_LOGROTATE_MAX_STDERR_SIZE
```

These env-vars cannot be changed since DC/OS 1.13 due to [MESOS-9564](https://issues.apache.org/jira/browse/MESOS-9564) and were intentionally not included:
```
CONTAINER_LOGGER_LOGROTATE_STDOUT_OPTIONS
CONTAINER_LOGGER_LOGROTATE_STDERR_OPTIONS
```

