### PR TITLE
[COPS-6607] expose useful UDF settings for Cassandra

### DIFF
--- a/frameworks/cassandra/src/main/dist/cassandra.yaml
+++ b/frameworks/cassandra/src/main/dist/cassandra.yaml
@@ -95,6 +95,14 @@ tracetype_repair_ttl: {{CASSANDRA_TRACETYPE_REPAIR_TTL}}
 gc_warn_threshold_in_ms: {{CASSANDRA_GC_WARN_THRESHOLD_IN_MS}}
 enable_user_defined_functions: {{CASSANDRA_ENABLE_USER_DEFINED_FUNCTIONS}}
 enable_scripted_user_defined_functions: {{CASSANDRA_ENABLE_SCRIPTED_USER_DEFINED_FUNCTIONS}}
+{{#CASSANDRA_ENABLE_USER_DEFINED_FUNCTIONS}}
+enable_user_defined_functions_threads: {{CASSANDRA_ENABLE_UDF_THREADS}}
+user_defined_function_warn_micros: {{CASSANDRA_UDF_WARN_MICROS}}
+user_defined_function_fail_micros: {{CASSANDRA_UDF_FAIL_MICROS}}
+user_defined_function_warn_heap_mb: {{CASSANDRA_UDF_WARN_HEAP_MB}}
+user_defined_function_fail_heap_mb: {{CASSANDRA_UDF_FAIL_HEAP_MB}}
+user_function_timeout_policy: {{CASSANDRA_USER_FUNC_TIMEOUT_POLICY}}
+{{/CASSANDRA_ENABLE_USER_DEFINED_FUNCTIONS}}
 windows_timer_interval: {{CASSANDRA_WINDOWS_TIMER_INTERVAL}}
 role_manager: {{CASSANDRA_ROLE_MANAGER}}
 roles_validity_in_ms: {{ROLES_VALIDITY_IN_MS}}

--- a/frameworks/cassandra/universe/config.json
+++ b/frameworks/cassandra/universe/config.json
@@ -1054,6 +1054,36 @@
           "description": "Java UDFs are always enabled, if enable_user_defined_functions is true. Enable this option to use UDFs with language javascript or any custom JSR-223 provider. This option has no effect if enable_user_defined_functions is false",
           "default": false
         },
+        "enable_user_defined_functions_threads": {
+          "type": "boolean",
+          "description": "Enables sandbox for asynchronous JavaScript UDF execution. Does not apply to Java UDFs. If enabled, only one instance of a function can run at one time. Asynchronous execution prevents UDFs from running too long or forever and destabilizing the cluster.",
+          "default": true
+        },
+        "user_defined_function_warn_micros": {
+          "type": "integer",
+          "description": "Threshold in microseconds (CPU time). When a UDF runs too long and this threshold is exceeded, a warning is logged and sent to the client.",
+          "default": 500
+        },
+        "user_defined_function_fail_micros": {
+          "type": "integer",
+          "description": "Threshold in microseconds (CPU time). When a fatal UDF run-time situation is detected and this threshold is exceeded, the UDF is stopped.",
+          "default": 10000
+        },
+        "user_defined_function_warn_heap_mb": {
+          "type": "integer",
+          "description": "Threshold in MB for heap allocations. When this threshold is exceeded, a warning is logged and sent to the client. Java UDFs always issue a warning. Scripted UDFs log a warning only if this property is set to true",
+          "default": 200
+        },
+        "user_defined_function_fail_heap_mb": {
+          "type": "integer",
+          "description": "Threshold in MB for heap allocations. When this threshold is exceeded, the UDF is stopped. Java UDFs fail and are safely stopped. Java UDFs always throw an exception. Scripted UDFs stop and throw an exception only if this property is set to true",
+          "default": 500
+        },
+        "user_function_timeout_policy":{
+          "type": "string",
+          "description": "Defines action when a scripted UDF exceeds user_defined_function_fail_micros threshold. Applies only when enable_user_defined_functions_threads is set to true. Accepted values: die, die_immediate, ignore.",
+          "default": "die"
+        },
         "cdc_enabled": {
           "type": "boolean",
           "description": "Enable / disable CDC functionality on a per-node basis. This modifies the logic used for write path allocation rejection",

--- a/frameworks/cassandra/universe/marathon.json.mustache
+++ b/frameworks/cassandra/universe/marathon.json.mustache
@@ -265,6 +265,12 @@
 
     "TASKCFG_ALL_CASSANDRA_ENABLE_USER_DEFINED_FUNCTIONS": "{{cassandra.enable_user_defined_functions}}",
     "TASKCFG_ALL_CASSANDRA_ENABLE_SCRIPTED_USER_DEFINED_FUNCTIONS": "{{cassandra.enable_scripted_user_defined_functions}}",
+    "TASKCFG_ALL_CASSANDRA_ENABLE_UDF_THREADS": "{{cassandra.enable_user_defined_functions_threads}}",
+    "TASKCFG_ALL_CASSANDRA_UDF_WARN_MICROS": "{{cassandra.user_defined_function_warn_micros}}",
+    "TASKCFG_ALL_CASSANDRA_UDF_FAIL_MICROS": "{{cassandra.user_defined_function_fail_micros}}",
+    "TASKCFG_ALL_CASSANDRA_UDF_WARN_HEAP_MB": "{{cassandra.user_defined_function_warn_heap_mb}}",
+    "TASKCFG_ALL_CASSANDRA_UDF_FAIL_HEAP_MB": "{{cassandra.user_defined_function_fail_heap_mb}}",
+    "TASKCFG_ALL_CASSANDRA_USER_FUNC_TIMEOUT_POLICY": "{{cassandra.user_function_timeout_policy}}",
 
     "TASKCFG_ALL_METRICS_PERIOD_MIN": "{{cassandra.metrics_period_min}}",
 


### PR DESCRIPTION
## Jira Ticket
[COPS-6607](https://jira.d2iq.com/browse/COPS-6607)

## Description
This PR adds some useful UDF settings for Cassandra along with their default values as mentioned below:
```
enable_user_defined_functions_threads: true
user_defined_function_warn_micros: 500
user_defined_function_fail_micros: 10000
user_defined_function_warn_heap_mb: 200
user_defined_function_fail_heap_mb: 500
user_function_timeout_policy: die
```
