### PR TITLE
Hello-World DVDI Integration Tests.

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -12,6 +12,7 @@ import sys
 import time
 
 import sdk_diag
+import sdk_external_volumes
 import sdk_repository
 import sdk_package_registry
 import sdk_utils
@@ -71,6 +72,14 @@ def configure_universe(tmpdir_factory):
         yield from sdk_package_registry.package_registry_session(tmpdir_factory)
     else:
         yield from sdk_repository.universe_session()
+
+
+@pytest.fixture(scope="session", autouse=True)
+def configure_external_volumes():
+    if is_env_var_set("EXTERNAL_VOLUMES_ENABLED", default=""):
+        yield from sdk_external_volumes.external_volumes_session()
+    else:
+        yield
 
 
 @pytest.hookimpl(tryfirst=True, hookwrapper=True)

--- a/frameworks/helloworld/src/main/dist/external-volumes.yml
+++ b/frameworks/helloworld/src/main/dist/external-volumes.yml
@@ -1,0 +1,82 @@
+name: {{FRAMEWORK_NAME}}
+scheduler:
+  principal: {{FRAMEWORK_PRINCIPAL}}
+  user: {{FRAMEWORK_USER}}
+pods:
+  hello:
+    count: {{HELLO_COUNT}}
+    placement: '{{{HELLO_PLACEMENT}}}'
+    external-volumes:
+      hello-volume:
+        type: DOCKER
+        volume-mode: RW
+        container-path: hello-container-path
+        driver-name: {{EXTERNAL_VOLUME_DRIVER_NAME}}
+        driver-options: {{EXTERNAL_VOLUME_DRIVER_OPTIONS}}
+        {{#HELLO_EXTERNAL_VOLUME_NAME}}
+        volume-name: {{HELLO_EXTERNAL_VOLUME_NAME}}
+        {{/HELLO_EXTERNAL_VOLUME_NAME}}
+    tasks:
+      server:
+        goal: RUNNING
+        cmd: env && echo hello >> hello-container-path/output && sleep $SLEEP_DURATION
+        cpus: {{HELLO_CPUS}}
+        memory: {{HELLO_MEM}}
+        env:
+          SLEEP_DURATION: {{SLEEP_DURATION}}
+        health-check:
+          cmd: stat hello-container-path/output
+          interval: 5
+          grace-period: 30
+          delay: 0
+          timeout: 10
+          max-consecutive-failures: 3
+        labels: {{HELLO_LABELS}}
+  world:
+      count: {{WORLD_COUNT}}
+      allow-decommission: true
+      placement: '{{{WORLD_PLACEMENT}}}'
+      external-volumes:
+        world-volume:
+          type: DOCKER
+          volume-mode: RW
+          container-path: world-container-path
+          driver-name: {{EXTERNAL_VOLUME_DRIVER_NAME}}
+          driver-options: {{EXTERNAL_VOLUME_DRIVER_OPTIONS}}
+          {{#WORLD_EXTERNAL_VOLUME_NAME}}
+            volume-name: {{WORLD_EXTERNAL_VOLUME_NAME}}
+          {{/WORLD_EXTERNAL_VOLUME_NAME}}
+      tasks:
+        server:
+          goal: RUNNING
+          cmd: |
+                 # for graceful shutdown
+                 #  trap SIGTERM and mock a cleanup timeframe
+                 terminated () {
+                   echo "$(date) received SIGTERM, zzz for 3 ..."
+                   sleep 3
+                   echo "$(date) ... all clean, peace out"
+                   exit 0
+                 }
+                 trap terminated SIGTERM
+                 echo "$(date) trapping SIGTERM, watch here for the signal..."
+
+                 echo "${TASK_NAME}" >>world-container-path/output &&
+                 # instead of running for a short duration (equal to SLEEP_DURATION), run infinitely
+                 # to allow for testing of SIGTERM..grace..SIGKILL
+                 while true; do
+                   sleep 0.1
+                 done
+          cpus: {{WORLD_CPUS}}
+          memory: {{WORLD_MEM}}
+          env:
+            SLEEP_DURATION: {{SLEEP_DURATION}}
+          readiness-check:
+            # wordcount (wc) will report an error if the file does not exist, which effectively is zero (0) bytes
+            # so send the error to /dev/null, BUT also zero-left-pad the variable BYTES to ensure that it is zero
+            # on empty for comparison sake.
+            cmd: BYTES="$(wc -c world-container-path/output 2>/dev/null| awk '{print $1;}')" && [ 0$BYTES -gt 0 ]
+            interval: {{WORLD_READINESS_CHECK_INTERVAL}}
+            delay: {{WORLD_READINESS_CHECK_DELAY}}
+            timeout: {{WORLD_READINESS_CHECK_TIMEOUT}}
+          kill-grace-period: {{WORLD_KILL_GRACE_PERIOD}}

--- a/frameworks/helloworld/tests/conftest.py
+++ b/frameworks/helloworld/tests/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+import sdk_external_volumes
 import sdk_security
 from tests import config
 
@@ -6,6 +7,12 @@ from tests import config
 @pytest.fixture(scope="session")
 def configure_security(configure_universe):
     yield from sdk_security.security_session(config.SERVICE_NAME)
+
+
+@pytest.fixture(scope="session")
+def configure_external_volumes():
+    # Handle creation of external volumes.
+    yield from sdk_external_volumes.external_volumes_session()
 
 
 # pytest fixtures to run hello-world scale test located in frameworks/helloworld/tests/scale

--- a/frameworks/helloworld/tests/test_external_volumes.py
+++ b/frameworks/helloworld/tests/test_external_volumes.py
@@ -32,16 +32,18 @@ def test_default_deployment():
             "external_volumes": {
                 "pod-replacement-failure-policy": {
                     "enable-automatic-pod-replacement": True,
-                    "permanent-failure-timeout-secs": 30
-                }
-            }
-        }
+                    "permanent-failure-timeout-secs": 30,
+                },
+            },
+        },
     }
