### PR TITLE
External Volumes Integration Tests for Hello-World and Cassandra.

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -76,7 +76,7 @@ def configure_universe(tmpdir_factory):
 
 @pytest.fixture(scope="session", autouse=True)
 def configure_external_volumes():
-    if is_env_var_set("ENABLE_EXTERNAL_VOLUMES", default=""):
+    if is_env_var_set("ENABLE_EXTERNAL_VOLUMES", default=str(False)):
         yield from sdk_external_volumes.external_volumes_session()
     else:
         yield

--- a/frameworks/cassandra/src/main/dist/svc.yml
+++ b/frameworks/cassandra/src/main/dist/svc.yml
@@ -63,7 +63,7 @@ pods:
         type: DOCKER
         container-path: container-path
         driver-name: {{CASSANDRA_EXTERNAL_VOLUME_DRIVER_NAME}}
-        driver-options: '{{{CASSANDRA_EXTERNAL_VOLUME_PORTWORX_OPTIONS}}}'
+        driver-options: '{{{CASSANDRA_EXTERNAL_VOLUME_DRIVER_OPTIONS}}}'
         {{#CASSANDRA_EXTERNAL_VOLUME_NAME}}
         volume-name: {{CASSANDRA_EXTERNAL_VOLUME_NAME}}
         {{/CASSANDRA_EXTERNAL_VOLUME_NAME}}

--- a/frameworks/cassandra/tests/conftest.py
+++ b/frameworks/cassandra/tests/conftest.py
@@ -1,6 +1,7 @@
 from typing import Iterator
 
 import pytest
+import sdk_external_volumes
 import sdk_security
 from tests import config
 
@@ -8,3 +9,9 @@ from tests import config
 @pytest.fixture(scope="session")
 def configure_security(configure_universe: None) -> Iterator[None]:
     yield from sdk_security.security_session(config.SERVICE_NAME)
+
+
+@pytest.fixture(scope="session")
+def configure_external_volumes():
+    # Handle creation of external volumes.
+    yield from sdk_external_volumes.external_volumes_session()

--- a/frameworks/cassandra/tests/test_external_volumes.py
+++ b/frameworks/cassandra/tests/test_external_volumes.py
@@ -1,0 +1,88 @@
+import logging
+import pytest
+import re
+
+import sdk_agents
+import sdk_install
+import sdk_plan
+import sdk_tasks
+from tests import config
+
+log = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def configure_package(configure_security):
+    try:
+        sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
+        yield  # let the test session execute
+    finally:
+        sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
+
+
+@pytest.mark.external_volumes
+@pytest.mark.sanity
+@pytest.mark.dcos_min_version("2.1")
+def test_default_deployment():
+    # Test default installation with external volumes.
+    # Ensure service comes up successfully.
+    options = {
+        "service": {
+            "pod-replacement-failure-policy": {
+                "enable-automatic-pod-replacement": True,
+                "permanent-failure-timeout-secs": 30,
+            }
+        },
+        "nodes": {
+            "external_volume": {
+                "enabled": True
+            }
+        }
+    }
+    sdk_install.install(
+        config.PACKAGE_NAME,
+        config.SERVICE_NAME,
+        3,
+        additional_options=options,
+        wait_for_deployment=True,
+    )
+    # Wait for scheduler to restart.
+    sdk_plan.wait_for_completed_deployment(config.SERVICE_NAME)
+
+
+@pytest.mark.external_volumes
+@pytest.mark.sanity
+def test_auto_replace_on_drain():
+    candidate_tasks = sdk_tasks.get_tasks_avoiding_scheduler(
+        config.SERVICE_NAME, re.compile("^node-[0-9]+-server$")
+    )
+
+    assert len(candidate_tasks) != 0, "Could not find a node to drain"
+
+    # Pick the host of the first task from the above list
+    replace_agent_id = candidate_tasks[0].agent_id
+    replace_tasks = [task for task in candidate_tasks if task.agent_id == replace_agent_id]
+    log.info(
+        "Tasks on agent {} to be replaced after drain: {}".format(replace_agent_id, replace_tasks)
+    )
+    sdk_agents.drain_agent(replace_agent_id)
+
+    sdk_plan.wait_for_kicked_off_recovery(config.SERVICE_NAME)
+    sdk_plan.wait_for_completed_recovery(config.SERVICE_NAME)
+
+    new_tasks = sdk_tasks.get_summary()
+
+    for replaced_task in replace_tasks:
+        new_task = [
+            task
+            for task in new_tasks
+            if task.name == replaced_task.name and task.id != replaced_task.id
+        ][0]
+        log.info(
+            "Checking affected task has moved to a new agent:\n"
+            "old={}\nnew={}".format(replaced_task, new_task)
+        )
+        assert replaced_task.agent_id != new_task.agent_id
+
+    # Reactivate the drained agent, otherwise uninstall plans will be halted for portworx
+    sdk_agents.reactivate_agent(replace_agent_id)

--- a/frameworks/cassandra/tests/test_external_volumes.py
+++ b/frameworks/cassandra/tests/test_external_volumes.py
@@ -40,8 +40,8 @@ def test_default_deployment():
     sdk_plan.wait_for_completed_deployment(config.SERVICE_NAME)
 
 
-# @pytest.mark.external_volumes
-# @pytest.mark.sanity
+@pytest.mark.skip(reason="Conflicts with Cassandra Custom Recovery Manager")
+@pytest.mark.sanity
 def test_auto_replace_on_drain():
     candidate_tasks = sdk_tasks.get_tasks_avoiding_scheduler(
         config.SERVICE_NAME, re.compile("^node-[0-9]+-server$")

--- a/frameworks/cassandra/tests/test_external_volumes.py
+++ b/frameworks/cassandra/tests/test_external_volumes.py
@@ -33,11 +33,7 @@ def test_default_deployment():
                 "permanent-failure-timeout-secs": 30,
             }
         },
-        "nodes": {
-            "external_volume": {
-                "enabled": True
-            }
-        }
+        "nodes": {"external_volume": {"enabled": True}},
     }
     sdk_install.install(
         config.PACKAGE_NAME,

--- a/frameworks/cassandra/tests/test_external_volumes.py
+++ b/frameworks/cassandra/tests/test_external_volumes.py
@@ -27,12 +27,6 @@ def test_default_deployment():
     # Test default installation with external volumes.
     # Ensure service comes up successfully.
     options = {
-        "service": {
-            "pod-replacement-failure-policy": {
-                "enable-automatic-pod-replacement": True,
-                "permanent-failure-timeout-secs": 30,
-            }
-        },
         "nodes": {"external_volume": {"enabled": True}},
     }
     sdk_install.install(
@@ -46,8 +40,8 @@ def test_default_deployment():
     sdk_plan.wait_for_completed_deployment(config.SERVICE_NAME)
 
 
-@pytest.mark.external_volumes
-@pytest.mark.sanity
+# @pytest.mark.external_volumes
+# @pytest.mark.sanity
 def test_auto_replace_on_drain():
     candidate_tasks = sdk_tasks.get_tasks_avoiding_scheduler(
         config.SERVICE_NAME, re.compile("^node-[0-9]+-server$")

--- a/frameworks/cassandra/universe/config.json
+++ b/frameworks/cassandra/universe/config.json
@@ -437,19 +437,19 @@
           "type": "object",
           "properties": {
             "enable-automatic-pod-replacement": {
-                "description": "Determines whether pods should be replaced automatically on failure.",
-                "type": "boolean",
-                "default": false
+              "description": "Determines whether pods should be replaced automatically on failure.",
+              "type": "boolean",
+              "default": false
             },
             "permanent-failure-timeout-secs": {
-                "description": "Default time to wait before declaring a pod as permanently failed in seconds.",
-                "type": "integer",
-                "default": 120
+              "description": "Default time to wait before declaring a pod as permanently failed in seconds.",
+              "type": "integer",
+              "default": 120
             },
             "min-replace-delay-secs": {
-                "description": "Default time to wait between successive pod-replace operations in seconds.",
-                "type": "integer",
-                "default": 240
+              "description": "Default time to wait between successive pod-replace operations in seconds.",
+              "type": "integer",
+              "default": 240
             }
           }
         }

--- a/frameworks/cassandra/universe/config.json
+++ b/frameworks/cassandra/universe/config.json
@@ -527,10 +527,6 @@
             "driver_name": {
               "type": "string",
               "description": "External Volume storage provider to use.",
-              "enum": [
-                "pxd",
-                "generic"
-              ],
               "default": "pxd"
             }
           }

--- a/frameworks/cassandra/universe/config.json
+++ b/frameworks/cassandra/universe/config.json
@@ -47,16 +47,6 @@
           "type": "string",
           "default": ""
         },
