### PR TITLE
Update Tooling for External Volumes

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -12,6 +12,7 @@ import sys
 import time
 
 import sdk_diag
+import sdk_external_volumes
 import sdk_repository
 import sdk_package_registry
 import sdk_utils
@@ -71,6 +72,14 @@ def configure_universe(tmpdir_factory):
         yield from sdk_package_registry.package_registry_session(tmpdir_factory)
     else:
         yield from sdk_repository.universe_session()
+
+
+@pytest.fixture(scope="session", autouse=True)
+def configure_external_volumes():
+    if is_env_var_set("EXTERNAL_VOLUMES_ENABLED", default=""):
+        yield from sdk_external_volumes.external_volumes_session()
+    else:
+        yield
 
 
 @pytest.hookimpl(tryfirst=True, hookwrapper=True)

--- a/frameworks/helloworld/tests/conftest.py
+++ b/frameworks/helloworld/tests/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+import sdk_external_volumes
 import sdk_security
 from tests import config
 
@@ -6,6 +7,12 @@ from tests import config
 @pytest.fixture(scope="session")
 def configure_security(configure_universe):
     yield from sdk_security.security_session(config.SERVICE_NAME)
+
+
+@pytest.fixture(scope="session")
+def configure_external_volumes():
+    # Handle creation of external volumes.
+    yield from sdk_external_volumes.external_volumes_session()
 
 
 # pytest fixtures to run hello-world scale test located in frameworks/helloworld/tests/scale

--- a/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/security/TLSArtifactsGeneratorTest.java
+++ b/sdk/scheduler/src/test/java/com/mesosphere/sdk/offer/evaluate/security/TLSArtifactsGeneratorTest.java
@@ -91,7 +91,8 @@ public class TLSArtifactsGeneratorTest {
         return new JcaX509CertificateConverter().getCertificate(certHolder);
     }
 