-    sdk_install.install(config.PACKAGE_NAME,
-                        config.SERVICE_NAME,
-                        3,
-                        additional_options=options,
-                        wait_for_deployment=True)
+    sdk_install.install(
+        config.PACKAGE_NAME,
+        config.SERVICE_NAME,
+        3,
+        additional_options=options,
+        wait_for_deployment=True,
+    )
     # Wait for scheduler to restart.
     sdk_plan.wait_for_completed_deployment(config.SERVICE_NAME)
 
@@ -59,7 +61,7 @@ def test_auto_replace_on_drain():
     replace_agent_id = candidate_tasks[0].agent_id
     replace_tasks = [task for task in candidate_tasks if task.agent_id == replace_agent_id]
     log.info(
-        "Tasks on agent {} to be replaced after drain: {}".format(replace_agent_id, replace_tasks)
+        "Tasks on agent {} to be replaced after drain: {}".format(replace_agent_id, replace_tasks),
     )
     sdk_agents.drain_agent(replace_agent_id)
 
@@ -76,7 +78,7 @@ def test_auto_replace_on_drain():
         ][0]
         log.info(
             "Checking affected task has moved to a new agent:\n"
-            "old={}\nnew={}".format(replaced_task, new_task)
+            "old={}\nnew={}".format(replaced_task, new_task),
         )
         assert replaced_task.agent_id != new_task.agent_id
 

--- a/frameworks/helloworld/tests/test_external_volumes.py
+++ b/frameworks/helloworld/tests/test_external_volumes.py
@@ -1,0 +1,84 @@
+import logging
+import pytest
+import re
+
+import sdk_agents
+import sdk_install
+import sdk_plan
+import sdk_tasks
+from tests import config
+
+log = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def configure_package(configure_security):
+    try:
+        sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
+        yield  # let the test session execute
+    finally:
+        sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
+
+
+@pytest.mark.external_volumes
+@pytest.mark.sanity
+@pytest.mark.dcos_min_version("2.1")
+def test_default_deployment():
+    # Test default installation with external volumes.
+    # Ensure service comes up successfully.
+    options = {
+        "service": {
+            "yaml": "external-volumes",
+            "external_volumes": {
+                "pod-replacement-failure-policy": {
+                    "enable-automatic-pod-replacement": True,
+                    "permanent-failure-timeout-secs": 30
+                }
+            }
+        }
+    }
+    sdk_install.install(config.PACKAGE_NAME,
+                        config.SERVICE_NAME,
+                        3,
+                        additional_options=options,
+                        wait_for_deployment=True)
+    # Wait for scheduler to restart.
+    sdk_plan.wait_for_completed_deployment(config.SERVICE_NAME)
+
+
+@pytest.mark.external_volumes
+@pytest.mark.sanity
+def test_auto_replace_on_drain():
+    candidate_tasks = sdk_tasks.get_tasks_avoiding_scheduler(
+        config.SERVICE_NAME, re.compile("^(hello|world)-[0-9]+-server$")
+    )
+
+    assert len(candidate_tasks) != 0, "Could not find a node to drain"
+
+    # Pick the host of the first task from the above list
+    replace_agent_id = candidate_tasks[0].agent_id
+    replace_tasks = [task for task in candidate_tasks if task.agent_id == replace_agent_id]
+    log.info(
+        "Tasks on agent {} to be replaced after drain: {}".format(replace_agent_id, replace_tasks)
+    )
+    sdk_agents.drain_agent(replace_agent_id)
+
+    sdk_plan.wait_for_kicked_off_recovery(config.SERVICE_NAME)
+    sdk_plan.wait_for_completed_recovery(config.SERVICE_NAME)
+
+    new_tasks = sdk_tasks.get_summary()
+
+    for replaced_task in replace_tasks:
+        new_task = [
+            task
+            for task in new_tasks
+            if task.name == replaced_task.name and task.id != replaced_task.id
+        ][0]
+        log.info(
+            "Checking affected task has moved to a new agent:\n"
+            "old={}\nnew={}".format(replaced_task, new_task)
+        )
+        assert replaced_task.agent_id != new_task.agent_id
+
+    # Reactivate the drained agent, otherwise uninstall plans will be halted for portworx
+    sdk_agents.reactivate_agent(replace_agent_id)

