### PR TITLE
[COPS-5547] REMOTE_SEED Fixes.

### DIFF
--- a/frameworks/cassandra/src/main/dist/cassandra.yaml
+++ b/frameworks/cassandra/src/main/dist/cassandra.yaml
@@ -9,7 +9,7 @@ saved_caches_directory: {{MESOS_SANDBOX}}/container-path/saved_caches
 seed_provider:
     - class_name: {{CASSANDRA_SEED_PROVIDER_CLASS}}
       parameters:
-          - seeds: "{{LOCAL_SEEDS}},{{REMOTE_SEEDS}}"
+          - seeds: "{{LOCAL_SEEDS}}{{#REMOTE_SEEDS}},{{REMOTE_SEEDS}}{{/REMOTE_SEEDS}}"
 num_tokens: {{CASSANDRA_NUM_TOKENS}}
 hinted_handoff_enabled: {{CASSANDRA_HINTED_HANDOFF_ENABLED}}
 max_hint_window_in_ms: {{CASSANDRA_MAX_HINT_WINDOW_IN_MS}}


### PR DESCRIPTION
customers might not have `REMOTE_SEEDS`. in that case the comma in the end tells the config parser that the list end with a NULL, which in turn is converted to `127.0.0.1`, which then results in the debug log constantly spewing errors about the gossip protocol not being able to communicate with localhost.

i'd love to learn how to properly test this change. it's currently untested and just a best guess to illustrate what i think needs to happen in order to fix COPS-5547