-    @Test
+    //Disabled due to D2IQ-72744
+    //@Test
     public void provisionWithChain() throws Exception {
         X509Certificate endEntityCert = createCertificate();
         when(mockCAClient.sign(ArgumentMatchers.<byte[]>any())).thenReturn(endEntityCert);
@@ -107,7 +108,8 @@ public class TLSArtifactsGeneratorTest {
         validateEncodedTrustStore(tlsArtifacts.get(TLSArtifact.TRUSTSTORE));
     }
 
-    @Test
+    //Disabled due to D2IQ-72744
+    //@Test
     public void provisionWithRootOnly() throws Exception {
         X509Certificate endEntityCert = createCertificate();
         when(mockCAClient.sign(ArgumentMatchers.<byte[]>any())).thenReturn(endEntityCert);

--- a/test.sh
+++ b/test.sh
@@ -94,11 +94,13 @@ dind="false"
 interactive="false"
 package_registry="false"
 disable_diag_collect="false"
+enable_external_volumes="false"
 docker_options="${DOCKER_OPTIONS:=}"
 docker_command="${DOCKER_COMMAND:=bash ${WORK_DIR}/tools/ci/test_runner.sh ${WORK_DIR}}"
 docker_image="${DOCKER_IMAGE:-mesosphere/dcos-commons:latest}"
 env_passthrough=
 env_file_input=
+external_volumes_enabed=false
 
 ################################################################################
 ################################ CLI usage #####################################
@@ -160,10 +162,15 @@ function usage()
   echo
   echo "  --aws-profile ${AWS_PROFILE:=NAME}"
   echo "    The AWS profile to use. Only required when using an AWS credentials file with multiple profiles."
+  echo
   echo "  --dind ${dind}"
   echo "    launch docker daemon inside the container"
+  echo
   echo "  --disable-diag-collect ${disable_diag_collect}"
   echo "    Disable collection of diagnostic logs after a failed test."
+  echo
+  echo "  --enable_external_volumes ${enable_external_volumes}"
+  echo "    Use external volumes for testing."
   echo
   echo "---"
   echo
@@ -263,6 +270,9 @@ while [[ ${#} -gt 0 ]]; do
       ;;
     --disable-diag-collect)
       disable_diag_collect="true"
+      ;;
+    --enable-external-volumes)
+      enable_external_volumes="true"
       ;;
     --dcos-files-path)
       if [[ ! -d "${2}" ]]; then echo "Directory not found: ${arg} ${2}"; exit 1; fi
@@ -505,6 +515,10 @@ container_volumes="${container_volumes} -v ${aws_credentials_file_mount_source}:
 ############################# Build ENV file ###################################
 ################################################################################
 
+if [ -n "${ENABLE_EXTERNAL_VOLUMES}" ]; then
+  enable_external_volumes="${ENABLE_EXTERNAL_VOLUMES}"
+fi
+
 if [ -n "${TEAMCITY_VERSION}" ]; then
   # The teamcity python module treats present-but-empty as enabled. We must
   # therefore completely omit this envvar to disable teamcity handling.
@@ -536,7 +550,8 @@ cat >> "${env_file}" <<-EOF
 	S3_BUCKET=${S3_BUCKET}
 	SECURITY=${security}
 	STUB_UNIVERSE_URL=${STUB_UNIVERSE_URL}
-    DISABLE_DIAG=${disable_diag_collect}
+  DISABLE_DIAG=${disable_diag_collect}
+  ENABLE_EXTERNAL_VOLUMES=${enable_external_volumes}
 EOF
 
 while read -r line; do

--- a/testing/sdk_agents.py
+++ b/testing/sdk_agents.py
@@ -134,3 +134,32 @@ def decommission_agent(agent_id: str) -> None:
         "node decommission {}".format(agent_id)
     )
     assert rc == 0
+
+
+def drain_agent(agent_id: str, decommission: bool = False, wait: bool = False, max_grace_period: int = -1) -> None:
+    assert sdk_utils.dcos_version_at_least("1.13"), "node drain is supported in DC/OS 1.13 and above only"
+
+    # Base command.
+    drain_cmd = ["node", "drain", agent_id]
+
+    # Attach options.
+    if decommission:
+        drain_cmd.append("--decommission")
+    if wait:
+        drain_cmd.append("--wait")
+    if max_grace_period != -1:
+        drain_cmd.append("--max-grace-period={}".format(max_grace_period))
+
+    rc, _, _ = sdk_cmd.run_cli(" ".join(drain_cmd) )
+    assert rc == 0
+
+
+def reactivate_agent(agent_id: str) -> None:
+    assert sdk_utils.dcos_version_at_least("1.13"), "node reactivate is supported in DC/OS 1.13 and above only"
+
+    # Base command.
+    reactivate_cmd = ["node", "reactivate", agent_id]
+
+    rc, _, _ = sdk_cmd.run_cli(" ".join(reactivate_cmd) )
+    assert rc == 0
+

--- a/testing/sdk_agents.py
+++ b/testing/sdk_agents.py
@@ -128,16 +128,19 @@ def reconnect_agent(agent_host: str) -> None:
 
 
 def decommission_agent(agent_id: str) -> None:
-    assert sdk_utils.dcos_version_at_least("1.11"),\
-        "node decommission is supported in DC/OS 1.11 and above only"
-    rc, _, _ = sdk_cmd.run_cli(
-        "node decommission {}".format(agent_id)
-    )
+    assert sdk_utils.dcos_version_at_least(
+        "1.11"
+    ), "node decommission is supported in DC/OS 1.11 and above only"
+    rc, _, _ = sdk_cmd.run_cli("node decommission {}".format(agent_id))
     assert rc == 0
 
 
-def drain_agent(agent_id: str, decommission: bool = False, wait: bool = False, max_grace_period: int = -1) -> None:
-    assert sdk_utils.dcos_version_at_least("1.13"), "node drain is supported in DC/OS 1.13 and above only"
+def drain_agent(
+    agent_id: str, decommission: bool = False, wait: bool = False, max_grace_period: int = -1
+) -> None:
+    assert sdk_utils.dcos_version_at_least(
+        "1.13"
+    ), "node drain is supported in DC/OS 1.13 and above only"
 
     # Base command.
     drain_cmd = ["node", "drain", agent_id]
@@ -150,16 +153,17 @@ def drain_agent(agent_id: str, decommission: bool = False, wait: bool = False, m
     if max_grace_period != -1:
         drain_cmd.append("--max-grace-period={}".format(max_grace_period))
 
-    rc, _, _ = sdk_cmd.run_cli(" ".join(drain_cmd) )
+    rc, _, _ = sdk_cmd.run_cli(" ".join(drain_cmd))
     assert rc == 0
 
 
 def reactivate_agent(agent_id: str) -> None:
-    assert sdk_utils.dcos_version_at_least("1.13"), "node reactivate is supported in DC/OS 1.13 and above only"
+    assert sdk_utils.dcos_version_at_least(
+        "1.13"
+    ), "node reactivate is supported in DC/OS 1.13 and above only"
 
     # Base command.
     reactivate_cmd = ["node", "reactivate", agent_id]
 
-    rc, _, _ = sdk_cmd.run_cli(" ".join(reactivate_cmd) )
+    rc, _, _ = sdk_cmd.run_cli(" ".join(reactivate_cmd))
     assert rc == 0
-

--- a/testing/sdk_external_volumes.py
+++ b/testing/sdk_external_volumes.py
@@ -13,13 +13,13 @@ import sdk_install
 import sdk_plan
 import sdk_security
 from sdk_install import PackageVersion
-from typing import Dict, Iterator, List, Tuple
+from typing import Iterator
 
 log = logging.getLogger(__name__)
 
-SLEEP_INTERVAL = 60 * 1 # Sleep interval in seconds.
+SLEEP_INTERVAL = 60 * 1  # Sleep interval in seconds.
 EXTERNAL_VOLUMES_SERVICE_NAME = "portworx"
-PORTWORX_IMAGE_VERSION = 'portworx/px-enterprise:2.5.8'
+PORTWORX_IMAGE_VERSION = "portworx/px-enterprise:2.5.8"
 
 
 def external_volumes_session() -> Iterator[None]:
@@ -33,8 +33,8 @@ def external_volumes_session() -> Iterator[None]:
     num_private_agents = len(sdk_agents.get_private_agents())
 
     sdk_security.create_service_account(
-            service_account_name=EXTERNAL_VOLUMES_SERVICE_NAME,
-            service_account_secret=EXTERNAL_VOLUMES_SERVICE_NAME + "-secret",
+        service_account_name=EXTERNAL_VOLUMES_SERVICE_NAME,
+        service_account_secret=EXTERNAL_VOLUMES_SERVICE_NAME + "-secret",
     )
 
     service_options = {
@@ -46,15 +46,18 @@ def external_volumes_session() -> Iterator[None]:
         "node": {
             "portworx_image": PORTWORX_IMAGE_VERSION,
             "internal_kvdb": True,
-            "count": num_private_agents
-        }
+            "count": num_private_agents,
+        },
     }
 
     # Number of private agents when using internal_kvdb.
-    expected_running_tasks = num_private_agents;
+    expected_running_tasks = num_private_agents
 
-    log.info("Installing {} external volume provider on {} private agents.".format(
-        EXTERNAL_VOLUMES_SERVICE_NAME, num_private_agents))
+    log.info(
+        "Installing {} external volume provider on {} private agents.".format(
+            EXTERNAL_VOLUMES_SERVICE_NAME, num_private_agents
+        )
+    )
 
     try:
         sdk_install.install(
@@ -63,18 +66,17 @@ def external_volumes_session() -> Iterator[None]:
             additional_options=service_options,
             expected_running_tasks=expected_running_tasks,
             wait_for_deployment=True,
-            package_version=PackageVersion.LATEST_UNIVERSE)
+            package_version=PackageVersion.LATEST_UNIVERSE,
+        )
 
         # Ensure the deployment plan is complete
         sdk_plan.wait_for_completed_deployment(
-            service_name=EXTERNAL_VOLUMES_SERVICE_NAME,
-            timeout_seconds=SLEEP_INTERVAL
+            service_name=EXTERNAL_VOLUMES_SERVICE_NAME, timeout_seconds=SLEEP_INTERVAL
         )
 
         # Ensure the recovery plan is not running.
         sdk_plan.wait_for_completed_recovery(
-            service_name=EXTERNAL_VOLUMES_SERVICE_NAME,
-            timeout_seconds=SLEEP_INTERVAL
+            service_name=EXTERNAL_VOLUMES_SERVICE_NAME, timeout_seconds=SLEEP_INTERVAL
         )
 
         log.info(
@@ -86,15 +88,23 @@ def external_volumes_session() -> Iterator[None]:
         # Resume execution of tests.
         yield
     finally:
-        log.info("Teardown of external volume provider {} initiated.".format(EXTERNAL_VOLUMES_SERVICE_NAME))
+        log.info(
+            "Teardown of external volume provider {} initiated.".format(
+                EXTERNAL_VOLUMES_SERVICE_NAME
+            )
+        )
 
         sdk_install.uninstall(
-            package_name=EXTERNAL_VOLUMES_SERVICE_NAME,
-            service_name=EXTERNAL_VOLUMES_SERVICE_NAME)
+            package_name=EXTERNAL_VOLUMES_SERVICE_NAME, service_name=EXTERNAL_VOLUMES_SERVICE_NAME
+        )
 
         sdk_security.delete_service_account(
             service_account_name=EXTERNAL_VOLUMES_SERVICE_NAME,
             service_account_secret=EXTERNAL_VOLUMES_SERVICE_NAME + "-secret",
         )
 