--- a/frameworks/helloworld/universe/config.json
+++ b/frameworks/helloworld/universe/config.json
@@ -246,20 +246,23 @@
             },
             "pod-replacement-failure-policy": {
               "description": "Options relating to automatic pod-replacement failure policies with external-volumes.",
-              "enable-automatic-pod-replacement": {
-                  "description": "Determines whether pods should be replaced automatically on failure.",
-                  "type": "boolean",
-                  "default": false
-              },
-              "permanent-failure-timeout-secs": {
-                  "description": "Default time to wait before declaring a pod as permanently failed in seconds.",
-                  "type": "integer",
-                  "default": 120
-              },
-              "min-replace-delay-secs": {
-                  "description": "Default time to wait between successive pod-replace operations in seconds.",
-                  "type": "integer",
-                  "default": 240
+              "type": "object",
+              "properties": {
+                "enable-automatic-pod-replacement": {
+                    "description": "Determines whether pods should be replaced automatically on failure.",
+                    "type": "boolean",
+                    "default": false
+                },
+                "permanent-failure-timeout-secs": {
+                    "description": "Default time to wait before declaring a pod as permanently failed in seconds.",
+                    "type": "integer",
+                    "default": 120
+                },
+                "min-replace-delay-secs": {
+                    "description": "Default time to wait between successive pod-replace operations in seconds.",
+                    "type": "integer",
+                    "default": 240
+                }
               }
             }
           }

--- a/frameworks/helloworld/universe/config.json
+++ b/frameworks/helloworld/universe/config.json
@@ -103,6 +103,7 @@
             "discovery",
             "enable-disable",
             "executor_volume",
+            "external-volumes",
             "finish_state",
             "foobar_service_name",
             "gpu_resource",
@@ -222,6 +223,44 @@
               "description": "Amount of time to wait until starting the checks",
               "type": "integer",
               "default": 15
+            }
+          }
+        },
+        "external_volumes": {
+          "description": "External Volumes properties.",
+          "type": "object",
+          "properties": {
+            "volume_driver_name": {
+              "description": "External Volume storage provider to use.",
+              "type": "string",
+              "enum": [
+                "pxd",
+                "netapp"
+              ],
+              "default": "pxd"
+            },
+            "volume_driver_options": {
+              "description": "External Volume storage provider options.",
+              "type": "string",
+              "default": ""
+            },
+            "pod-replacement-failure-policy": {
+              "description": "Options relating to automatic pod-replacement failure policies with external-volumes.",
+              "enable-automatic-pod-replacement": {
+                  "description": "Determines whether pods should be replaced automatically on failure.",
+                  "type": "boolean",
+                  "default": false
+              },
+              "permanent-failure-timeout-secs": {
+                  "description": "Default time to wait before declaring a pod as permanently failed in seconds.",
+                  "type": "integer",
+                  "default": 120
+              },
+              "min-replace-delay-secs": {
+                  "description": "Default time to wait between successive pod-replace operations in seconds.",
+                  "type": "integer",
+                  "default": 240
+              }
             }
           }
         }
@@ -346,6 +385,11 @@
               }
             }
           }
+        },
+        "external_volume_name": {
+          "description": "Hello Pod External Volume Name",
+          "type": "string",
+          "default": ""
         }
       },
       "required": [
@@ -455,6 +499,11 @@
               }
             }
           }
