### PR TITLE
[D2IQ-72495] Add configurable logrotate options

### DIFF
--- a/frameworks/cassandra/universe/config.json
+++ b/frameworks/cassandra/universe/config.json
@@ -62,6 +62,22 @@
           ],
           "default": "INFO"
         },
+        "logrotate_options": {
+          "description": "The logrotate options for the DC/OS service.",
+          "type": "object",
+          "properties": {
+            "stdout_max_size": {
+              "description": "Logrotate stdout max size. Sizes must be an integer of less than 2^64 and must be suffixed with a unit such as B (bytes), KB, MB, GB, or TB. There should be no whitespace between the integer and unit.",
+              "type": "string",
+              "default": "8MB"
+            },
+            "stderr_max_size": {
+              "description": "Logrotate stderr max size. Sizes must be an integer of less than 2^64 and must be suffixed with a unit such as B (bytes), KB, MB, GB, or TB. There should be no whitespace between the integer and unit.",
+              "type": "string",
+              "default": "8MB"
+            }
+          }
+        },
         "data_center": {
           "description": "The name of the data center this cluster is running in",
           "type": "string",

--- a/frameworks/cassandra/universe/marathon.json.mustache
+++ b/frameworks/cassandra/universe/marathon.json.mustache
@@ -256,6 +256,9 @@
     "LIBMESOS_URI": "{{resource.assets.uris.libmesos-bundle-tar-gz}}",
     "BACKUP_RESTORE_STRATEGY": "{{service.backup_restore_strategy}}",
 
+    "CONTAINER_LOGGER_LOGROTATE_MAX_STDOUT_SIZE": "{{service.logrotate_options.stdout_max_size}}",
+    "CONTAINER_LOGGER_LOGROTATE_MAX_STDERR_SIZE": "{{service.logrotate_options.stderr_max_size}}",
+
     "READINESS_CHECK_INTERVAL": "{{service.readiness_check.interval}}",
     "READINESS_CHECK_DELAY": "{{service.readiness_check.delay}}",
     "READINESS_CHECK_TIMEOUT": "{{service.readiness_check.timeout}}",

--- a/frameworks/hdfs/universe/config.json
+++ b/frameworks/hdfs/universe/config.json
@@ -62,6 +62,22 @@
           ],
           "default": "INFO"
         },
+        "logrotate_options": {
+          "description": "The logrotate options for the DC/OS service.",
+          "type": "object",
+          "properties": {
+            "stdout_max_size": {
+              "description": "Logrotate stdout max size. Sizes must be an integer of less than 2^64 and must be suffixed with a unit such as B (bytes), KB, MB, GB, or TB. There should be no whitespace between the integer and unit.",
+              "type": "string",
+              "default": "8MB"
+            },
+            "stderr_max_size": {
+              "description": "Logrotate stderr max size. Sizes must be an integer of less than 2^64 and must be suffixed with a unit such as B (bytes), KB, MB, GB, or TB. There should be no whitespace between the integer and unit.",
+              "type": "string",
+              "default": "8MB"
+            }
+          }
+        },
         "deploy_strategy": {
           "description": "HDFS deployment strategy. [parallel, serial]",
           "type": "string",

--- a/frameworks/hdfs/universe/marathon.json.mustache
+++ b/frameworks/hdfs/universe/marathon.json.mustache
@@ -131,6 +131,9 @@
     "DATA_NODE_RLIMIT_NOFILE_SOFT" : "{{data_node.rlimits.rlimit_nofile.soft}}",
     "DATA_NODE_RLIMIT_NOFILE_HARD" : "{{data_node.rlimits.rlimit_nofile.hard}}",
 
+    "CONTAINER_LOGGER_LOGROTATE_MAX_STDOUT_SIZE": "{{service.logrotate_options.stdout_max_size}}",
+    "CONTAINER_LOGGER_LOGROTATE_MAX_STDERR_SIZE": "{{service.logrotate_options.stderr_max_size}}",
+
     {{#service.security.kerberos.enabled}}
     "SECURITY_KERBEROS_KEYTAB_SECRET": "{{service.security.kerberos.keytab_secret}}",
     "SECURITY_KERBEROS_ENABLED": "{{service.security.kerberos.enabled}}",


### PR DESCRIPTION
Resolves [D2IQ-72495](https://jira.d2iq.com/browse/D2IQ-72495)
This patch allows the following env-vars to be altered:
```
CONTAINER_LOGGER_LOGROTATE_MAX_STDOUT_SIZE
CONTAINER_LOGGER_LOGROTATE_MAX_STDERR_SIZE
```
Relates to https://github.com/mesosphere/dcos-commons/pull/3242