### PR TITLE
Update the ssh_path

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -84,7 +84,7 @@ else
   pytest_m="sanity and not azure"
 fi
 gradle_cache="${DCOS_COMMONS_DIRECTORY}/.gradle_cache"
-ssh_path="${HOME}/.ssh/ccm.pem"
+ssh_path="${HOME}/.ssh/id_rsa"
 ssh_user="centos"
 aws_credentials_path="${HOME}/.aws/credentials"
 enterprise="true"


### PR DESCRIPTION
While running the the zookeeper tests locally on a cluster created using terraform, I was constantly getting
```
sdk_cmd.py                 219 INFO     Got exit code 255 to command: ssh -oBatchMode=yes -oStrictHostKeyChecking=no -oConnectTimeout=50 -A -q -l centos  54.158.200.145 -- "ssh -oBatchMode=yes -oStrictHostKeyChecking=no -oConnectTimeout=50 -A -q -l centos 172.16.1.238 -- \"sudo usermod -aG docker centos\""
sdk_cmd.py                 409 INFO     NOTE: Could be due to mis-configured SSH credentials. Configured keys are: 
```
Since we are using `id_rsa.pub` for creating the tf cluster, I replaced `ccm.pem` with the private RSA key `id_rsa` and it worked.