### PR TITLE
Add container-path for pods with multiple external-volumes.

### DIFF
--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/ExternalVolumeProviderFactory.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/ExternalVolumeProviderFactory.java
@@ -14,6 +14,7 @@ public final class ExternalVolumeProviderFactory {
   public static ExternalVolumeProvider getExternalVolumeProvider(
       String serviceName,
       Optional<String> volumeName,
+      Optional<String> containerPath,
       String driverName,
       String podType,
       int podIndex,
@@ -23,6 +24,7 @@ public final class ExternalVolumeProviderFactory {
       return new PortworxVolumeProvider(
           serviceName,
           volumeName,
+          containerPath,
           podType,
           podIndex,
           driverOptions);
@@ -30,6 +32,7 @@ public final class ExternalVolumeProviderFactory {
       return new GenericDockerVolumeProvider(
           serviceName,
           volumeName,
+          containerPath,
           podType,
           podIndex,
           driverOptions);

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/GenericDockerVolumeProvider.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/GenericDockerVolumeProvider.java
@@ -17,6 +17,7 @@ public class GenericDockerVolumeProvider implements ExternalVolumeProvider {
   public GenericDockerVolumeProvider(
       String serviceName,
       Optional<String> providedVolumeName,
+      Optional<String> containerPath,
       String podType,
       int podIndex,
       Map<String, String> driverOptions)
@@ -27,6 +28,9 @@ public class GenericDockerVolumeProvider implements ExternalVolumeProvider {
       volumeNameUnescaped = providedVolumeName.get();
     } else {
       volumeNameUnescaped = providedVolumeName.filter(name -> !name.isEmpty()).orElse(serviceName) + '_' + podType;
+      if (containerPath.isPresent()) {
+        volumeNameUnescaped = volumeNameUnescaped + '-' + containerPath.get();
+      }
     }
 
     String volumeNameEscaped = SchedulerUtils.withEscapedSlashes(volumeNameUnescaped);

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/GenericDockerVolumeProvider.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/GenericDockerVolumeProvider.java
@@ -29,7 +29,7 @@ public class GenericDockerVolumeProvider implements ExternalVolumeProvider {
     } else {
       volumeNameUnescaped = providedVolumeName.filter(name -> !name.isEmpty()).orElse(serviceName) + '_' + podType;
       if (containerPath.isPresent()) {
-        volumeNameUnescaped = volumeNameUnescaped + '-' + containerPath.get();
+        volumeNameUnescaped = volumeNameUnescaped + '_' + containerPath.get();
       }
     }
 

--- a/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/PortworxVolumeProvider.java
+++ b/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/PortworxVolumeProvider.java
@@ -20,6 +20,7 @@ public class PortworxVolumeProvider implements ExternalVolumeProvider {
   public PortworxVolumeProvider(
       String serviceName,
       Optional<String> providedVolumeName,
+      Optional<String> containerPath,
       String podType,
       int podIndex,
       Map<String, String> driverOptions)
@@ -30,6 +31,9 @@ public class PortworxVolumeProvider implements ExternalVolumeProvider {
       volumeNameUnescaped = providedVolumeName.get();
     } else {
       volumeNameUnescaped = providedVolumeName.filter(name -> !name.isEmpty()).orElse(serviceName) + '-' + podType;
+      if (containerPath.isPresent()) {
+        volumeNameUnescaped = volumeNameUnescaped + '-' + containerPath.get();
+      }
     }
 
     String volumeNameEscaped = SchedulerUtils.withEscapedSlashes(volumeNameUnescaped);


### PR DESCRIPTION
Add `container-path` to the external volume when a pod has multiple external-volumes defined.
This is only used when the user does not explicitly set a external-volume name.