-        "permanent-failure-timeout-secs": {
-          "type": "integer",
-          "description": "Time in seconds to wait before declaring a task as permanently failed.",
-          "default": 120
-        },
-        "min-replace-delay-secs": {
-          "type": "integer",
-          "description": "Time to wait between destructive task recoveries.",
-          "default": 240
-        },
         "log_level": {
           "description": "The log level for the DC/OS service.",
           "type": "string",
@@ -441,6 +431,27 @@
               "minimum": 15
             }
           }
+        },
+        "pod-replacement-failure-policy": {
+          "description": "Options relating to automatic pod-replacement failure policies.",
+          "type": "object",
+          "properties": {
+            "enable-automatic-pod-replacement": {
+                "description": "Determines whether pods should be replaced automatically on failure.",
+                "type": "boolean",
+                "default": false
+            },
+            "permanent-failure-timeout-secs": {
+                "description": "Default time to wait before declaring a pod as permanently failed in seconds.",
+                "type": "integer",
+                "default": 120
+            },
+            "min-replace-delay-secs": {
+                "description": "Default time to wait between successive pod-replace operations in seconds.",
+                "type": "integer",
+                "default": 240
+            }
+          }
         }
       },
       "required": [
@@ -495,18 +506,18 @@
           }
         },
         "external_volume": {
+          "description": "Cassandra external volume configuration.",
           "type": "object",
-          "description": "The Cassandra external volume configuration.\nOnly Portworx external volumes are supported.",
           "properties": {
             "enabled": {
               "type": "boolean",
-              "description": "If true, external profile will be used.",
+              "description": "If true, external volumes will be used.",
               "default": false
             },
-            "portworx_volume_options": {
+            "driver_options": {
               "type": "string",
               "default": "size=10",
-              "description": "Volume options."
+              "description": "External Volume storage provider options."
             },
             "volume_name": {
               "type": "string",
@@ -515,7 +526,11 @@
             },
             "driver_name": {
               "type": "string",
-              "description": "Docker volume driver name.",
+              "description": "External Volume storage provider to use.",
+              "enum": [
+                "pxd",
+                "generic"
+              ],
               "default": "pxd"
             }
           }

--- a/frameworks/cassandra/universe/marathon.json.mustache
+++ b/frameworks/cassandra/universe/marathon.json.mustache
@@ -41,8 +41,6 @@
     "FRAMEWORK_LOG_LEVEL": "{{service.log_level}}",
     "CASSANDRA_VERSION": "3.11.6",
     "S3CLI_VERSION": "s3cli-0.0.55-linux-amd64",
-    "PERMANENT_FAILURE_TIMEOUT_SECS": "{{service.permanent-failure-timeout-secs}}",
-    "MIN_REPLACE_DELAY_SECS": "{{service.min-replace-delay-secs}}",
 
     {{#service.service_account_secret}}
     "DCOS_SERVICE_ACCOUNT_CREDENTIAL": "secrets/service-account.json",
@@ -112,10 +110,16 @@
     {{#nodes.volume_profile}}
     "CASSANDRA_VOLUME_PROFILE": "{{nodes.volume_profile}}",
     {{/nodes.volume_profile}}
+
     "CASSANDRA_EXTERNAL_VOLUME_ENABLED" : "{{nodes.external_volume.enabled}}",
-    "CASSANDRA_EXTERNAL_VOLUME_PORTWORX_OPTIONS" : "{{nodes.external_volume.portworx_volume_options}}",
+    "CASSANDRA_EXTERNAL_VOLUME_DRIVER_OPTIONS" : "{{nodes.external_volume.driver_options}}",
     "CASSANDRA_EXTERNAL_VOLUME_NAME" : "{{nodes.external_volume.volume_name}}",
     "CASSANDRA_EXTERNAL_VOLUME_DRIVER_NAME" : "{{nodes.external_volume.driver_name}}",
+
+    "ENABLE_AUTOMATIC_POD_REPLACEMENT": "{{service.pod-replacement-failure-policy.enable-automatic-pod-replacement}}",
+    "PERMANENT_FAILURE_TIMEOUT_SECS": "{{service.pod-replacement-failure-policy.permanent-failure-timeout-secs}}",
+    "MIN_REPLACE_DELAY_SECS": "{{service.pod-replacement-failure-policy.min-replace-delay-secs}}",
+
     "TASKCFG_ALL_CASSANDRA_HEAP_SIZE_MB": "{{nodes.heap.size}}",
     "TASKCFG_ALL_CASSANDRA_HEAP_NEW_MB": "{{nodes.heap.new}}",
     "CASSANDRA_JAVA_URI": "{{resource.assets.uris.cassandra-jre-tar-gz}}",

--- a/frameworks/helloworld/src/main/dist/external-volumes.yml
+++ b/frameworks/helloworld/src/main/dist/external-volumes.yml
@@ -1,0 +1,82 @@
+name: {{FRAMEWORK_NAME}}
+scheduler:
+  principal: {{FRAMEWORK_PRINCIPAL}}
+  user: {{FRAMEWORK_USER}}
+pods:
+  hello:
+    count: {{HELLO_COUNT}}
+    placement: '{{{HELLO_PLACEMENT}}}'
+    external-volumes:
+      hello-volume:
+        type: DOCKER
+        volume-mode: RW
+        container-path: hello-container-path
+        driver-name: {{EXTERNAL_VOLUME_DRIVER_NAME}}
+        driver-options: {{EXTERNAL_VOLUME_DRIVER_OPTIONS}}
+        {{#HELLO_EXTERNAL_VOLUME_NAME}}
+        volume-name: {{HELLO_EXTERNAL_VOLUME_NAME}}
+        {{/HELLO_EXTERNAL_VOLUME_NAME}}
+    tasks:
+      server:
+        goal: RUNNING
+        cmd: env && echo hello >> hello-container-path/output && sleep $SLEEP_DURATION
+        cpus: {{HELLO_CPUS}}
+        memory: {{HELLO_MEM}}
+        env:
+          SLEEP_DURATION: {{SLEEP_DURATION}}
+        health-check:
+          cmd: stat hello-container-path/output
+          interval: 5
+          grace-period: 30
+          delay: 0
+          timeout: 10
+          max-consecutive-failures: 3
+        labels: {{HELLO_LABELS}}
+  world:
+      count: {{WORLD_COUNT}}
+      allow-decommission: true
+      placement: '{{{WORLD_PLACEMENT}}}'
+      external-volumes:
+        world-volume:
+          type: DOCKER
+          volume-mode: RW
+          container-path: world-container-path
+          driver-name: {{EXTERNAL_VOLUME_DRIVER_NAME}}
+          driver-options: {{EXTERNAL_VOLUME_DRIVER_OPTIONS}}
+          {{#WORLD_EXTERNAL_VOLUME_NAME}}
+            volume-name: {{WORLD_EXTERNAL_VOLUME_NAME}}
+          {{/WORLD_EXTERNAL_VOLUME_NAME}}
+      tasks:
+        server:
+          goal: RUNNING
+          cmd: |
+                 # for graceful shutdown
+                 #  trap SIGTERM and mock a cleanup timeframe
+                 terminated () {
+                   echo "$(date) received SIGTERM, zzz for 3 ..."
+                   sleep 3
+                   echo "$(date) ... all clean, peace out"
+                   exit 0
+                 }
+                 trap terminated SIGTERM
+                 echo "$(date) trapping SIGTERM, watch here for the signal..."
+
+                 echo "${TASK_NAME}" >>world-container-path/output &&
+                 # instead of running for a short duration (equal to SLEEP_DURATION), run infinitely
+                 # to allow for testing of SIGTERM..grace..SIGKILL
+                 while true; do
+                   sleep 0.1
+                 done
+          cpus: {{WORLD_CPUS}}
+          memory: {{WORLD_MEM}}
+          env:
+            SLEEP_DURATION: {{SLEEP_DURATION}}
+          readiness-check:
+            # wordcount (wc) will report an error if the file does not exist, which effectively is zero (0) bytes
+            # so send the error to /dev/null, BUT also zero-left-pad the variable BYTES to ensure that it is zero
+            # on empty for comparison sake.
+            cmd: BYTES="$(wc -c world-container-path/output 2>/dev/null| awk '{print $1;}')" && [ 0$BYTES -gt 0 ]
+            interval: {{WORLD_READINESS_CHECK_INTERVAL}}
+            delay: {{WORLD_READINESS_CHECK_DELAY}}
+            timeout: {{WORLD_READINESS_CHECK_TIMEOUT}}
+          kill-grace-period: {{WORLD_KILL_GRACE_PERIOD}}

--- a/frameworks/helloworld/src/main/dist/multiport.yml
+++ b/frameworks/helloworld/src/main/dist/multiport.yml
@@ -9,6 +9,8 @@ pods:
       - {{BOOTSTRAP_URI}}
     resource-sets:
       multi-port-resources:
+        cpus: {{HELLO_CPUS}}
+        memory: {{HELLO_MEM}}
         ports:
           port_one:
             port: {{HELLO_PORT_ONE}}
@@ -51,7 +53,5 @@ pods:
           sum=$(($exit_1+$exit_2))
           echo "exit codes : ${exit_1} ${exit_2} and sum : ${sum}"
           exit $sum
-        cpus: {{HELLO_CPUS}}
-        memory: {{HELLO_MEM}}
         env:
           HELLO_PORT_ONE: {{HELLO_PORT_ONE}}

--- a/frameworks/helloworld/tests/test_external_volumes.py
+++ b/frameworks/helloworld/tests/test_external_volumes.py
@@ -32,16 +32,18 @@ def test_default_deployment():
             "external_volumes": {
                 "pod-replacement-failure-policy": {
                     "enable-automatic-pod-replacement": True,
-                    "permanent-failure-timeout-secs": 30
+                    "permanent-failure-timeout-secs": 30,
                 }
-            }
+            },
         }
     }
-    sdk_install.install(config.PACKAGE_NAME,
-                        config.SERVICE_NAME,
-                        3,
-                        additional_options=options,
-                        wait_for_deployment=True)
+    sdk_install.install(
+        config.PACKAGE_NAME,
+        config.SERVICE_NAME,
+        3,
+        additional_options=options,
+        wait_for_deployment=True,
+    )
     # Wait for scheduler to restart.
     sdk_plan.wait_for_completed_deployment(config.SERVICE_NAME)
 

--- a/frameworks/helloworld/tests/test_external_volumes.py
+++ b/frameworks/helloworld/tests/test_external_volumes.py
@@ -1,0 +1,84 @@
+import logging
+import pytest
+import re
+
+import sdk_agents
+import sdk_install
+import sdk_plan
+import sdk_tasks
+from tests import config
+
+log = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def configure_package(configure_security):
+    try:
+        sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
+        yield  # let the test session execute
+    finally:
+        sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
+
+
+@pytest.mark.external_volumes
+@pytest.mark.sanity
+@pytest.mark.dcos_min_version("2.1")
+def test_default_deployment():
+    # Test default installation with external volumes.
+    # Ensure service comes up successfully.
+    options = {
+        "service": {
+            "yaml": "external-volumes",
+            "external_volumes": {
+                "pod-replacement-failure-policy": {
+                    "enable-automatic-pod-replacement": True,
+                    "permanent-failure-timeout-secs": 30
+                }
+            }
+        }
+    }
+    sdk_install.install(config.PACKAGE_NAME,
+                        config.SERVICE_NAME,
+                        3,
+                        additional_options=options,
+                        wait_for_deployment=True)
+    # Wait for scheduler to restart.
+    sdk_plan.wait_for_completed_deployment(config.SERVICE_NAME)
+
+
+@pytest.mark.external_volumes
+@pytest.mark.sanity
+def test_auto_replace_on_drain():
+    candidate_tasks = sdk_tasks.get_tasks_avoiding_scheduler(
+        config.SERVICE_NAME, re.compile("^(hello|world)-[0-9]+-server$")
+    )
+
+    assert len(candidate_tasks) != 0, "Could not find a node to drain"
+
+    # Pick the host of the first task from the above list
+    replace_agent_id = candidate_tasks[0].agent_id
+    replace_tasks = [task for task in candidate_tasks if task.agent_id == replace_agent_id]
+    log.info(
+        "Tasks on agent {} to be replaced after drain: {}".format(replace_agent_id, replace_tasks)
+    )
+    sdk_agents.drain_agent(replace_agent_id)
+
+    sdk_plan.wait_for_kicked_off_recovery(config.SERVICE_NAME)
+    sdk_plan.wait_for_completed_recovery(config.SERVICE_NAME)
+
+    new_tasks = sdk_tasks.get_summary()
+
+    for replaced_task in replace_tasks:
+        new_task = [
+            task
+            for task in new_tasks
+            if task.name == replaced_task.name and task.id != replaced_task.id
+        ][0]
+        log.info(
+            "Checking affected task has moved to a new agent:\n"
+            "old={}\nnew={}".format(replaced_task, new_task)
+        )
+        assert replaced_task.agent_id != new_task.agent_id
+
+    # Reactivate the drained agent, otherwise uninstall plans will be halted for portworx
+    sdk_agents.reactivate_agent(replace_agent_id)

--- a/frameworks/helloworld/tests/test_quota_upgrade.py
+++ b/frameworks/helloworld/tests/test_quota_upgrade.py
@@ -32,6 +32,7 @@ def configure_package(configure_security):
         sdk_marathon.delete_group(group_id=ENFORCED_ROLE)
 
 
+@pytest.mark.skip(reason="Not compatible with recent quota changes made to Marathon")
 @pytest.mark.quota_test
 @pytest.mark.quota_upgrade
 @pytest.mark.dcos_min_version("1.14")

--- a/frameworks/helloworld/universe/config.json
+++ b/frameworks/helloworld/universe/config.json
@@ -235,7 +235,7 @@
               "type": "string",
               "enum": [
                 "pxd",
-                "netapp"
+                "generic"
               ],
               "default": "pxd"
             },

--- a/frameworks/helloworld/universe/config.json
+++ b/frameworks/helloworld/universe/config.json
@@ -246,20 +246,23 @@
             },
             "pod-replacement-failure-policy": {
               "description": "Options relating to automatic pod-replacement failure policies with external-volumes.",
-              "enable-automatic-pod-replacement": {
-                  "description": "Determines whether pods should be replaced automatically on failure.",
-                  "type": "boolean",
-                  "default": false
-              },
-              "permanent-failure-timeout-secs": {
-                  "description": "Default time to wait before declaring a pod as permanently failed in seconds.",
-                  "type": "integer",
-                  "default": 120
-              },
-              "min-replace-delay-secs": {
-                  "description": "Default time to wait between successive pod-replace operations in seconds.",
-                  "type": "integer",
-                  "default": 240
+              "type": "object",
+              "properties": {
+                "enable-automatic-pod-replacement": {
+                    "description": "Determines whether pods should be replaced automatically on failure.",
+                    "type": "boolean",
+                    "default": false
+                },
+                "permanent-failure-timeout-secs": {
+                    "description": "Default time to wait before declaring a pod as permanently failed in seconds.",
+                    "type": "integer",
+                    "default": 120
+                },
+                "min-replace-delay-secs": {
+                    "description": "Default time to wait between successive pod-replace operations in seconds.",
+                    "type": "integer",
+                    "default": 240
+                }
               }
             }
           }

--- a/frameworks/helloworld/universe/config.json
+++ b/frameworks/helloworld/universe/config.json
@@ -233,10 +233,6 @@
             "volume_driver_name": {
               "description": "External Volume storage provider to use.",
               "type": "string",
-              "enum": [
-                "pxd",
-                "generic"
-              ],
               "default": "pxd"
             },
             "volume_driver_options": {

--- a/frameworks/helloworld/universe/config.json
+++ b/frameworks/helloworld/universe/config.json
@@ -103,6 +103,7 @@
             "discovery",
             "enable-disable",
             "executor_volume",
+            "external-volumes",
             "finish_state",
             "foobar_service_name",
             "gpu_resource",
@@ -222,6 +223,44 @@
               "description": "Amount of time to wait until starting the checks",
               "type": "integer",
               "default": 15
+            }
+          }
+        },
+        "external_volumes": {
+          "description": "External Volumes properties.",
+          "type": "object",
+          "properties": {
+            "volume_driver_name": {
+              "description": "External Volume storage provider to use.",
+              "type": "string",
+              "enum": [
+                "pxd",
+                "netapp"
+              ],
+              "default": "pxd"
+            },
+            "volume_driver_options": {
+              "description": "External Volume storage provider options.",
+              "type": "string",
+              "default": ""
+            },
+            "pod-replacement-failure-policy": {
+              "description": "Options relating to automatic pod-replacement failure policies with external-volumes.",
+              "enable-automatic-pod-replacement": {
+                  "description": "Determines whether pods should be replaced automatically on failure.",
+                  "type": "boolean",
+                  "default": false
+              },
+              "permanent-failure-timeout-secs": {
+                  "description": "Default time to wait before declaring a pod as permanently failed in seconds.",
+                  "type": "integer",
+                  "default": 120
+              },
+              "min-replace-delay-secs": {
+                  "description": "Default time to wait between successive pod-replace operations in seconds.",
+                  "type": "integer",
+                  "default": 240
+              }
             }
           }
         }
@@ -346,6 +385,11 @@
               }
             }
           }
