### PR TITLE
Add --insecure flag to dcos-login. Enable external volumes by default. Add --disable-external-volumes flag.

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -76,7 +76,7 @@ def configure_universe(tmpdir_factory):
 
 @pytest.fixture(scope="session", autouse=True)
 def configure_external_volumes():
-    if is_env_var_set("EXTERNAL_VOLUMES_ENABLED", default=""):
+    if is_env_var_set("ENABLE_EXTERNAL_VOLUMES", default=""):
         yield from sdk_external_volumes.external_volumes_session()
     else:
         yield

--- a/frameworks/cassandra/src/main/dist/svc.yml
+++ b/frameworks/cassandra/src/main/dist/svc.yml
@@ -103,14 +103,12 @@ pods:
             port: {{SECURE_JMX_RMI_PORT}}
           {{/TASKCFG_ALL_SECURE_JMX_ENABLED}}
       sidecar-resources:
-        cpus: 0.01
+        cpus: 1
         memory: 1024
     tasks:
       server:
         goal: RUNNING
         resource-set: server-resources
-        resource-limits:
-          cpus: unlimited
         cmd: |
                 set -e
 

--- a/test.sh
+++ b/test.sh
@@ -94,13 +94,12 @@ dind="false"
 interactive="false"
 package_registry="false"
 disable_diag_collect="false"
-enable_external_volumes="false"
+enable_external_volumes="true"
 docker_options="${DOCKER_OPTIONS:=}"
 docker_command="${DOCKER_COMMAND:=bash ${WORK_DIR}/tools/ci/test_runner.sh ${WORK_DIR}}"
 docker_image="${DOCKER_IMAGE:-mesosphere/dcos-commons:latest}"
 env_passthrough=
 env_file_input=
-external_volumes_enabed=false
 
 ################################################################################
 ################################ CLI usage #####################################
@@ -273,6 +272,9 @@ while [[ ${#} -gt 0 ]]; do
       ;;
     --enable-external-volumes)
       enable_external_volumes="true"
+      ;;
+    --disable-external-volumes)
+      enable_external_volumes="false"
       ;;
     --dcos-files-path)
       if [[ ! -d "${2}" ]]; then echo "Directory not found: ${arg} ${2}"; exit 1; fi

--- a/tools/dcos_login.py
+++ b/tools/dcos_login.py
@@ -186,7 +186,7 @@ def configure_cli(
     # Attach to cluster via CLI
     dcos_run_cli("cluster attach {}".format(cluster_name))
     dcos_run_cli(
-        "cluster setup --no-check {} --username {} --password {}".format(
+        "cluster setup --insecure --no-check {} --username {} --password {}".format(
             dcosurl, dcos_login_username, dcos_login_password
         )
     )


### PR DESCRIPTION
- Add `--insecure` flag to dcos-login which prevents authentication with dev clusters.
- Add `--disable-external-volumes` flag.
- Enable external-volumes by default.