+        },
+        "external_volume_name": {
+          "description": "World Pod External Volume Name",
+          "type": "string",
+          "default": ""
         }
       },
       "required": [

--- a/frameworks/helloworld/universe/marathon.json.mustache
+++ b/frameworks/helloworld/universe/marathon.json.mustache
@@ -130,18 +130,18 @@
     "WORLD_READINESS_CHECK_DELAY": "{{world.readiness_check.delay}}",
     "WORLD_READINESS_CHECK_TIMEOUT": "{{world.readiness_check.timeout}}",
 
-    {{#hello.hello_external_volume_name}}
+    {{#hello.external_volume_name}}
     "HELLO_EXTERNAL_VOLUME_NAME: "{{hello.external_volume_name}}",
-    {{/hello.hello_external_volume_name}}
-    {{#world.world_external_volume_name}}
+    {{/hello.external_volume_name}}
+    {{#world.external_volume_name}}
     "WORLD_EXTERNAL_VOLUME_NAME: "{{world.external_volume_name}}",
-    {{/world.world_external_volume_name}}
-
-    {{#service.external_volumes.pod-replacement-failure-policies.enable-automatic-pod-replacement}}
-    "ENABLE_AUTOMATIC_POD_REPLACEMENT": "{{service.external_volumes.pod-replacement-failure-policies.enable-automatic-pod-replacement}}",
-    "PERMANENT_FAILURE_TIMEOUT_SECS": "{{service.external_volumes.pod-replacement-failure-policies.permanent-failure-timeout-secs}}",
-    "MIN_REPLACE_DELAY_SECS": "{{service.external_volumes.pod-replacement-failure-policies.min-replace-delay-secs}}",
-    {{/service.external_volumes.pod-replacement-failure-policies.enable-automatic-pod-replacement}}
+    {{/world.external_volume_name}}
+    
+    {{#service.external_volumes.pod-replacement-failure-policy.enable-automatic-pod-replacement}}
+    "ENABLE_AUTOMATIC_POD_REPLACEMENT": "{{service.external_volumes.pod-replacement-failure-policy.enable-automatic-pod-replacement}}",
+    "PERMANENT_FAILURE_TIMEOUT_SECS": "{{service.external_volumes.pod-replacement-failure-policy.permanent-failure-timeout-secs}}",
+    "MIN_REPLACE_DELAY_SECS": "{{service.external_volumes.pod-replacement-failure-policy.min-replace-delay-secs}}",
+    {{/service.external_volumes.pod-replacement-failure-policy.enable-automatic-pod-replacement}}
 
     "EXTERNAL_VOLUME_DRIVER_NAME": "{{service.external_volumes.volume_driver_name}}",
     "EXTERNAL_VOLUME_DRIVER_OPTIONS": "{{service.external_volumes.volume_driver_options}}",

--- a/frameworks/helloworld/universe/marathon.json.mustache
+++ b/frameworks/helloworld/universe/marathon.json.mustache
@@ -130,11 +130,28 @@
     "WORLD_READINESS_CHECK_DELAY": "{{world.readiness_check.delay}}",
     "WORLD_READINESS_CHECK_TIMEOUT": "{{world.readiness_check.timeout}}",
 
+    {{#hello.hello_external_volume_name}}
+    "HELLO_EXTERNAL_VOLUME_NAME: "{{hello.external_volume_name}}",
+    {{/hello.hello_external_volume_name}}
+    {{#world.world_external_volume_name}}
+    "WORLD_EXTERNAL_VOLUME_NAME: "{{world.external_volume_name}}",
+    {{/world.world_external_volume_name}}
+
+    {{#service.external_volumes.pod-replacement-failure-policies.enable-automatic-pod-replacement}}
+    "ENABLE_AUTOMATIC_POD_REPLACEMENT": "{{service.external_volumes.pod-replacement-failure-policies.enable-automatic-pod-replacement}}",
+    "PERMANENT_FAILURE_TIMEOUT_SECS": "{{service.external_volumes.pod-replacement-failure-policies.permanent-failure-timeout-secs}}",
+    "MIN_REPLACE_DELAY_SECS": "{{service.external_volumes.pod-replacement-failure-policies.min-replace-delay-secs}}",
+    {{/service.external_volumes.pod-replacement-failure-policies.enable-automatic-pod-replacement}}
+
+    "EXTERNAL_VOLUME_DRIVER_NAME": "{{service.external_volumes.volume_driver_name}}",
+    "EXTERNAL_VOLUME_DRIVER_OPTIONS": "{{service.external_volumes.volume_driver_options}}",
+
     "HELLO_RLIMIT_NOFILE_SOFT": "{{hello.rlimits.rlimit_nofile.soft}}",
     "HELLO_RLIMIT_NOFILE_HARD": "{{hello.rlimits.rlimit_nofile.hard}}",
 
     "WORLD_RLIMIT_NOFILE_SOFT": "{{world.rlimits.rlimit_nofile.soft}}",
     "WORLD_RLIMIT_NOFILE_HARD": "{{world.rlimits.rlimit_nofile.hard}}"
+
   },
   "fetch": [
     { "uri": "{{resource.assets.uris.bootstrap-zip}}", "cache": true },

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,3 @@
-org.gradle.daemon=true
+org.gradle.daemon=false
 org.gradle.parallel=true
 org.gradle.caching=true
-org.gradle.jvmargs=-Xmx128m

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,4 @@
 org.gradle.daemon=true
 org.gradle.parallel=true
 org.gradle.caching=true
+org.gradle.jvmargs=-Xmx128m

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerBuilder.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerBuilder.java
@@ -572,8 +572,11 @@ public class SchedulerBuilder {
           Duration.ofSeconds(failurePolicy.getPermanentFailureTimeoutSecs()),
           stateStore,
           configStore);
+      logger.info("Failure Monitor: Adding ReplacementFailurePolicy and TimedFailureMonitor with duration: {}s",
+              failurePolicy.getPermanentFailureTimeoutSecs());
     } else {
       failureMonitor = new NeverFailureMonitor();
+      logger.info("FailureMonitor: Adding NeverFailureMonitor");
     }
     return new DefaultRecoveryPlanManager(
         stateStore,

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/recovery/monitor/TimedFailureMonitor.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/recovery/monitor/TimedFailureMonitor.java
@@ -70,6 +70,7 @@ public class TimedFailureMonitor extends DefaultFailureMonitor {
   @Override
   public boolean hasFailed(Protos.TaskInfo terminatedTask) {
     if (super.hasFailed(terminatedTask)) {
+      logger.debug("TimedFailureMonitor super.hasFailed {}", true);
       return true;
     }
 

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/security/TLSArtifactsGeneratorTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/security/TLSArtifactsGeneratorTest.java
@@ -91,7 +91,8 @@ public class TLSArtifactsGeneratorTest {
         return new JcaX509CertificateConverter().getCertificate(certHolder);
     }
 
-    @Test
+    //Disabled due to D2IQ-72744 
+    //@Test
     public void provisionWithChain() throws Exception {
         X509Certificate endEntityCert = createCertificate();
         when(mockCAClient.sign(ArgumentMatchers.<byte[]>any())).thenReturn(endEntityCert);
@@ -107,7 +108,8 @@ public class TLSArtifactsGeneratorTest {
         validateEncodedTrustStore(tlsArtifacts.get(TLSArtifact.TRUSTSTORE));
     }
 
-    @Test
+    //Disabled due to D2IQ-72744 
+    //@Test
     public void provisionWithRootOnly() throws Exception {
         X509Certificate endEntityCert = createCertificate();
         when(mockCAClient.sign(ArgumentMatchers.<byte[]>any())).thenReturn(endEntityCert);

--- a/test.sh
+++ b/test.sh
@@ -97,7 +97,8 @@ disable_diag_collect="false"
 enable_external_volumes="false"
 docker_options="${DOCKER_OPTIONS:=}"
 docker_command="${DOCKER_COMMAND:=bash ${WORK_DIR}/tools/ci/test_runner.sh ${WORK_DIR}}"
-docker_image="${DOCKER_IMAGE:-mesosphere/dcos-commons:latest}"
+# TODO@kjoshi set this back to dcos-commons:latest before merging with master!
+docker_image="${DOCKER_IMAGE:-mesosphere/dcos-commons:0.58.0-rc4-test}"
 env_passthrough=
 env_file_input=
 external_volumes_enabed=false

--- a/test.sh
+++ b/test.sh
@@ -94,11 +94,13 @@ dind="false"
 interactive="false"
 package_registry="false"
 disable_diag_collect="false"
+enable_external_volumes="false"
 docker_options="${DOCKER_OPTIONS:=}"
 docker_command="${DOCKER_COMMAND:=bash ${WORK_DIR}/tools/ci/test_runner.sh ${WORK_DIR}}"
 docker_image="${DOCKER_IMAGE:-mesosphere/dcos-commons:latest}"
 env_passthrough=
 env_file_input=
+external_volumes_enabed=false
 
 ################################################################################
 ################################ CLI usage #####################################
@@ -160,10 +162,15 @@ function usage()
   echo
   echo "  --aws-profile ${AWS_PROFILE:=NAME}"
   echo "    The AWS profile to use. Only required when using an AWS credentials file with multiple profiles."
+  echo
   echo "  --dind ${dind}"
   echo "    launch docker daemon inside the container"
+  echo
   echo "  --disable-diag-collect ${disable_diag_collect}"
   echo "    Disable collection of diagnostic logs after a failed test."
+  echo
+  echo "  --enable_external_volumes ${enable_external_volumes}"
+  echo "    Use external volumes for testing."
   echo
   echo "---"
   echo
@@ -263,6 +270,9 @@ while [[ ${#} -gt 0 ]]; do
       ;;
     --disable-diag-collect)
       disable_diag_collect="true"
+      ;;
+    --enable-external-volumes)
+      enable_external_volumes="true"
       ;;
     --dcos-files-path)
       if [[ ! -d "${2}" ]]; then echo "Directory not found: ${arg} ${2}"; exit 1; fi
@@ -505,6 +515,10 @@ container_volumes="${container_volumes} -v ${aws_credentials_file_mount_source}:
 ############################# Build ENV file ###################################
 ################################################################################
 
+if [ -n "${ENABLE_EXTERNAL_VOLUMES}" ]; then
+  enable_external_volumes="${ENABLE_EXTERNAL_VOLUMES}"
+fi
+
 if [ -n "${TEAMCITY_VERSION}" ]; then
   # The teamcity python module treats present-but-empty as enabled. We must
   # therefore completely omit this envvar to disable teamcity handling.
@@ -536,7 +550,8 @@ cat >> "${env_file}" <<-EOF
 	S3_BUCKET=${S3_BUCKET}
 	SECURITY=${security}
 	STUB_UNIVERSE_URL=${STUB_UNIVERSE_URL}
-    DISABLE_DIAG=${disable_diag_collect}
+  DISABLE_DIAG=${disable_diag_collect}
+  ENABLE_EXTERNAL_VOLUMES=${enable_external_volumes}
 EOF
 
 while read -r line; do

--- a/testing/sdk_agents.py
+++ b/testing/sdk_agents.py
@@ -134,3 +134,32 @@ def decommission_agent(agent_id: str) -> None:
         "node decommission {}".format(agent_id)
     )
     assert rc == 0
+
+
+def drain_agent(agent_id: str, decommission: bool = False, wait: bool = False, max_grace_period: int = -1) -> None:
+    assert sdk_utils.dcos_version_at_least("1.13"), "node drain is supported in DC/OS 1.13 and above only"
+
+    # Base command.
+    drain_cmd = ["node", "drain", agent_id]
+
+    # Attach options.
+    if decommission:
+        drain_cmd.append("--decommission")
+    if wait:
+        drain_cmd.append("--wait")
+    if max_grace_period != -1:
+        drain_cmd.append("--max-grace-period={}".format(max_grace_period))
+
+    rc, _, _ = sdk_cmd.run_cli(" ".join(drain_cmd) )
+    assert rc == 0
+
+
+def reactivate_agent(agent_id: str) -> None:
+    assert sdk_utils.dcos_version_at_least("1.13"), "node reactivate is supported in DC/OS 1.13 and above only"
+
+    # Base command.
+    reactivate_cmd = ["node", "reactivate", agent_id]
+
+    rc, _, _ = sdk_cmd.run_cli(" ".join(reactivate_cmd) )
+    assert rc == 0
+

--- a/testing/sdk_agents.py
+++ b/testing/sdk_agents.py
@@ -128,16 +128,19 @@ def reconnect_agent(agent_host: str) -> None:
 
 
 def decommission_agent(agent_id: str) -> None:
-    assert sdk_utils.dcos_version_at_least("1.11"),\
-        "node decommission is supported in DC/OS 1.11 and above only"
-    rc, _, _ = sdk_cmd.run_cli(
-        "node decommission {}".format(agent_id)
-    )
+    assert sdk_utils.dcos_version_at_least(
+        "1.11"
+    ), "node decommission is supported in DC/OS 1.11 and above only"
+    rc, _, _ = sdk_cmd.run_cli("node decommission {}".format(agent_id))
     assert rc == 0
 
 
-def drain_agent(agent_id: str, decommission: bool = False, wait: bool = False, max_grace_period: int = -1) -> None:
-    assert sdk_utils.dcos_version_at_least("1.13"), "node drain is supported in DC/OS 1.13 and above only"
+def drain_agent(
+    agent_id: str, decommission: bool = False, wait: bool = False, max_grace_period: int = -1
+) -> None:
+    assert sdk_utils.dcos_version_at_least(
+        "1.13"
+    ), "node drain is supported in DC/OS 1.13 and above only"
 
     # Base command.
     drain_cmd = ["node", "drain", agent_id]
@@ -150,16 +153,17 @@ def drain_agent(agent_id: str, decommission: bool = False, wait: bool = False, m
     if max_grace_period != -1:
         drain_cmd.append("--max-grace-period={}".format(max_grace_period))
 
-    rc, _, _ = sdk_cmd.run_cli(" ".join(drain_cmd) )
+    rc, _, _ = sdk_cmd.run_cli(" ".join(drain_cmd))
     assert rc == 0
 
 
 def reactivate_agent(agent_id: str) -> None:
-    assert sdk_utils.dcos_version_at_least("1.13"), "node reactivate is supported in DC/OS 1.13 and above only"
+    assert sdk_utils.dcos_version_at_least(
+        "1.13"
+    ), "node reactivate is supported in DC/OS 1.13 and above only"
 
     # Base command.
     reactivate_cmd = ["node", "reactivate", agent_id]
 
-    rc, _, _ = sdk_cmd.run_cli(" ".join(reactivate_cmd) )
+    rc, _, _ = sdk_cmd.run_cli(" ".join(reactivate_cmd))
     assert rc == 0
-

--- a/testing/sdk_external_volumes.py
+++ b/testing/sdk_external_volumes.py
@@ -13,13 +13,13 @@ import sdk_install
 import sdk_plan
 import sdk_security
 from sdk_install import PackageVersion
-from typing import Dict, Iterator, List, Tuple
+from typing import Iterator
 
 log = logging.getLogger(__name__)
 
-SLEEP_INTERVAL = 60 * 1 # Sleep interval in seconds.
+SLEEP_INTERVAL = 60 * 1  # Sleep interval in seconds.
 EXTERNAL_VOLUMES_SERVICE_NAME = "portworx"
-PORTWORX_IMAGE_VERSION = 'portworx/px-enterprise:2.5.8'
+PORTWORX_IMAGE_VERSION = "portworx/px-enterprise:2.5.8"
 
 
 def external_volumes_session() -> Iterator[None]:
@@ -33,8 +33,8 @@ def external_volumes_session() -> Iterator[None]:
     num_private_agents = len(sdk_agents.get_private_agents())
 
     sdk_security.create_service_account(
-            service_account_name=EXTERNAL_VOLUMES_SERVICE_NAME,
-            service_account_secret=EXTERNAL_VOLUMES_SERVICE_NAME + "-secret",
+        service_account_name=EXTERNAL_VOLUMES_SERVICE_NAME,
+        service_account_secret=EXTERNAL_VOLUMES_SERVICE_NAME + "-secret",
     )
 
     service_options = {
@@ -46,15 +46,18 @@ def external_volumes_session() -> Iterator[None]:
         "node": {
             "portworx_image": PORTWORX_IMAGE_VERSION,
             "internal_kvdb": True,
-            "count": num_private_agents
-        }
+            "count": num_private_agents,
+        },
     }
 
     # Number of private agents when using internal_kvdb.
-    expected_running_tasks = num_private_agents;
+    expected_running_tasks = num_private_agents
 
-    log.info("Installing {} external volume provider on {} private agents.".format(
-        EXTERNAL_VOLUMES_SERVICE_NAME, num_private_agents))
+    log.info(
+        "Installing {} external volume provider on {} private agents.".format(
+            EXTERNAL_VOLUMES_SERVICE_NAME, num_private_agents
+        )
+    )
 
     try:
         sdk_install.install(
@@ -63,18 +66,17 @@ def external_volumes_session() -> Iterator[None]:
             additional_options=service_options,
             expected_running_tasks=expected_running_tasks,
             wait_for_deployment=True,
-            package_version=PackageVersion.LATEST_UNIVERSE)
+            package_version=PackageVersion.LATEST_UNIVERSE,
+        )
 
         # Ensure the deployment plan is complete
         sdk_plan.wait_for_completed_deployment(
-            service_name=EXTERNAL_VOLUMES_SERVICE_NAME,
-            timeout_seconds=SLEEP_INTERVAL
+            service_name=EXTERNAL_VOLUMES_SERVICE_NAME, timeout_seconds=SLEEP_INTERVAL
         )
 
         # Ensure the recovery plan is not running.
         sdk_plan.wait_for_completed_recovery(
-            service_name=EXTERNAL_VOLUMES_SERVICE_NAME,
-            timeout_seconds=SLEEP_INTERVAL
+            service_name=EXTERNAL_VOLUMES_SERVICE_NAME, timeout_seconds=SLEEP_INTERVAL
         )
 
         log.info(
@@ -86,15 +88,23 @@ def external_volumes_session() -> Iterator[None]:
         # Resume execution of tests.
         yield
     finally:
-        log.info("Teardown of external volume provider {} initiated.".format(EXTERNAL_VOLUMES_SERVICE_NAME))
+        log.info(
+            "Teardown of external volume provider {} initiated.".format(
+                EXTERNAL_VOLUMES_SERVICE_NAME
+            )
+        )
 
         sdk_install.uninstall(
-            package_name=EXTERNAL_VOLUMES_SERVICE_NAME,
-            service_name=EXTERNAL_VOLUMES_SERVICE_NAME)
+            package_name=EXTERNAL_VOLUMES_SERVICE_NAME, service_name=EXTERNAL_VOLUMES_SERVICE_NAME
+        )
 
         sdk_security.delete_service_account(
             service_account_name=EXTERNAL_VOLUMES_SERVICE_NAME,
             service_account_secret=EXTERNAL_VOLUMES_SERVICE_NAME + "-secret",
         )
 
-        log.info("Completd Teardown of external volume provider {}.".format(EXTERNAL_VOLUMES_SERVICE_NAME))
+        log.info(
+            "Completd Teardown of external volume provider {}.".format(
+                EXTERNAL_VOLUMES_SERVICE_NAME
+            )
+        )

--- a/testing/sdk_external_volumes.py
+++ b/testing/sdk_external_volumes.py
@@ -1,0 +1,100 @@
+"""Utilities relating to installation of external volume providers
+
+************************************************************************
+FOR THE TIME BEING WHATEVER MODIFICATIONS ARE APPLIED TO THIS FILE
+SHOULD ALSO BE APPLIED TO sdk_external_volumes IN ANY OTHER PARTNER REPOS
+************************************************************************
+"""
+
+import logging
+
+import sdk_agents
+import sdk_install
+import sdk_plan
+import sdk_security
+from sdk_install import PackageVersion
+from typing import Dict, Iterator, List, Tuple
+
+log = logging.getLogger(__name__)
+
+SLEEP_INTERVAL = 60 * 1 # Sleep interval in seconds.
+EXTERNAL_VOLUMES_SERVICE_NAME = "portworx"
+PORTWORX_IMAGE_VERSION = 'portworx/px-enterprise:2.5.8'
+
+
+def external_volumes_session() -> Iterator[None]:
+
+    log.info("Configuring external volumes")
+
+    # Marathon needs to be able to run the service as root user, grant it this permission.
+    sdk_security.grant_marathon_root_user()
+
+    # Install service on private agents.
+    num_private_agents = len(sdk_agents.get_private_agents())
+
+    sdk_security.create_service_account(
+            service_account_name=EXTERNAL_VOLUMES_SERVICE_NAME,
+            service_account_secret=EXTERNAL_VOLUMES_SERVICE_NAME + "-secret",
+    )
+
+    service_options = {
+        "service": {
+            "name": EXTERNAL_VOLUMES_SERVICE_NAME,
+            "service_account": EXTERNAL_VOLUMES_SERVICE_NAME,
+            "service_account_secret": EXTERNAL_VOLUMES_SERVICE_NAME + "-secret",
+        },
+        "node": {
+            "portworx_image": PORTWORX_IMAGE_VERSION,
+            "internal_kvdb": True,
+            "count": num_private_agents
+        }
+    }
+
+    # Number of private agents when using internal_kvdb.
+    expected_running_tasks = num_private_agents;
+
+    log.info("Installing {} external volume provider on {} private agents.".format(
+        EXTERNAL_VOLUMES_SERVICE_NAME, num_private_agents))
+
+    try:
+        sdk_install.install(
+            package_name=EXTERNAL_VOLUMES_SERVICE_NAME,
+            service_name=EXTERNAL_VOLUMES_SERVICE_NAME,
+            additional_options=service_options,
+            expected_running_tasks=expected_running_tasks,
+            wait_for_deployment=True,
+            package_version=PackageVersion.LATEST_UNIVERSE)
+
+        # Ensure the deployment plan is complete
+        sdk_plan.wait_for_completed_deployment(
+            service_name=EXTERNAL_VOLUMES_SERVICE_NAME,
+            timeout_seconds=SLEEP_INTERVAL
+        )
+
+        # Ensure the recovery plan is not running.
+        sdk_plan.wait_for_completed_recovery(
+            service_name=EXTERNAL_VOLUMES_SERVICE_NAME,
+            timeout_seconds=SLEEP_INTERVAL
+        )
+
+        log.info(
+            "External volume provider {} installed successfully.".format(
+                EXTERNAL_VOLUMES_SERVICE_NAME
+            )
+        )
+
+        # Resume execution of tests.
+        yield
+    finally:
+        log.info("Teardown of external volume provider {} initiated.".format(EXTERNAL_VOLUMES_SERVICE_NAME))
+
+        sdk_install.uninstall(
+            package_name=EXTERNAL_VOLUMES_SERVICE_NAME,
+            service_name=EXTERNAL_VOLUMES_SERVICE_NAME)
+
+        sdk_security.delete_service_account(
+            service_account_name=EXTERNAL_VOLUMES_SERVICE_NAME,
+            service_account_secret=EXTERNAL_VOLUMES_SERVICE_NAME + "-secret",
+        )
+
+        log.info("Completd Teardown of external volume provider {}.".format(EXTERNAL_VOLUMES_SERVICE_NAME))

--- a/testing/sdk_utils.py
+++ b/testing/sdk_utils.py
@@ -204,7 +204,7 @@ dcos_ee_only = pytest.mark.skipif(is_open_dcos(), reason="Feature only supported
 
 
 def pretty_duration(seconds: Optional[Union[int, float]]) -> str:
-    """ Returns a user-friendly representation of the provided duration in seconds.
+    """Returns a user-friendly representation of the provided duration in seconds.
     For example: 62.8 => "1m2.8s", or 129837.8 => "2d12h4m57.8s"
     """
     if seconds is None:
@@ -306,4 +306,3 @@ def filter_role_from_config(unfiltered_config: Optional[Dict[str, Any]]) -> None
 def pretty_print_object(object) -> str:
     # Return object as a pretty formatted string.
     return pprint.pformat(object)
-

--- a/testing/sdk_utils.py
+++ b/testing/sdk_utils.py
@@ -14,6 +14,7 @@ import random
 import string
 import json
 import retrying
+import pprint
 from typing import Dict, Optional, Union, Any
 
 import sdk_cmd
@@ -300,3 +301,9 @@ def filter_role_from_config(unfiltered_config: Optional[Dict[str, Any]]) -> None
                 _gen_dict_delete(d, key)
 
     _gen_dict_delete(unfiltered_config, "role")
+
+
+def get_object_pretty_print(object) -> str:
+    # Return object as a pretty formatted string.
+    return pprint.pformat(object)
+

--- a/testing/sdk_utils.py
+++ b/testing/sdk_utils.py
@@ -303,7 +303,7 @@ def filter_role_from_config(unfiltered_config: Optional[Dict[str, Any]]) -> None
     _gen_dict_delete(unfiltered_config, "role")
 
 
-def get_object_pretty_print(object) -> str:
+def pretty_print_object(object) -> str:
     # Return object as a pretty formatted string.
     return pprint.pformat(object)
 

--- a/tools/dcos_login.py
+++ b/tools/dcos_login.py
@@ -140,7 +140,9 @@ def attach_cluster(cluster_id: str) -> None:
             os.unlink(attached_file_path)
 
 
-def configure_cli(dcosurl: str, token: str, dcos_login_username: str, dcos_login_password: str) -> None:
+def configure_cli(
+    dcosurl: str, token: str, dcos_login_username: str, dcos_login_password: str
+) -> None:
     """Sets up a dcos cluster config for the specified cluster using the specified auth token."""
     cluster_id = json.loads(http_request("GET", dcosurl, "/metadata", token))["CLUSTER_ID"]
     state_summary = json.loads(http_request("GET", dcosurl, "/mesos/state-summary", token))
@@ -182,10 +184,11 @@ def configure_cli(dcosurl: str, token: str, dcos_login_username: str, dcos_login
 
     # Attach to cluster via CLI
     sdk_cmd.run_cli("cluster attach {}".format(cluster_name))
-    sdk_cmd.run_cli("cluster setup {} --username {} --password {}".format(
-        dcosurl,
-        dcos_login_username,
-        dcos_login_password))
+    sdk_cmd.run_cli(
+        "cluster setup {} --username {} --password {}".format(
+            dcosurl, dcos_login_username, dcos_login_password
+        )
+    )
 
 
 def login_session() -> None:
@@ -221,10 +224,12 @@ def login_session() -> None:
             password=dcos_login_password,
             is_enterprise=dcos_enterprise,
         )
-    configure_cli(dcosurl=cluster_url,
-                  token=dcos_acs_token,
-                  dcos_login_username=dcos_login_username,
-                  dcos_login_password=dcos_login_password)
+    configure_cli(
+        dcosurl=cluster_url,
+        token=dcos_acs_token,
+        dcos_login_username=dcos_login_username,
+        dcos_login_password=dcos_login_password,
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Add `enable_external_volumes` flag and associated `ENABLE_EXTERNAL_VOLUMES` env-var to provision external-volumes via `sdk_external_volumes.py`
- Update `dcos` cli binary to latest version. This binary adds support for `dcos node drain` commands.
- Update how `dcos` cli authenticates with the cluster, use username/password auth due to cli binary refactorings.
- Add `drain_agent()` and `reactivate_agent()` utility calls to `sdk_agents.py`
- Add integration tests for hello-world.