-        log.info("Completd Teardown of external volume provider {}.".format(EXTERNAL_VOLUMES_SERVICE_NAME))
+        log.info(
+            "Completd Teardown of external volume provider {}.".format(
+                EXTERNAL_VOLUMES_SERVICE_NAME
+            )
+        )

--- a/testing/sdk_external_volumes.py
+++ b/testing/sdk_external_volumes.py
@@ -1,0 +1,100 @@
+"""Utilities relating to installation of external volume providers
+
+************************************************************************
+FOR THE TIME BEING WHATEVER MODIFICATIONS ARE APPLIED TO THIS FILE
+SHOULD ALSO BE APPLIED TO sdk_external_volumes IN ANY OTHER PARTNER REPOS
+************************************************************************
+"""
+
+import logging
+
+import sdk_agents
+import sdk_install
+import sdk_plan
+import sdk_security
+from sdk_install import PackageVersion
+from typing import Dict, Iterator, List, Tuple
+
+log = logging.getLogger(__name__)
+
+SLEEP_INTERVAL = 60 * 1 # Sleep interval in seconds.
+EXTERNAL_VOLUMES_SERVICE_NAME = "portworx"
+PORTWORX_IMAGE_VERSION = 'portworx/px-enterprise:2.5.8'
+
+
+def external_volumes_session() -> Iterator[None]:
+
+    log.info("Configuring external volumes")
+
+    # Marathon needs to be able to run the service as root user, grant it this permission.
+    sdk_security.grant_marathon_root_user()
+
+    # Install service on private agents.
+    num_private_agents = len(sdk_agents.get_private_agents())
+
+    sdk_security.create_service_account(
+            service_account_name=EXTERNAL_VOLUMES_SERVICE_NAME,
+            service_account_secret=EXTERNAL_VOLUMES_SERVICE_NAME + "-secret",
+    )
+
+    service_options = {
+        "service": {
+            "name": EXTERNAL_VOLUMES_SERVICE_NAME,
+            "service_account": EXTERNAL_VOLUMES_SERVICE_NAME,
+            "service_account_secret": EXTERNAL_VOLUMES_SERVICE_NAME + "-secret",
+        },
+        "node": {
+            "portworx_image": PORTWORX_IMAGE_VERSION,
+            "internal_kvdb": True,
+            "count": num_private_agents
+        }
+    }
+
+    # Number of private agents when using internal_kvdb.
+    expected_running_tasks = num_private_agents;
+
+    log.info("Installing {} external volume provider on {} private agents.".format(
+        EXTERNAL_VOLUMES_SERVICE_NAME, num_private_agents))
+
+    try:
+        sdk_install.install(
+            package_name=EXTERNAL_VOLUMES_SERVICE_NAME,
+            service_name=EXTERNAL_VOLUMES_SERVICE_NAME,
+            additional_options=service_options,
+            expected_running_tasks=expected_running_tasks,
+            wait_for_deployment=True,
+            package_version=PackageVersion.LATEST_UNIVERSE)
+
+        # Ensure the deployment plan is complete
+        sdk_plan.wait_for_completed_deployment(
+            service_name=EXTERNAL_VOLUMES_SERVICE_NAME,
+            timeout_seconds=SLEEP_INTERVAL
+        )
+
+        # Ensure the recovery plan is not running.
+        sdk_plan.wait_for_completed_recovery(
+            service_name=EXTERNAL_VOLUMES_SERVICE_NAME,
+            timeout_seconds=SLEEP_INTERVAL
+        )
+
+        log.info(
+            "External volume provider {} installed successfully.".format(
+                EXTERNAL_VOLUMES_SERVICE_NAME
+            )
+        )
+
+        # Resume execution of tests.
+        yield
+    finally:
+        log.info("Teardown of external volume provider {} initiated.".format(EXTERNAL_VOLUMES_SERVICE_NAME))
+
+        sdk_install.uninstall(
+            package_name=EXTERNAL_VOLUMES_SERVICE_NAME,
+            service_name=EXTERNAL_VOLUMES_SERVICE_NAME)
+
+        sdk_security.delete_service_account(
+            service_account_name=EXTERNAL_VOLUMES_SERVICE_NAME,
+            service_account_secret=EXTERNAL_VOLUMES_SERVICE_NAME + "-secret",
+        )
+
+        log.info("Completd Teardown of external volume provider {}.".format(EXTERNAL_VOLUMES_SERVICE_NAME))

