### PR TITLE
HDFS & Cassandra CI Fixes

### DIFF
--- a/frameworks/cassandra/tests/test_backup_and_restore.py
+++ b/frameworks/cassandra/tests/test_backup_and_restore.py
@@ -114,6 +114,7 @@ def test_backup_and_restore_to_s3() -> None:
     )
 
 
+@pytest.mark.skip(reason="Infra Issues:D2IQ-69805")
 @pytest.mark.aws
 @pytest.mark.sanity
 def test_backup_and_restore_to_s3_compatible_storage() -> None:

--- a/frameworks/cassandra/tests/test_sanity.py
+++ b/frameworks/cassandra/tests/test_sanity.py
@@ -106,7 +106,7 @@ def test_metrics() -> None:
 
 @pytest.mark.sanity
 def test_custom_jmx_port() -> None:
-    expected_open_port = ":7200 (LISTEN)"
+    expected_open_port = ":7200"
 
     new_config = {"cassandra": {"jmx_port": 7200}}
 
@@ -122,7 +122,7 @@ def test_custom_jmx_port() -> None:
     tasks = sdk_tasks.get_service_tasks(config.get_foldered_service_name(), "node")
 
     for task in tasks:
-        _, stdout, _ = sdk_cmd.run_cli("task exec {} lsof -i :7200".format(task.id))
+        _, stdout, _ = sdk_cmd.run_cli("task exec {} netstat -nlp | grep :7200".format(task.id))
         assert expected_open_port in stdout
 
 

--- a/frameworks/hdfs/tests/config.py
+++ b/frameworks/hdfs/tests/config.py
@@ -6,6 +6,7 @@ import uuid
 import sdk_cmd
 import sdk_hosts
 import sdk_plan
+import sdk_security
 import sdk_tasks
 import sdk_utils
 
@@ -115,6 +116,8 @@ def get_hdfs_client_app(service_name, kerberos=None) -> dict:
     18/08/21 20:36:57 FATAL conf.Configuration: error parsing conf core-site.xml
            org.xml.sax.SAXParseException; Premature end of file.
     """
+    # Task below runs as user root, grant Marathon the ability to launch client in strict mode.
+    sdk_security.grant_marathon_root_user()
     app = {
         "id": CLIENT_APP_NAME,
         "mem": 1024,

--- a/testing/sdk_security.py
+++ b/testing/sdk_security.py
@@ -394,6 +394,25 @@ def openssl_ciphers() -> Set[str]:
     )
 
 
+def grant_marathon_root_user() -> None:
+    # This grants dcos_marathon to launch tasks as the root user.
+    log.info("Granting root permissions to dcos_marathon")
+    permissions = [
+        {
+            "user": "dcos_marathon",
+            "acl": "dcos:mesos:master:task:user:root",
+            "description": "Service dcos_marathon may register with the Mesos master with user root",
+            "action": "create",
+        }
+    ]
+
+    for permission in permissions:
+        _grant(
+            permission["user"], permission["acl"], permission["description"], permission["action"]
+        )
+    log.info("Permission setup completed for dcos_marathon")
+
+
 def is_cipher_enabled(
     service_name: str, task_name: str, cipher: str, endpoint: str, openssl_timeout: str = "1"
 ) -> bool:


### PR DESCRIPTION
- Fixes issues in `test_sanity.test_custom_jmx_port` where the `lsof` command is missing.
- Skip `test_backup_and_restore_to_s3_compatible_storage` till [D2IQ-69805](https://jira.d2iq.com/browse/D2IQ-69805) is resolved.
- Grants `dcos_marathon` permissions to run Apps with `root` user, this is specifically needed to launch `hdfs-client` which is used in many tests for HDFS.