+        },
+        "external_volume_name": {
+          "description": "Hello Pod External Volume Name",
+          "type": "string",
+          "default": ""
         }
       },
       "required": [
@@ -455,6 +499,11 @@
               }
             }
           }
+        },
+        "external_volume_name": {
+          "description": "World Pod External Volume Name",
+          "type": "string",
+          "default": ""
         }
       },
       "required": [

--- a/frameworks/helloworld/universe/config.json
+++ b/frameworks/helloworld/universe/config.json
@@ -251,7 +251,7 @@
                 "enable-automatic-pod-replacement": {
                     "description": "Determines whether pods should be replaced automatically on failure.",
                     "type": "boolean",
-                    "default": false
+                    "default": true
                 },
                 "permanent-failure-timeout-secs": {
                     "description": "Default time to wait before declaring a pod as permanently failed in seconds.",

--- a/frameworks/helloworld/universe/config.json
+++ b/frameworks/helloworld/universe/config.json
@@ -249,19 +249,19 @@
               "type": "object",
               "properties": {
                 "enable-automatic-pod-replacement": {
-                    "description": "Determines whether pods should be replaced automatically on failure.",
-                    "type": "boolean",
-                    "default": true
+                  "description": "Determines whether pods should be replaced automatically on failure.",
+                  "type": "boolean",
+                  "default": true
                 },
                 "permanent-failure-timeout-secs": {
-                    "description": "Default time to wait before declaring a pod as permanently failed in seconds.",
-                    "type": "integer",
-                    "default": 120
+                  "description": "Default time to wait before declaring a pod as permanently failed in seconds.",
+                  "type": "integer",
+                  "default": 120
                 },
                 "min-replace-delay-secs": {
-                    "description": "Default time to wait between successive pod-replace operations in seconds.",
-                    "type": "integer",
-                    "default": 240
+                  "description": "Default time to wait between successive pod-replace operations in seconds.",
+                  "type": "integer",
+                  "default": 240
                 }
               }
             }

--- a/frameworks/helloworld/universe/marathon.json.mustache
+++ b/frameworks/helloworld/universe/marathon.json.mustache
@@ -130,18 +130,18 @@
     "WORLD_READINESS_CHECK_DELAY": "{{world.readiness_check.delay}}",
     "WORLD_READINESS_CHECK_TIMEOUT": "{{world.readiness_check.timeout}}",
 
-    {{#hello.hello_external_volume_name}}
+    {{#hello.external_volume_name}}
     "HELLO_EXTERNAL_VOLUME_NAME: "{{hello.external_volume_name}}",
-    {{/hello.hello_external_volume_name}}
-    {{#world.world_external_volume_name}}
+    {{/hello.external_volume_name}}
+    {{#world.external_volume_name}}
     "WORLD_EXTERNAL_VOLUME_NAME: "{{world.external_volume_name}}",
-    {{/world.world_external_volume_name}}
-
-    {{#service.external_volumes.pod-replacement-failure-policies.enable-automatic-pod-replacement}}
-    "ENABLE_AUTOMATIC_POD_REPLACEMENT": "{{service.external_volumes.pod-replacement-failure-policies.enable-automatic-pod-replacement}}",
-    "PERMANENT_FAILURE_TIMEOUT_SECS": "{{service.external_volumes.pod-replacement-failure-policies.permanent-failure-timeout-secs}}",
-    "MIN_REPLACE_DELAY_SECS": "{{service.external_volumes.pod-replacement-failure-policies.min-replace-delay-secs}}",
-    {{/service.external_volumes.pod-replacement-failure-policies.enable-automatic-pod-replacement}}
+    {{/world.external_volume_name}}
+    
+    {{#service.external_volumes.pod-replacement-failure-policy.enable-automatic-pod-replacement}}
+    "ENABLE_AUTOMATIC_POD_REPLACEMENT": "{{service.external_volumes.pod-replacement-failure-policy.enable-automatic-pod-replacement}}",
+    "PERMANENT_FAILURE_TIMEOUT_SECS": "{{service.external_volumes.pod-replacement-failure-policy.permanent-failure-timeout-secs}}",
+    "MIN_REPLACE_DELAY_SECS": "{{service.external_volumes.pod-replacement-failure-policy.min-replace-delay-secs}}",
+    {{/service.external_volumes.pod-replacement-failure-policy.enable-automatic-pod-replacement}}
 
     "EXTERNAL_VOLUME_DRIVER_NAME": "{{service.external_volumes.volume_driver_name}}",
     "EXTERNAL_VOLUME_DRIVER_OPTIONS": "{{service.external_volumes.volume_driver_options}}",

--- a/frameworks/helloworld/universe/marathon.json.mustache
+++ b/frameworks/helloworld/universe/marathon.json.mustache
@@ -130,11 +130,28 @@
     "WORLD_READINESS_CHECK_DELAY": "{{world.readiness_check.delay}}",
     "WORLD_READINESS_CHECK_TIMEOUT": "{{world.readiness_check.timeout}}",
 
+    {{#hello.hello_external_volume_name}}
+    "HELLO_EXTERNAL_VOLUME_NAME: "{{hello.external_volume_name}}",
+    {{/hello.hello_external_volume_name}}
+    {{#world.world_external_volume_name}}
+    "WORLD_EXTERNAL_VOLUME_NAME: "{{world.external_volume_name}}",
+    {{/world.world_external_volume_name}}
+
+    {{#service.external_volumes.pod-replacement-failure-policies.enable-automatic-pod-replacement}}
+    "ENABLE_AUTOMATIC_POD_REPLACEMENT": "{{service.external_volumes.pod-replacement-failure-policies.enable-automatic-pod-replacement}}",
+    "PERMANENT_FAILURE_TIMEOUT_SECS": "{{service.external_volumes.pod-replacement-failure-policies.permanent-failure-timeout-secs}}",
+    "MIN_REPLACE_DELAY_SECS": "{{service.external_volumes.pod-replacement-failure-policies.min-replace-delay-secs}}",
+    {{/service.external_volumes.pod-replacement-failure-policies.enable-automatic-pod-replacement}}
+
+    "EXTERNAL_VOLUME_DRIVER_NAME": "{{service.external_volumes.volume_driver_name}}",
+    "EXTERNAL_VOLUME_DRIVER_OPTIONS": "{{service.external_volumes.volume_driver_options}}",
+
     "HELLO_RLIMIT_NOFILE_SOFT": "{{hello.rlimits.rlimit_nofile.soft}}",
     "HELLO_RLIMIT_NOFILE_HARD": "{{hello.rlimits.rlimit_nofile.hard}}",
 
     "WORLD_RLIMIT_NOFILE_SOFT": "{{world.rlimits.rlimit_nofile.soft}}",
     "WORLD_RLIMIT_NOFILE_HARD": "{{world.rlimits.rlimit_nofile.hard}}"
+
   },
   "fetch": [
     { "uri": "{{resource.assets.uris.bootstrap-zip}}", "cache": true },

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerBuilder.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/SchedulerBuilder.java
@@ -572,8 +572,11 @@ public class SchedulerBuilder {
           Duration.ofSeconds(failurePolicy.getPermanentFailureTimeoutSecs()),
           stateStore,
           configStore);
+      logger.info("Failure Monitor: Adding ReplacementFailurePolicy and TimedFailureMonitor with duration: {}s",
+              failurePolicy.getPermanentFailureTimeoutSecs());
     } else {
       failureMonitor = new NeverFailureMonitor();
+      logger.info("FailureMonitor: Adding NeverFailureMonitor");
     }
     return new DefaultRecoveryPlanManager(
         stateStore,

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/recovery/monitor/TimedFailureMonitor.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/scheduler/recovery/monitor/TimedFailureMonitor.java
@@ -70,6 +70,7 @@ public class TimedFailureMonitor extends DefaultFailureMonitor {
   @Override
   public boolean hasFailed(Protos.TaskInfo terminatedTask) {
     if (super.hasFailed(terminatedTask)) {
+      logger.debug("TimedFailureMonitor super.hasFailed {}", true);
       return true;
     }
 

--- a/testing/sdk_external_volumes.py
+++ b/testing/sdk_external_volumes.py
@@ -32,16 +32,18 @@ def external_volumes_session() -> Iterator[None]:
     # Install service on private agents.
     num_private_agents = len(sdk_agents.get_private_agents())
 
-    sdk_security.create_service_account(
-        service_account_name=EXTERNAL_VOLUMES_SERVICE_NAME,
+    sdk_security.setup_security(
+        service_name=EXTERNAL_VOLUMES_SERVICE_NAME,
+        linux_user="root",
+        service_account=EXTERNAL_VOLUMES_SERVICE_NAME,
         service_account_secret=EXTERNAL_VOLUMES_SERVICE_NAME + "-secret",
     )
 
     service_options = {
         "service": {
             "name": EXTERNAL_VOLUMES_SERVICE_NAME,
-            "service_account": EXTERNAL_VOLUMES_SERVICE_NAME,
-            "service_account_secret": EXTERNAL_VOLUMES_SERVICE_NAME + "-secret",
+            "principal": EXTERNAL_VOLUMES_SERVICE_NAME,
+            "secret_name": EXTERNAL_VOLUMES_SERVICE_NAME + "-secret",
         },
         "node": {
             "portworx_image": PORTWORX_IMAGE_VERSION,


### PR DESCRIPTION
SDK:
- Add improved logging to indicate Pod-Replacement policy has been used.

Hello-World:
- Add scenario with external-volumes and basic integration test.

Cassandra:
- Add flag to enable/disable Pod-Replacement failure policy.
- Remove mentions of Portworx from service spec, switch NetApp to Generic Driver.
- Add basic integration test.