### PR TITLE
[WIP][DNM] Remove use of dcos-commons:latest for dev-builds.

### DIFF
--- a/Jenkinsfile.dcos-commons
+++ b/Jenkinsfile.dcos-commons
@@ -26,6 +26,14 @@ pipeline {
     }
  
     stages {
+
+        stage('Env Variables Available') {
+            steps {
+               sh "printenv"
+            }
+            
+        }
+
         stage('docker login') {
             steps {
                 // Login to the Docker registry.


### PR DESCRIPTION
Currently all PRs use the `dcos-commons:latest` tag as seen [here]https://github.com/mesosphere/dcos-commons/blob/master/Jenkinsfile.dcos-commons#L54).

Having multiple PRs update the test or tooling harnesses becomes difficult in such a scenario where only one image can be tested at any point. This PR investigates fixes to this limitation.