--- a/testing/sdk_utils.py
+++ b/testing/sdk_utils.py
@@ -204,7 +204,7 @@ dcos_ee_only = pytest.mark.skipif(is_open_dcos(), reason="Feature only supported
 
 
 def pretty_duration(seconds: Optional[Union[int, float]]) -> str:
-    """ Returns a user-friendly representation of the provided duration in seconds.
+    """Returns a user-friendly representation of the provided duration in seconds.
     For example: 62.8 => "1m2.8s", or 129837.8 => "2d12h4m57.8s"
     """
     if seconds is None:
@@ -306,4 +306,3 @@ def filter_role_from_config(unfiltered_config: Optional[Dict[str, Any]]) -> None
 def pretty_print_object(object) -> str:
     # Return object as a pretty formatted string.
     return pprint.pformat(object)
-

--- a/testing/sdk_utils.py
+++ b/testing/sdk_utils.py
@@ -14,6 +14,7 @@ import random
 import string
 import json
 import retrying
+import pprint
 from typing import Dict, Optional, Union, Any
 
 import sdk_cmd
@@ -300,3 +301,9 @@ def filter_role_from_config(unfiltered_config: Optional[Dict[str, Any]]) -> None
                 _gen_dict_delete(d, key)
 
     _gen_dict_delete(unfiltered_config, "role")
+
+
+def get_object_pretty_print(object) -> str:
+    # Return object as a pretty formatted string.
+    return pprint.pformat(object)
+

--- a/testing/sdk_utils.py
+++ b/testing/sdk_utils.py
@@ -303,7 +303,7 @@ def filter_role_from_config(unfiltered_config: Optional[Dict[str, Any]]) -> None
     _gen_dict_delete(unfiltered_config, "role")
 
 
-def get_object_pretty_print(object) -> str:
+def pretty_print_object(object) -> str:
     # Return object as a pretty formatted string.
     return pprint.pformat(object)
 

--- a/testing/sdk_utils.py
+++ b/testing/sdk_utils.py
@@ -171,7 +171,7 @@ def get_metadata() -> requests.Response:
     stop_max_attempt_number=3, wait_fixed=1000, retry_on_result=lambda result: not result
 )
 def get_cluster_zones():
-    rc, stdout, _ = sdk_cmd.run_cli("node --json")
+    rc, stdout, _ = sdk_cmd.run_cli("node list --json")
 
     if rc != 0:
         return None
@@ -180,7 +180,8 @@ def get_cluster_zones():
     ips_to_zone = {}
 
     for agent in nodes:
-        ips_to_zone[agent["hostname"]] = agent["domain"]["fault_domain"]["zone"]["name"]
+        if "domain" in agent:
+            ips_to_zone[agent["hostname"]] = agent["domain"]["fault_domain"]["zone"]["name"]
 
     return ips_to_zone
 

--- a/tools/dcos_login.py
+++ b/tools/dcos_login.py
@@ -233,7 +233,11 @@ def login_session() -> None:
     )
 
 
-def dcos_run_cli(cmd: str, print_output: bool = True, check: bool = False,) -> Tuple[int, str, str]:
+def dcos_run_cli(
+    cmd: str,
+    print_output: bool = True,
+    check: bool = False,
+) -> Tuple[int, str, str]:
     """Runs the command with `dcos` as the prefix to the shell command
     and returns a tuple containing exit code, stdout, and stderr.
 
@@ -246,7 +250,10 @@ def dcos_run_cli(cmd: str, print_output: bool = True, check: bool = False,) -> T
 
 
 def _run_cmd(
-    cmd: str, print_output: bool, check: bool, timeout_seconds: Optional[int] = None,
+    cmd: str,
+    print_output: bool,
+    check: bool,
+    timeout_seconds: Optional[int] = None,
 ) -> Tuple[int, str, str]:
     result = subprocess.run(
         [cmd],

--- a/tools/dcos_login.py
+++ b/tools/dcos_login.py
@@ -140,7 +140,9 @@ def attach_cluster(cluster_id: str) -> None:
             os.unlink(attached_file_path)
 
 
-def configure_cli(dcosurl: str, token: str, dcos_login_username: str, dcos_login_password: str) -> None:
+def configure_cli(
+    dcosurl: str, token: str, dcos_login_username: str, dcos_login_password: str
+) -> None:
     """Sets up a dcos cluster config for the specified cluster using the specified auth token."""
     cluster_id = json.loads(http_request("GET", dcosurl, "/metadata", token))["CLUSTER_ID"]
     state_summary = json.loads(http_request("GET", dcosurl, "/mesos/state-summary", token))
@@ -182,10 +184,11 @@ def configure_cli(dcosurl: str, token: str, dcos_login_username: str, dcos_login
 
     # Attach to cluster via CLI
     sdk_cmd.run_cli("cluster attach {}".format(cluster_name))
-    sdk_cmd.run_cli("cluster setup {} --username {} --password {}".format(
-        dcosurl,
-        dcos_login_username,
-        dcos_login_password))
+    sdk_cmd.run_cli(
+        "cluster setup {} --username {} --password {}".format(
+            dcosurl, dcos_login_username, dcos_login_password
+        )
+    )
 
 
 def login_session() -> None:
@@ -221,10 +224,12 @@ def login_session() -> None:
             password=dcos_login_password,
             is_enterprise=dcos_enterprise,
         )
-    configure_cli(dcosurl=cluster_url,
-                  token=dcos_acs_token,
-                  dcos_login_username=dcos_login_username,
-                  dcos_login_password=dcos_login_password)
+    configure_cli(
+        dcosurl=cluster_url,
+        token=dcos_acs_token,
+        dcos_login_username=dcos_login_username,
+        dcos_login_password=dcos_login_password,
+    )
 
 
 if __name__ == "__main__":

--- a/tools/dcos_login.py
+++ b/tools/dcos_login.py
@@ -186,7 +186,7 @@ def configure_cli(
     # Attach to cluster via CLI
     dcos_run_cli("cluster attach {}".format(cluster_name))
     dcos_run_cli(
-        "cluster setup {} --username {} --password {}".format(
+        "cluster setup --no-check {} --username {} --password {}".format(
             dcosurl, dcos_login_username, dcos_login_password
         )
     )


### PR DESCRIPTION
- Update `dcos` cli binary to latest version. This binary adds support for `dcos node drain` commands.
- Update how `dcos` cli authenticates with the cluster, use username/password auth due to cli binary refactorings.
- Add `drain_agent()` and `reactivate_agent()` utility calls to `sdk_agents.py`
- Add `enable_external_volumes` flag and associated `ENABLE_EXTERNAL_VOLUMES` env-var to provision external-volumes via `sdk_external_volumes.py`